### PR TITLE
Wire CostTracker into project runs; persist cost_log.json for all attempts

### DIFF
--- a/lib/checkpoint.py
+++ b/lib/checkpoint.py
@@ -339,3 +339,34 @@ def get_next_stage(
         if stage not in completed:
             return stage
     return None
+
+
+def get_project_cost_tracker(
+    pipeline_dir: Path,
+    project_id: str,
+    config: Any = None,
+) -> Any:
+    """Create or reload a CostTracker bound to a project's cost_log.json.
+
+    Always writes to <pipeline_dir>/<project_id>/cost_log.json so that
+    every paid operation — including failed attempts — is persisted in the
+    project-local cost ledger rather than inferred from asset_manifest.json.
+
+    Existing cost_log.json entries are reloaded automatically, making the
+    tracker safe to call across multiple pipeline stages or agent turns.
+    """
+    from tools.cost_tracker import CostTracker, BudgetMode as _BudgetMode
+
+    if config is None:
+        from lib.config_model import OpenMontageConfig
+        config = OpenMontageConfig.load()
+
+    cost_log_path = pipeline_dir / project_id / "cost_log.json"
+    return CostTracker(
+        budget_total_usd=config.budget.total_usd,
+        reserve_pct=config.budget.reserve_pct,
+        single_action_approval_usd=config.budget.single_action_approval_usd,
+        require_approval_for_new_paid_tool=config.budget.require_approval_for_new_paid_tool,
+        mode=_BudgetMode(config.budget.mode.value),
+        cost_log_path=cost_log_path,
+    )

--- a/tests/contracts/test_phase0_contracts.py
+++ b/tests/contracts/test_phase0_contracts.py
@@ -23,6 +23,7 @@ from lib.checkpoint import (
     CheckpointValidationError,
     STAGES,
     get_next_stage,
+    get_project_cost_tracker,
     read_checkpoint,
     write_checkpoint,
 )
@@ -532,6 +533,52 @@ class TestCostTracker:
             "scene visual types have not been enriched yet" in note
             for note in estimate["assumptions"]
         )
+
+
+# ---- Project Cost Tracker (wired to project cost_log.json) ----
+
+class TestProjectCostTracker:
+    def test_factory_sets_project_cost_log_path(self, tmp_path):
+        tracker = get_project_cost_tracker(tmp_path, "proj_a")
+        assert tracker.cost_log_path == tmp_path / "proj_a" / "cost_log.json"
+
+    def test_factory_persists_cost_log_on_first_operation(self, tmp_path):
+        tracker = get_project_cost_tracker(tmp_path, "proj_b")
+        tracker.approve_tool("image_selector")
+        eid = tracker.estimate("image_selector", "generate", 0.10)
+        tracker.reserve(eid)
+        tracker.reconcile(eid, 0.08, success=True)
+        assert (tmp_path / "proj_b" / "cost_log.json").exists()
+
+    def test_factory_tracks_failed_paid_attempts(self, tmp_path):
+        tracker = get_project_cost_tracker(tmp_path, "proj_c")
+        tracker.approve_tool("kling_fal")
+        eid = tracker.estimate("kling_fal", "video_generate", 0.30)
+        tracker.reserve(eid)
+        tracker.reconcile(eid, 0.30, success=False)
+        assert tracker.budget_spent_usd == 0.30
+        log = json.loads((tmp_path / "proj_c" / "cost_log.json").read_text())
+        assert any(e["status"] == "failed" for e in log["entries"])
+
+    def test_factory_reloads_prior_entries_across_stages(self, tmp_path):
+        t1 = get_project_cost_tracker(tmp_path, "proj_d")
+        t1.approve_tool("elevenlabs_tts")
+        eid = t1.estimate("elevenlabs_tts", "narration", 0.05)
+        t1.reserve(eid)
+        t1.reconcile(eid, 0.05)
+
+        t2 = get_project_cost_tracker(tmp_path, "proj_d")
+        assert t2.budget_spent_usd == 0.05
+
+    def test_different_projects_have_isolated_cost_logs(self, tmp_path):
+        ta = get_project_cost_tracker(tmp_path, "proj_x")
+        ta.approve_tool("flux_fal")
+        eid = ta.estimate("flux_fal", "image", 0.20)
+        ta.reserve(eid)
+        ta.reconcile(eid, 0.20)
+
+        tb = get_project_cost_tracker(tmp_path, "proj_y")
+        assert tb.budget_spent_usd == 0.0
 
 
 # ---- Pipeline Instruction Architecture ----


### PR DESCRIPTION
Closes #20

## Summary

- Add `get_project_cost_tracker(pipeline_dir, project_id, config=None)` factory to `lib/checkpoint.py`
- The factory creates a `CostTracker` bound to `<pipeline_dir>/<project_id>/cost_log.json`, loaded from project config
- Existing entries are reloaded automatically across agent turns / pipeline stages
- Failed paid attempts are tracked via `reconcile(entry_id, actual_usd, success=False)` — they land in `cost_log.json` with `status: "failed"` so spend is never undercounted
- `asset_manifest.json` remains the asset inventory artifact; `cost_log.json` is the authoritative spend ledger

## What changed

**`lib/checkpoint.py`** — added `get_project_cost_tracker()` factory (no changes to existing functions)

**`tests/contracts/test_phase0_contracts.py`** — added `TestProjectCostTracker` with 5 tests:
- Correct `cost_log_path` set to project directory
- Cost log file is created on first operation
- Failed paid attempts are written with `status: "failed"` and counted in spent budget
- Entries reload correctly across stages (cross-turn persistence)
- Different projects have isolated cost logs

## Test plan

- [ ] `python3 -m pytest tests/contracts/test_phase0_contracts.py -v` — all new tests pass, no regressions
- [ ] Pre-existing failures are all `ModuleNotFoundError: No module named 'numpy'` (unrelated to this change)