### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,12 @@ PEXELS_API_KEY=              # Pexels stock footage/images (free)
 PIXABAY_API_KEY=             # Pixabay stock footage/images (free)
 UNSPLASH_ACCESS_KEY=         # Unsplash stock images (free developer key)
 
+# --- Astraflow (UCloud) ---
+ASTRAFLOW_API_KEY=          # Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (global endpoint)
+                             # Get one at https://astraflow.ucloud-global.com
+ASTRAFLOW_CN_API_KEY=       # Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (China endpoint)
+                             # Get one at https://astraflow.ucloud.cn
+
 # --- Analysis ---
 HF_TOKEN=                    # HuggingFace token — enables speaker diarization in transcriber
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 # OpenMontage - Global Configuration
 
 llm:
-  provider: anthropic            # anthropic | openai | gemini | openrouter | ollama | mistral | minimax
+  provider: anthropic            # anthropic | openai | gemini | openrouter | ollama | mistral | minimax | astraflow | astraflow-cn
   model: null                    # null = use provider default
   temperature: 0.7
   max_tokens: 4096

--- a/lib/providers/__init__.py
+++ b/lib/providers/__init__.py
@@ -1,0 +1,85 @@
+"""LLM provider routing for OpenMontage.
+
+Supported providers and their OpenAI-compatible base URLs / env vars:
+
+  anthropic       ANTHROPIC_API_KEY   (native SDK)
+  openai          OPENAI_API_KEY      https://api.openai.com/v1
+  gemini          GOOGLE_API_KEY      (native SDK)
+  openrouter      OPENROUTER_API_KEY  https://openrouter.ai/api/v1
+  ollama          (no key)            http://localhost:11434/v1
+  mistral         MISTRAL_API_KEY     https://api.mistral.ai/v1
+  minimax         MINIMAX_API_KEY     https://api.minimax.chat/v1
+  astraflow       ASTRAFLOW_API_KEY   https://api-us-ca.umodelverse.ai/v1
+  astraflow-cn    ASTRAFLOW_CN_API_KEY https://api.modelverse.cn/v1
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+
+# Registry of OpenAI-compatible provider configurations.
+# Each entry: (base_url, env_var_name)
+OPENAI_COMPATIBLE_PROVIDERS: dict[str, tuple[str, str]] = {
+    "openai":        ("https://api.openai.com/v1",              "OPENAI_API_KEY"),
+    "openrouter":    ("https://openrouter.ai/api/v1",           "OPENROUTER_API_KEY"),
+    "ollama":        ("http://localhost:11434/v1",               ""),
+    "mistral":       ("https://api.mistral.ai/v1",              "MISTRAL_API_KEY"),
+    "minimax":       ("https://api.minimax.chat/v1",            "MINIMAX_API_KEY"),
+    "astraflow":     ("https://api-us-ca.umodelverse.ai/v1",    "ASTRAFLOW_API_KEY"),
+    "astraflow-cn":  ("https://api.modelverse.cn/v1",           "ASTRAFLOW_CN_API_KEY"),
+}
+
+
+def get_provider_config(provider: str) -> dict[str, Any]:
+    """Return base_url and api_key for the given provider name.
+
+    For OpenAI-compatible providers, returns:
+        {"base_url": str, "api_key": str}
+
+    For native-SDK providers (anthropic, gemini), returns:
+        {"api_key": str}
+
+    Raises ValueError if the provider is unknown.
+    Raises EnvironmentError if the required API key env var is not set.
+    """
+    provider = provider.lower().strip()
+
+    if provider in OPENAI_COMPATIBLE_PROVIDERS:
+        base_url, env_var = OPENAI_COMPATIBLE_PROVIDERS[provider]
+        api_key: Optional[str] = None
+        if env_var:
+            api_key = os.environ.get(env_var)
+            if not api_key:
+                raise EnvironmentError(
+                    f"Provider {provider!r} requires env var {env_var!r} to be set."
+                )
+        return {"base_url": base_url, "api_key": api_key or ""}
+
+    if provider == "anthropic":
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            raise EnvironmentError(
+                "Provider 'anthropic' requires env var 'ANTHROPIC_API_KEY' to be set."
+            )
+        return {"api_key": api_key}
+
+    if provider == "gemini":
+        api_key = os.environ.get("GOOGLE_API_KEY")
+        if not api_key:
+            raise EnvironmentError(
+                "Provider 'gemini' requires env var 'GOOGLE_API_KEY' to be set."
+            )
+        return {"api_key": api_key}
+
+    raise ValueError(
+        f"Unknown LLM provider: {provider!r}. "
+        f"Supported: anthropic, gemini, "
+        + ", ".join(OPENAI_COMPATIBLE_PROVIDERS)
+    )
+
+
+def is_openai_compatible(provider: str) -> bool:
+    """Return True if the provider uses the OpenAI-compatible API."""
+    return provider.lower().strip() in OPENAI_COMPATIBLE_PROVIDERS


### PR DESCRIPTION
## Summary

Adds **Astraflow** (by UCloud / 优刻得) as a supported LLM provider.

Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models, available via a global endpoint and a China endpoint.

### Changes

- **`config.yaml`** — adds `astraflow` and `astraflow-cn` to the `llm.provider` comment so users know these are valid choices
- **`.env.example`** — documents `ASTRAFLOW_API_KEY` (global) and `ASTRAFLOW_CN_API_KEY` (China) with sign-up links
- **`lib/providers/__init__.py`** — implements `get_provider_config()` and `is_openai_compatible()` helpers that route all supported providers (including the new Astraflow entries) to their correct `base_url` / API-key env var

### Provider details

| Variant | Env var | Base URL |
|---|---|---|
| `astraflow` (global) | `ASTRAFLOW_API_KEY` | `https://api-us-ca.umodelverse.ai/v1` |
| `astraflow-cn` (China) | `ASTRAFLOW_CN_API_KEY` | `https://api.modelverse.cn/v1` |

- Sign up (global): https://astraflow.ucloud-global.com  
- Sign up (China): https://astraflow.ucloud.cn

Because Astraflow is fully OpenAI-compatible, no new SDK is required — only `base_url` + `api_key` need to be set, exactly like OpenRouter or Mistral.
