### PR TITLE
feat(publish): add final package helper

### DIFF
--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -534,6 +534,7 @@ Each stage produces one canonical artifact that becomes the contract for the nex
 | `assets` | `*-director.md` | `asset_manifest` | Provenance, paths, model/tool metadata, scene linkage |
 | `edit` | `*-director.md` | `edit_decisions` | Concrete cuts, overlays, subtitle/music decisions |
 | `compose` | `*-director.md` | `render_report` | Output paths, encoding profile, verification notes |
+| post-compose / publish prep | `publish_packager` | `final_package_manifest` | Final package file list, cover/first-frame handling, input/output refs |
 
 Stage contract rules:
 

--- a/docs/PUBLISH_PACKAGER.md
+++ b/docs/PUBLISH_PACKAGER.md
@@ -42,6 +42,12 @@ with the cover and keeps the original audio timing.
 review pages that depend on adjacent images, audio, or other assets; they stay
 at their original path so their embedded media still works.
 
+Set `require_timing_qa=true` for final packages whose narration, subtitles,
+screen states, or motion timing changed materially. The package will only pass
+when a Timing QA artifact is attached through `extra_files` or
+`reference_files` using a role such as `visual_timing_review_page`,
+`visual_timing_annotated_review`, or `timing_qa_page`.
+
 Packaging also writes `FINAL_PACKAGE.md`, a standard package summary with
 absolute paths for the video, cover, copied files, reference pages, and
 checksums. Prefer this over adding ad hoc archive-manifest sidecars.
@@ -55,7 +61,7 @@ Creates a local confirmation page for the package:
 - `final_package_review.json`
 
 The page embeds the packaged video, cover, copied file list, reference page
-list, checksums, verification status, and copy-path shortcuts. It is a lightweight
+list, checksums, Timing QA status, verification status, and copy-path shortcuts. It is a lightweight
 handoff check: if something is wrong, tell the agent what to adjust and rerun
 packaging. The UI language can be set with `language`, or left as `auto` to
 infer Chinese/English from captions, script sidecars, references, and package

--- a/docs/PUBLISH_PACKAGER.md
+++ b/docs/PUBLISH_PACKAGER.md
@@ -1,0 +1,120 @@
+# Publish Packager
+
+`publish_packager` turns an approved render into a final delivery package. It is
+the last-mile helper after composition, timing review, and variant selection.
+
+It does not choose the best cut, replace review platforms, or publish to an
+external site. Use `variant_manager` to decide which render is current for a
+channel, then pass the approved video and sidecars into `publish_packager`.
+
+## Operations
+
+### `package`
+
+Copies the final video, optional cover, and sidecar files into a package
+directory, then writes `final_package_manifest.json` with paths, checksums,
+duration metadata, cover provenance, reference pages, and verification warnings.
+
+```json
+{
+  "operation": "package",
+  "video_path": "projects/demo/renders/final.mp4",
+  "cover_path": "projects/demo/assets/cover.jpg",
+  "output_dir": "projects/demo/final/final-v1",
+  "project_id": "demo",
+  "variant_id": "final-v1",
+  "channel": "landing_page",
+  "cover_mode": "replace_first_frame",
+  "extra_files": [
+    { "path": "projects/demo/artifacts/variant_review_notes.json", "role": "variant_review_notes" }
+  ],
+  "reference_files": [
+    { "path": "projects/demo/reviews/visual-timing/review.html", "role": "visual_timing_review_page" },
+    { "path": "projects/demo/reviews/tts-lab/compare.html", "role": "tts_segment_review_page" }
+  ]
+}
+```
+
+`cover_mode="replace_first_frame"` replaces only the first visible video frame
+with the cover and keeps the original audio timing.
+
+`extra_files` are copied into the package. Use `reference_files` for local HTML
+review pages that depend on adjacent images, audio, or other assets; they stay
+at their original path so their embedded media still works.
+
+Packaging also writes `FINAL_PACKAGE.md`, a standard package summary with
+absolute paths for the video, cover, copied files, reference pages, and
+checksums. Prefer this over adding ad hoc archive-manifest sidecars.
+
+### `review`
+
+Creates a local confirmation page for the package:
+
+- `final_package_review.html`
+- `final_package_review.md`
+- `final_package_review.json`
+
+The page embeds the packaged video, cover, copied file list, reference page
+list, checksums, verification status, and copy-path shortcuts. It is a lightweight
+handoff check: if something is wrong, tell the agent what to adjust and rerun
+packaging. The UI language can be set with `language`, or left as `auto` to
+infer Chinese/English from captions, script sidecars, references, and package
+metadata.
+
+```json
+{
+  "operation": "review",
+  "manifest_path": "projects/demo/final/final-v1/final_package_manifest.json",
+  "review_output_dir": "projects/demo/final/final-v1/review",
+  "language": "auto"
+}
+```
+
+### `annotate`
+
+Optionally records a pasted package review JSON as
+`final_package_review_notes.json` and returns the next workflow step. This is
+kept for teams that want an explicit package approval trail; the default local
+confirmation page does not require it.
+
+```json
+{
+  "operation": "annotate",
+  "review_payload": {
+    "version": "1.0",
+    "run_id": "demo-landing-page-final-v1-package-review",
+    "manifest_path": "projects/demo/final/final-v1/final_package_manifest.json",
+    "decision": "NEEDS_REVISION",
+    "notes": "Use the approved cover image before delivery."
+  }
+}
+```
+
+Result behavior:
+
+- `APPROVED` -> `review_complete=true`, `next_operation=deliver_or_publish`
+- `NEEDS_REVISION` -> `review_complete=false`, `next_operation=repackage_final`
+- `WRONG_PACKAGE` -> `review_complete=false`, `next_operation=rebuild_package_inputs`
+
+After a package is revised, run `package` and `review` again. If a team uses
+explicit package approvals, repeat `annotate` until it records `APPROVED`;
+otherwise the local confirmation page is enough for a human to spot issues and
+tell the agent what to adjust.
+
+## Relationship To Variant Manager
+
+`variant_manager` answers: "Which candidate render is the approved version for
+this channel?"
+
+`publish_packager` answers: "Is the final delivery package complete and ready to
+hand off?"
+
+The recommended flow is:
+
+1. Generate one or more render candidates.
+2. Use `variant_manager review` and `annotate` until a candidate is approved.
+3. Pass the approved candidate's package inputs into `publish_packager package`.
+4. Use `publish_packager review` to inspect the final video, cover, copied
+   sidecars, and reference pages.
+5. If anything is wrong, adjust the inputs and rerun `package` + `review`;
+   otherwise deliver or publish the package.

--- a/pipeline_defs/animated-explainer.yaml
+++ b/pipeline_defs/animated-explainer.yaml
@@ -254,7 +254,9 @@ stages:
       - proposal_packet
     produces:
       - publish_log
-    tools_available: []
+      - final_package_manifest
+    tools_available:
+      - publish_packager
     checkpoint_required: true
     human_approval_default: true
     review_focus:
@@ -263,4 +265,5 @@ stages:
       - Export package structured correctly
     success_criteria:
       - Schema-valid publish_log
+      - Final package manifest present when publish_packager is used
       - Export directory contains video, metadata, and thumbnail concept

--- a/pipeline_defs/screen-demo.yaml
+++ b/pipeline_defs/screen-demo.yaml
@@ -234,7 +234,9 @@ stages:
       - brief
     produces:
       - publish_log
-    tools_available: []
+      - final_package_manifest
+    tools_available:
+      - publish_packager
     checkpoint_required: true
     human_approval_default: true
     review_focus:
@@ -243,4 +245,5 @@ stages:
       - Export package is complete
     success_criteria:
       - Schema-valid publish_log artifact
+      - Final package manifest present when publish_packager is used
       - Export directory contains video, metadata, and thumbnail concept

--- a/schemas/artifacts/__init__.py
+++ b/schemas/artifacts/__init__.py
@@ -31,6 +31,7 @@ ARTIFACT_NAMES = [
     "final_review",
     "character_qa_report",
     "video_analysis_brief",
+    "final_package_manifest",
 ]
 
 

--- a/schemas/artifacts/final_package_manifest.schema.json
+++ b/schemas/artifacts/final_package_manifest.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "openmontage/artifacts/final_package_manifest",
+  "title": "Final Package Manifest",
+  "description": "Records the files and verification metadata for a final publish-ready deliverable package.",
+  "type": "object",
+  "required": ["version", "created_at", "package_dir", "video", "files"],
+  "properties": {
+    "version": { "type": "string", "const": "1.0" },
+    "created_at": { "type": "string", "format": "date-time" },
+    "package_dir": { "type": "string" },
+    "project_id": { "type": "string" },
+    "variant_id": { "type": "string" },
+    "channel": { "type": "string" },
+    "cover_direction": {
+      "type": "object",
+      "description": "Copied from the script artifact when available, so the final cover can be traced back to the early creative intent.",
+      "additionalProperties": true
+    },
+    "cover_policy": {
+      "type": "object",
+      "description": "Copied from the script artifact when available, so the final cover/first-frame decision can be audited.",
+      "additionalProperties": true
+    },
+    "video": {
+      "type": "object",
+      "required": ["source_path", "package_path"],
+      "properties": {
+        "source_path": { "type": "string" },
+        "package_path": { "type": "string" },
+        "duration_seconds": { "type": ["number", "null"] },
+        "source_duration_seconds": { "type": ["number", "null"] },
+        "duration_delta_seconds": { "type": ["number", "null"] },
+        "cover_first_frame": { "type": "boolean" },
+        "cover_mode": { "type": "string", "enum": ["none", "replace_first_frame"] },
+        "first_frame_verified": { "type": ["boolean", "null"] }
+      },
+      "additionalProperties": false
+    },
+    "cover": {
+      "type": "object",
+      "properties": {
+        "source_path": { "type": "string" },
+        "package_path": { "type": "string" },
+        "role": { "type": "string", "enum": ["poster", "first_frame", "poster_and_first_frame"] },
+        "source_kind": {
+          "type": "string",
+          "enum": ["rendered_frame", "generated_image", "generated_video_frame", "source_footage_frame", "manual_design", "unknown"]
+        },
+        "generator": {
+          "type": "object",
+          "description": "Optional provenance for generated covers, such as provider/model/prompt id.",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["role", "path", "sha256", "size_bytes"],
+        "properties": {
+          "role": { "type": "string" },
+          "path": { "type": "string" },
+          "sha256": { "type": "string" },
+          "size_bytes": { "type": "integer", "minimum": 0 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "verification": {
+      "type": "object",
+      "properties": {
+        "duration_tolerance_seconds": { "type": "number" },
+        "passed": { "type": "boolean" },
+        "warnings": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/artifacts/final_package_manifest.schema.json
+++ b/schemas/artifacts/final_package_manifest.schema.json
@@ -104,6 +104,24 @@
           },
           "additionalProperties": false
         },
+        "timing_qa": {
+          "type": "object",
+          "properties": {
+            "status": { "type": "string" },
+            "required": { "type": "boolean" },
+            "reference_count": { "type": "integer", "minimum": 0 },
+            "roles": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "paths": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "message": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
         "passed": { "type": "boolean" },
         "warnings": {
           "type": "array",

--- a/schemas/artifacts/final_package_manifest.schema.json
+++ b/schemas/artifacts/final_package_manifest.schema.json
@@ -62,6 +62,23 @@
         "required": ["role", "path", "sha256", "size_bytes"],
         "properties": {
           "role": { "type": "string" },
+          "label": { "type": "string" },
+          "path": { "type": "string" },
+          "sha256": { "type": "string" },
+          "size_bytes": { "type": "integer", "minimum": 0 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "references": {
+      "type": "array",
+      "description": "Local reference files/pages that remain at their original path because they may depend on adjacent assets.",
+      "items": {
+        "type": "object",
+        "required": ["role", "path", "sha256", "size_bytes"],
+        "properties": {
+          "role": { "type": "string" },
+          "label": { "type": "string" },
           "path": { "type": "string" },
           "sha256": { "type": "string" },
           "size_bytes": { "type": "integer", "minimum": 0 }

--- a/schemas/artifacts/final_package_manifest.schema.json
+++ b/schemas/artifacts/final_package_manifest.schema.json
@@ -90,6 +90,20 @@
       "type": "object",
       "properties": {
         "duration_tolerance_seconds": { "type": "number" },
+        "audio_min_mean_volume_db": { "type": "number" },
+        "audio": {
+          "type": "object",
+          "properties": {
+            "status": { "type": "string" },
+            "reason": { "type": "string" },
+            "message": { "type": "string" },
+            "has_audio_stream": { "type": "boolean" },
+            "mean_volume_db": { "type": "number" },
+            "max_volume_db": { "type": ["number", "null"] },
+            "threshold_mean_volume_db": { "type": "number" }
+          },
+          "additionalProperties": false
+        },
         "passed": { "type": "boolean" },
         "warnings": {
           "type": "array",

--- a/schemas/artifacts/script.schema.json
+++ b/schemas/artifacts/script.schema.json
@@ -9,6 +9,64 @@
     "version": { "type": "string", "const": "1.0" },
     "title": { "type": "string" },
     "total_duration_seconds": { "type": "number", "minimum": 1 },
+    "cover_direction": {
+      "type": "object",
+      "description": "Early creative intent for the final cover/poster frame. This guides production, but the final cover asset is selected or generated at publish time.",
+      "properties": {
+        "primary_message": { "type": "string" },
+        "visual_anchor": { "type": "string" },
+        "title": { "type": "string" },
+        "subtitle": { "type": "string" },
+        "style_notes": { "type": "string" },
+        "candidate_source": {
+          "type": "string",
+          "enum": ["rendered_frame", "generated_image", "generated_video_frame", "source_footage_frame", "manual_design", "unspecified"],
+          "description": "Likely source for the final cover asset. This is a planning hint, not a binding provider choice."
+        },
+        "avoid": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "cover_policy": {
+      "type": "object",
+      "description": "Workflow decision for whether a cover/poster frame is needed, whether the user should approve it, and whether it should become the first video frame.",
+      "required": ["required", "reason", "user_decision", "first_frame_mode"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "reason": { "type": "string" },
+        "user_decision": {
+          "type": "string",
+          "enum": ["none", "review_final_cover", "approve_before_publish"],
+          "description": "none for drafts/internal tests; review_final_cover when the cover affects presentation; approve_before_publish for brand-sensitive external releases."
+        },
+        "first_frame_mode": {
+          "type": "string",
+          "enum": ["none", "replace_first_frame"],
+          "description": "replace_first_frame makes the poster the first visible frame without adding time before the original audio."
+        },
+        "triggers": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "external_distribution",
+              "page_embed",
+              "product_marketing",
+              "tutorial_or_demo",
+              "user_requested",
+              "weak_initial_frame",
+              "draft_or_internal_only",
+              "source_footage_only"
+            ]
+          }
+        },
+        "notes": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
     "sections": {
       "type": "array",
       "items": {

--- a/skills/pipelines/explainer/publish-director.md
+++ b/skills/pipelines/explainer/publish-director.md
@@ -11,6 +11,8 @@ This is where a great video reaches its audience. Without proper metadata and pa
 | Layer | Resource | Purpose |
 |-------|----------|---------|
 | Schema | `schemas/artifacts/publish_log.schema.json` | Artifact validation |
+| Optional schema | `schemas/artifacts/final_package_manifest.schema.json` | Final package file list, cover, checksum, and verification metadata |
+| Optional tool | `publish_packager` | Copy final assets, optionally replace the first video frame with the cover, and write a final package manifest |
 | Prior artifacts | `state.artifacts["compose"]["render_report"]`, `state.artifacts["proposal"]["proposal_packet"]`, `state.artifacts["research"]["research_brief"]` | Video file and original proposal |
 | Playbook | Active style playbook | Visual style for thumbnail |
 
@@ -47,7 +49,23 @@ Collect everything needed for metadata:
 - 3-5 relevant hashtags
 - Mix trending and niche
 
-### Step 3: Generate Thumbnail Concept
+### Step 3: Resolve Cover Policy, Direction, and Thumbnail Concept
+
+Read `script.cover_policy` first:
+
+- if `required` is `false`, do not create a final cover unless the target
+  platform requires one;
+- if `required` is `true`, use `cover_direction` as the creative brief for the
+  poster/thumbnail;
+- if `user_decision` is `review_final_cover` or `approve_before_publish`,
+  present the final cover before final delivery/publish;
+- if `first_frame_mode` is `replace_first_frame`, pass
+  `cover_mode: "replace_first_frame"` to `publish_packager` after the cover is
+  selected.
+
+Do not treat `cover_direction` as a finished asset: review the completed video
+first, then choose whether the final cover should be generated from the
+direction, derived from a strong frame, or supplied by the user.
 
 Describe a thumbnail that:
 1. Uses the playbook's visual style
@@ -100,6 +118,16 @@ exports/
     thumbnails/
       concept.json          # Thumbnail concept (or generated image)
 ```
+
+For final deliverables, use `publish_packager` when available instead of
+manually copying files. It should package the approved render, cover/poster
+image, subtitles, metadata, and review sidecars into a final directory and
+write `final_package_manifest.json`.
+
+When `cover_policy.first_frame_mode` is `replace_first_frame`, prefer
+`cover_mode: "replace_first_frame"` rather than prepending extra video time.
+This swaps the first visible frame while keeping the original audio timing and
+avoids accidental narration drift.
 
 ### Step 6: Build Publish Log
 

--- a/skills/pipelines/explainer/publish-director.md
+++ b/skills/pipelines/explainer/publish-director.md
@@ -124,6 +124,12 @@ manually copying files. It should package the approved render, cover/poster
 image, subtitles, metadata, and review sidecars into a final directory and
 write `final_package_manifest.json`.
 
+If the approved render has material narration, subtitle, screen-state, or motion
+timing changes, run Visual Timing QA before packaging and pass its review page
+or annotated notes as a `reference_files` entry. Set `require_timing_qa=true`
+for that package so the final package manifest and review page clearly show
+whether the Timing QA gate was satisfied.
+
 When `cover_policy.first_frame_mode` is `replace_first_frame`, prefer
 `cover_mode: "replace_first_frame"` rather than prepending extra video time.
 This swaps the first visible frame while keeping the original audio timing and

--- a/skills/pipelines/explainer/script-director.md
+++ b/skills/pipelines/explainer/script-director.md
@@ -129,6 +129,67 @@ Write directions that TTS can actually implement. Reference ElevenLabs capabilit
 
 Avoid directions TTS can't do: "smile while speaking", "gesture toward screen", "look at camera."
 
+#### Cover Policy and Direction
+
+Decide whether the video needs a cover/poster frame while writing the script.
+Do not ask the user for every routine project; apply the workflow rules below
+and only escalate when the cover affects brand, external distribution, or a
+page's first impression.
+
+Default to `cover_policy.required: true` when:
+
+- the video will be embedded on a page, list, knowledge base, install page, or
+  product page where it appears static before playback;
+- the video will be shared externally or in a feed;
+- the video is marketing, education, tutorial, product demo, sales enablement,
+  or an executive/meeting opener;
+- the user explicitly mentions cover, poster, first frame, thumbnail, or
+  "what shows before playback";
+- the first rendered frame is likely to be black, blank, loading, transitional,
+  or too weak to represent the video.
+
+Default to `cover_policy.required: false` for internal drafts, technical smoke
+tests, TTS auditions, motion tests, source-footage-only processing, and other
+non-distribution intermediates.
+
+Use `user_decision: "review_final_cover"` when the user should see the final
+cover before delivery. Use `approve_before_publish` for brand-sensitive
+external releases. Use `none` only when skipping the cover or when the workflow
+can safely proceed without user review.
+
+Then add `cover_direction` when a cover is required. It gives production a
+clear first impression to design toward, while the publish stage picks or
+generates the final cover after the completed video can be reviewed.
+
+Add a top-level `cover_direction` object when the video will be distributed in
+a feed, embedded on a landing page, or shown before playback:
+
+```json
+{
+  "cover_policy": {
+    "required": true,
+    "reason": "Video will be embedded on a product page before playback",
+    "user_decision": "review_final_cover",
+    "first_frame_mode": "replace_first_frame",
+    "triggers": ["page_embed", "product_marketing"]
+  },
+  "cover_direction": {
+    "primary_message": "The one idea a viewer should understand before pressing play",
+    "visual_anchor": "The strongest visual motif or frame family to build around",
+    "title": "Short cover title",
+    "subtitle": "Optional supporting line",
+    "style_notes": "High-contrast glass UI, product name visible, no tiny text",
+    "candidate_source": "generated_image",
+    "avoid": ["generic stock imagery", "text-heavy layouts"]
+  }
+}
+```
+
+Treat this as creative intent. The publish stage may use the final render,
+`cover_direction`, and platform needs to create a final poster image or replace
+the video's first frame for static embeds. `candidate_source` is a planning
+hint only; it may point to a rendered frame, generated image, generated video
+frame, source-footage frame, or manual design.
 #### Enhancement Cues
 
 Every section should have at least one enhancement cue. These tell the Scene Planner and Asset Generator what visuals to create.

--- a/skills/pipelines/screen-demo/publish-director.md
+++ b/skills/pipelines/screen-demo/publish-director.md
@@ -9,6 +9,8 @@ Package the finished demo so the user can publish it quickly and so the metadata
 | Layer | Resource | Purpose |
 |-------|----------|---------|
 | Schema | `schemas/artifacts/publish_log.schema.json` | Artifact validation |
+| Optional schema | `schemas/artifacts/final_package_manifest.schema.json` | Final package file list, cover, checksum, and verification metadata |
+| Optional tool | `publish_packager` | Copy final assets, optionally replace the first video frame with the cover, and write a final package manifest |
 | Prior artifacts | `state.artifacts["compose"]["render_report"]`, `state.artifacts["idea"]["brief"]`, `state.artifacts["script"]["script"]` | Video, brief, and sections |
 | Playbook | Active style playbook | Thumbnail and copy tone |
 
@@ -50,6 +52,17 @@ If a thumbnail concept is needed, it should show:
 
 Store the concept in `publish_log.metadata.thumbnail_concepts`.
 
+Read `script.cover_policy` before creating cover assets. If it is missing,
+infer it from the distribution context: page embeds, product demos, tutorials,
+and external sharing usually need a cover; internal drafts and raw capture
+tests usually do not.
+
+If the policy requires a cover, use `cover_direction` as the thumbnail/poster
+brief and compare it against the finished render. The final cover may be
+generated from that direction, selected from a strong rendered frame, or
+supplied by the user. If `user_decision` requests review, show the final cover
+before final handoff or publish.
+
 ### 4. Package By Platform
 
 Prepare:
@@ -65,6 +78,12 @@ For developer or product-demo content, also package:
 - commands shown,
 - software/version mentions,
 - error terms if it is a troubleshooting demo.
+
+Use `publish_packager` when available to produce a final package directory and
+`final_package_manifest.json`. If `cover_policy.first_frame_mode` is
+`replace_first_frame`, use `cover_mode: "replace_first_frame"` so the cover
+becomes the first visible frame without adding extra time before the original
+audio.
 
 ### 5. Quality Gate
 

--- a/skills/pipelines/screen-demo/script-director.md
+++ b/skills/pipelines/screen-demo/script-director.md
@@ -97,7 +97,43 @@ Recommended `script.metadata` fields:
 - `callout_candidates`
 - `sections_needing_zoom`
 
-### 7. Quality Gate
+### 7. Set Cover Policy and Direction When Needed
+
+If the demo will be embedded on a page, shared in a feed, or used as a product
+intro, add a top-level `cover_policy` and `cover_direction` object to the
+script. The policy decides whether a cover is needed and whether the user must
+review it; the direction names the first impression the static video should
+create before playback.
+
+Default to a required cover for demos used on pages, docs, app listings,
+release notes, product intros, and external sharing. Skip it for raw screen
+captures, draft workflow checks, and short internal troubleshooting clips.
+
+```json
+{
+  "cover_policy": {
+    "required": true,
+    "reason": "Screen demo will be embedded in a product doc page",
+    "user_decision": "review_final_cover",
+    "first_frame_mode": "replace_first_frame",
+    "triggers": ["page_embed", "tutorial_or_demo"]
+  },
+  "cover_direction": {
+    "primary_message": "What the demo proves at a glance",
+    "visual_anchor": "The recognizable product/tool surface or result state",
+    "title": "Short cover title",
+    "subtitle": "Optional supporting line",
+    "style_notes": "Readable at small size, product UI visible",
+    "candidate_source": "rendered_frame",
+    "avoid": ["generic setup screens", "dense screenshots"]
+  }
+}
+```
+
+This is not the final cover asset. It guides capture, zoom choices, and the
+publish-stage poster/first-frame decision after the finished render exists.
+
+### 8. Quality Gate
 
 | Criterion | Question |
 |-----------|----------|

--- a/tests/tools/test_publish_packager.py
+++ b/tests/tools/test_publish_packager.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from schemas.artifacts import load_schema, validate_artifact
+from tools.publishers.publish_packager import PublishPackager
+from tools.tool_registry import ToolRegistry
+
+
+def test_final_package_manifest_schema_is_registered():
+    schema = load_schema("final_package_manifest")
+
+    assert schema["title"] == "Final Package Manifest"
+
+
+def test_package_copies_assets_and_writes_manifest(tmp_path: Path):
+    video = tmp_path / "render.mp4"
+    cover = tmp_path / "cover.jpg"
+    captions = tmp_path / "captions.srt"
+    script = tmp_path / "script.json"
+    video.write_bytes(b"fake video")
+    cover.write_bytes(b"fake cover")
+    captions.write_text("1\n00:00:00,000 --> 00:00:01,000\nHello\n", encoding="utf-8")
+    script.write_text(
+        json.dumps(
+            {
+                "version": "1.0",
+                "title": "Demo",
+                "total_duration_seconds": 10,
+                "cover_direction": {
+                    "primary_message": "A clear promise before playback",
+                    "visual_anchor": "A product UI close-up",
+                    "candidate_source": "generated_image",
+                },
+                "cover_policy": {
+                    "required": True,
+                    "reason": "Embedded product page video",
+                    "user_decision": "review_final_cover",
+                    "first_frame_mode": "replace_first_frame",
+                    "triggers": ["page_embed", "product_marketing"],
+                },
+                "sections": [
+                    {
+                        "id": "s1",
+                        "text": "Hello",
+                        "start_seconds": 0,
+                        "end_seconds": 10,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = PublishPackager().execute(
+        {
+            "video_path": str(video),
+            "cover_path": str(cover),
+            "script_path": str(script),
+            "output_dir": str(tmp_path / "final"),
+            "project_id": "demo",
+            "variant_id": "v1",
+            "channel": "default",
+            "cover_mode": "none",
+            "cover_source_kind": "generated_image",
+            "cover_generator": {"provider": "image2", "model": "example"},
+            "extra_files": [{"path": str(captions), "role": "captions"}],
+        }
+    )
+
+    assert result.success, result.error
+    manifest_path = tmp_path / "final" / "final_package_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    validate_artifact("final_package_manifest", manifest)
+    assert manifest["cover_direction"]["primary_message"] == "A clear promise before playback"
+    assert manifest["cover_policy"]["user_decision"] == "review_final_cover"
+    assert manifest["cover_policy"]["first_frame_mode"] == "replace_first_frame"
+    assert manifest["cover"]["source_kind"] == "generated_image"
+    assert manifest["cover"]["generator"]["provider"] == "image2"
+    assert manifest["video"]["cover_mode"] == "none"
+    assert manifest["video"]["cover_first_frame"] is False
+    roles = {entry["role"] for entry in manifest["files"]}
+    assert roles == {"video", "cover", "captions"}
+    assert (tmp_path / "final" / "video" / "render.mp4").exists()
+    assert (tmp_path / "final" / "cover" / "cover.jpg").exists()
+    assert (tmp_path / "final" / "sidecars" / "captions.srt").exists()
+
+
+def test_script_schema_accepts_cover_policy():
+    script = {
+        "version": "1.0",
+        "title": "Cover Policy Demo",
+        "total_duration_seconds": 30,
+        "cover_policy": {
+            "required": False,
+            "reason": "Internal timing smoke test",
+            "user_decision": "none",
+            "first_frame_mode": "none",
+            "triggers": ["draft_or_internal_only"],
+        },
+        "sections": [
+            {
+                "id": "s1",
+                "text": "Hello",
+                "start_seconds": 0,
+                "end_seconds": 30,
+            }
+        ],
+    }
+
+    validate_artifact("script", script)
+
+
+def test_package_blocks_nonempty_output_without_overwrite(tmp_path: Path):
+    video = tmp_path / "render.mp4"
+    video.write_bytes(b"fake video")
+    output_dir = tmp_path / "final"
+    output_dir.mkdir()
+    (output_dir / "existing.txt").write_text("keep", encoding="utf-8")
+
+    result = PublishPackager().execute(
+        {"video_path": str(video), "output_dir": str(output_dir)}
+    )
+
+    assert not result.success
+    assert "not empty" in result.error
+
+
+def test_package_requires_cover_for_first_frame_mode(tmp_path: Path):
+    video = tmp_path / "render.mp4"
+    video.write_bytes(b"fake video")
+
+    result = PublishPackager().execute(
+        {
+            "video_path": str(video),
+            "output_dir": str(tmp_path / "final"),
+            "cover_mode": "replace_first_frame",
+        }
+    )
+
+    assert not result.success
+    assert "cover_path is required" in result.error
+
+
+def test_package_uses_cover_policy_first_frame_mode_when_cover_mode_omitted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    video = tmp_path / "render.mp4"
+    cover = tmp_path / "cover.jpg"
+    script = tmp_path / "script.json"
+    video.write_bytes(b"fake video")
+    cover.write_bytes(b"fake cover")
+    script.write_text(
+        json.dumps(
+            {
+                "version": "1.0",
+                "title": "Demo",
+                "total_duration_seconds": 10,
+                "cover_policy": {
+                    "required": True,
+                    "reason": "Page embed",
+                    "user_decision": "review_final_cover",
+                    "first_frame_mode": "replace_first_frame",
+                },
+                "sections": [
+                    {
+                        "id": "s1",
+                        "text": "Hello",
+                        "start_seconds": 0,
+                        "end_seconds": 10,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_replace_first_frame(self, video_path: Path, cover_path: Path, output_path: Path):
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(video_path.read_bytes())
+
+    monkeypatch.setattr(PublishPackager, "_replace_first_frame", fake_replace_first_frame)
+
+    result = PublishPackager().execute(
+        {
+            "video_path": str(video),
+            "cover_path": str(cover),
+            "script_path": str(script),
+            "output_dir": str(tmp_path / "final"),
+        }
+    )
+
+    assert result.success, result.error
+    assert result.data["video"]["cover_mode"] == "replace_first_frame"
+    assert result.data["video"]["cover_first_frame"] is True
+
+
+def test_dry_run_reports_first_frame_ffmpeg_need(tmp_path: Path):
+    plan = PublishPackager().dry_run(
+        {
+            "video_path": str(tmp_path / "render.mp4"),
+            "output_dir": str(tmp_path / "final"),
+            "cover_mode": "replace_first_frame",
+        }
+    )
+
+    assert plan["requires_ffmpeg"] is True
+    assert any(path.endswith("final_package_manifest.json") for path in plan["would_write"])
+
+
+@pytest.mark.skipif(
+    shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None,
+    reason="ffmpeg/ffprobe not installed",
+)
+def test_replace_first_frame_keeps_duration_stable(tmp_path: Path):
+    video = tmp_path / "source.mp4"
+    cover = tmp_path / "cover.jpg"
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=size=320x180:rate=30",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=1000:sample_rate=44100",
+            "-t",
+            "1",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-c:a",
+            "aac",
+            str(video),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=blue:size=320x180",
+            "-frames:v",
+            "1",
+            str(cover),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    result = PublishPackager().execute(
+        {
+            "video_path": str(video),
+            "cover_path": str(cover),
+            "output_dir": str(tmp_path / "final"),
+            "cover_mode": "replace_first_frame",
+            "duration_tolerance_seconds": 0.15,
+        }
+    )
+
+    assert result.success, result.error
+    assert result.data["video"]["cover_first_frame"] is True
+    assert abs(result.data["video"]["duration_delta_seconds"]) <= 0.15
+
+
+def test_publish_packager_is_discoverable():
+    registry = ToolRegistry()
+    registry.discover()
+
+    tool = registry.get("publish_packager")
+    assert tool is not None
+    assert "write_final_package_manifest" in tool.capabilities

--- a/tests/tools/test_publish_packager.py
+++ b/tests/tools/test_publish_packager.py
@@ -183,6 +183,59 @@ def test_package_blocks_effectively_silent_audio_track(
     assert result.data["verification"]["passed"] is False
 
 
+def test_package_requires_timing_qa_when_gate_enabled(tmp_path: Path):
+    video = tmp_path / "render.mp4"
+    video.write_bytes(b"fake video")
+
+    result = PublishPackager().execute(
+        {
+            "video_path": str(video),
+            "output_dir": str(tmp_path / "final"),
+            "require_timing_qa": True,
+        }
+    )
+
+    assert not result.success
+    assert "Timing QA reference is required" in result.error
+    assert result.data["verification"]["timing_qa"]["status"] == "missing_required"
+    assert result.data["verification"]["passed"] is False
+
+
+def test_package_accepts_timing_qa_reference_when_gate_enabled(tmp_path: Path):
+    video = tmp_path / "render.mp4"
+    timing_page = tmp_path / "timing.html"
+    video.write_bytes(b"fake video")
+    timing_page.write_text("<html>Timing QA</html>", encoding="utf-8")
+
+    result = PublishPackager().execute(
+        {
+            "video_path": str(video),
+            "output_dir": str(tmp_path / "final"),
+            "require_timing_qa": True,
+            "reference_files": [
+                {
+                    "path": str(timing_page),
+                    "role": "visual_timing_review_page",
+                    "label": "Timing QA",
+                }
+            ],
+        }
+    )
+
+    assert result.success, result.error
+    manifest = json.loads(
+        (tmp_path / "final" / "final_package_manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    validate_artifact("final_package_manifest", manifest)
+    timing_qa = manifest["verification"]["timing_qa"]
+    assert timing_qa["status"] == "passed"
+    assert timing_qa["required"] is True
+    assert timing_qa["reference_count"] == 1
+    assert timing_qa["roles"] == ["visual_timing_review_page"]
+
+
 def test_package_uses_cover_policy_first_frame_mode_when_cover_mode_omitted(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/tools/test_publish_packager.py
+++ b/tests/tools/test_publish_packager.py
@@ -152,6 +152,37 @@ def test_package_requires_cover_for_first_frame_mode(tmp_path: Path):
     assert "cover_path is required" in result.error
 
 
+def test_package_blocks_effectively_silent_audio_track(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    video = tmp_path / "render.mp4"
+    video.write_bytes(b"fake video")
+
+    def fake_audio_check(self, video_path: Path, min_mean_volume_db: float):
+        return {
+            "status": "failed",
+            "has_audio_stream": True,
+            "mean_volume_db": -91.0,
+            "max_volume_db": -91.0,
+            "threshold_mean_volume_db": min_mean_volume_db,
+            "message": "Audio mean volume -91.0 dB is at or below threshold -60.0 dB; the packaged video may be silent.",
+        }
+
+    monkeypatch.setattr(PublishPackager, "_audio_loudness_check", fake_audio_check)
+
+    result = PublishPackager().execute(
+        {
+            "video_path": str(video),
+            "output_dir": str(tmp_path / "final"),
+        }
+    )
+
+    assert not result.success
+    assert "may be silent" in result.error
+    assert result.data["verification"]["audio"]["status"] == "failed"
+    assert result.data["verification"]["passed"] is False
+
+
 def test_package_uses_cover_policy_first_frame_mode_when_cover_mode_omitted(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/tools/test_publish_packager.py
+++ b/tests/tools/test_publish_packager.py
@@ -85,10 +85,15 @@ def test_package_copies_assets_and_writes_manifest(tmp_path: Path):
     assert manifest["video"]["cover_mode"] == "none"
     assert manifest["video"]["cover_first_frame"] is False
     roles = {entry["role"] for entry in manifest["files"]}
-    assert roles == {"video", "cover", "captions"}
+    assert roles == {"video", "cover", "captions", "final_package_summary"}
     assert (tmp_path / "final" / "video" / "render.mp4").exists()
     assert (tmp_path / "final" / "cover" / "cover.jpg").exists()
     assert (tmp_path / "final" / "sidecars" / "captions.srt").exists()
+    summary = tmp_path / "final" / "FINAL_PACKAGE.md"
+    assert summary.exists()
+    assert str(tmp_path / "final" / "video" / "render.mp4") in summary.read_text(
+        encoding="utf-8"
+    )
 
 
 def test_script_schema_accepts_cover_policy():
@@ -211,6 +216,173 @@ def test_dry_run_reports_first_frame_ffmpeg_need(tmp_path: Path):
 
     assert plan["requires_ffmpeg"] is True
     assert any(path.endswith("final_package_manifest.json") for path in plan["would_write"])
+
+
+def test_review_generates_local_html_with_detected_language(tmp_path: Path):
+    video = tmp_path / "render.mp4"
+    cover = tmp_path / "cover.jpg"
+    captions = tmp_path / "captions.srt"
+    video.write_bytes(b"fake video")
+    cover.write_bytes(b"fake cover")
+    captions.write_text(
+        "1\n00:00:00,000 --> 00:00:01,000\n最终视频字幕\n",
+        encoding="utf-8",
+    )
+    package = PublishPackager().execute(
+        {
+            "video_path": str(video),
+            "cover_path": str(cover),
+            "output_dir": str(tmp_path / "final"),
+            "project_id": "demo",
+            "variant_id": "v1",
+            "channel": "landing_page",
+            "extra_files": [{"path": str(captions), "role": "captions"}],
+        }
+    )
+    assert package.success, package.error
+
+    result = PublishPackager().execute(
+        {
+            "operation": "review",
+            "manifest_path": str(tmp_path / "final" / "final_package_manifest.json"),
+            "review_output_dir": str(tmp_path / "review"),
+            "language": "auto",
+        }
+    )
+
+    assert result.success, result.error
+    assert result.data["language"] == "zh"
+    html = (tmp_path / "review" / "final_package_review.html").read_text(
+        encoding="utf-8"
+    )
+    assert "最终交付包确认" in html
+    assert "<video controls" in html
+    assert 'class="cover"' in html
+    assert "如果发现视频、封面或附属文件不对" in html
+
+
+def test_review_uses_labels_for_html_review_artifacts(tmp_path: Path):
+    video = tmp_path / "render.mp4"
+    timing_page = tmp_path / "timing.html"
+    video.write_bytes(b"fake video")
+    timing_page.write_text("<html>Timing</html>", encoding="utf-8")
+    package = PublishPackager().execute(
+        {
+            "video_path": str(video),
+            "output_dir": str(tmp_path / "final"),
+            "reference_files": [
+                {
+                    "path": str(timing_page),
+                    "role": "visual_timing_review_page",
+                    "label": "Timing QA 页面",
+                }
+            ],
+        }
+    )
+    assert package.success, package.error
+    manifest = json.loads(
+        (tmp_path / "final" / "final_package_manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    validate_artifact("final_package_manifest", manifest)
+    page_entry = next(
+        item
+        for item in manifest["references"]
+        if item["role"] == "visual_timing_review_page"
+    )
+    assert page_entry["label"] == "Timing QA 页面"
+
+    result = PublishPackager().execute(
+        {
+            "operation": "review",
+            "manifest_path": str(tmp_path / "final" / "final_package_manifest.json"),
+            "review_output_dir": str(tmp_path / "review"),
+            "language": "zh",
+        }
+    )
+    assert result.success, result.error
+    html = (tmp_path / "review" / "final_package_review.html").read_text(
+        encoding="utf-8"
+    )
+    assert "Timing QA 页面" in html
+    assert "相关页面" in html
+    assert "timing.html" in html
+
+
+def test_annotate_records_approved_review_payload(tmp_path: Path):
+    video = tmp_path / "render.mp4"
+    video.write_bytes(b"fake video")
+    package = PublishPackager().execute(
+        {
+            "video_path": str(video),
+            "output_dir": str(tmp_path / "final"),
+            "project_id": "demo",
+            "variant_id": "v1",
+            "channel": "landing_page",
+        }
+    )
+    assert package.success, package.error
+    manifest_path = tmp_path / "final" / "final_package_manifest.json"
+
+    result = PublishPackager().execute(
+        {
+            "operation": "annotate",
+            "review_payload": {
+                "version": "1.0",
+                "run_id": "demo-review",
+                "manifest_path": str(manifest_path),
+                "decision": "APPROVED",
+                "notes": "",
+            },
+        }
+    )
+
+    assert result.success, result.error
+    assert result.data["review_complete"] is True
+    assert result.data["next_operation"] == "deliver_or_publish"
+    notes_path = tmp_path / "final" / "final_package_review_notes.json"
+    notes = json.loads(notes_path.read_text(encoding="utf-8"))
+    assert notes["decision"] == "APPROVED"
+    assert notes["package"]["video_path"].endswith("render.mp4")
+
+
+def test_annotate_records_revision_request(tmp_path: Path):
+    video = tmp_path / "render.mp4"
+    video.write_bytes(b"fake video")
+    package = PublishPackager().execute(
+        {
+            "video_path": str(video),
+            "output_dir": str(tmp_path / "final"),
+            "project_id": "demo",
+            "variant_id": "v1",
+        }
+    )
+    assert package.success, package.error
+    manifest_path = tmp_path / "final" / "final_package_manifest.json"
+
+    result = PublishPackager().execute(
+        {
+            "operation": "annotate",
+            "review_payload": {
+                "version": "1.0",
+                "run_id": "demo-review",
+                "manifest_path": str(manifest_path),
+                "decision": "NEEDS_REVISION",
+                "notes": "Cover file is not the approved one.",
+            },
+        }
+    )
+
+    assert result.success, result.error
+    assert result.data["review_complete"] is False
+    assert result.data["next_operation"] == "repackage_final"
+    notes = json.loads(
+        (tmp_path / "final" / "final_package_review_notes.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert notes["notes"] == "Cover file is not the approved one."
 
 
 @pytest.mark.skipif(

--- a/tools/publishers/publish_packager.py
+++ b/tools/publishers/publish_packager.py
@@ -1,0 +1,418 @@
+"""Publish-stage final package helper for OpenMontage projects."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from tools.analysis.audio_probe import probe_duration
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _file_entry(path: Path, role: str) -> dict[str, Any]:
+    return {
+        "role": role,
+        "path": str(path),
+        "sha256": _sha256(path),
+        "size_bytes": path.stat().st_size,
+    }
+
+
+def _copy_file(src: Path, dst: Path) -> Path:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dst)
+    return dst
+
+
+class PublishPackager(BaseTool):
+    name = "publish_packager"
+    version = "0.1.0"
+    tier = ToolTier.PUBLISH
+    capability = "publishing"
+    provider = "openmontage"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.DETERMINISTIC
+    runtime = ToolRuntime.LOCAL
+
+    dependencies = ["cmd:ffprobe"]
+    install_instructions = (
+        "Install FFmpeg (includes ffprobe). FFmpeg itself is only required when "
+        "cover_mode='replace_first_frame'."
+    )
+
+    capabilities = [
+        "package_final_video",
+        "copy_cover_asset",
+        "replace_video_first_frame_with_cover",
+        "write_final_package_manifest",
+        "verify_duration_delta",
+    ]
+    best_for = [
+        "turning an approved render into a publish-ready final package",
+        "recording checksums and source paths for final deliverables",
+        "making a cover image become the first visible frame without shifting audio",
+    ]
+    not_good_for = [
+        "deciding the creative concept for a cover",
+        "publishing to external platforms",
+        "replacing project or version tracking",
+    ]
+
+    input_schema = {
+        "type": "object",
+        "required": ["video_path", "output_dir"],
+        "properties": {
+            "video_path": {"type": "string"},
+            "output_dir": {"type": "string"},
+            "project_id": {"type": "string"},
+            "variant_id": {"type": "string"},
+            "channel": {"type": "string"},
+            "cover_path": {
+                "type": "string",
+                "description": "Optional poster/cover image to copy into the package.",
+            },
+            "cover_source_kind": {
+                "type": "string",
+                "enum": [
+                    "rendered_frame",
+                    "generated_image",
+                    "generated_video_frame",
+                    "source_footage_frame",
+                    "manual_design",
+                    "unknown",
+                ],
+                "default": "unknown",
+                "description": "Where the cover asset came from; useful for model-generated or manual covers.",
+            },
+            "cover_generator": {
+                "type": "object",
+                "description": "Optional cover provenance, such as provider/model/prompt id.",
+            },
+            "cover_mode": {
+                "type": "string",
+                "enum": ["none", "replace_first_frame"],
+                "default": "none",
+                "description": "replace_first_frame swaps only the first video frame and keeps original audio timing.",
+            },
+            "script_path": {
+                "type": "string",
+                "description": "Optional script JSON. cover_direction is copied from it when present.",
+            },
+            "extra_files": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["path", "role"],
+                    "properties": {
+                        "path": {"type": "string"},
+                        "role": {"type": "string"},
+                    },
+                    "additionalProperties": False,
+                },
+                "description": "Optional sidecar files, such as subtitles, review notes, or metadata.",
+            },
+            "duration_tolerance_seconds": {
+                "type": "number",
+                "default": 0.15,
+                "description": "Allowed duration delta after packaging.",
+            },
+            "overwrite": {"type": "boolean", "default": False},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=2, ram_mb=512, vram_mb=0, disk_mb=1000, network_required=False
+    )
+    retry_policy = RetryPolicy(max_retries=0, retryable_errors=[])
+    idempotency_key_fields = [
+        "video_path",
+        "output_dir",
+        "cover_path",
+        "cover_mode",
+        "variant_id",
+    ]
+    side_effects = ["writes final package files and manifest JSON"]
+    user_visible_verification = [
+        "Open the packaged video and confirm the first frame, subtitles, and audio sync.",
+        "Review final_package_manifest.json before marking a variant as published.",
+    ]
+
+    def get_status(self) -> ToolStatus:
+        if shutil.which("ffprobe"):
+            return ToolStatus.AVAILABLE
+        return ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        return 0.0
+
+    def dry_run(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        cover_mode = inputs.get("cover_mode", "none")
+        return {
+            "tool": self.name,
+            "estimated_cost_usd": 0.0,
+            "estimated_runtime_seconds": self.estimate_runtime(inputs),
+            "status": self.get_status().value,
+            "would_execute": True,
+            "would_write": [
+                str(Path(inputs["output_dir"]).expanduser() / "video" / Path(inputs["video_path"]).name),
+                str(Path(inputs["output_dir"]).expanduser() / "final_package_manifest.json"),
+            ],
+            "requires_ffmpeg": cover_mode == "replace_first_frame",
+        }
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        return 30.0 if inputs.get("cover_mode") == "replace_first_frame" else 2.0
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        start = time.time()
+        try:
+            result = self._package(inputs)
+        except Exception as exc:
+            result = ToolResult(success=False, error=f"{type(exc).__name__}: {exc}")
+        result.duration_seconds = round(time.time() - start, 2)
+        return result
+
+    def _package(self, inputs: dict[str, Any]) -> ToolResult:
+        video_path = Path(inputs["video_path"]).expanduser().resolve()
+        output_dir = Path(inputs["output_dir"]).expanduser().resolve()
+        cover_path = (
+            Path(inputs["cover_path"]).expanduser().resolve()
+            if inputs.get("cover_path")
+            else None
+        )
+        cover_direction, cover_policy = self._cover_metadata(inputs.get("script_path"))
+        cover_mode = inputs.get("cover_mode") or (
+            cover_policy or {}
+        ).get("first_frame_mode", "none")
+        overwrite = bool(inputs.get("overwrite", False))
+        tolerance = float(inputs.get("duration_tolerance_seconds", 0.15))
+
+        if not video_path.exists():
+            return ToolResult(success=False, error=f"Video not found: {video_path}")
+        if cover_mode == "replace_first_frame" and not cover_path:
+            return ToolResult(
+                success=False,
+                error="cover_path is required when cover_mode='replace_first_frame'",
+            )
+        if cover_path and not cover_path.exists():
+            return ToolResult(success=False, error=f"Cover not found: {cover_path}")
+        if output_dir.exists() and any(output_dir.iterdir()) and not overwrite:
+            return ToolResult(
+                success=False,
+                error=f"Output directory is not empty: {output_dir}. Pass overwrite=true.",
+            )
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        video_out = output_dir / "video" / video_path.name
+        cover_out = output_dir / "cover" / cover_path.name if cover_path else None
+
+        source_duration = probe_duration(video_path)
+        if cover_mode == "replace_first_frame":
+            video_out = video_out.with_name(f"{video_out.stem}-cover-first-frame{video_out.suffix}")
+            self._replace_first_frame(video_path, cover_path, video_out)
+        else:
+            _copy_file(video_path, video_out)
+
+        if cover_path and cover_out:
+            _copy_file(cover_path, cover_out)
+
+        files = [_file_entry(video_out, "video")]
+        if cover_out:
+            files.append(_file_entry(cover_out, "cover"))
+
+        for item in inputs.get("extra_files", []) or []:
+            src = Path(item["path"]).expanduser().resolve()
+            if not src.exists():
+                return ToolResult(success=False, error=f"Extra file not found: {src}")
+            dst = output_dir / "sidecars" / src.name
+            _copy_file(src, dst)
+            files.append(_file_entry(dst, item["role"]))
+
+        package_duration = probe_duration(video_out)
+        duration_delta = (
+            round(package_duration - source_duration, 3)
+            if package_duration is not None and source_duration is not None
+            else None
+        )
+        warnings: list[str] = []
+        if duration_delta is not None and abs(duration_delta) > tolerance:
+            warnings.append(
+                f"Duration delta {duration_delta}s exceeds tolerance {tolerance}s"
+            )
+
+        manifest: dict[str, Any] = {
+            "version": "1.0",
+            "created_at": _now(),
+            "package_dir": str(output_dir),
+            "video": {
+                "source_path": str(video_path),
+                "package_path": str(video_out),
+                "duration_seconds": package_duration,
+                "source_duration_seconds": source_duration,
+                "duration_delta_seconds": duration_delta,
+                "cover_first_frame": cover_mode == "replace_first_frame",
+                "cover_mode": cover_mode,
+                "first_frame_verified": None,
+            },
+            "files": files,
+            "verification": {
+                "duration_tolerance_seconds": tolerance,
+                "passed": not warnings,
+                "warnings": warnings,
+            },
+        }
+        for key in ("project_id", "variant_id", "channel"):
+            if inputs.get(key):
+                manifest[key] = inputs[key]
+        if cover_direction:
+            manifest["cover_direction"] = cover_direction
+        if cover_policy:
+            manifest["cover_policy"] = cover_policy
+        if cover_out:
+            manifest["cover"] = {
+                "source_path": str(cover_path),
+                "package_path": str(cover_out),
+                "role": (
+                    "poster_and_first_frame"
+                    if cover_mode == "replace_first_frame"
+                    else "poster"
+                ),
+                "source_kind": inputs.get("cover_source_kind", "unknown"),
+            }
+            if inputs.get("cover_generator"):
+                manifest["cover"]["generator"] = inputs["cover_generator"]
+
+        manifest_path = output_dir / "final_package_manifest.json"
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+        return ToolResult(
+            success=not warnings,
+            data=manifest,
+            artifacts=[str(output_dir), str(manifest_path)],
+            error="; ".join(warnings) if warnings else None,
+        )
+
+    def _cover_metadata(
+        self, script_path: str | None
+    ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+        if not script_path:
+            return None, None
+        path = Path(script_path).expanduser().resolve()
+        if not path.exists():
+            return None, None
+        try:
+            script = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return None, None
+        return script.get("cover_direction"), script.get("cover_policy")
+
+    def _replace_first_frame(self, video_path: Path, cover_path: Path, output_path: Path) -> None:
+        ffmpeg = shutil.which("ffmpeg")
+        if not ffmpeg:
+            raise RuntimeError("ffmpeg not found on PATH")
+        width, height, fps = self._video_info(video_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        frame_seconds = 1 / fps
+        filter_complex = (
+            f"[1:v]scale={width}:{height}:force_original_aspect_ratio=decrease,"
+            f"pad={width}:{height}:(ow-iw)/2:(oh-ih)/2,setsar=1,"
+            f"trim=duration={frame_seconds},setpts=PTS-STARTPTS[cover];"
+            f"[0:v]trim=start={frame_seconds},setpts=PTS-STARTPTS[tail];"
+            f"[cover][tail]concat=n=2:v=1:a=0[v]"
+        )
+        cmd = [
+            ffmpeg,
+            "-y",
+            "-i",
+            str(video_path),
+            "-loop",
+            "1",
+            "-i",
+            str(cover_path),
+            "-filter_complex",
+            filter_complex,
+            "-map",
+            "[v]",
+            "-map",
+            "0:a?",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-c:a",
+            "copy",
+            "-movflags",
+            "+faststart",
+            "-shortest",
+            str(output_path),
+        ]
+        subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=600)
+
+    def _video_info(self, video_path: Path) -> tuple[int, int, float]:
+        ffprobe = shutil.which("ffprobe")
+        if not ffprobe:
+            raise RuntimeError("ffprobe not found on PATH")
+        result = subprocess.run(
+            [
+                ffprobe,
+                "-v",
+                "quiet",
+                "-print_format",
+                "json",
+                "-select_streams",
+                "v:0",
+                "-show_streams",
+                str(video_path),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=15,
+        )
+        data = json.loads(result.stdout)
+        stream = data.get("streams", [{}])[0]
+        width = int(stream.get("width") or 1920)
+        height = int(stream.get("height") or 1080)
+        fps_raw = stream.get("avg_frame_rate") or stream.get("r_frame_rate") or "30/1"
+        try:
+            numerator, denominator = fps_raw.split("/", 1)
+            fps = float(numerator) / float(denominator)
+        except Exception:
+            fps = 30.0
+        if fps <= 0:
+            fps = 30.0
+        return width, height, fps

--- a/tools/publishers/publish_packager.py
+++ b/tools/publishers/publish_packager.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import shutil
 import subprocess
 import time
 from datetime import datetime, timezone
+from html import escape
 from pathlib import Path
 from typing import Any
 
@@ -53,6 +55,27 @@ def _copy_file(src: Path, dst: Path) -> Path:
     return dst
 
 
+def _as_file_uri(path: str | None) -> str:
+    if not path:
+        return ""
+    return Path(path).expanduser().resolve().as_uri()
+
+
+def _human_size(size_bytes: Any) -> str:
+    try:
+        size = float(size_bytes)
+    except (TypeError, ValueError):
+        return "0 B"
+    units = ["B", "KB", "MB", "GB", "TB"]
+    for unit in units:
+        if size < 1024 or unit == units[-1]:
+            if unit == "B":
+                return f"{int(size)} {unit}"
+            return f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{int(size_bytes)} B"
+
+
 class PublishPackager(BaseTool):
     name = "publish_packager"
     version = "0.1.0"
@@ -75,6 +98,7 @@ class PublishPackager(BaseTool):
         "copy_cover_asset",
         "replace_video_first_frame_with_cover",
         "write_final_package_manifest",
+        "create_final_package_review_page",
         "verify_duration_delta",
     ]
     best_for = [
@@ -90,10 +114,42 @@ class PublishPackager(BaseTool):
 
     input_schema = {
         "type": "object",
-        "required": ["video_path", "output_dir"],
         "properties": {
+            "operation": {
+                "type": "string",
+                "enum": ["package", "review", "annotate"],
+                "default": "package",
+                "description": "package creates the final package; review creates a local confirmation page; annotate optionally records explicit package review JSON.",
+            },
             "video_path": {"type": "string"},
             "output_dir": {"type": "string"},
+            "manifest_path": {
+                "type": "string",
+                "description": "Path to final_package_manifest.json for review/annotate operations.",
+            },
+            "review_output_dir": {
+                "type": "string",
+                "description": "Directory for final package review artifacts.",
+            },
+            "run_id": {"type": "string"},
+            "language": {
+                "type": "string",
+                "enum": ["auto", "en", "zh"],
+                "default": "auto",
+                "description": "Review UI language. auto detects from script, captions, and package metadata.",
+            },
+            "review_payload": {
+                "type": "object",
+                "description": "Review JSON pasted back from the generated review page.",
+            },
+            "annotations_path": {
+                "type": "string",
+                "description": "Path to review JSON pasted back from the generated review page.",
+            },
+            "review_notes_output_path": {
+                "type": "string",
+                "description": "Optional output path for recorded review notes.",
+            },
             "project_id": {"type": "string"},
             "variant_id": {"type": "string"},
             "channel": {"type": "string"},
@@ -136,10 +192,31 @@ class PublishPackager(BaseTool):
                     "properties": {
                         "path": {"type": "string"},
                         "role": {"type": "string"},
+                        "label": {
+                            "type": "string",
+                            "description": "Optional human-friendly label for the package review page.",
+                        },
                     },
                     "additionalProperties": False,
                 },
                 "description": "Optional sidecar files, such as subtitles, review notes, or metadata.",
+            },
+            "reference_files": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["path", "role"],
+                    "properties": {
+                        "path": {"type": "string"},
+                        "role": {"type": "string"},
+                        "label": {
+                            "type": "string",
+                            "description": "Optional human-friendly label for the package review page.",
+                        },
+                    },
+                    "additionalProperties": False,
+                },
+                "description": "Optional local reference pages/files that should remain at their original path, such as HTML review pages with adjacent assets.",
             },
             "duration_tolerance_seconds": {
                 "type": "number",
@@ -163,8 +240,8 @@ class PublishPackager(BaseTool):
     ]
     side_effects = ["writes final package files and manifest JSON"]
     user_visible_verification = [
-        "Open the packaged video and confirm the first frame, subtitles, and audio sync.",
-        "Review final_package_manifest.json before marking a variant as published.",
+        "Open the packaged video or final package review page and confirm the first frame, subtitles, audio sync, and included sidecars.",
+        "If the package contents are wrong, tell the agent what to fix and rerun packaging.",
     ]
 
     def get_status(self) -> ToolStatus:
@@ -176,9 +253,40 @@ class PublishPackager(BaseTool):
         return 0.0
 
     def dry_run(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        operation = inputs.get("operation", "package")
+        if operation == "review":
+            manifest_path = self._manifest_path(inputs)
+            review_dir = self._review_output_dir(inputs, manifest_path)
+            return {
+                "tool": self.name,
+                "operation": operation,
+                "estimated_cost_usd": 0.0,
+                "estimated_runtime_seconds": 1.0,
+                "status": self.get_status().value,
+                "would_execute": True,
+                "would_write": [
+                    str(review_dir / "final_package_review.json"),
+                    str(review_dir / "final_package_review.md"),
+                    str(review_dir / "final_package_review.html"),
+                ],
+            }
+        if operation == "annotate":
+            manifest_path = self._manifest_path(inputs)
+            return {
+                "tool": self.name,
+                "operation": operation,
+                "estimated_cost_usd": 0.0,
+                "estimated_runtime_seconds": 1.0,
+                "status": self.get_status().value,
+                "would_execute": True,
+                "would_write": [
+                    str(self._review_notes_output_path(inputs, manifest_path)),
+                ],
+            }
         cover_mode = inputs.get("cover_mode", "none")
         return {
             "tool": self.name,
+            "operation": operation,
             "estimated_cost_usd": 0.0,
             "estimated_runtime_seconds": self.estimate_runtime(inputs),
             "status": self.get_status().value,
@@ -196,13 +304,25 @@ class PublishPackager(BaseTool):
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
         start = time.time()
         try:
-            result = self._package(inputs)
+            operation = inputs.get("operation", "package")
+            if operation == "package":
+                result = self._package(inputs)
+            elif operation == "review":
+                result = self._review(inputs)
+            elif operation == "annotate":
+                result = self._annotate(inputs)
+            else:
+                result = ToolResult(success=False, error=f"Unsupported operation: {operation}")
         except Exception as exc:
             result = ToolResult(success=False, error=f"{type(exc).__name__}: {exc}")
         result.duration_seconds = round(time.time() - start, 2)
         return result
 
     def _package(self, inputs: dict[str, Any]) -> ToolResult:
+        if not inputs.get("video_path"):
+            return ToolResult(success=False, error="video_path is required for package")
+        if not inputs.get("output_dir"):
+            return ToolResult(success=False, error="output_dir is required for package")
         video_path = Path(inputs["video_path"]).expanduser().resolve()
         output_dir = Path(inputs["output_dir"]).expanduser().resolve()
         cover_path = (
@@ -256,7 +376,20 @@ class PublishPackager(BaseTool):
                 return ToolResult(success=False, error=f"Extra file not found: {src}")
             dst = output_dir / "sidecars" / src.name
             _copy_file(src, dst)
-            files.append(_file_entry(dst, item["role"]))
+            entry = _file_entry(dst, item["role"])
+            if item.get("label"):
+                entry["label"] = item["label"]
+            files.append(entry)
+
+        references = []
+        for item in inputs.get("reference_files", []) or []:
+            src = Path(item["path"]).expanduser().resolve()
+            if not src.exists():
+                return ToolResult(success=False, error=f"Reference file not found: {src}")
+            entry = _file_entry(src, item["role"])
+            if item.get("label"):
+                entry["label"] = item["label"]
+            references.append(entry)
 
         package_duration = probe_duration(video_out)
         duration_delta = (
@@ -285,6 +418,7 @@ class PublishPackager(BaseTool):
                 "first_frame_verified": None,
             },
             "files": files,
+            "references": references,
             "verification": {
                 "duration_tolerance_seconds": tolerance,
                 "passed": not warnings,
@@ -312,6 +446,11 @@ class PublishPackager(BaseTool):
             if inputs.get("cover_generator"):
                 manifest["cover"]["generator"] = inputs["cover_generator"]
 
+        summary_path = output_dir / "FINAL_PACKAGE.md"
+        summary_path.write_text(self._package_summary_markdown(manifest), encoding="utf-8")
+        files.append(_file_entry(summary_path, "final_package_summary"))
+        manifest["files"] = files
+
         manifest_path = output_dir / "final_package_manifest.json"
         manifest_path.write_text(
             json.dumps(manifest, indent=2, ensure_ascii=False) + "\n",
@@ -323,6 +462,733 @@ class PublishPackager(BaseTool):
             data=manifest,
             artifacts=[str(output_dir), str(manifest_path)],
             error="; ".join(warnings) if warnings else None,
+        )
+
+    def _package_summary_markdown(self, manifest: dict[str, Any]) -> str:
+        lines = [
+            "# Final Package",
+            "",
+            f"- Project: `{manifest.get('project_id') or ''}`",
+            f"- Variant: `{manifest.get('variant_id') or ''}`",
+            f"- Channel: `{manifest.get('channel') or ''}`",
+            f"- Package directory: `{manifest.get('package_dir') or ''}`",
+            f"- Created at: `{manifest.get('created_at') or ''}`",
+            "",
+            "## Video",
+            "",
+            f"- Source: `{(manifest.get('video') or {}).get('source_path') or ''}`",
+            f"- Packaged: `{(manifest.get('video') or {}).get('package_path') or ''}`",
+            f"- Duration: `{(manifest.get('video') or {}).get('duration_seconds')}`",
+            f"- Cover frame written in package: `{(manifest.get('video') or {}).get('cover_first_frame')}`",
+            "",
+        ]
+        cover = manifest.get("cover") or {}
+        if cover:
+            lines.extend(
+                [
+                    "## Cover",
+                    "",
+                    f"- Source: `{cover.get('source_path') or ''}`",
+                    f"- Packaged: `{cover.get('package_path') or ''}`",
+                    f"- Role: `{cover.get('role') or ''}`",
+                    f"- Source kind: `{cover.get('source_kind') or ''}`",
+                    "",
+                ]
+            )
+        lines.extend(["## Files", ""])
+        for item in manifest.get("files") or []:
+            lines.append(
+                f"- `{item.get('role')}` `{item.get('path')}` "
+                f"({item.get('size_bytes')} bytes, sha256 `{item.get('sha256')}`)"
+            )
+        references = manifest.get("references") or []
+        if references:
+            lines.extend(["", "## Reference Pages", ""])
+            for item in references:
+                lines.append(
+                    f"- `{item.get('role')}` `{item.get('path')}` "
+                    f"({item.get('size_bytes')} bytes, sha256 `{item.get('sha256')}`)"
+                )
+        warnings = (manifest.get("verification") or {}).get("warnings") or []
+        lines.extend(
+            [
+                "",
+                "## Verification",
+                "",
+                f"- Passed: `{(manifest.get('verification') or {}).get('passed')}`",
+                f"- Warnings: `{'; '.join(warnings) if warnings else 'none'}`",
+                "",
+            ]
+        )
+        return "\n".join(lines)
+
+    def _manifest_path(self, inputs: dict[str, Any]) -> Path:
+        if inputs.get("manifest_path"):
+            return Path(inputs["manifest_path"]).expanduser().resolve()
+        if inputs.get("output_dir"):
+            return (
+                Path(inputs["output_dir"]).expanduser().resolve()
+                / "final_package_manifest.json"
+            )
+        raise ValueError("manifest_path or output_dir is required")
+
+    def _review_output_dir(self, inputs: dict[str, Any], manifest_path: Path) -> Path:
+        if inputs.get("review_output_dir"):
+            return Path(inputs["review_output_dir"]).expanduser().resolve()
+        return manifest_path.parent / "final-package-review"
+
+    def _review_notes_output_path(
+        self, inputs: dict[str, Any], manifest_path: Path
+    ) -> Path:
+        if inputs.get("review_notes_output_path"):
+            return Path(inputs["review_notes_output_path"]).expanduser().resolve()
+        return manifest_path.with_name("final_package_review_notes.json")
+
+    def _read_manifest(self, manifest_path: Path) -> dict[str, Any]:
+        if not manifest_path.exists():
+            raise FileNotFoundError(f"Final package manifest not found: {manifest_path}")
+        return json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    def _review_payload(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        if inputs.get("review_payload"):
+            return dict(inputs["review_payload"])
+        if inputs.get("annotations_path"):
+            path = Path(inputs["annotations_path"]).expanduser().resolve()
+            return json.loads(path.read_text(encoding="utf-8"))
+        raise ValueError("review_payload or annotations_path is required for annotate")
+
+    def _review(self, inputs: dict[str, Any]) -> ToolResult:
+        manifest_path = self._manifest_path(inputs)
+        manifest = self._read_manifest(manifest_path)
+        review_dir = self._review_output_dir(inputs, manifest_path)
+        review_dir.mkdir(parents=True, exist_ok=True)
+        language = self._detect_review_language(manifest, inputs)
+        run_id = inputs.get("run_id") or self._default_review_run_id(manifest)
+        review_data = {
+            "version": "1.0",
+            "operation": "review",
+            "run_id": run_id,
+            "created_at": _now(),
+            "language": language,
+            "manifest_path": str(manifest_path),
+            "package_dir": manifest.get("package_dir"),
+            "project_id": manifest.get("project_id"),
+            "variant_id": manifest.get("variant_id"),
+            "channel": manifest.get("channel"),
+            "video": manifest.get("video", {}),
+            "cover": manifest.get("cover", {}),
+            "files": manifest.get("files", []),
+            "references": manifest.get("references", []),
+            "verification": manifest.get("verification", {}),
+            "cover_direction": manifest.get("cover_direction"),
+            "cover_policy": manifest.get("cover_policy"),
+            "review_state": self._review_state(manifest),
+        }
+        json_path = review_dir / "final_package_review.json"
+        md_path = review_dir / "final_package_review.md"
+        html_path = review_dir / "final_package_review.html"
+        json_path.write_text(
+            json.dumps(review_data, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        md_path.write_text(self._review_markdown(review_data), encoding="utf-8")
+        html_path.write_text(self._review_html(review_data), encoding="utf-8")
+        return ToolResult(
+            success=True,
+            data={
+                "operation": "review",
+                "run_id": run_id,
+                "language": language,
+                "review_json": str(json_path),
+                "review_markdown": str(md_path),
+                "review_html": str(html_path),
+                "next_step": "Open final_package_review.html. If the package is wrong, tell the agent what to adjust and rerun packaging.",
+            },
+            artifacts=[str(json_path), str(md_path), str(html_path)],
+        )
+
+    def _annotate(self, inputs: dict[str, Any]) -> ToolResult:
+        payload = self._review_payload(inputs)
+        manifest_path = (
+            Path(payload.get("manifest_path")).expanduser().resolve()
+            if payload.get("manifest_path")
+            else self._manifest_path(inputs)
+        )
+        manifest = self._read_manifest(manifest_path)
+        decision = str(payload.get("decision") or "UNREVIEWED").upper()
+        notes = str(payload.get("notes") or "")
+        review_complete = decision == "APPROVED"
+        if decision == "APPROVED":
+            next_operation = "deliver_or_publish"
+        elif decision == "WRONG_PACKAGE":
+            next_operation = "rebuild_package_inputs"
+        else:
+            next_operation = "repackage_final"
+
+        review_notes = {
+            "version": "1.0",
+            "run_id": payload.get("run_id") or self._default_review_run_id(manifest),
+            "saved_at": _now(),
+            "manifest_path": str(manifest_path),
+            "project_id": manifest.get("project_id"),
+            "variant_id": manifest.get("variant_id"),
+            "channel": manifest.get("channel"),
+            "decision": decision,
+            "notes": notes,
+            "reviewer": "human",
+            "review_complete": review_complete,
+            "next_operation": next_operation,
+            "package": {
+                "package_dir": manifest.get("package_dir"),
+                "video_path": (manifest.get("video") or {}).get("package_path"),
+                "cover_path": (manifest.get("cover") or {}).get("package_path"),
+                "verification_passed": (manifest.get("verification") or {}).get("passed"),
+            },
+            "package_manifest": str(manifest_path),
+            "review_payload": payload,
+        }
+        output_path = self._review_notes_output_path(inputs, manifest_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(
+            json.dumps(review_notes, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        md_path = output_path.with_suffix(".md")
+        md_path.write_text(self._annotated_markdown(review_notes), encoding="utf-8")
+        return ToolResult(
+            success=True,
+            data={
+                "operation": "annotate",
+                "decision": decision,
+                "review_complete": review_complete,
+                "next_operation": next_operation,
+                "review_notes": str(output_path),
+                "review_markdown": str(md_path),
+                "package_manifest": str(manifest_path),
+            },
+            artifacts=[str(output_path), str(md_path)],
+        )
+
+    def _default_review_run_id(self, manifest: dict[str, Any]) -> str:
+        parts = [
+            manifest.get("project_id") or "project",
+            manifest.get("channel") or "default",
+            manifest.get("variant_id") or "final",
+            "package-review",
+        ]
+        return "-".join(self._slug(str(part)) for part in parts if part)
+
+    @staticmethod
+    def _slug(value: str) -> str:
+        value = re.sub(r"[^A-Za-z0-9._-]+", "-", value.strip())
+        value = re.sub(r"-{2,}", "-", value).strip("-")
+        return value or "item"
+
+    def _review_state(self, manifest: dict[str, Any]) -> dict[str, Any]:
+        verification = manifest.get("verification") or {}
+        warnings = verification.get("warnings") or []
+        if warnings or verification.get("passed") is False:
+            state = "needs_check"
+        else:
+            state = "ready_for_review"
+        return {
+            "state": state,
+            "file_count": len(manifest.get("files") or []),
+            "has_cover": bool(manifest.get("cover")),
+            "cover_first_frame": bool((manifest.get("video") or {}).get("cover_first_frame")),
+            "verification_passed": verification.get("passed"),
+            "warning_count": len(warnings),
+        }
+
+    def _detect_review_language(
+        self, manifest: dict[str, Any], inputs: dict[str, Any]
+    ) -> str:
+        requested = str(inputs.get("language") or "auto").lower()
+        if requested in {"zh", "en"}:
+            return requested
+        text_parts = [
+            manifest.get("project_id") or "",
+            manifest.get("variant_id") or "",
+            manifest.get("channel") or "",
+            json.dumps(manifest.get("cover_direction") or {}, ensure_ascii=False),
+            json.dumps(manifest.get("cover_policy") or {}, ensure_ascii=False),
+        ]
+        for file_info in (manifest.get("files") or []) + (manifest.get("references") or []):
+            role = str(file_info.get("role") or "").lower()
+            if role in {"captions", "subtitles", "script", "transcript", "narration_map"}:
+                path = Path(str(file_info.get("path") or "")).expanduser()
+                if path.exists() and path.stat().st_size <= 1024 * 1024:
+                    try:
+                        text_parts.append(path.read_text(encoding="utf-8", errors="ignore"))
+                    except OSError:
+                        pass
+        merged = "\n".join(text_parts)
+        return "zh" if re.search(r"[\u4e00-\u9fff]", merged) else "en"
+
+    def _review_labels(self, language: str) -> dict[str, str]:
+        if language == "zh":
+            return {
+                "title": "最终交付包确认",
+                "description": "检查最终视频、封面、附属文件和校验结果。如果内容不对，直接告诉 Agent 需要调整哪里。",
+                "project": "项目",
+                "variant": "版本",
+                "channel": "渠道",
+                "state": "状态",
+                "video": "最终视频",
+                "cover": "封面",
+                "files": "交付文件",
+                "references": "相关页面",
+                "verification": "校验结果",
+                "cover_policy": "封面策略",
+                "confirm_title": "打包内容确认",
+                "wrong_package": "打包目标不准确",
+                "confirm_hint": "如果发现视频、封面或附属文件不对，直接告诉 Agent 需要调整哪里，它会重新打包。",
+                "back_top": "返回顶部",
+                "path": "路径",
+                "copy_path": "复制路径",
+                "path_copied": "路径已复制",
+                "role": "角色",
+                "size": "大小",
+                "sha": "SHA-256",
+                "passed": "通过",
+                "duration": "时长",
+                "cover_first_frame": "封面帧",
+                "warnings": "警告",
+                "none": "无",
+                "no_cover_policy": "未记录封面策略。若脚本 JSON 提供 cover_policy 或 cover_direction，后续会在这里展示。",
+                "yes": "是",
+                "no": "否",
+                "ready_for_review": "待确认",
+                "needs_check": "需检查",
+            }
+        return {
+            "title": "Final Package Confirmation",
+            "description": "Check the final video, cover, sidecar files, and verification result. If anything is wrong, tell the Agent what to adjust.",
+            "project": "Project",
+            "variant": "Variant",
+            "channel": "Channel",
+            "state": "State",
+            "video": "Final video",
+            "cover": "Cover",
+                "files": "Package files",
+                "references": "Reference pages",
+                "verification": "Verification",
+            "cover_policy": "Cover policy",
+            "confirm_title": "Package content check",
+            "wrong_package": "Wrong package target",
+            "confirm_hint": "If the video, cover, or sidecar files are wrong, tell the Agent what to adjust and it will repackage.",
+            "back_top": "Back to top",
+            "path": "Path",
+            "copy_path": "Copy path",
+            "path_copied": "Path copied",
+            "role": "Role",
+            "size": "Size",
+            "sha": "SHA-256",
+            "passed": "Passed",
+            "duration": "Duration",
+            "cover_first_frame": "Cover frame",
+            "warnings": "Warnings",
+            "none": "None",
+            "no_cover_policy": "No cover policy was recorded. Future packages will show cover_policy or cover_direction here when the script JSON provides it.",
+            "yes": "Yes",
+            "no": "No",
+            "ready_for_review": "Ready for review",
+            "needs_check": "Needs check",
+        }
+
+    def _role_label(self, role: str, language: str) -> str:
+        labels = {
+            "zh": {
+                "video": "最终视频",
+                "cover": "封面",
+                "captions": "字幕",
+                "subtitles": "字幕",
+                "script": "脚本",
+                "transcript": "文稿",
+                "visual_timing_review": "Timing QA",
+                "narration_map": "旁白记录",
+                "archive_manifest": "归档说明",
+                "final_package_summary": "交付包说明",
+                "visual_timing_review_page": "Timing QA 页面",
+                "tts_segment_review_page": "旁白试听页面",
+                "narration_review_page": "旁白页面",
+                "variant_review_notes": "版本评审",
+                "final_package_review_notes": "交付评审",
+            },
+            "en": {
+                "video": "Video",
+                "cover": "Cover",
+                "captions": "Captions",
+                "subtitles": "Subtitles",
+                "script": "Script",
+                "transcript": "Transcript",
+                "visual_timing_review": "Timing QA",
+                "narration_map": "Narration map",
+                "archive_manifest": "Archive manifest",
+                "final_package_summary": "Package summary",
+                "visual_timing_review_page": "Timing QA page",
+                "tts_segment_review_page": "Narration audition page",
+                "narration_review_page": "Narration page",
+                "variant_review_notes": "Variant review",
+                "final_package_review_notes": "Package review",
+            },
+        }
+        return labels.get(language, labels["en"]).get(role, role)
+
+    def _state_label(self, state: str, labels: dict[str, str]) -> str:
+        return labels.get(state, state)
+
+    def _bool_label(self, value: Any, labels: dict[str, str]) -> str:
+        if value is True:
+            return labels["yes"]
+        if value is False:
+            return labels["no"]
+        return labels["none"]
+
+    def _review_markdown(self, review_data: dict[str, Any]) -> str:
+        lines = [
+            f"# {self._review_labels(review_data.get('language', 'en'))['title']}: {review_data.get('run_id')}",
+            "",
+            f"- Project: `{review_data.get('project_id') or ''}`",
+            f"- Variant: `{review_data.get('variant_id') or ''}`",
+            f"- Channel: `{review_data.get('channel') or ''}`",
+            f"- Manifest: `{review_data.get('manifest_path')}`",
+            "",
+            "## Files",
+        ]
+        for item in review_data.get("files") or []:
+            lines.append(
+                f"- `{item.get('role')}`: `{item.get('path')}` ({item.get('size_bytes')} bytes)"
+            )
+        references = review_data.get("references") or []
+        if references:
+            lines.extend(["", "## References"])
+            for item in references:
+                lines.append(
+                    f"- `{item.get('role')}`: `{item.get('path')}` ({item.get('size_bytes')} bytes)"
+                )
+        verification = review_data.get("verification") or {}
+        lines.extend(
+            [
+                "",
+                "## Verification",
+                f"- Passed: `{verification.get('passed')}`",
+                f"- Warnings: `{'; '.join(verification.get('warnings') or []) or 'none'}`",
+                "",
+                "If the package contents are wrong, tell the agent what to adjust and rerun packaging.",
+            ]
+        )
+        return "\n".join(lines) + "\n"
+
+    def _annotated_markdown(self, review_notes: dict[str, Any]) -> str:
+        return "\n".join(
+            [
+                f"# Final Package Review Notes: {review_notes.get('run_id')}",
+                "",
+                f"- Decision: `{review_notes.get('decision')}`",
+                f"- Review complete: `{review_notes.get('review_complete')}`",
+                f"- Next operation: `{review_notes.get('next_operation')}`",
+                f"- Package manifest: `{review_notes.get('package_manifest')}`",
+                "",
+                "## Notes",
+                review_notes.get("notes") or "",
+                "",
+            ]
+        )
+
+    def _review_html(self, review_data: dict[str, Any]) -> str:
+        language = review_data.get("language") or "en"
+        labels = self._review_labels(language)
+        payload = json.dumps(review_data, ensure_ascii=False)
+        script_payload = (
+            payload.replace("&", "\\u0026")
+            .replace("<", "\\u003c")
+            .replace(">", "\\u003e")
+        )
+        video = review_data.get("video") or {}
+        cover = review_data.get("cover") or {}
+        verification = review_data.get("verification") or {}
+        video_src = _as_file_uri(video.get("package_path"))
+        cover_src = _as_file_uri(cover.get("package_path"))
+        warnings = verification.get("warnings") or []
+        warning_text = "; ".join(str(item) for item in warnings) or labels["none"]
+        files_html = "\n".join(
+            self._file_row_html(item, labels) for item in review_data.get("files") or []
+        )
+        references_html = "\n".join(
+            self._file_row_html(item, labels) for item in review_data.get("references") or []
+        )
+        cover_policy = review_data.get("cover_policy") or {}
+        cover_direction = review_data.get("cover_direction") or {}
+        policy_text = json.dumps(
+            {"cover_policy": cover_policy, "cover_direction": cover_direction},
+            ensure_ascii=False,
+            indent=2,
+        )
+        if not cover_policy and not cover_direction:
+            policy_text = labels["no_cover_policy"]
+        duration = video.get("duration_seconds")
+        duration_text = f"{float(duration):.2f}s" if isinstance(duration, (int, float)) else labels["none"]
+        return f"""<!doctype html>
+<html lang="{escape(language)}">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>{escape(labels["title"])}</title>
+<style>
+:root {{
+  color-scheme: dark;
+  --bg: #07111f;
+  --panel: #101b2b;
+  --panel2: #0b1423;
+  --line: #29405f;
+  --text: #eef6ff;
+  --muted: #aab8cd;
+  --cyan: #45d7ff;
+  --green: #55d99f;
+  --warn: #ffce4a;
+}}
+* {{ box-sizing: border-box; }}
+body {{
+  margin: 0;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at 30% 0%, rgba(69,215,255,.13), transparent 34%), var(--bg);
+  color: var(--text);
+}}
+main {{ width: min(1120px, calc(100vw - 48px)); margin: 0 auto; padding: 36px 0 80px; }}
+.hero, .card {{
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: linear-gradient(180deg, rgba(18,31,49,.95), rgba(10,18,31,.94));
+  box-shadow: 0 18px 60px rgba(0,0,0,.28);
+}}
+.hero {{ padding: 28px; margin-bottom: 24px; }}
+h1 {{ margin: 0 0 10px; font-size: clamp(32px, 5vw, 54px); letter-spacing: 0; }}
+p {{ color: var(--muted); line-height: 1.65; }}
+.pills {{ display: flex; flex-wrap: wrap; gap: 12px; margin-top: 22px; }}
+.pill {{
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 10px 14px;
+  color: var(--muted);
+  background: rgba(255,255,255,.03);
+}}
+.pill strong {{ color: var(--text); }}
+.grid {{ display: grid; grid-template-columns: 1.45fr .9fr; gap: 20px; align-items: start; }}
+.card {{ padding: 22px; margin-bottom: 20px; }}
+h2 {{ margin: 0 0 16px; font-size: 24px; letter-spacing: 0; }}
+video, img.cover {{
+  width: 100%;
+  display: block;
+  border-radius: 14px;
+  border: 1px solid rgba(255,255,255,.12);
+  background: #020712;
+}}
+video {{ max-height: 64vh; }}
+.metric-grid {{ display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }}
+.metric {{
+  min-height: 86px;
+  border: 1px solid rgba(255,255,255,.1);
+  border-radius: 16px;
+  padding: 14px;
+  background: rgba(255,255,255,.035);
+}}
+.metric span {{
+  display: block;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.35;
+  margin-bottom: 10px;
+}}
+.metric strong {{
+  display: block;
+  color: var(--text);
+  font-size: 22px;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+}}
+.metric.ok strong {{ color: var(--green); }}
+.metric.warn strong {{ color: var(--warn); }}
+table {{ width: 100%; border-collapse: collapse; color: var(--muted); }}
+th, td {{ padding: 11px 8px; border-bottom: 1px solid rgba(255,255,255,.08); text-align: left; vertical-align: top; }}
+th {{ color: var(--text); font-weight: 700; }}
+td.path {{ overflow-wrap: anywhere; max-width: 420px; }}
+pre {{
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  color: var(--muted);
+  background: rgba(0,0,0,.22);
+  border: 1px solid rgba(255,255,255,.1);
+  border-radius: 14px;
+  padding: 16px;
+}}
+button {{
+  border: 0;
+  border-radius: 999px;
+  padding: 15px 24px;
+  color: #06111f;
+  font-weight: 800;
+  font-size: 18px;
+  background: linear-gradient(135deg, #62dcff, #54d68f);
+  cursor: pointer;
+}}
+.hint {{ color: var(--muted); }}
+.confirm-note {{
+  border: 1px solid rgba(69,215,255,.32);
+  border-radius: 16px;
+  padding: 14px 16px;
+  background: rgba(69,215,255,.1);
+  color: var(--muted);
+  line-height: 1.6;
+}}
+.copy-path {{
+  margin-left: 8px;
+  width: 30px;
+  height: 30px;
+  display: inline-grid;
+  place-items: center;
+  border: 1px solid rgba(69,215,255,.28);
+  border-radius: 50%;
+  padding: 0;
+  color: var(--cyan);
+  background: rgba(69,215,255,.08);
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  vertical-align: middle;
+}}
+.copy-path:hover {{
+  border-color: rgba(69,215,255,.62);
+  background: rgba(69,215,255,.16);
+}}
+.top-button {{
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  display: none;
+  z-index: 10;
+}}
+.top-button.show {{ display: inline-flex; }}
+@media (max-width: 860px) {{
+  main {{ width: min(100vw - 28px, 1120px); padding-top: 22px; }}
+  .grid {{ grid-template-columns: 1fr; }}
+  .metric-grid {{ grid-template-columns: 1fr; }}
+}}
+</style>
+</head>
+<body>
+<main id="top">
+  <section class="hero">
+    <h1>{escape(labels["title"])}</h1>
+    <p>{escape(labels["description"])}</p>
+    <div class="pills">
+      <span class="pill">{escape(labels["project"])}: <strong>{escape(str(review_data.get("project_id") or ""))}</strong></span>
+      <span class="pill">{escape(labels["variant"])}: <strong>{escape(str(review_data.get("variant_id") or ""))}</strong></span>
+      <span class="pill">{escape(labels["channel"])}: <strong>{escape(str(review_data.get("channel") or ""))}</strong></span>
+    </div>
+  </section>
+
+  <section class="grid">
+    <div>
+      <section class="card">
+        <h2>{escape(labels["video"])}</h2>
+        <video controls preload="metadata" src="{escape(video_src, quote=True)}"></video>
+      </section>
+      <section class="card">
+        <h2>{escape(labels["files"])}</h2>
+        <table>
+          <thead><tr><th>{escape(labels["role"])}</th><th>{escape(labels["path"])}</th><th>{escape(labels["size"])}</th><th>{escape(labels["sha"])}</th></tr></thead>
+          <tbody>{files_html}</tbody>
+        </table>
+      </section>
+      {f'''<section class="card">
+        <h2>{escape(labels["references"])}</h2>
+        <table>
+          <thead><tr><th>{escape(labels["role"])}</th><th>{escape(labels["path"])}</th><th>{escape(labels["size"])}</th><th>{escape(labels["sha"])}</th></tr></thead>
+          <tbody>{references_html}</tbody>
+        </table>
+      </section>''' if references_html else ""}
+    </div>
+    <div>
+      <section class="card">
+        <h2>{escape(labels["cover"])}</h2>
+        {f'<img class="cover" src="{escape(cover_src, quote=True)}" alt="cover" />' if cover_src else f'<p>{escape(labels["none"])}</p>'}
+      </section>
+      <section class="card">
+        <h2>{escape(labels["verification"])}</h2>
+        <div class="metric-grid">
+          <div class="metric ok"><span>{escape(labels["passed"])}</span><strong>{escape(self._bool_label(verification.get("passed"), labels))}</strong></div>
+          <div class="metric"><span>{escape(labels["duration"])}</span><strong>{escape(duration_text)}</strong></div>
+          <div class="metric"><span>{escape(labels["cover_first_frame"])}</span><strong>{escape(self._bool_label(video.get("cover_first_frame"), labels))}</strong></div>
+          <div class="metric warn"><span>{escape(labels["warnings"])}</span><strong>{escape(warning_text)}</strong></div>
+        </div>
+      </section>
+      <section class="card">
+        <h2>{escape(labels["cover_policy"])}</h2>
+        <pre>{escape(policy_text)}</pre>
+      </section>
+      <section class="card">
+        <h2>{escape(labels["confirm_title"])}</h2>
+        <p class="confirm-note">{escape(labels["confirm_hint"])}</p>
+      </section>
+    </div>
+  </section>
+</main>
+<button type="button" class="top-button" id="top-button">{escape(labels["back_top"])}</button>
+<script id="review-data" type="application/json">{script_payload}</script>
+<script>
+(() => {{
+  const reviewData = JSON.parse(document.getElementById('review-data').textContent);
+  const pathCopied = {json.dumps(labels["path_copied"], ensure_ascii=False)};
+  document.querySelectorAll('[data-copy-path]').forEach((button) => {{
+    button.addEventListener('click', async () => {{
+      const value = button.getAttribute('data-copy-path') || '';
+      const original = button.textContent;
+      try {{
+        await navigator.clipboard.writeText(value);
+        button.setAttribute('aria-label', pathCopied);
+        button.textContent = '✓';
+        setTimeout(() => {{
+          button.textContent = original;
+          button.setAttribute('aria-label', original);
+        }}, 1400);
+      }} catch (error) {{
+        window.prompt('Copy path', value);
+      }}
+    }});
+  }});
+  const topButton = document.getElementById('top-button');
+  window.addEventListener('scroll', () => {{
+    topButton.classList.toggle('show', window.scrollY > 600);
+  }});
+  topButton.addEventListener('click', () => window.scrollTo({{ top: 0, behavior: 'smooth' }}));
+}})();
+</script>
+</body>
+</html>
+"""
+
+    def _file_row_html(self, item: dict[str, Any], labels: dict[str, str]) -> str:
+        path = str(item.get("path") or "")
+        uri = _as_file_uri(path) if path else ""
+        file_name = Path(path).name if path else labels["none"]
+        path_html = (
+            f'<a href="{escape(uri, quote=True)}" title="{escape(path, quote=True)}">{escape(file_name)}</a>'
+            f'<button type="button" class="copy-path" data-copy-path="{escape(path, quote=True)}" aria-label="{escape(labels["copy_path"], quote=True)}" title="{escape(labels["copy_path"], quote=True)}">⧉</button>'
+            if uri
+            else escape(file_name)
+        )
+        sha = str(item.get("sha256") or "")
+        language = "zh" if labels.get("yes") == "是" else "en"
+        role = str(item.get("role") or "")
+        role_label = str(item.get("label") or self._role_label(role, language))
+        return (
+            "<tr>"
+            f"<td>{escape(role_label)}</td>"
+            f"<td class=\"path\">{path_html}</td>"
+            f"<td>{escape(_human_size(item.get('size_bytes') or 0))}</td>"
+            f"<td>{escape(sha[:12])}</td>"
+            "</tr>"
         )
 
     def _cover_metadata(

--- a/tools/publishers/publish_packager.py
+++ b/tools/publishers/publish_packager.py
@@ -101,6 +101,7 @@ class PublishPackager(BaseTool):
         "create_final_package_review_page",
         "verify_duration_delta",
         "verify_audio_is_not_silent",
+        "verify_timing_qa_reference",
     ]
     best_for = [
         "turning an approved render into a publish-ready final package",
@@ -229,6 +230,11 @@ class PublishPackager(BaseTool):
                 "default": -60.0,
                 "description": "Minimum allowed mean volume when an audio stream exists. Lower values are treated as effectively silent.",
             },
+            "require_timing_qa": {
+                "type": "boolean",
+                "default": False,
+                "description": "Require a visual timing QA reference file/page before final packaging can pass.",
+            },
             "overwrite": {"type": "boolean", "default": False},
         },
     }
@@ -343,6 +349,7 @@ class PublishPackager(BaseTool):
         overwrite = bool(inputs.get("overwrite", False))
         tolerance = float(inputs.get("duration_tolerance_seconds", 0.15))
         audio_threshold = float(inputs.get("audio_min_mean_volume_db", -60.0))
+        require_timing_qa = bool(inputs.get("require_timing_qa", False))
 
         if not video_path.exists():
             return ToolResult(success=False, error=f"Video not found: {video_path}")
@@ -412,6 +419,13 @@ class PublishPackager(BaseTool):
         audio_check = self._audio_loudness_check(video_out, audio_threshold)
         if audio_check.get("status") == "failed":
             warnings.append(str(audio_check.get("message") or "Audio loudness check failed"))
+        timing_qa_check = self._timing_qa_check(
+            files,
+            references,
+            required=require_timing_qa,
+        )
+        if timing_qa_check.get("status") == "missing_required":
+            warnings.append(str(timing_qa_check["message"]))
 
         manifest: dict[str, Any] = {
             "version": "1.0",
@@ -433,6 +447,7 @@ class PublishPackager(BaseTool):
                 "duration_tolerance_seconds": tolerance,
                 "audio_min_mean_volume_db": audio_threshold,
                 "audio": audio_check,
+                "timing_qa": timing_qa_check,
                 "passed": not warnings,
                 "warnings": warnings,
             },
@@ -538,6 +553,14 @@ class PublishPackager(BaseTool):
                     f"- Audio check: `{audio.get('status')}`",
                     f"- Audio mean volume: `{audio.get('mean_volume_db')}`",
                     f"- Audio max volume: `{audio.get('max_volume_db')}`",
+                ]
+            )
+        timing_qa = (manifest.get("verification") or {}).get("timing_qa") or {}
+        if timing_qa:
+            lines.extend(
+                [
+                    f"- Timing QA: `{timing_qa.get('status')}`",
+                    f"- Timing QA references: `{timing_qa.get('reference_count')}`",
                 ]
             )
         lines.append("")
@@ -777,6 +800,7 @@ class PublishPackager(BaseTool):
                 "warnings": "警告",
                 "audio": "音频",
                 "audio_mean": "平均音量",
+                "timing_qa": "Timing QA",
                 "none": "无",
                 "no_cover_policy": "未记录封面策略。若脚本 JSON 提供 cover_policy 或 cover_direction，后续会在这里展示。",
                 "yes": "是",
@@ -813,6 +837,7 @@ class PublishPackager(BaseTool):
             "warnings": "Warnings",
             "audio": "Audio",
             "audio_mean": "Mean volume",
+            "timing_qa": "Timing QA",
             "none": "None",
             "no_cover_policy": "No cover policy was recorded. Future packages will show cover_policy or cover_direction here when the script JSON provides it.",
             "yes": "Yes",
@@ -893,12 +918,14 @@ class PublishPackager(BaseTool):
                     f"- `{item.get('role')}`: `{item.get('path')}` ({item.get('size_bytes')} bytes)"
                 )
         verification = review_data.get("verification") or {}
+        timing_qa = verification.get("timing_qa") or {}
         lines.extend(
             [
                 "",
                 "## Verification",
                 f"- Passed: `{verification.get('passed')}`",
                 f"- Warnings: `{'; '.join(verification.get('warnings') or []) or 'none'}`",
+                f"- Timing QA: `{timing_qa.get('status') or 'none'}`",
                 "",
                 "If the package contents are wrong, tell the agent what to adjust and rerun packaging.",
             ]
@@ -938,7 +965,9 @@ class PublishPackager(BaseTool):
         warnings = verification.get("warnings") or []
         warning_text = "; ".join(str(item) for item in warnings) or labels["none"]
         audio = verification.get("audio") or {}
+        timing_qa = verification.get("timing_qa") or {}
         audio_status = str(audio.get("status") or labels["none"])
+        timing_qa_status = str(timing_qa.get("status") or labels["none"])
         mean_volume = audio.get("mean_volume_db")
         audio_mean_text = (
             f"{float(mean_volume):.1f} dB"
@@ -1155,6 +1184,7 @@ button {{
           <div class="metric"><span>{escape(labels["cover_first_frame"])}</span><strong>{escape(self._bool_label(video.get("cover_first_frame"), labels))}</strong></div>
           <div class="metric"><span>{escape(labels["audio"])}</span><strong>{escape(audio_status)}</strong></div>
           <div class="metric"><span>{escape(labels["audio_mean"])}</span><strong>{escape(audio_mean_text)}</strong></div>
+          <div class="metric"><span>{escape(labels["timing_qa"])}</span><strong>{escape(timing_qa_status)}</strong></div>
           <div class="metric warn"><span>{escape(labels["warnings"])}</span><strong>{escape(warning_text)}</strong></div>
         </div>
       </section>
@@ -1334,6 +1364,49 @@ button {{
                 f"threshold {min_mean_volume_db} dB; the packaged video may be silent."
             )
         return check
+
+    def _timing_qa_check(
+        self,
+        files: list[dict[str, Any]],
+        references: list[dict[str, Any]],
+        *,
+        required: bool,
+    ) -> dict[str, Any]:
+        timing_roles = {
+            "visual_timing_review",
+            "visual_timing_review_page",
+            "visual_timing_annotated_review",
+            "visual_timing_notes",
+            "timing_qa",
+            "timing_qa_page",
+            "timing_qa_notes",
+        }
+        matches = [
+            item
+            for item in [*files, *references]
+            if str(item.get("role") or "").lower() in timing_roles
+        ]
+        if matches:
+            return {
+                "status": "passed",
+                "required": required,
+                "reference_count": len(matches),
+                "roles": [str(item.get("role") or "") for item in matches],
+                "paths": [str(item.get("path") or "") for item in matches],
+            }
+        if required:
+            return {
+                "status": "missing_required",
+                "required": True,
+                "reference_count": 0,
+                "message": "Timing QA reference is required before final packaging can pass.",
+            }
+        return {
+            "status": "not_provided",
+            "required": False,
+            "reference_count": 0,
+            "message": "No Timing QA reference was attached to this final package.",
+        }
 
     def _replace_first_frame(self, video_path: Path, cover_path: Path, output_path: Path) -> None:
         ffmpeg = shutil.which("ffmpeg")

--- a/tools/publishers/publish_packager.py
+++ b/tools/publishers/publish_packager.py
@@ -100,6 +100,7 @@ class PublishPackager(BaseTool):
         "write_final_package_manifest",
         "create_final_package_review_page",
         "verify_duration_delta",
+        "verify_audio_is_not_silent",
     ]
     best_for = [
         "turning an approved render into a publish-ready final package",
@@ -223,6 +224,11 @@ class PublishPackager(BaseTool):
                 "default": 0.15,
                 "description": "Allowed duration delta after packaging.",
             },
+            "audio_min_mean_volume_db": {
+                "type": "number",
+                "default": -60.0,
+                "description": "Minimum allowed mean volume when an audio stream exists. Lower values are treated as effectively silent.",
+            },
             "overwrite": {"type": "boolean", "default": False},
         },
     }
@@ -336,6 +342,7 @@ class PublishPackager(BaseTool):
         ).get("first_frame_mode", "none")
         overwrite = bool(inputs.get("overwrite", False))
         tolerance = float(inputs.get("duration_tolerance_seconds", 0.15))
+        audio_threshold = float(inputs.get("audio_min_mean_volume_db", -60.0))
 
         if not video_path.exists():
             return ToolResult(success=False, error=f"Video not found: {video_path}")
@@ -402,6 +409,9 @@ class PublishPackager(BaseTool):
             warnings.append(
                 f"Duration delta {duration_delta}s exceeds tolerance {tolerance}s"
             )
+        audio_check = self._audio_loudness_check(video_out, audio_threshold)
+        if audio_check.get("status") == "failed":
+            warnings.append(str(audio_check.get("message") or "Audio loudness check failed"))
 
         manifest: dict[str, Any] = {
             "version": "1.0",
@@ -421,6 +431,8 @@ class PublishPackager(BaseTool):
             "references": references,
             "verification": {
                 "duration_tolerance_seconds": tolerance,
+                "audio_min_mean_volume_db": audio_threshold,
+                "audio": audio_check,
                 "passed": not warnings,
                 "warnings": warnings,
             },
@@ -517,9 +529,18 @@ class PublishPackager(BaseTool):
                 "",
                 f"- Passed: `{(manifest.get('verification') or {}).get('passed')}`",
                 f"- Warnings: `{'; '.join(warnings) if warnings else 'none'}`",
-                "",
             ]
         )
+        audio = (manifest.get("verification") or {}).get("audio") or {}
+        if audio:
+            lines.extend(
+                [
+                    f"- Audio check: `{audio.get('status')}`",
+                    f"- Audio mean volume: `{audio.get('mean_volume_db')}`",
+                    f"- Audio max volume: `{audio.get('max_volume_db')}`",
+                ]
+            )
+        lines.append("")
         return "\n".join(lines)
 
     def _manifest_path(self, inputs: dict[str, Any]) -> Path:
@@ -754,6 +775,8 @@ class PublishPackager(BaseTool):
                 "duration": "时长",
                 "cover_first_frame": "封面帧",
                 "warnings": "警告",
+                "audio": "音频",
+                "audio_mean": "平均音量",
                 "none": "无",
                 "no_cover_policy": "未记录封面策略。若脚本 JSON 提供 cover_policy 或 cover_direction，后续会在这里展示。",
                 "yes": "是",
@@ -788,6 +811,8 @@ class PublishPackager(BaseTool):
             "duration": "Duration",
             "cover_first_frame": "Cover frame",
             "warnings": "Warnings",
+            "audio": "Audio",
+            "audio_mean": "Mean volume",
             "none": "None",
             "no_cover_policy": "No cover policy was recorded. Future packages will show cover_policy or cover_direction here when the script JSON provides it.",
             "yes": "Yes",
@@ -912,6 +937,14 @@ class PublishPackager(BaseTool):
         cover_src = _as_file_uri(cover.get("package_path"))
         warnings = verification.get("warnings") or []
         warning_text = "; ".join(str(item) for item in warnings) or labels["none"]
+        audio = verification.get("audio") or {}
+        audio_status = str(audio.get("status") or labels["none"])
+        mean_volume = audio.get("mean_volume_db")
+        audio_mean_text = (
+            f"{float(mean_volume):.1f} dB"
+            if isinstance(mean_volume, (int, float))
+            else labels["none"]
+        )
         files_html = "\n".join(
             self._file_row_html(item, labels) for item in review_data.get("files") or []
         )
@@ -1120,6 +1153,8 @@ button {{
           <div class="metric ok"><span>{escape(labels["passed"])}</span><strong>{escape(self._bool_label(verification.get("passed"), labels))}</strong></div>
           <div class="metric"><span>{escape(labels["duration"])}</span><strong>{escape(duration_text)}</strong></div>
           <div class="metric"><span>{escape(labels["cover_first_frame"])}</span><strong>{escape(self._bool_label(video.get("cover_first_frame"), labels))}</strong></div>
+          <div class="metric"><span>{escape(labels["audio"])}</span><strong>{escape(audio_status)}</strong></div>
+          <div class="metric"><span>{escape(labels["audio_mean"])}</span><strong>{escape(audio_mean_text)}</strong></div>
           <div class="metric warn"><span>{escape(labels["warnings"])}</span><strong>{escape(warning_text)}</strong></div>
         </div>
       </section>
@@ -1204,6 +1239,101 @@ button {{
         except json.JSONDecodeError:
             return None, None
         return script.get("cover_direction"), script.get("cover_policy")
+
+    def _audio_loudness_check(self, video_path: Path, min_mean_volume_db: float) -> dict[str, Any]:
+        ffprobe = shutil.which("ffprobe")
+        ffmpeg = shutil.which("ffmpeg")
+        if not ffprobe or not ffmpeg:
+            return {
+                "status": "skipped",
+                "reason": "ffprobe or ffmpeg not found",
+                "threshold_mean_volume_db": min_mean_volume_db,
+            }
+
+        try:
+            probe = subprocess.run(
+                [
+                    ffprobe,
+                    "-v",
+                    "quiet",
+                    "-print_format",
+                    "json",
+                    "-select_streams",
+                    "a",
+                    "-show_streams",
+                    str(video_path),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            streams = json.loads(probe.stdout or "{}").get("streams") or []
+        except Exception:
+            return {
+                "status": "skipped",
+                "reason": "audio stream probe failed",
+                "threshold_mean_volume_db": min_mean_volume_db,
+            }
+        if not streams:
+            return {
+                "status": "skipped",
+                "reason": "no audio stream",
+                "has_audio_stream": False,
+                "threshold_mean_volume_db": min_mean_volume_db,
+            }
+
+        try:
+            result = subprocess.run(
+                [
+                    ffmpeg,
+                    "-hide_banner",
+                    "-i",
+                    str(video_path),
+                    "-af",
+                    "volumedetect",
+                    "-f",
+                    "null",
+                    "-",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=180,
+            )
+        except subprocess.TimeoutExpired:
+            return {
+                "status": "skipped",
+                "reason": "volumedetect timed out",
+                "has_audio_stream": True,
+                "threshold_mean_volume_db": min_mean_volume_db,
+            }
+
+        stderr = result.stderr or ""
+        mean_match = re.search(r"mean_volume:\s*(-?[\d.]+)\s*dB", stderr)
+        max_match = re.search(r"max_volume:\s*(-?[\d.]+)\s*dB", stderr)
+        if not mean_match:
+            return {
+                "status": "skipped",
+                "reason": "volumedetect did not report mean volume",
+                "has_audio_stream": True,
+                "threshold_mean_volume_db": min_mean_volume_db,
+            }
+
+        mean_volume = float(mean_match.group(1))
+        max_volume = float(max_match.group(1)) if max_match else None
+        passed = mean_volume > min_mean_volume_db
+        check = {
+            "status": "passed" if passed else "failed",
+            "has_audio_stream": True,
+            "mean_volume_db": mean_volume,
+            "max_volume_db": max_volume,
+            "threshold_mean_volume_db": min_mean_volume_db,
+        }
+        if not passed:
+            check["message"] = (
+                f"Audio mean volume {mean_volume} dB is at or below "
+                f"threshold {min_mean_volume_db} dB; the packaged video may be silent."
+            )
+        return check
 
     def _replace_first_frame(self, video_path: Path, cover_path: Path, output_path: Path) -> None:
         ffmpeg = shutil.which("ffmpeg")


### PR DESCRIPTION
## Summary

- add `cover_policy` and `cover_direction` metadata to script artifacts so cover/poster needs are decided during planning, not bolted on at the end
- add a `publish_packager` tool for packaging final deliverables, copying sidecars, recording checksums, and optionally replacing the first video frame with the selected cover without prepending extra time
- add `final_package_manifest` to record final package files, cover provenance, duration verification, and cover policy/direction audit metadata
- wire the helper into explainer and screen-demo publish-stage docs and pipeline definitions

## Why

OpenMontage already has a publish stage and `publish_log`, but there is no small local helper for assembling a final deliverable package or preserving the reasoning behind cover/first-frame choices. This keeps the change scoped to publish prep rather than adding a parallel "finalizer" stage.

The cover metadata is intentionally provider-neutral: covers can come from rendered frames, generated images, generated video frames, source footage, or manual design.

## Tests

- `.venv/bin/python -m pytest tests/tools/test_publish_packager.py -q`
