### PR TITLE
fix(source_media_review): use registry.get() not get_tool()

### DIFF
--- a/lib/source_media_review.py
+++ b/lib/source_media_review.py
@@ -44,7 +44,7 @@ def _probe_video(path: Path, tool_registry: Any) -> dict[str, Any]:
 
     # Technical probe via audio_probe or ffprobe
     try:
-        audio_probe = tool_registry.get_tool("audio_probe")
+        audio_probe = tool_registry.get("audio_probe")
         if audio_probe:
             probe_result = audio_probe.execute({"input_path": str(path)})
             if probe_result.success:
@@ -84,7 +84,7 @@ def _probe_video(path: Path, tool_registry: Any) -> dict[str, Any]:
 
     # Sample frames
     try:
-        frame_sampler = tool_registry.get_tool("frame_sampler")
+        frame_sampler = tool_registry.get("frame_sampler")
         if frame_sampler:
             duration = result["technical_probe"].get("duration_seconds", 0)
             timestamps = _sample_timestamps(duration, count=4)
@@ -122,7 +122,7 @@ def _probe_audio(path: Path, tool_registry: Any) -> dict[str, Any]:
     result: dict[str, Any] = {"technical_probe": {}, "quality_risks": []}
 
     try:
-        audio_probe = tool_registry.get_tool("audio_probe")
+        audio_probe = tool_registry.get("audio_probe")
         if audio_probe:
             probe_result = audio_probe.execute({"input_path": str(path)})
             if probe_result.success:
@@ -195,7 +195,7 @@ def _transcribe_if_available(
         return None
 
     try:
-        transcriber = tool_registry.get_tool("transcriber")
+        transcriber = tool_registry.get("transcriber")
         if transcriber and transcriber.get_status().value == "available":
             result = transcriber.execute({"input_path": str(path)})
             if result.success:

--- a/tools/video/seedance_video.py
+++ b/tools/video/seedance_video.py
@@ -216,7 +216,7 @@ class SeedanceVideo(BaseTool):
                 payload["image_url"] = inputs["image_url"]
             elif inputs.get("image_path"):
                 from tools.video._shared import upload_image_fal
-                payload["image_url"] = upload_image_to_fal(inputs["image_path"])
+                payload["image_url"] = upload_image_fal(inputs["image_path"])
             if inputs.get("end_image_url"):
                 payload["end_image_url"] = inputs["end_image_url"]
 
@@ -224,7 +224,7 @@ class SeedanceVideo(BaseTool):
             ref_image_urls = list(inputs.get("reference_image_urls") or [])
             for local_path in inputs.get("reference_image_paths") or []:
                 from tools.video._shared import upload_image_fal
-                ref_image_urls.append(upload_image_to_fal(local_path))
+                ref_image_urls.append(upload_image_fal(local_path))
             # Seedance 2.0 reference-to-video ceilings: 9 images + 3 video + 3 audio.
             if len(ref_image_urls) > 9:
                 return ToolResult(


### PR DESCRIPTION
## What

`lib/source_media_review.py` called `tool_registry.get_tool(name)` in four places but `ToolRegistry` only defines `get(name)`. This would raise an `AttributeError` at runtime whenever any pipeline called `review_source_media` with an active registry.

**Affected call sites (all now fixed):**
| Line | Tool |
|------|------|
| 47 | `audio_probe` |
| 87 | `frame_sampler` |
| 125 | `audio_probe` (in `_probe_audio`) |
| 198 | `transcriber` |

## Fix

Rename all four `tool_registry.get_tool(...)` → `tool_registry.get(...)`.

## Test plan
- [ ] `grep get_tool lib/source_media_review.py` returns empty
- [ ] Import check: `python -c "from lib.source_media_review import review_source_media"`