### PR TITLE
feat(tts): extend Doubao controls and caption rendering

### DIFF
--- a/.agents/skills/doubao-tts/SKILL.md
+++ b/.agents/skills/doubao-tts/SKILL.md
@@ -41,6 +41,8 @@ result = TTSSelector().execute({
     "voice_id": "zh_female_vv_uranus_bigtts",
     "output_path": "projects/my-video/assets/audio/narration.mp3",
     "speech_rate": 0,
+    "emotion": "neutral",
+    "emotion_scale": 1,
     "enable_timestamp": True,
 })
 ```
@@ -76,14 +78,40 @@ The provider writes:
 
 - `voice_id`: Doubao `speaker` / voice type. Defaults to `DOUBAO_SPEECH_VOICE_TYPE`.
 - `resource_id`: use `seed-tts-2.0` for Doubao Speech 2.0 voices.
+- `model`: optional `req_params.model` for compatible voices, such as `seed-tts-2.0-expressive` or `seed-tts-2.0-standard`.
 - `speech_rate`: `0` is normal, `100` is 2x, `-50` is 0.5x.
+- `emotion`: optional emotion/style value. Common values include `neutral`, `happy`, `sad`, `angry`, `surprised`, `excited`, `coldness`, `tender`, `storytelling`, `news`, and `advertising`; support depends on the selected voice.
+- `emotion_scale`: optional emotion intensity from `1` to `5`; use `1` for restrained narration.
+- `loudness_rate`: optional loudness from `-50` to `100`.
+- `post_process_pitch`: optional pitch shift from `-12` to `12`.
 - `sample_rate`: default `24000`.
+- `bit_rate`: optional MP3 bit rate.
 - `enable_timestamp`: default `true`.
 - `return_usage`: default `true`, requests usage metadata when available.
+- `explicit_language`: optional language hint such as `zh-cn`, `en`, or `crosslingual`. Leave unset unless needed.
+- `context_texts`: optional list of context/style strings, when supported by the endpoint and voice.
+- `silence_duration`: optional trailing silence in milliseconds.
+- `enable_language_detector`, `disable_emoji_filter`, `max_length_to_filter_parenthesis`, `unsupported_char_ratio_thresh`: optional provider additions.
+- `mute_cut_threshold` and `mute_cut_remain_ms`: optional mute-cut controls.
+- `extra_audio_params` and `extra_additions`: advanced escape hatches for newly documented Doubao fields. Use these only when the field is in the current Volcengine docs.
 
 Do not pass `additions.explicit_language` by default. Some endpoint/key combinations reject `zh-cn` with `unsupported additions explicit language zh-cn`.
 
 For calm Mandarin explainers, start with `speech_rate: 0`. If the result is too long for the approved format, make a short comparison sample with `speech_rate: 25` or `50` before regenerating the full narration. Do not speed up only to match a previous provider's duration if the user prefers Doubao's natural pace.
+
+For production narration where Doubao sounds too theatrical, keep the line in the script and adjust controls before rewriting:
+
+```python
+result = DoubaoTTS().execute({
+    "text": "大家好，我是 Ray 的 AI 助理。有一天，Ray 发来一段很长的安装指令。",
+    "voice_id": "zh_female_vv_uranus_bigtts",
+    "speech_rate": 8,
+    "emotion": "neutral",
+    "emotion_scale": 1,
+    "post_process_pitch": 2,
+    "output_path": "projects/my-video/assets/audio/tone_test.mp3",
+})
+```
 
 ## Troubleshooting
 

--- a/remotion-composer/src/Explainer.tsx
+++ b/remotion-composer/src/Explainer.tsx
@@ -308,6 +308,8 @@ export interface ExplainerProps {
   overlays?: Overlay[];
   captions?: WordCaption[];
   audio?: AudioConfig;
+  captionWordsPerPage?: number;
+  captionFontSize?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -813,8 +815,8 @@ export const Explainer: React.FC<ExplainerProps> = (props) => {
       {captions && captions.length > 0 && (
         <CaptionOverlay
           words={captions}
-          wordsPerPage={6}
-          fontSize={42}
+          wordsPerPage={props.captionWordsPerPage ?? 6}
+          fontSize={props.captionFontSize ?? 42}
           highlightColor={theme.captionHighlightColor}
           backgroundColor={theme.captionBackgroundColor}
         />

--- a/remotion-composer/src/Root.tsx
+++ b/remotion-composer/src/Root.tsx
@@ -127,9 +127,15 @@ const calculateMetadata: CalculateMetadataFunction<ExplainerProps> = async ({
   if (cuts.length === 0) {
     return { durationInFrames: 30 * 60 };
   }
-  const lastEnd = Math.max(...cuts.map((c) => c.out_seconds || 0));
-  // Add 1 second padding for final fade
-  return { durationInFrames: Math.ceil((lastEnd + 1) * 30) };
+  const lastFrame = Math.max(
+    ...cuts.map((c) => {
+      const from = Math.round((c.in_seconds || 0) * 30);
+      const duration = Math.round(((c.out_seconds || 0) - (c.in_seconds || 0)) * 30);
+      return from + duration;
+    })
+  );
+  // Match Sequence rounding so paused playback ends on the final visual frame.
+  return { durationInFrames: lastFrame };
 };
 
 export const Root: React.FC = () => {

--- a/remotion-composer/src/components/TextCard.tsx
+++ b/remotion-composer/src/components/TextCard.tsx
@@ -1,4 +1,4 @@
-import { AbsoluteFill, spring, useCurrentFrame, useVideoConfig } from "remotion";
+import { AbsoluteFill, interpolate, spring, useCurrentFrame, useVideoConfig } from "remotion";
 
 interface TextCardProps {
   text: string;
@@ -16,7 +16,8 @@ export const TextCard: React.FC<TextCardProps> = ({
   const frame = useCurrentFrame();
   const { fps } = useVideoConfig();
 
-  const opacity = spring({ frame, fps, config: { damping: 20 } });
+  const entrance = spring({ frame, fps, config: { damping: 20 } });
+  const opacity = interpolate(entrance, [0, 1], [0.92, 1]);
   const scale = spring({
     frame,
     fps,
@@ -44,6 +45,7 @@ export const TextCard: React.FC<TextCardProps> = ({
           textAlign: "center",
           maxWidth: "80%",
           lineHeight: 1.3,
+          whiteSpace: "pre-line",
         }}
       >
         {text}

--- a/skills/core/subtitle-sync.md
+++ b/skills/core/subtitle-sync.md
@@ -93,6 +93,13 @@ The `subtitle_gen` tool groups words respecting `max_words_per_cue` and
 `max_chars_per_line`. When word timestamps are unavailable, it falls back
 to segment-level timing with even distribution.
 
+When using `remotion_caption_burn` with Chinese TTS providers that may emit
+character-level timestamps, pass `protected_terms` for product names, skill
+names, acronyms, and other phrases that should stay intact. The Remotion caption
+burner also protects common terms and Chinese phrases found inside `「...」` or
+`『...』` in the source segment text, so names such as `系统提交发布助手` are not
+split across caption tokens.
+
 ## Quality Checklist
 
 - [ ] Every spoken word appears in a subtitle cue

--- a/tests/tools/test_remotion_caption_burn.py
+++ b/tests/tools/test_remotion_caption_burn.py
@@ -1,0 +1,41 @@
+from tools.video.remotion_caption_burn import RemotionCaptionBurn
+
+
+def test_chinese_protected_terms_merge_character_timestamps():
+    tool = RemotionCaptionBurn()
+    text = "系统提交发布助手"
+    segments = [
+        {
+            "text": f"如果你同时安装了「{text}」这个 Skill。",
+            "start": 0.0,
+            "end": 1.8,
+            "words": [
+                {"word": char, "start": index * 0.1, "end": (index + 1) * 0.1}
+                for index, char in enumerate(text)
+            ],
+        }
+    ]
+
+    captions = tool._segments_to_word_captions(
+        segments,
+        protected_terms=tool._caption_protected_terms(segments, None),
+    )
+
+    assert captions == [{"word": text, "startMs": 0, "endMs": 800}]
+
+
+def test_explicit_protected_terms_prevent_caption_splits():
+    captions = [
+        {"word": "系", "startMs": 0, "endMs": 100},
+        {"word": "统", "startMs": 100, "endMs": 200},
+        {"word": "问", "startMs": 200, "endMs": 300},
+        {"word": "题", "startMs": 300, "endMs": 400},
+        {"word": "分", "startMs": 400, "endMs": 500},
+        {"word": "析", "startMs": 500, "endMs": 600},
+        {"word": "助", "startMs": 600, "endMs": 700},
+        {"word": "手", "startMs": 700, "endMs": 800},
+    ]
+
+    protected = RemotionCaptionBurn._protect_caption_terms(captions, ["系统问题分析助手"])
+
+    assert protected == [{"word": "系统问题分析助手", "startMs": 0, "endMs": 800}]

--- a/tools/audio/doubao_tts.py
+++ b/tools/audio/doubao_tts.py
@@ -25,7 +25,7 @@ from tools.base_tool import (
 
 class DoubaoTTS(BaseTool):
     name = "doubao_tts"
-    version = "0.1.0"
+    version = "0.2.0"
     tier = ToolTier.VOICE
     capability = "tts"
     provider = "doubao"
@@ -83,15 +83,23 @@ class DoubaoTTS(BaseTool):
                 "default": "seed-tts-2.0",
                 "description": "Volcengine resource id. Use seed-tts-2.0 for Doubao Speech 2.0 voices.",
             },
+            "model": {
+                "type": "string",
+                "description": "Optional req_params.model for compatible voices, e.g. seed-tts-2.0-expressive or seed-tts-2.0-standard.",
+            },
             "format": {
                 "type": "string",
                 "default": "mp3",
-                "enum": ["mp3", "ogg_opus", "pcm"],
+                "enum": ["mp3", "ogg_opus", "pcm", "wav"],
             },
             "sample_rate": {
                 "type": "integer",
                 "default": 24000,
                 "enum": [8000, 16000, 22050, 24000, 32000, 44100, 48000],
+            },
+            "bit_rate": {
+                "type": "integer",
+                "description": "Optional MP3 bit rate, when supported by the endpoint.",
             },
             "speech_rate": {
                 "type": "integer",
@@ -99,6 +107,79 @@ class DoubaoTTS(BaseTool):
                 "minimum": -50,
                 "maximum": 100,
                 "description": "Doubao speech rate. 0=normal, 100=2x, -50=0.5x.",
+            },
+            "emotion": {
+                "type": "string",
+                "description": "Optional Doubao emotion value, e.g. neutral, news, storytelling. Supported values depend on voice.",
+            },
+            "emotion_scale": {
+                "type": "number",
+                "minimum": 1,
+                "maximum": 5,
+                "description": "Emotion intensity when emotion is set. 1 is least expressive, 5 is strongest.",
+            },
+            "loudness_rate": {
+                "type": "integer",
+                "minimum": -50,
+                "maximum": 100,
+                "description": "Doubao loudness rate. 0=normal, 100=2x, -50=0.5x.",
+            },
+            "explicit_language": {
+                "type": "string",
+                "description": "Optional additions.explicit_language, e.g. zh-cn, en, crosslingual. Leave unset unless needed.",
+            },
+            "context_texts": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional context strings to guide style or dialogue context when supported.",
+            },
+            "silence_duration": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 30000,
+                "description": "Optional trailing silence in milliseconds.",
+            },
+            "enable_language_detector": {
+                "type": "boolean",
+                "description": "Optional automatic language detection.",
+            },
+            "disable_emoji_filter": {
+                "type": "boolean",
+                "description": "Optional emoji filter control.",
+            },
+            "mute_cut_threshold": {
+                "type": "integer",
+                "description": "Optional mute cutting threshold; sent with mute_cut_remain_ms as string additions.",
+            },
+            "mute_cut_remain_ms": {
+                "type": "integer",
+                "description": "Optional silence length to keep after mute cutting; sent as a string addition.",
+            },
+            "max_length_to_filter_parenthesis": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 100,
+                "description": "Optional parenthesis filtering threshold.",
+            },
+            "unsupported_char_ratio_thresh": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "description": "Optional unsupported-character ratio threshold.",
+            },
+            "post_process_pitch": {
+                "type": "integer",
+                "minimum": -12,
+                "maximum": 12,
+                "description": "Optional post-process pitch shift in semitones.",
+            },
+            "extra_audio_params": {
+                "type": "object",
+                "description": "Advanced raw req_params.audio_params overrides for newly documented Doubao fields.",
+            },
+            "extra_additions": {
+                "type": "object",
+                "description": "Advanced raw req_params.additions overrides for newly documented Doubao fields.",
             },
             "enable_timestamp": {
                 "type": "boolean",
@@ -270,10 +351,16 @@ class DoubaoTTS(BaseTool):
                 "provider": self.provider,
                 "model": resource_id,
                 "resource_id": resource_id,
+                "request_model": inputs.get("model"),
                 "voice_id": voice_id,
                 "format": fmt,
                 "sample_rate": inputs.get("sample_rate", 24000),
+                "bit_rate": inputs.get("bit_rate"),
                 "speech_rate": inputs.get("speech_rate", 0),
+                "emotion": inputs.get("emotion"),
+                "emotion_scale": inputs.get("emotion_scale"),
+                "loudness_rate": inputs.get("loudness_rate"),
+                "post_process_pitch": inputs.get("post_process_pitch"),
                 "text_length": len(text),
                 "task_id": task_id,
                 "task_status": data.get("task_status"),
@@ -316,18 +403,49 @@ class DoubaoTTS(BaseTool):
             "speech_rate": inputs.get("speech_rate", 0),
             "enable_timestamp": bool(inputs.get("enable_timestamp", True)),
         }
+        for key in ("bit_rate", "emotion", "emotion_scale", "loudness_rate"):
+            if inputs.get(key) is not None:
+                audio_params[key] = inputs[key]
+        extra_audio_params = inputs.get("extra_audio_params")
+        if isinstance(extra_audio_params, dict):
+            audio_params.update({key: value for key, value in extra_audio_params.items() if value is not None})
+
         additions = {
             "disable_markdown_filter": bool(inputs.get("disable_markdown_filter", False)),
         }
+        for key in (
+            "explicit_language",
+            "context_texts",
+            "silence_duration",
+            "enable_language_detector",
+            "disable_emoji_filter",
+            "max_length_to_filter_parenthesis",
+            "unsupported_char_ratio_thresh",
+        ):
+            if inputs.get(key) is not None:
+                additions[key] = inputs[key]
+        if inputs.get("mute_cut_threshold") is not None:
+            additions["mute_cut_threshold"] = str(inputs["mute_cut_threshold"])
+        if inputs.get("mute_cut_remain_ms") is not None:
+            additions["mute_cut_remain_ms"] = str(inputs["mute_cut_remain_ms"])
+        if inputs.get("post_process_pitch") is not None:
+            additions["post_process"] = {"pitch": inputs["post_process_pitch"]}
+        extra_additions = inputs.get("extra_additions")
+        if isinstance(extra_additions, dict):
+            additions.update({key: value for key, value in extra_additions.items() if value is not None})
+
+        req_params = {
+            "text": inputs["text"],
+            "speaker": voice_id,
+            "audio_params": audio_params,
+            "additions": json.dumps(additions, ensure_ascii=False),
+        }
+        if inputs.get("model") is not None:
+            req_params["model"] = inputs["model"]
         return {
             "user": {"uid": inputs.get("user_id", "openmontage")},
             "unique_id": request_id,
-            "req_params": {
-                "text": inputs["text"],
-                "speaker": voice_id,
-                "audio_params": audio_params,
-                "additions": json.dumps(additions, ensure_ascii=False),
-            },
+            "req_params": req_params,
         }
 
     def _poll_query(

--- a/tools/video/remotion_caption_burn.py
+++ b/tools/video/remotion_caption_burn.py
@@ -120,6 +120,14 @@ class RemotionCaptionBurn(BaseTool):
                     "correct replacement. Example: {\"cloud\": \"Claude\"}."
                 ),
             },
+            "protected_terms": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Terms that must not be split across generated caption tokens. "
+                    "Useful for Chinese TTS timestamps that may arrive character by character."
+                ),
+            },
             "overlays": {
                 "type": "array",
                 "description": (
@@ -180,7 +188,10 @@ class RemotionCaptionBurn(BaseTool):
     # ------------------------------------------------------------------ #
 
     def _segments_to_word_captions(
-        self, segments: list[dict], corrections: dict[str, str] | None = None
+        self,
+        segments: list[dict],
+        corrections: dict[str, str] | None = None,
+        protected_terms: list[str] | None = None,
     ) -> list[dict]:
         """Convert transcriber segments to [{word, startMs, endMs}, ...]."""
         captions: list[dict] = []
@@ -214,10 +225,13 @@ class RemotionCaptionBurn(BaseTool):
                         "startMs": int((seg["start"] + i * per_word) * 1000),
                         "endMs": int((seg["start"] + (i + 1) * per_word) * 1000),
                     })
-        return captions
+        return self._protect_caption_terms(captions, protected_terms)
 
     def _srt_to_word_captions(
-        self, srt_path: str, corrections: dict[str, str] | None = None
+        self,
+        srt_path: str,
+        corrections: dict[str, str] | None = None,
+        protected_terms: list[str] | None = None,
     ) -> list[dict]:
         """Parse SRT file into word captions."""
         content = Path(srt_path).read_text(encoding="utf-8")
@@ -258,7 +272,71 @@ class RemotionCaptionBurn(BaseTool):
                     "startMs": int(start_ms + i * per_word),
                     "endMs": int(start_ms + (i + 1) * per_word),
                 })
-        return captions
+        return self._protect_caption_terms(captions, protected_terms)
+
+    @classmethod
+    def _protect_caption_terms(cls, captions: list[dict], protected_terms: list[str] | None = None) -> list[dict]:
+        """Merge adjacent caption tokens when they form a protected term."""
+        terms = cls._normalized_protected_terms(protected_terms)
+        if not terms or not captions:
+            return captions
+        merged: list[dict] = []
+        index = 0
+        max_term_len = max(len(term) for term in terms)
+        while index < len(captions):
+            best_end = None
+            best_text = ""
+            collected = ""
+            end_limit = min(len(captions), index + max_term_len)
+            for end in range(index, end_limit):
+                collected += cls._caption_match_text(str(captions[end].get("word", "")))
+                if collected in terms:
+                    best_end = end
+                    best_text = collected
+            if best_end is not None and best_end > index:
+                merged.append(
+                    {
+                        **captions[index],
+                        "word": best_text,
+                        "endMs": captions[best_end]["endMs"],
+                    }
+                )
+                index = best_end + 1
+            else:
+                merged.append(captions[index])
+                index += 1
+        return merged
+
+    @classmethod
+    def _caption_protected_terms(cls, segments: list[dict] | None, explicit_terms: list[str] | None) -> list[str]:
+        terms = list(explicit_terms or [])
+        for seg in segments or []:
+            text = str(seg.get("text") or "")
+            terms.extend(re.findall(r"「([^」]{2,30})」", text))
+            terms.extend(re.findall(r"『([^』]{2,30})』", text))
+        return cls._normalized_protected_terms(terms)
+
+    @staticmethod
+    def _normalized_protected_terms(terms: list[str] | None) -> list[str]:
+        normalized = []
+        defaults = [
+            "AI ToB",
+            "JoyCode",
+            "Graylog",
+            "traceId",
+            "系统提交发布助手",
+            "系统问题分析助手",
+        ]
+        for term in [*defaults, *(terms or [])]:
+            clean = re.sub(r"\s+", "", str(term or "").strip())
+            if len(clean) >= 2 and clean not in normalized:
+                normalized.append(clean)
+        normalized.sort(key=len, reverse=True)
+        return normalized
+
+    @staticmethod
+    def _caption_match_text(text: str) -> str:
+        return re.sub(r"[\s，。！？、,.!?;:：；“”\"'‘’（）()【】\[\]<>《》]+", "", text)
 
     # ------------------------------------------------------------------ #
     #  Remotion render
@@ -458,11 +536,12 @@ class RemotionCaptionBurn(BaseTool):
         # Build word captions from segments or SRT
         segments = inputs.get("segments")
         srt_path = inputs.get("srt_path")
+        protected_terms = self._caption_protected_terms(segments, inputs.get("protected_terms"))
 
         if segments:
-            captions = self._segments_to_word_captions(segments, corrections)
+            captions = self._segments_to_word_captions(segments, corrections, protected_terms)
         elif srt_path:
-            captions = self._srt_to_word_captions(srt_path, corrections)
+            captions = self._srt_to_word_captions(srt_path, corrections, protected_terms)
         else:
             return ToolResult(
                 success=False,
@@ -485,4 +564,7 @@ class RemotionCaptionBurn(BaseTool):
             result = self._render_ffmpeg(input_path, output_path, captions)
 
         result.duration_seconds = round(time.time() - start, 2)
+        if result.success:
+            result.data = result.data or {}
+            result.data["protected_terms_count"] = len(protected_terms)
         return result


### PR DESCRIPTION
## Summary

This builds on the merged Doubao Speech provider by adding the controls we needed while producing longer Mandarin narration:

- expose advanced Doubao request parameters such as `model`, `emotion`, `emotion_scale`, `loudness_rate`, mute-cut controls, pitch post-processing, and raw escape hatches for newly documented fields
- document a production workflow for reducing theatrical delivery without rewriting approved narration
- add caption overlay sizing options for Remotion explainers
- preserve newlines in text cards and avoid fully transparent entrance frames
- align Remotion metadata duration with rounded sequence frame math so paused playback lands on the final visual frame

## Verification

- `python3 -m py_compile tools/audio/doubao_tts.py`
- `git diff --check c2f83f1^ c2f83f1`