### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/skills/INDEX.md
+++ b/skills/INDEX.md
@@ -307,3 +307,4 @@ Claude Code accesses them via symlinks in `.claude/skills/`.
 | **Design** | `tailwind-design-system`, `web-design-guidelines`, `vercel-react-best-practices`, `vercel-composition-patterns` | `wshobson/agents`, `vercel-labs/agent-skills` |
 | **AI Video (HeyGen)** | `heygen`, `avatar-video`, `create-video`, `faceswap`, `ai-video-gen`, `video-download`, `video-edit`, `video-translate`, `video-understand`, `visual-style` | `heygen-com/skills` |
 | **Infrastructure** | `acestep`, `ltx2`, `playwright-recording` | `digitalsamba/claude-code-video-toolkit` |
+| **AI Generation (MiniMax)** | `mmx-cli` | `MiniMax-AI/cli` |


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` (`skill/` path) to the Installed Agent Skills (Layer 3) table in `skills/INDEX.md` so the mmx-cli skill is discoverable out of the box
- Users can install via `npx skills add MiniMax-AI/cli` — the SKILL.md is fetched directly from [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md)
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md, no changes needed in this project

**1 line changed, 0 new files.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard and includes agent-specific flags (`--non-interactive`, `--quiet`, `--output json`).

## Test plan

- `npx skills add MiniMax-AI/cli` installs successfully
- Ask agent "generate a jazz instrumental" — agent invokes `mmx music generate` via terminal