### PR TITLE
fix(hyperframes): avoid scaffold root selector lint warning

### DIFF
--- a/tests/tools/test_hyperframes_compose.py
+++ b/tests/tools/test_hyperframes_compose.py
@@ -822,7 +822,9 @@ def test_hyperframes_root_composition_has_data_start_and_duration(tmp_path):
     assert result.success, result.error
     html = (workspace / "index.html").read_text(encoding="utf-8")
     # Must have all four required root attributes per the HyperFrames contract.
+    assert 'id="root"' in html
     assert 'data-composition-id="root"' in html
+    assert '[data-composition-id="root"]' not in html
     assert 'data-start="0"' in html  # per SKILL.md: root composition: use "0"
     # data-duration must match the timeline total; value can be '5' or '5.0' etc.
     import re
@@ -937,7 +939,9 @@ def test_scaffold_workspace_generates_html_and_assets(tmp_path: Path):
     html = index.read_text(encoding="utf-8")
 
     # HyperFrames authoring contract requirements we MUST emit:
+    assert 'id="root"' in html
     assert 'data-composition-id="root"' in html
+    assert '[data-composition-id="root"]' not in html
     assert 'window.__timelines["root"]' in html
     assert 'paused: true' in html
     assert 'class="clip' in html

--- a/tools/video/hyperframes_compose.py
+++ b/tools/video/hyperframes_compose.py
@@ -1000,7 +1000,7 @@ class HyperFramesCompose(BaseTool):
       {vars_css}
     }}
     body {{ margin: 0; background: var(--color-bg); color: var(--color-fg); font-family: var(--font-body); }}
-    [data-composition-id="root"] {{
+    #root {{
       position: relative;
       width: {width}px;
       height: {height}px;
@@ -1015,7 +1015,7 @@ class HyperFramesCompose(BaseTool):
   <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
 </head>
 <body>
-  <div data-composition-id="root" data-start="0" data-duration="{self._f(total_duration)}" data-width="{width}" data-height="{height}">
+  <div id="root" data-composition-id="root" data-start="0" data-duration="{self._f(total_duration)}" data-width="{width}" data-height="{height}">
     {"".join(clip_html)}
     {"".join(audio_html)}
     <script>


### PR DESCRIPTION
## Summary
- add an explicit `id="root"` to generated HyperFrames root compositions
- target root sizing styles with `#root` instead of `[data-composition-id="root"]`
- add regression coverage so scaffold output stays lint-clean

## Verification
- `.venv/bin/python -m pytest tests/tools/test_hyperframes_compose.py -q`
- generated a smoke HyperFrames workspace and confirmed `hyperframes lint` reports 0 warnings