### PR TITLE
feat(hyperframes): add inspect and snapshot QA ops

### DIFF
--- a/skills/core/hyperframes.md
+++ b/skills/core/hyperframes.md
@@ -240,8 +240,13 @@ declaring a render complete:
    contrast ratios, verifies `window.__timelines` registration and
    `class="clip"` on timed elements. MUST pass before render (contrast can
    be deferred with `--no-contrast` during iteration, but not for final).
-3. **`npx hyperframes render --quality standard`** — produces the MP4.
-4. **Post-render final review** — probe with ffprobe, sample frames,
+3. **`npx hyperframes inspect --json`** — samples the timeline for text
+   overflow, container clipping, and layout problems. Use this before final
+   render for text-heavy or UI-heavy HyperFrames scenes.
+4. **`npx hyperframes snapshot`** — captures key PNG frames for human review
+   and visual QA. Use explicit timestamps when the script has important beats.
+5. **`npx hyperframes render --quality standard`** — produces the MP4.
+6. **Post-render final review** — probe with ffprobe, sample frames,
    transcribe audio, compare to script. Same contract as the Remotion path.
    See `final_review.schema.json`.
 
@@ -249,6 +254,11 @@ If lint or validate fails, do **not** render. Fix the composition and re-run.
 Silent render from a failing composition is a contract violation — the whole
 point of HyperFrames is that validate catches issues that FFmpeg or Remotion
 cannot.
+
+If `inspect` reports layout issues, treat them as QA blockers for final
+delivery unless the issue is an intentional off-screen animation state. If
+`snapshot` frames show unexpected blank, cropped, or overlapping states, fix
+the composition before rendering the final delivery.
 
 ---
 

--- a/tests/qa/test_09_hyperframes_compose.py
+++ b/tests/qa/test_09_hyperframes_compose.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """QA Test 09: HyperFrames end-to-end — scaffold + lint + validate + render.
 
-This test hits the real HyperFrames CLI via `npx @hyperframes/cli`. On first
-run, npm fetches the package (slow — ~30-90s) and then Chrome downloads its
+This test hits the real HyperFrames CLI via `npx hyperframes`. On first
+run, npm fetches the package (slow -- ~30-90s) and then Chrome downloads its
 browser for validation (~30s extra, cached thereafter). Skip unless
 HYPERFRAMES_QA=1 is set so CI doesn't pay the cost on every run.
 
@@ -11,6 +11,7 @@ The test is still valuable even without `--render`:
     composition.
   - lint exercises the static contract checker.
   - validate exercises the browser-based contract + contrast audit.
+  - inspect and snapshot exercise layout QA and visual keyframe capture.
 
 Full render (operation='render') is optional and gated on HYPERFRAMES_QA_RENDER=1.
 """
@@ -146,6 +147,29 @@ def test_hyperframes_scaffold_lint_validate(tmp_path: Path):
     # what we care about is that it at least ran and produced a report.
     assert "exit_code" in validate.data
     assert validate.data.get("stderr_tail") is not None or validate.data.get("report")
+
+    # 4. Inspect — layout QA for text/container overflow.
+    inspect = HyperFramesCompose().execute(
+        {
+            "operation": "inspect",
+            "workspace_path": str(workspace),
+            "samples": 3,
+            "max_issues": 20,
+        }
+    )
+    assert "exit_code" in inspect.data
+    assert inspect.data.get("stderr_tail") is not None or inspect.data.get("report")
+
+    # 5. Snapshot — keyframe capture for visual review.
+    snapshot = HyperFramesCompose().execute(
+        {
+            "operation": "snapshot",
+            "workspace_path": str(workspace),
+            "snapshot_frames": 2,
+        }
+    )
+    assert snapshot.success, snapshot.error
+    assert snapshot.data["snapshot_count"] >= 1
 
 
 @pytest.mark.skipif(

--- a/tests/tools/test_hyperframes_compose.py
+++ b/tests/tools/test_hyperframes_compose.py
@@ -353,6 +353,81 @@ def test_hyperframes_render_requires_workspace():
     assert ("workspace" in err) or ("runtime" in err) or ("hyperframes" in err)
 
 
+def test_hyperframes_inspect_invokes_cli_with_layout_options(monkeypatch, tmp_path):
+    workspace = tmp_path / "hyperframes"
+    workspace.mkdir()
+    (workspace / "index.html").write_text("<html></html>", encoding="utf-8")
+    calls = []
+
+    def fake_run_hf(self, args, *, cwd, timeout, check):
+        calls.append({"args": args, "cwd": cwd, "timeout": timeout, "check": check})
+        return __import__("subprocess").CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=json.dumps({"ok": True, "issues": []}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(HyperFramesCompose, "_run_hf", fake_run_hf)
+    result = HyperFramesCompose().execute(
+        {
+            "operation": "inspect",
+            "workspace_path": str(workspace),
+            "samples": 4,
+            "timestamps": [1.5, 3],
+            "overflow_tolerance_px": 3,
+            "max_issues": 12,
+            "collapse_static": False,
+            "strict": True,
+        }
+    )
+
+    assert result.success
+    assert result.data["report"]["ok"] is True
+    args = calls[0]["args"]
+    assert args[:2] == ["inspect", "--json"]
+    assert "--samples=4" in args
+    assert "--tolerance=3" in args
+    assert "--max-issues=12" in args
+    assert "--no-collapse-static" in args
+    assert "--strict" in args
+    assert "--at" in args
+    assert args[args.index("--at") + 1] == "1.5,3"
+
+
+def test_hyperframes_snapshot_collects_new_png_artifacts(monkeypatch, tmp_path):
+    workspace = tmp_path / "hyperframes"
+    workspace.mkdir()
+    (workspace / "index.html").write_text("<html></html>", encoding="utf-8")
+    before = workspace / "existing.png"
+    before.write_bytes(b"before")
+
+    def fake_run_hf(self, args, *, cwd, timeout, check):
+        (workspace / "snapshots").mkdir(exist_ok=True)
+        (workspace / "snapshots" / "frame-0001.png").write_bytes(b"after")
+        return __import__("subprocess").CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout="Captured 1 frame",
+            stderr="",
+        )
+
+    monkeypatch.setattr(HyperFramesCompose, "_run_hf", fake_run_hf)
+    result = HyperFramesCompose().execute(
+        {
+            "operation": "snapshot",
+            "workspace_path": str(workspace),
+            "snapshot_frames": 1,
+            "timestamps": [2],
+        }
+    )
+
+    assert result.success
+    assert result.data["snapshot_count"] == 1
+    assert result.artifacts == result.data["snapshots"]
+    assert result.artifacts[0].endswith("frame-0001.png")
+
+
 # ------------------------------------------------------------------
 # video_compose runtime routing
 # ------------------------------------------------------------------

--- a/tools/video/hyperframes_compose.py
+++ b/tools/video/hyperframes_compose.py
@@ -2,10 +2,10 @@
 
 Sibling to `video_compose` (FFmpeg + Remotion). This tool owns the HyperFrames
 runtime end-to-end: workspace materialization, `hyperframes lint`,
-`hyperframes validate`, and `hyperframes render`. It is invoked by
+`hyperframes validate`, visual QA helpers, and `hyperframes render`. It is invoked by
 `video_compose` when `edit_decisions.render_runtime == "hyperframes"`, and
 can also be called directly by pipelines that want HyperFrames-specific
-operations (lint-only, validate-only, scaffold-only).
+operations (lint-only, validate-only, inspect-only, snapshot-only, scaffold-only).
 
 This tool deliberately does NOT attempt parity with every Remotion scene
 component. See `skills/core/hyperframes.md` for what is in scope in Phase 1
@@ -81,6 +81,8 @@ class HyperFramesCompose(BaseTool):
         "hyperframes_render",
         "hyperframes_lint",
         "hyperframes_validate",
+        "hyperframes_inspect",
+        "hyperframes_snapshot",
         "hyperframes_doctor",
         "scaffold_workspace",
         "add_block",
@@ -109,6 +111,8 @@ class HyperFramesCompose(BaseTool):
                     "render",
                     "lint",
                     "validate",
+                    "inspect",
+                    "snapshot",
                     "doctor",
                     "scaffold_workspace",
                     "add_block",
@@ -117,6 +121,8 @@ class HyperFramesCompose(BaseTool):
                     "render: materialize workspace + lint + validate + render to MP4. "
                     "lint: run `hyperframes lint` on an existing workspace. "
                     "validate: run `hyperframes validate` (browser-based). "
+                    "inspect: run `hyperframes inspect` for layout overflow QA. "
+                    "snapshot: run `hyperframes snapshot` to capture keyframes. "
                     "doctor: run `hyperframes doctor` to check environment. "
                     "scaffold_workspace: materialize HTML/CSS/assets but do not render. "
                     "add_block: run `hyperframes add <name>` to install a registry "
@@ -195,6 +201,36 @@ class HyperFramesCompose(BaseTool):
                     "while iterating; forbidden for final delivery."
                 ),
             },
+            "samples": {
+                "type": "integer",
+                "default": 9,
+                "description": "Number of timeline samples for operation='inspect'.",
+            },
+            "timestamps": {
+                "type": "array",
+                "items": {"type": "number"},
+                "description": "Specific timestamps for inspect or snapshot operations.",
+            },
+            "overflow_tolerance_px": {
+                "type": "number",
+                "default": 2,
+                "description": "Allowed pixel overflow for operation='inspect'.",
+            },
+            "max_issues": {
+                "type": "integer",
+                "default": 80,
+                "description": "Maximum issues returned by operation='inspect'.",
+            },
+            "collapse_static": {
+                "type": "boolean",
+                "default": True,
+                "description": "Collapse repeated static inspect issues across samples.",
+            },
+            "snapshot_frames": {
+                "type": "integer",
+                "default": 5,
+                "description": "Number of evenly spaced keyframes for operation='snapshot'.",
+            },
         },
     }
 
@@ -208,6 +244,7 @@ class HyperFramesCompose(BaseTool):
         "writes HTML/CSS/JS files into workspace_path",
         "copies asset files into workspace_path/assets/",
         "writes MP4 to output_path",
+        "writes PNG screenshots in snapshot mode",
     ]
     user_visible_verification = [
         "Play the rendered MP4 and verify scene pacing, typography, and audio",
@@ -399,6 +436,10 @@ class HyperFramesCompose(BaseTool):
                 result = self._lint(inputs)
             elif operation == "validate":
                 result = self._validate(inputs)
+            elif operation == "inspect":
+                result = self._inspect(inputs)
+            elif operation == "snapshot":
+                result = self._snapshot(inputs)
             elif operation == "render":
                 result = self._render(inputs)
             elif operation == "add_block":
@@ -590,6 +631,78 @@ class HyperFramesCompose(BaseTool):
             success=ok,
             data=data,
             error=None if ok else f"hyperframes validate exit {proc.returncode}",
+        )
+
+    def _inspect(self, inputs: dict[str, Any]) -> ToolResult:
+        """Run HyperFrames layout inspection for overflow and container issues."""
+        workspace = self._require_workspace(inputs)
+        if not (workspace / "index.html").exists():
+            return ToolResult(
+                success=False,
+                error=f"No index.html in {workspace}. Run scaffold_workspace first.",
+            )
+        args = [
+            "inspect",
+            "--json",
+            f"--samples={int(inputs.get('samples', 9))}",
+            f"--tolerance={inputs.get('overflow_tolerance_px', 2)}",
+            f"--timeout={int(inputs.get('timeout_ms', 5000))}",
+            f"--max-issues={int(inputs.get('max_issues', 80))}",
+        ]
+        timestamps = self._timestamp_arg(inputs.get("timestamps"))
+        if timestamps:
+            args.extend(["--at", timestamps])
+        if inputs.get("collapse_static", True) is False:
+            args.append("--no-collapse-static")
+        if inputs.get("strict"):
+            args.append("--strict")
+
+        proc = self._run_hf(args, cwd=workspace, timeout=300, check=False)
+        data = self._command_result_data(proc)
+        data["operation"] = "inspect"
+        ok = proc.returncode == 0
+        return ToolResult(
+            success=ok,
+            data=data,
+            error=None if ok else f"hyperframes inspect exit {proc.returncode}",
+        )
+
+    def _snapshot(self, inputs: dict[str, Any]) -> ToolResult:
+        """Capture keyframes from a HyperFrames workspace for visual QA."""
+        workspace = self._require_workspace(inputs)
+        if not (workspace / "index.html").exists():
+            return ToolResult(
+                success=False,
+                error=f"No index.html in {workspace}. Run scaffold_workspace first.",
+            )
+        before = self._png_files(workspace)
+        args = [
+            "snapshot",
+            f"--frames={int(inputs.get('snapshot_frames', 5))}",
+            f"--timeout={int(inputs.get('timeout_ms', 5000))}",
+        ]
+        timestamps = self._timestamp_arg(inputs.get("timestamps"))
+        if timestamps:
+            args.extend(["--at", timestamps])
+
+        proc = self._run_hf(args, cwd=workspace, timeout=300, check=False)
+        data = self._command_result_data(proc)
+        after = self._png_files(workspace)
+        new_files = [str(path) for path in after if path not in before]
+        data.update(
+            {
+                "operation": "snapshot",
+                "workspace": str(workspace),
+                "snapshot_count": len(new_files),
+                "snapshots": new_files,
+            }
+        )
+        ok = proc.returncode == 0
+        return ToolResult(
+            success=ok,
+            data=data,
+            artifacts=new_files,
+            error=None if ok else f"hyperframes snapshot exit {proc.returncode}",
         )
 
     def _add_block(self, inputs: dict[str, Any]) -> ToolResult:
@@ -1167,6 +1280,32 @@ class HyperFramesCompose(BaseTool):
             return json.loads(stdout[start : end + 1])
         except json.JSONDecodeError:
             return None
+
+    def _command_result_data(self, proc: subprocess.CompletedProcess) -> dict[str, Any]:
+        data: dict[str, Any] = {"exit_code": proc.returncode}
+        payload = self._parse_json_output(proc.stdout)
+        if payload is not None:
+            data["report"] = payload
+        else:
+            data["stdout_tail"] = (proc.stdout or "")[-4000:]
+        data["stderr_tail"] = (proc.stderr or "")[-2000:]
+        return data
+
+    @staticmethod
+    def _timestamp_arg(raw: Any) -> str:
+        if not raw:
+            return ""
+        if isinstance(raw, str):
+            return raw
+        if isinstance(raw, (int, float)):
+            return str(raw)
+        if isinstance(raw, list):
+            return ",".join(str(float(item)).rstrip("0").rstrip(".") for item in raw)
+        return ""
+
+    @staticmethod
+    def _png_files(workspace: Path) -> set[Path]:
+        return {path.resolve() for path in workspace.rglob("*.png") if path.is_file()}
 
     @staticmethod
     def _f(v: float) -> str:


### PR DESCRIPTION
## Summary
- add `inspect` operation wrapping `hyperframes inspect --json` for layout overflow QA
- add `snapshot` operation wrapping `hyperframes snapshot` and returning generated PNG artifacts
- document inspect/snapshot in the HyperFrames validation protocol
- update opt-in QA smoke coverage for inspect/snapshot and fix stale CLI package wording

## Verification
- `.venv/bin/python -m pytest tests/tools/test_hyperframes_compose.py -q`
- ran real `inspect` and `snapshot` operations against a local HyperFrames smoke workspace