### PR TITLE
Align pipeline prompts with custom visual identity workflow

### DIFF
--- a/pipeline_defs/animated-explainer.yaml
+++ b/pipeline_defs/animated-explainer.yaml
@@ -38,9 +38,12 @@ orchestration:
   max_wall_time_minutes: 20
 
 compatible_playbooks:
-  - clean-professional
-  - flat-motion-graphics
-  - minimalist-diagram
+  recommended:
+    - clean-professional
+    - flat-motion-graphics
+  also_works:
+    - minimalist-diagram
+  custom_allowed: true
 
 stages:
   # ── Pre-Production ──────────────────────────────────────────────

--- a/pipeline_defs/animation.yaml
+++ b/pipeline_defs/animation.yaml
@@ -38,10 +38,13 @@ orchestration:
   max_wall_time_minutes: 15
 
 compatible_playbooks:
-  - clean-professional
-  - flat-motion-graphics
-  - minimalist-diagram
-  - anime-ghibli
+  recommended:
+    - flat-motion-graphics
+    - anime-ghibli
+  also_works:
+    - clean-professional
+    - minimalist-diagram
+  custom_allowed: true
 
 stages:
   # ── Pre-Production ──────────────────────────────────────────────

--- a/pipeline_defs/avatar-spokesperson.yaml
+++ b/pipeline_defs/avatar-spokesperson.yaml
@@ -36,8 +36,11 @@ required_skills:
   - meta/checkpoint-protocol
 
 compatible_playbooks:
-  - clean-professional
-  - flat-motion-graphics
+  recommended:
+    - clean-professional
+    - flat-motion-graphics
+  also_works: []
+  custom_allowed: true
 
 stages:
   - name: idea
@@ -201,4 +204,3 @@ stages:
     success_criteria:
       - Schema-valid publish_log artifact
       - Export package contains video and metadata outputs
-

--- a/pipeline_defs/cinematic.yaml
+++ b/pipeline_defs/cinematic.yaml
@@ -38,9 +38,9 @@ required_skills:
 
 compatible_playbooks:
   recommended:
-    - clean-professional
     - flat-motion-graphics
   also_works:
+    - clean-professional
     - minimalist-diagram
   custom_allowed: true
 

--- a/pipeline_defs/clip-factory.yaml
+++ b/pipeline_defs/clip-factory.yaml
@@ -36,8 +36,11 @@ required_skills:
   - meta/checkpoint-protocol
 
 compatible_playbooks:
-  - clean-professional
-  - flat-motion-graphics
+  recommended:
+    - clean-professional
+    - flat-motion-graphics
+  also_works: []
+  custom_allowed: true
 
 stages:
   - name: idea

--- a/pipeline_defs/hybrid.yaml
+++ b/pipeline_defs/hybrid.yaml
@@ -36,9 +36,12 @@ required_skills:
   - meta/checkpoint-protocol
 
 compatible_playbooks:
-  - clean-professional
-  - flat-motion-graphics
-  - minimalist-diagram
+  recommended:
+    - clean-professional
+    - flat-motion-graphics
+  also_works:
+    - minimalist-diagram
+  custom_allowed: true
 
 stages:
   - name: idea
@@ -219,4 +222,3 @@ stages:
     success_criteria:
       - Schema-valid publish_log artifact
       - Export package contains video and metadata outputs
-

--- a/pipeline_defs/localization-dub.yaml
+++ b/pipeline_defs/localization-dub.yaml
@@ -35,8 +35,11 @@ required_skills:
   - meta/checkpoint-protocol
 
 compatible_playbooks:
-  - clean-professional
-  - flat-motion-graphics
+  recommended:
+    - clean-professional
+    - flat-motion-graphics
+  also_works: []
+  custom_allowed: true
 
 stages:
   - name: idea
@@ -202,4 +205,3 @@ stages:
     success_criteria:
       - Schema-valid publish_log artifact
       - Export package contains localized video and metadata outputs
-

--- a/pipeline_defs/podcast-repurpose.yaml
+++ b/pipeline_defs/podcast-repurpose.yaml
@@ -37,8 +37,11 @@ required_skills:
   - meta/checkpoint-protocol
 
 compatible_playbooks:
-  - clean-professional
-  - flat-motion-graphics
+  recommended:
+    - clean-professional
+    - flat-motion-graphics
+  also_works: []
+  custom_allowed: true
 
 stages:
   - name: idea

--- a/pipeline_defs/screen-demo.yaml
+++ b/pipeline_defs/screen-demo.yaml
@@ -36,8 +36,11 @@ required_skills:
   - meta/checkpoint-protocol
 
 compatible_playbooks:
-  - clean-professional
-  - minimalist-diagram
+  recommended:
+    - minimalist-diagram
+    - clean-professional
+  also_works: []
+  custom_allowed: true
 
 stages:
   - name: idea

--- a/pipeline_defs/talking-head.yaml
+++ b/pipeline_defs/talking-head.yaml
@@ -34,7 +34,10 @@ orchestration:
   max_send_backs: 3
 
 compatible_playbooks:
-  - clean-professional
+  recommended:
+    - clean-professional
+  also_works: []
+  custom_allowed: true
 
 stages:
   - name: idea

--- a/skills/core/remotion.md
+++ b/skills/core/remotion.md
@@ -60,7 +60,7 @@ The `anime_scene` type renders 1-4 images with smooth crossfade transitions, cin
 
 **Key prop:** `sceneDurationSeconds` is automatically passed by `SceneRenderer` — this fixes a critical Remotion pitfall where `useVideoConfig().durationInFrames` returns the full composition duration, not the scene's Sequence duration.
 
-**Multi-image crossfade math:** Each image owns an equal time segment. Fade-out of image N and fade-in of image N+1 OVERLAP by `crossfadeDur` (~1.2s) so there's never a dead frame. Generate 2-3 images per scene with same style prefix + different seeds for subtle motion effect.
+**Multi-image crossfade math:** Each image owns an equal time segment. Fade-out of image N and fade-in of image N+1 OVERLAP by `crossfadeDur` (~1.2s) so there's never a dead frame. Generate 2-3 images per scene from the same visual system, but vary the shot, subject, and lighting per beat. Nearby seeds help create subtle motion without flattening the whole sequence into one repeated prompt.
 
 **Reference composition:** `remotion-composer/public/demo-props/mori-no-seishin.json` — 6 anime scenes, 30 seconds, with particles, lighting, overlays, and ambient music.
 
@@ -75,9 +75,9 @@ professional video with zero external dependencies.
 
 These rules were discovered through systematic render testing and produce cinematic results:
 
-**1. ALL-DARK BACKGROUNDS (mandatory).** Set `backgroundColor: "#0F172A"` on EVERY scene.
+**1. Commit to one background family per video.** Use a coherent background treatment derived from the playbook or custom identity instead of forcing every sequence into the same dark dashboard look.
 This prevents jarring white↔dark flash transitions and makes chart colors pop dramatically.
-Dark backgrounds transform basic charts into cinematic data visualization.
+The goal is visual cohesion, not a mandatory dark theme.
 
 **2. Flat props format.** All scene properties go at the TOP LEVEL of the cut object
 (e.g., `cut.text`, `cut.chartData`), NOT nested under a `props` key.

--- a/skills/creative/image-gen-usage.md
+++ b/skills/creative/image-gen-usage.md
@@ -9,7 +9,7 @@
 FLUX RESOLUTION:  1920x1088 (16:9) | 1088x1920 (9:16) — must be multiples of 16
 MAX TOTAL:        4 megapixels (width x height)
 CONSISTENCY:      Use hero image as input_image for subsequent frames
-STYLE PREFIX:     Set in playbook, prepend to every prompt
+STYLE SYSTEM:     Derive from subject + audience + tone, then adapt per scene
 BATCH STRATEGY:   Hero at max quality → iterate with klein → final pass with pro
 ```
 
@@ -29,14 +29,19 @@ All FLUX dimensions **must be multiples of 16**. Maximum total is 4MP.
 
 The biggest challenge: making 8-12 generated images look like they belong in the same video.
 
-### Strategy 1 — Style Prefix (Always Use)
+### Strategy 1 — Shared Visual System (Always Use)
 
-Prepend the playbook's `image_prompt_prefix` to every prompt. Example from `clean-professional`:
+Define a shared visual system for the project first, then adapt it per scene.
+Capture the project's:
 
-```
-"Clean, minimal illustration with soft shadows, muted color palette,
-white background, professional vector art style. [YOUR SCENE DESCRIPTION]"
-```
+- dominant mood and texture,
+- palette direction,
+- lighting bias,
+- rendering medium,
+- character/environment consistency anchors.
+
+The playbook's `image_prompt_prefix` is source material, not something to paste
+verbatim into every prompt. Distill it into a shorter scene-appropriate anchor.
 
 ### Strategy 2 — Hero Reference Image (Recommended)
 
@@ -148,17 +153,17 @@ optimized for image/video generation providers.
 2. **Hands and fingers** — DALL-E 3 and FLUX still struggle. Avoid prompts requiring detailed hand poses
 3. **Inconsistent characters** — Without reference images, the same character will look different each time. Always use the hero reference strategy
 4. **Over-prompting** — Long, complex prompts produce unpredictable results. Keep to 2-3 sentences
-5. **Ignoring the playbook** — Every image must match the style playbook. The style prefix is not optional
+5. **Over-unifying prompts** — Forcing the exact same style phrase into every prompt makes scenes look samey. Keep the visual system consistent, but let each scene express its own subject, shot, and emotional beat.
 
 ## Applying to OpenMontage
 
 When using the `image_selector` tool in the asset stage:
 
-1. **Always prepend the playbook's style prefix** to every prompt
+1. **Design the visual system first** from the proposal or custom playbook: mood, palette, texture, motion energy
 2. **Generate a hero image first** at highest quality, use as reference for all others
 3. **Use `1920x1088`** for 16:9 video frames (FLUX multiple-of-16 requirement)
 4. **Never request text in images** — add text overlays in the compose stage
 5. **Budget check** — estimate total image cost before generating; switch to local diffusers if over budget
 6. **Iterate with klein** during planning, finalize with pro
-7. **Keep prompts to 2-3 sentences** — style prefix + scene description + composition
+7. **Keep prompts to 2-3 sentences** — scene-specific camera/lighting + adapted visual anchor + concrete subject
 8. **Match the scene plan** — each image maps to a specific scene in the script

--- a/skills/creative/image-provider-usage.md
+++ b/skills/creative/image-provider-usage.md
@@ -102,9 +102,11 @@ When mixing stock and generated images in the same video, visual consistency is 
 Apply the playbook's color grading LUT to both stock and generated images in the compose stage.
 This unifies the look. The `color_grade` enhancement tool handles this.
 
-### Strategy: Match Playbook Style in Prompts
-When generating images, always prepend the playbook's `image_prompt_prefix`. When searching stock,
-use the playbook's color names in search filters (Pexels supports color filtering).
+### Strategy: Match The Visual Identity, Not A Copied Prefix
+When generating images, adapt the playbook's mood, palette, texture, and medium
+into a short scene-specific anchor. When searching stock, filter for the same
+emotional and visual qualities: color, lighting, environment, composition, era,
+and texture. Use the playbook as a consistency source, not a script to paste.
 
 ### Strategy: Avoid Mixing Styles Within a Scene
 Don't use a stock photo for one element and an AI illustration for another in the same scene.

--- a/skills/pipelines/animation/asset-director.md
+++ b/skills/pipelines/animation/asset-director.md
@@ -39,16 +39,19 @@ When `animation_mode == "image_animation"`, each scene needs **2-3 images** for 
 
 **Image generation workflow:**
 
-1. **Define a STYLE_PREFIX** — a consistent prompt prefix used across ALL images in the project. This ensures visual coherence. Store it as a reusable asset.
+1. **Define a VISUAL SYSTEM** — a reusable set of anchors used across all images in the project. This ensures visual coherence without flattening every shot into the same prompt. Store it as reusable metadata.
    ```
-   Example: "Studio Ghibli anime style, hand-painted watercolor aesthetic,
-   soft diffused lighting, lush natural environment, warm color palette,
-   painterly brushstrokes visible, high detail..."
+   Example: "Hand-painted nature fantasy, warm moss-and-amber palette,
+   soft diffused light, painterly foliage textures, gentle wonder."
    ```
+   Then adapt it per scene:
+   - Scene 1: wide establishing forest valley, mist, sunrise
+   - Scene 2: close character beat, lantern glow, drifting spores
+   - Scene 3: abstract magical energy reveal, brighter accent contrast
 
 2. **Use seed management** — for each scene, use nearby seed values (e.g., seed 100 and 101) for the A/B variants. Same prompt + different seed = same composition with subtle differences = natural crossfade motion.
 
-3. **Generate one test image first** — render a single scene to verify the style prefix produces good results at 1920×1080 before batch generating all images.
+3. **Generate one test image first** — render a single scene to verify the visual system produces good results at 1920×1080 before batch generating all images.
 
 4. **Batch generation** — generate all scene images. Skip any that already exist on disk (idempotent).
 
@@ -111,6 +114,7 @@ the AI model's training data — it may be wrong or outdated.
 - Using high-variance generation when a deterministic asset would work better.
 - Rebuilding the same title or label system repeatedly.
 - Hiding failed asset paths instead of reporting them.
+- Treating "consistency" as "same prompt every time." Good animation keeps a recognizable world while still letting each beat feel fresh.
 
 
 ## When You Do Not Know How

--- a/skills/pipelines/animation/proposal-director.md
+++ b/skills/pipelines/animation/proposal-director.md
@@ -212,7 +212,7 @@ For each concept, specify:
 - Hook must promise a VISUAL experience, not just information
 - Hook must be grounded in a specific research finding
 
-#### 4b: Animation Approach and Approach
+#### 4b: Animation Approach and Visual Identity
 
 For each concept, specify:
 - **Animation approach**: `image_animation` / `clip_video` / `manim` / `remotion_dataviz` / `diagram_stills` / `mixed`
@@ -220,7 +220,10 @@ For each concept, specify:
 - **Image/video generation provider**: which specific provider from the preflight scan (e.g., "FLUX via fal.ai", "gpt-image-1 via OpenAI", "Stable Diffusion local")
 - **Reuse strategy**: What's the visual system? (recurring motifs, layout grid, color scheme, transition family)
 - **Complexity estimate**: How many unique scene types vs. reusable templates?
-- **Style playbook**: which playbook from `styles/*.yaml` (e.g., `anime-ghibli`, `clean-professional`)
+- **Visual identity**: palette, typography, texture, motion energy, and why they fit this subject, audience, and platform
+- **Playbook strategy**: preset if it truly fits, or a custom playbook generated via `lib/playbook_generator.py`
+
+**Important:** Do not reduce animation identity to a preset name. A physics explainer, a startup launch video, and a dreamy anime short may all use Remotion, but they should not share the same color logic, typography, or motion cadence.
 
 #### 4c: Narrative Structure
 

--- a/skills/pipelines/animation/scene-director.md
+++ b/skills/pipelines/animation/scene-director.md
@@ -45,7 +45,7 @@ Use:
 
 Use `anime_scene` type for each scene. Plan:
 
-- **Images per scene**: 2-3 images with consistent style prefix and nearby seeds for crossfade effect
+- **Images per scene**: 2-3 images built from the same visual system and nearby seeds for crossfade effect
 - **Camera motion**: choose from `zoom-in`, `zoom-out`, `pan-left`, `pan-right`, `ken-burns`, `drift-up`, `drift-down`, `parallax`, `static` — vary per scene to prevent monotony
 - **Particle type**: choose from `fireflies`, `petals`, `sparkles`, `mist`, `light-rays` — match to scene mood
 - **Lighting**: optional `lightingFrom`/`lightingTo` gradient for atmospheric shifts within the scene
@@ -70,7 +70,7 @@ Use `anime_scene` type for each scene. Plan:
 | Lighting start | `lightingFrom` | `"rgba(255,200,100,0.15)"` or `"transparent"` |
 | Lighting end | `lightingTo` | `"rgba(255,107,157,0.08)"` or `"transparent"` |
 | Cinematic edge darken | `vignette` | `true` / `false` |
-| Scene background | `backgroundColor` | `"#0A0A1A"` |
+| Scene background | `backgroundColor` | theme-derived value such as `"#0A0A1A"` or `"#F6F1E8"` |
 
 Reference: `remotion-composer/public/demo-props/mori-no-seishin.json` — 6 scenes using this pattern.
 Reference: `remotion-composer/public/demo-props/deep-ocean.json` — 6 underwater scenes with different palette.

--- a/skills/pipelines/explainer/asset-director.md
+++ b/skills/pipelines/explainer/asset-director.md
@@ -79,9 +79,13 @@ For each script section:
 Process asset tasks grouped by tool for efficiency:
 
 **Images (`image_selector`)**:
-1. Build the prompt: `playbook.asset_generation.image_prompt_prefix` + scene description + style cues
+1. Build the prompt from the scene's actual purpose:
+   - scene-specific shot/lighting/texture cues from `shot_language`, `shot_intent`, and `texture_keywords`
+   - an adapted visual anchor from the playbook or custom identity
+   - the concrete subject/action/environment
+   Use `lib/shot_prompt_builder.py` when helpful.
 2. Add negative prompt from playbook
-3. Include consistency anchors (same palette, same style across all images)
+3. Include consistency anchors (same character/world/palette family), but do NOT reuse the exact same phrasing for every image
 4. Generate and verify the file exists
 5. If the result doesn't match expectations, refine the prompt and regenerate (max 2 retries)
 
@@ -202,7 +206,7 @@ the AI model's training data — it may be wrong or outdated.
 ## Common Pitfalls
 
 - **Generating before checking budget**: Always estimate total cost first. A 60-second video with 15 images can burn $3+ quickly.
-- **Inconsistent image style**: Each image_selector call is independent. Without explicit consistency anchors in every prompt, images will drift. Always include the playbook prefix.
+- **Inconsistent image style**: Each image_selector call is independent. Use consistent anchors, but adapt them per scene. If you paste the same style prefix into every prompt, the video will feel machine-made and repetitive.
 - **Ignoring narration timing**: If TTS produces 12s of audio for a 10s section, the edit phase will struggle. Check durations.
 - **Missing pronunciation guide**: "PostgreSQL" or "Kubernetes" will be mispronounced without explicit guidance.
 - **One retry then give up**: If an image doesn't match, refine the prompt specifically — don't just retry the same prompt.

--- a/skills/pipelines/explainer/proposal-director.md
+++ b/skills/pipelines/explainer/proposal-director.md
@@ -117,17 +117,36 @@ Choose the structure that best fits the research findings:
 | `tutorial` | Audience wants to DO something | `audience_insights.common_questions` are how-to |
 | `story` | Human interest angle exists | Expert voices or real-world cases available |
 
-#### 3c: Visual Approach and Playbook
+#### 3c: Visual Identity — Design It, Don't Pick It
 
-Match the visual approach to the content. **Check Remotion availability first** — if `video_compose` reports `render_engines.remotion: true`, the Remotion render path unlocks animated text cards, stat cards, charts, spring-physics transitions, and component-based scenes. This should change your visual design:
+**Your job is to design a visual identity for THIS video, not to pick from a preset menu.**
 
-| Content Type | Visual Approach (Remotion available) | Visual Approach (FFmpeg only) | Playbook |
-|--------------|--------------------------------------|-------------------------------|----------|
-| Technical architecture/process | Remotion animated diagrams, flowcharts with spring transitions | Static diagrams with Ken Burns motion | `minimalist-diagram` |
-| Data-heavy narrative | Remotion stat cards, animated charts, comparison cards | Static image cards with zoom-in | `flat-motion-graphics` |
-| Professional/business | Remotion text cards with clean typography | Image-based title cards | `clean-professional` |
-| Storytelling/analogy | Remotion scenes with animated character cards | Image sequence with pan | Warm/narrative playbook |
-| Tutorial/how-to | Screen captures + Remotion callout overlays | Screen captures + static overlays | `minimalist-diagram` |
+The existing playbooks (`clean-professional`, `flat-motion-graphics`, `minimalist-diagram`) are starting points, not destinations. Most videos should get a **custom visual identity** derived from the subject matter, audience, and tone. A video about coffee should feel warm and tactile. A video about cybersecurity should feel technical and urgent. A video about marine biology should feel deep and fluid.
+
+**How to design visual identity:**
+
+1. **Start from the content.** What colors does the subject naturally evoke? What textures, materials, lighting? A video about volcanoes should feel different from a video about meditation — in colors, motion speed, typography weight, and transition style.
+
+2. **Consider the audience.** A Gen Z TikTok audience expects bold, high-contrast, fast motion. A corporate training audience expects restrained, professional, readable. A kids' educational audience expects bright, playful, bouncy.
+
+3. **Consider the tone.** The user's mood board and creative intake should guide this. "Cinematic" means different colors/motion than "playful" which means different from "clinical."
+
+4. **Build the palette from the subject.** Don't default to blue. Choose 2-3 colors that serve the content:
+   - Primary: the dominant brand/feel color
+   - Accent: for emphasis, stats, highlights
+   - Background: sets the overall mood (light = approachable, dark = dramatic/technical)
+
+5. **Use a preset playbook only when it genuinely fits.** If the video is a straightforward corporate explainer, `clean-professional` is fine. But if the topic has its own visual world (nature, space, food, music, sports, history), design a custom identity.
+
+6. **Generate a custom playbook when presets don't match.** Use `lib/playbook_generator.py` to create one from your design decisions. The Remotion theme system will automatically derive colors, fonts, and motion from whatever playbook you create — including custom ones.
+
+**Record your visual identity choices in the proposal_packet:**
+- `production_plan.playbook`: name of preset OR "custom"
+- If custom, include color choices and font choices in the concept's `visual_approach`
+- Include the reasoning: "Warm amber palette because the subject is coffee craftsmanship"
+- Log as decision: `category: "playbook_selection"`
+
+**Check Remotion availability** — if `video_compose` reports `render_engines.remotion: true`, design for animated components (text cards, stat cards, charts, spring transitions). This is a major quality upgrade.
 
 **Remotion components available** (when Remotion engine is active):
 - `text_card` — animated text with spring entrance
@@ -138,7 +157,7 @@ Match the visual approach to the content. **Check Remotion availability first** 
 - `chart` — bar, line, pie charts with animated data entry
 - `kpi_grid` — multi-stat dashboard layout
 
-**Important:** When Remotion is available and the playbook is `flat-motion-graphics`, **always design for Remotion component scenes** rather than static AI-generated images with Ken Burns pan. This is the difference between a professional motion graphics video and a slideshow.
+**Important:** When Remotion is available, **always design for Remotion component scenes** rather than static AI-generated images with Ken Burns pan. This is the difference between a professional motion graphics video and a slideshow.
 
 #### 3d: Duration and Platform
 
@@ -401,7 +420,7 @@ The `selected_concept` in the proposal_packet effectively replaces what the old 
 **Concept 1: "The 200ms Journey" (data_driven)**
 - Hook: "Every website you visit starts with a 200-millisecond treasure hunt across the internet."
 - Structure: journey — follow a DNS query step by step
-- Visual: minimalist-diagram, animated packet flow
+- Visual: custom signal-map identity — midnight background, electric route traces, packet-flow motion language
 - Duration: 90s (YouTube)
 - Grounded in: recursive resolution timing data, audience gap about multi-step process
 - Why it works: Most viewers think DNS is instant and singular. Showing the real journey is the aha moment.
@@ -409,7 +428,7 @@ The `selected_concept` in the proposal_packet effectively replaces what the old 
 **Concept 2: "Your ISP Knows Everything" (contrarian)**
 - Hook: "Your internet provider logs every website you visit. Here's the 40-year-old system that makes it possible."
 - Structure: myth_busting — challenge "private browsing = private" belief
-- Visual: clean-professional, privacy-focused with dark tones
+- Visual: custom surveillance-noir identity — low-key contrast, privacy-warning accents, restrained typography
 - Duration: 75s (YouTube)
 - Grounded in: DNS privacy misconception (audience research), DoH trending signal
 - Why it works: Privacy is emotionally charged. The misconception that HTTPS = full privacy is widespread.
@@ -417,7 +436,7 @@ The `selected_concept` in the proposal_packet effectively replaces what the old 
 **Concept 3: "The Internet's Phone Book" (analogy)**
 - Hook: "DNS is a phone book designed in 1983 that somehow still runs the modern internet."
 - Structure: analogy — phone book metaphor through historical evolution
-- Visual: flat-motion-graphics, retro-to-modern visual timeline
+- Visual: custom retro-systems identity — off-white paper base, archival type, neon-modern contrast for present-day beats
 - Duration: 60s (LinkedIn)
 - Grounded in: audience knowledge gap about DNS age, landscape gap (no historical angle found)
 - Why it works: Simplest on-ramp for non-technical audience. The "still works after 40 years" angle is inherently surprising.

--- a/skills/pipelines/explainer/scene-director.md
+++ b/skills/pipelines/explainer/scene-director.md
@@ -67,7 +67,7 @@ Transform each script section into 1-3 visual scenes. Each scene is a distinct v
 
 | Type | Best For | Available Tools | Duration Guidance |
 |------|----------|-----------------|-------------------|
-| `hero_title` | Opening titles, dramatic reveals | Remotion HeroTitle (cyan first word, animated underline) | 3-5s |
+| `hero_title` | Opening titles, dramatic reveals | Remotion HeroTitle (theme-driven title treatment) | 3-5s |
 | `stat_card` | Big dramatic numbers, impactful metrics | Remotion StatCard (large stat + subtitle) | 4-6s |
 | `bar_chart` | Category comparisons, rankings | Remotion BarChart (animated grow-up/slide-in/pop) | 5-7s |
 | `line_chart` | Trends, time series, growth curves | Remotion LineChart (draw/fade animation, multi-series) | 5-7s |
@@ -84,7 +84,7 @@ Transform each script section into 1-3 visual scenes. Each scene is a distinct v
 | `broll` | Context, real-world examples | Stock or generated footage | 3-6s |
 | `screen_recording` | Code demos, UI walkthroughs | Recorded or simulated | 5-15s |
 
-**Zero-key scene selection:** When no image/video generation is available, prefer `hero_title`, `stat_card`, `bar_chart`, `line_chart`, `pie_chart`, `kpi_grid`, `comparison`, `callout`, `progress_bar`, and `text_card`. These render entirely from Remotion components with zero external dependencies and produce professional, animated results. See `skills/core/remotion.md` for the proven formula (all-dark backgrounds, KPI data formatting rules, overlay techniques).
+**Zero-key scene selection:** When no image/video generation is available, prefer `hero_title`, `stat_card`, `bar_chart`, `line_chart`, `pie_chart`, `kpi_grid`, `comparison`, `callout`, `progress_bar`, and `text_card`. These render entirely from Remotion components with zero external dependencies and can still feel distinct if you derive color, typography, and pacing from the subject instead of defaulting to a generic dashboard aesthetic.
 
 ### Step 4: Apply the Visual Technique Library
 
@@ -101,15 +101,15 @@ Show the abstract concept alongside its real-world analogy. Split screen or side
 - Example: "Left: actual vector space with dots. Right: a library with books sorted by topic."
 
 **Stat Card Punch**
-Full-screen number with impact animation (scale up, slight bounce). Use `stat_card` type with a dark background and bold accent color. Hold for 4-5 seconds.
+Full-screen number with impact animation (scale up, slight bounce). Use `stat_card` type with a background and accent treatment chosen for the video's identity. Hold for 4-5 seconds.
 - Tools: Remotion StatCard component
-- Example: stat="1ms", subtitle="vs 500ms with traditional search", accentColor="#22D3EE"
+- Example: stat="1ms", subtitle="vs 500ms with traditional search", accentColor="<theme_accent>"
 
 **Data Dashboard Sequence**
 A series of data visualization scenes that tell a story through numbers. Start with a KPI overview, then drill into specific charts. Use section_title overlays to group related data. This pattern works with zero external tools.
 - Tools: Remotion chart components (bar_chart, line_chart, pie_chart, kpi_grid)
 - Example: kpi_grid (4 key stats) → bar_chart (breakdown) → line_chart (trend) → pie_chart (distribution)
-- Always use dark backgrounds (`backgroundColor: "#0F172A"`) for cinematic feel.
+- Choose the background treatment from the visual identity: dark for dramatic/technical subjects, light for approachable/educational, textured or warm when the topic calls for it.
 
 **Before/After Split**
 Show the problem, then the solution using `comparison` type. The comparison card shows dual values side-by-side with animated entrance.
@@ -167,14 +167,14 @@ The style playbook constrains your visual choices:
 | `motion.transitions` | Allowed transition types (e.g., `gentle-fade`, `soft-dissolve`) |
 | `motion.animation_style` | Animation feel (e.g., `ease-in-out, organic curves`) |
 | `motion.pacing_rules` | Minimum hold times (e.g., "hold establishing shots for 2s minimum") |
-| `asset_generation.image_prompt_prefix` | Prepend to all image generation prompts |
+| `asset_generation.image_prompt_prefix` | Distill into a short visual anchor; do not paste verbatim into all prompts |
 | `asset_generation.consistency_anchors` | What must stay consistent across all images (color palette, lighting, style) |
 
 **Checklist before submitting:**
 - [ ] Every scene uses playbook-compatible transitions
 - [ ] All required_asset descriptions include style cues from the playbook
 - [ ] No scene violates pacing rules (min/max duration)
-- [ ] Image descriptions reference playbook's color palette and texture
+- [ ] Image descriptions reference the video's actual visual identity, not just a preset name
 
 ### Step 6: Verify Coverage and Variety
 
@@ -221,4 +221,5 @@ Call `handle_explainer_scene_plan(state, {"scene_plan": scene_plan_json})` to va
 - **Overly ambitious animations**: "Photorealistic 3D fly-through of a data center" can't be generated with current tools. Keep it achievable.
 - **No transition strategy**: Random transitions feel chaotic. Use the playbook's transition rules consistently. Reserve special transitions for topic shifts.
 - **Vague required_assets**: "An image about databases" is useless for prompt engineering. "Isometric illustration of a vector database with embedding vectors floating in 3D space, using the playbook's blue-green palette" is actionable.
+- **Preset thinking**: A scene plan that says "make it flat-motion-graphics" is not enough. The planner must specify what makes THIS video's motion graphics feel distinct.
 - **Static scenes for dynamic concepts**: If the narrator describes a process or transformation, the visual should move. Use animation or progressive reveal, not a static image.

--- a/skills/pipelines/talking-head/asset-director.md
+++ b/skills/pipelines/talking-head/asset-director.md
@@ -75,8 +75,8 @@ Create a composition JSON snippet for each overlay. These will be rendered by th
     "text": "Agentic AI: software that acts autonomously toward goals",
     "in_seconds": 0,
     "out_seconds": 4,
-    "backgroundColor": "#0F172A",
-    "accentColor": "#22D3EE",
+    "backgroundColor": "<theme_background>",
+    "accentColor": "<theme_accent>",
     "icon": "💡"
   },
   "overlay_timestamp": 22.0,
@@ -104,8 +104,8 @@ Create a composition JSON snippet for each overlay. These will be rendered by th
 
 The Explainer composition now includes an `AnimatedBackground` component that renders an animated gradient mesh, floating orbs, and a subtle grid pattern. This provides a far more professional look than flat solid colors.
 
-- Scene backgrounds should use `backgroundColor: "#0F172A"` which auto-converts to transparent, letting the animated gradient show through.
-- Do NOT use flat solid colors for backgrounds -- always let the AnimatedBackground render behind overlays.
+- Scene backgrounds should use the active theme background so the AnimatedBackground and overlay cards feel like one system.
+- Do NOT use arbitrary flat solid colors for backgrounds -- let the AnimatedBackground and theme drive the treatment.
 - When compositing green screen footage, render the AnimatedBackground as the replacement background (see compose-director Step 3c).
 
 **Component constraints:**
@@ -127,7 +127,7 @@ Key rules:
 - `kpi_grid` values MUST be purely numeric (e.g., `4.8`, `73`, `2400`). Formatted strings like `"15+"`, `"$4.8B"`, or `"2.4M"` will cause rendering errors. Use `stat_card` for string-formatted numbers instead.
 - Always check the target frame width before choosing a component. Portrait (720px) excludes `comparison`.
 
-**Dark theme for all overlays** -- use dark backgrounds (`#0F172A`, `#1E293B`) with light text. This ensures overlays are legible when composited on top of talking-head footage. The `#0F172A` backgroundColor is treated as transparent by the AnimatedBackground system, so overlays will show the animated gradient behind them.
+**Overlay theming rule** -- derive overlay backgrounds, accents, and text colors from the chosen playbook or custom identity. Use dark cards only when the footage/topic calls for it; a bright editorial talk can legitimately use light cards if contrast remains strong.
 
 **For simple text overlays** (if Remotion is overkill):
 

--- a/skills/pipelines/talking-head/compose-director.md
+++ b/skills/pipelines/talking-head/compose-director.md
@@ -161,7 +161,7 @@ remotion_caption_burn.execute({
     "corrections": {"cloud": "Claude", "co-pilot": "Copilot"},
     "words_per_page": 4,
     "font_size": 52,
-    "highlight_color": "#22D3EE",
+    "highlight_color": "<theme_accent>",
 })
 ```
 
@@ -195,7 +195,7 @@ remotion_caption_burn.execute({
     "corrections": {"cloud": "Claude"},
     "words_per_page": 4,
     "font_size": 52,
-    "highlight_color": "#22D3EE",
+    "highlight_color": "<theme_accent>",
     "overlays": [
         {
             "id": "term-agentic-ai",
@@ -205,8 +205,8 @@ remotion_caption_burn.execute({
             "in_seconds": 22.0,
             "out_seconds": 26.0,
             "position": "lower_third",
-            "backgroundColor": "#0F172A",
-            "accentColor": "#22D3EE"
+            "backgroundColor": "<theme_background>",
+            "accentColor": "<theme_accent>"
         },
         {
             "id": "stat-market-size",
@@ -216,7 +216,7 @@ remotion_caption_burn.execute({
             "in_seconds": 35.0,
             "out_seconds": 39.0,
             "position": "upper_third",
-            "accentColor": "#A78BFA"
+            "accentColor": "<theme_secondary_accent>"
         },
         {
             "id": "chart-growth",
@@ -231,7 +231,7 @@ remotion_caption_burn.execute({
             "in_seconds": 40.0,
             "out_seconds": 45.0,
             "position": "lower_third",
-            "chartColors": ["#22D3EE", "#A78BFA", "#F472B6", "#34D399"]
+            "chartColors": ["<theme_accent>", "<theme_secondary_accent>", "<theme_tertiary_accent>", "<theme_supporting_accent>"]
         }
     ]
 })
@@ -306,7 +306,7 @@ If the footage has a green/blue screen (detected in scene-director Step 0), foll
        "corrections": <corrections_dict>,
        "words_per_page": 4,
        "font_size": 52,
-       "highlight_color": "#22D3EE",
+        "highlight_color": "<theme_accent>",
        "overlays": <overlay_list_from_scene_plan>
    })
    ```

--- a/skills/pipelines/talking-head/executive-producer.md
+++ b/skills/pipelines/talking-head/executive-producer.md
@@ -25,7 +25,7 @@ The EP solves all of these by maintaining cumulative state and applying judgment
 | Pipeline | `pipeline_defs/talking-head.yaml` | Stage definitions, review focus, success criteria |
 | Skills | All 7 director skills + `meta/reviewer` | Stage execution knowledge |
 | Schemas | All artifact schemas | Validation |
-| Playbook | `clean-professional` (or user-selected) | Quality constraints |
+| Playbook | user-selected, footage-derived, or safe fallback | Quality constraints |
 | Tools | Full tool registry | Available capabilities |
 
 ## Key Difference from Explainer EP
@@ -49,7 +49,7 @@ The EP maintains a running state object that flows through the entire pipeline:
 ```
 EP_STATE:
   pipeline: talking-head
-  playbook: <selected playbook name, default: clean-professional>
+  playbook: <selected playbook name, custom identity, or safe fallback>
   raw_footage_path: <path to source footage>
   raw_footage_duration_seconds: <from ffprobe>
   raw_footage_resolution: <from ffprobe>
@@ -94,7 +94,7 @@ EP_STATE:
 ### Phase 0: Initialize
 
 1. Load the pipeline manifest (`talking-head.yaml`)
-2. Load the playbook (from user selection or default `clean-professional`)
+2. Load the playbook from user selection, brand system, or footage-derived visual identity. Use `clean-professional` only when no stronger identity is warranted.
 3. Set budget from configuration or user input (default: $0.50 — talking-head is mostly processing)
 4. Probe the raw footage with ffprobe: duration, resolution, fps, audio channels, codec
 5. Store footage metadata in EP_STATE
@@ -373,7 +373,7 @@ The EP doesn't replace any director skill — it wraps them. Each director skill
 
 ```
 [EP] Starting pipeline: talking-head v2.0
-[EP] Default budget: $0.50 | Playbook: clean-professional
+[EP] Default budget: $0.50 | Playbook: footage-derived identity (or safe fallback)
 
 [EP] Probing raw footage: interview_raw.mp4
 [EP] → Duration: 4m22s | Resolution: 1920x1080 | FPS: 30 | Audio: stereo AAC

--- a/skills/pipelines/talking-head/idea-director.md
+++ b/skills/pipelines/talking-head/idea-director.md
@@ -42,7 +42,7 @@ Create a brief artifact documenting:
 - **Hook**: What makes this worth watching?
 - **Key points**: Main topics covered in the footage
 - **Tone**: Match the speaker's actual tone (casual, professional, educational)
-- **Style**: Usually `clean-professional` for talking head
+- **Style**: Derive the overlay/look direction from the footage, speaker persona, audience, and platform. `clean-professional` is a safe fallback, not the default answer to every talking-head brief.
 - **Target platform**: Where this will be published
 - **Target duration**: May be shorter than raw footage (trimmed)
 

--- a/skills/pipelines/talking-head/scene-director.md
+++ b/skills/pipelines/talking-head/scene-director.md
@@ -192,8 +192,8 @@ For each approved overlay from Step 3, create an overlay scene entry:
   "content": {
     "text": "Agentic AI",
     "subtext": "Software that acts autonomously toward goals",
-    "backgroundColor": "#0F172A",
-    "accentColor": "#22D3EE"
+    "backgroundColor": "<theme_background>",
+    "accentColor": "<theme_accent>"
   },
   "position": "lower_third"
 }


### PR DESCRIPTION
## Summary
- update active pipeline manifests to advertise recommended playbooks plus `custom_allowed: true`
- rewrite proposal, scene, asset, and talking-head guidance to design visual identity from subject, audience, tone, and footage
- remove remaining instruction-layer bias toward verbatim playbook prefixes and hardcoded cyan/dark overlay examples

## Why
The theme system and custom playbook infrastructure were already implemented, but several active skills still nudged agents back toward preset playbooks and repeated style defaults. This PR aligns the prompt layer with the runtime so agents are told to create a bespoke visual identity when the brief calls for it.

## Validation
- loaded updated pipeline manifests through `lib.pipeline_loader`
- confirmed all touched active manifests validate successfully
