### PR TITLE
fix(seedance): correct upload_image_fal call name

### DIFF
--- a/tools/video/seedance_video.py
+++ b/tools/video/seedance_video.py
@@ -216,7 +216,7 @@ class SeedanceVideo(BaseTool):
                 payload["image_url"] = inputs["image_url"]
             elif inputs.get("image_path"):
                 from tools.video._shared import upload_image_fal
-                payload["image_url"] = upload_image_to_fal(inputs["image_path"])
+                payload["image_url"] = upload_image_fal(inputs["image_path"])
             if inputs.get("end_image_url"):
                 payload["end_image_url"] = inputs["end_image_url"]
 
@@ -224,7 +224,7 @@ class SeedanceVideo(BaseTool):
             ref_image_urls = list(inputs.get("reference_image_urls") or [])
             for local_path in inputs.get("reference_image_paths") or []:
                 from tools.video._shared import upload_image_fal
-                ref_image_urls.append(upload_image_to_fal(local_path))
+                ref_image_urls.append(upload_image_fal(local_path))
             # Seedance 2.0 reference-to-video ceilings: 9 images + 3 video + 3 audio.
             if len(ref_image_urls) > 9:
                 return ToolResult(


### PR DESCRIPTION
## What

Lines 219 and 227 of `tools/video/seedance_video.py` imported `upload_image_fal` from `_shared` but then called the non-existent `upload_image_to_fal`, which would raise a `NameError` at runtime.

**Affected paths:**
- `image_to_video` with a local `image_path`
- `reference_to_video` with any local paths in `reference_image_paths`

## Fix

Rename both call sites to match the imported function: `upload_image_fal`.

## Test plan
- [ ] Confirm `grep upload_image_to_fal tools/video/seedance_video.py` returns empty
- [ ] Run `seedance_video` with a local `image_path` in `image_to_video` mode (requires `FAL_KEY`)