### PR TITLE
feat(tts): add modern OpenAI audio providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ SUNO_API_KEY=your-key          # Full songs, instrumentals, any genre
 
 # Voice & images:
 ELEVENLABS_API_KEY=your-key    # Premium TTS, AI music, sound effects
-OPENAI_API_KEY=your-key        # OpenAI TTS, DALL-E 3 images
+OPENAI_API_KEY=your-key        # OpenAI TTS/audio-output narration, DALL-E 3 images
 XAI_API_KEY=your-key           # xAI Grok image edits/generation + Grok video generation
 GOOGLE_API_KEY=your-key        # Google Imagen images, Google TTS (700+ voices)
 
@@ -446,13 +446,14 @@ Each tool declares which Layer 3 skills it relies on. The agent reads Layer 1 to
 </details>
 
 <details>
-<summary><strong>Text-to-Speech — 4 providers</strong></summary>
+<summary><strong>Text-to-Speech — 5 providers</strong></summary>
 
 | Provider | Type | Notes |
 |----------|------|-------|
 | **ElevenLabs** | Cloud API | Premium voice quality |
 | **Google TTS** | Cloud API | 700+ voices, 50+ languages — best for localization |
-| **OpenAI TTS** | Cloud API | Fast, affordable |
+| **OpenAI Speech API** | Cloud API | Fast, affordable, instruction-directed with `gpt-4o-mini-tts` |
+| **OpenAI Audio TTS** | Cloud API | Audio-output chat models such as `gpt-audio-1.5` |
 | **Piper** | Local | Completely free, offline |
 
 </details>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -152,7 +152,7 @@ Selectors route based on: user preference when explicitly set, then scored ranki
 
 **Analysis (4):** transcriber (WhisperX), scene_detect, frame_sampler, video_understand (CLIP/BLIP-2)
 
-**Audio (8):** elevenlabs_tts, google_tts, openai_tts, piper_tts, tts_selector, music_gen, audio_mixer, audio_enhance
+**Audio (9):** elevenlabs_tts, google_tts, openai_audio_tts, openai_tts, piper_tts, tts_selector, music_gen, audio_mixer, audio_enhance
 
 **Avatar (2):** talking_head (SadTalker/MuseTalk), lip_sync (Wav2Lip)
 
@@ -383,7 +383,7 @@ All config is validated via Pydantic models in `lib/config_model.py`.
 | Variable | Used By | Purpose |
 |----------|---------|---------|
 | `ELEVENLABS_API_KEY` | elevenlabs_tts, music_gen | TTS, music, sound effects |
-| `OPENAI_API_KEY` | openai_tts, openai_image | TTS fallback, DALL-E 3 |
+| `OPENAI_API_KEY` | openai_tts, openai_audio_tts, openai_image | TTS fallback, audio-output narration, DALL-E 3 |
 | `XAI_API_KEY` | grok_image, grok_video | Grok image editing/generation, Grok video generation |
 | `FAL_KEY` | flux_image, kling_video, veo_video, minimax_video, recraft_image | fal.ai hosted models (FLUX, Veo, Kling, MiniMax, Recraft) |
 | `HEYGEN_API_KEY` | heygen_video | Multi-provider video generation |

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -278,7 +278,7 @@ Google TTS offers 700+ voices across 50+ languages. Voice names follow the patte
 
 > **Solid all-rounder.** DALL-E 3 handles complex multi-element compositions well. TTS is fast and affordable.
 
-**Tools unlocked:** `openai_tts`, `openai_image`
+**Tools unlocked:** `openai_tts`, `openai_audio_tts`, `openai_image`
 **Env var:** `OPENAI_API_KEY`
 
 #### Setup
@@ -296,6 +296,22 @@ Google TTS offers 700+ voices across 50+ languages. Voice names follow the patte
 | tts-1 | $15.00 |
 | tts-1-hd | $30.00 |
 | gpt-4o-mini-tts | $12.00 |
+
+The Speech API supports 13 built-in voices: `alloy`, `ash`, `ballad`,
+`coral`, `echo`, `fable`, `nova`, `onyx`, `sage`, `shimmer`, `verse`,
+`marin`, and `cedar`. For best quality, start with `marin` or `cedar`.
+Custom voice IDs are also supported for eligible accounts.
+
+#### Audio-output TTS
+
+`openai_audio_tts` uses audio-capable chat models such as `gpt-audio-1.5`
+through Chat Completions audio output. Use it when you want to audition the
+newer OpenAI audio model family for expressive narration. Use `openai_tts`
+when you need the dedicated Speech API path.
+
+Supported audio-output formats: `wav`, `mp3`, `flac`, `opus`, `pcm16`.
+This route does not return word-level timestamps; use transcription/alignment
+before subtitle timing.
 
 #### Image Pricing
 
@@ -725,7 +741,7 @@ These tools require only FFmpeg or Python packages — no GPU, no API key.
 | **Google** | `GOOGLE_API_KEY` | `google_tts`, `google_imagen` | Free tier + paid |
 | **ElevenLabs** | `ELEVENLABS_API_KEY` | `elevenlabs_tts`, `music_gen` | Free tier + paid |
 | **fal.ai** | `FAL_KEY` | `flux_image`, `recraft_image`, `kling_video`, `veo_video`, `minimax_video` | Pay-as-you-go |
-| **OpenAI** | `OPENAI_API_KEY` | `openai_tts`, `openai_image` | Paid only |
+| **OpenAI** | `OPENAI_API_KEY` | `openai_tts`, `openai_audio_tts`, `openai_image` | Paid only |
 | **xAI** | `XAI_API_KEY` | `grok_image`, `grok_video` | Paid only |
 | **Runway** | `RUNWAY_API_KEY` | `runway_video` | Free trial + paid |
 | **Higgsfield** | `HIGGSFIELD_API_KEY` + `HIGGSFIELD_API_SECRET` | `higgsfield_video` | Subscription ($15-84/mo) |

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -309,6 +309,11 @@ through Chat Completions audio output. Use it when you want to audition the
 newer OpenAI audio model family for expressive narration. Use `openai_tts`
 when you need the dedicated Speech API path.
 
+When routing through `tts_selector`, set `preferred_tool: "openai_audio_tts"`
+for the exact audio-output path, or set `preferred_provider: "openai"` with
+`prefer_audio_output: true` when you want OpenAI but specifically prefer the
+chat audio model route.
+
 Supported audio-output formats: `wav`, `mp3`, `flac`, `opus`, `pcm16`.
 This route does not return word-level timestamps; use transcription/alignment
 before subtitle timing.

--- a/skills/pipelines/explainer/compose-director.md
+++ b/skills/pipelines/explainer/compose-director.md
@@ -61,9 +61,11 @@ Before rendering, present the user with audio options and get their preferences.
 
 > **Audio setup for this video:**
 >
-> **Narration:** I can generate TTS narration using OpenAI TTS (`gpt-4o-mini-tts` — $0.015/min, 6 voices, voice direction). Which voice and tone would you like? I'll propose a voice based on the video topic, or you can choose:
+> **Narration:** I can generate TTS narration through `tts_selector`, including OpenAI Speech API (`gpt-4o-mini-tts`), OpenAI audio-output models (`gpt-audio-1.5`), ElevenLabs, Google TTS, or local Piper depending on what is configured. Which voice and tone would you like? I'll propose a voice based on the video topic, or you can choose:
 > - `onyx` — deep, authoritative (documentaries, tech)
 > - `echo` — resonant, futuristic (product ads, sci-fi)
+> - `marin` — high-quality OpenAI speech voice
+> - `cedar` — high-quality OpenAI speech voice
 > - `nova` — bright, energetic (upbeat, explainers)
 > - `fable` — warm, storytelling (narratives, education)
 > - `shimmer` — expressive, warm (organic, lifestyle)
@@ -85,8 +87,8 @@ Before rendering, present the user with audio options and get their preferences.
 
 2. **Generate TTS narration:**
    ```python
-   from tools.audio.openai_tts import OpenAITTS
-   result = OpenAITTS().execute({
+   from tools.audio.tts_selector import TTSSelector
+   result = TTSSelector().execute({
        'text': narration_script,
        'voice': '<user-chosen or agent-recommended>',
        'instructions': '<voice direction matching video tone>',

--- a/tests/contracts/test_phase3_contracts.py
+++ b/tests/contracts/test_phase3_contracts.py
@@ -26,7 +26,9 @@ from styles.playbook_loader import load_playbook, list_playbooks, validate_playb
 from tools.base_tool import ToolTier
 from tools.audio.music_gen import MusicGen
 from tools.tool_registry import ToolRegistry
+from tools.audio.doubao_tts import DoubaoTTS
 from tools.audio.elevenlabs_tts import ElevenLabsTTS
+from tools.audio.openai_audio_tts import OpenAIAudioTTS
 from tools.audio.openai_tts import OpenAITTS
 from tools.audio.piper_tts import PiperTTS
 from tools.audio.tts_selector import TTSSelector
@@ -102,13 +104,21 @@ class TestNewToolsRegistry:
 
     def test_voice_tier_tools(self):
         reg = ToolRegistry()
+        reg.register(DoubaoTTS())
         reg.register(ElevenLabsTTS())
+        reg.register(OpenAIAudioTTS())
         reg.register(OpenAITTS())
         reg.register(PiperTTS())
         voice_tools = reg.get_by_tier(ToolTier.VOICE)
-        assert len(voice_tools) == 3
+        assert len(voice_tools) == 5
         names = {t.name for t in voice_tools}
-        assert names == {"elevenlabs_tts", "openai_tts", "piper_tts"}
+        assert names == {
+            "doubao_tts",
+            "elevenlabs_tts",
+            "openai_audio_tts",
+            "openai_tts",
+            "piper_tts",
+        }
 
 
 class TestCapabilityMetadata:
@@ -123,17 +133,23 @@ class TestCapabilityMetadata:
 
     def test_provider_specific_tts_tools_register(self):
         reg = ToolRegistry()
+        reg.register(DoubaoTTS())
         reg.register(ElevenLabsTTS())
+        reg.register(OpenAIAudioTTS())
         reg.register(OpenAITTS())
         reg.register(PiperTTS())
         reg.register(TTSSelector())
         assert {tool.name for tool in reg.get_by_capability("tts")} == {
+            "doubao_tts",
             "elevenlabs_tts",
+            "openai_audio_tts",
             "openai_tts",
             "piper_tts",
             "tts_selector",
         }
+        assert {tool.name for tool in reg.get_by_provider("doubao")} == {"doubao_tts"}
         assert {tool.name for tool in reg.get_by_provider("elevenlabs")} == {"elevenlabs_tts"}
+        assert {tool.name for tool in reg.get_by_provider("openai_audio")} == {"openai_audio_tts"}
 
     def test_registry_catalog_views(self):
         reg = ToolRegistry()
@@ -143,7 +159,7 @@ class TestCapabilityMetadata:
         catalog = reg.capability_catalog()
         assert "tts" in catalog
         providers = {item["provider"] for item in catalog["tts"] if item["provider"] != "selector"}
-        assert providers == {"elevenlabs", "google_tts", "openai", "piper"}
+        assert providers == {"doubao", "elevenlabs", "google_tts", "openai_audio", "openai", "piper"}
 
 
 # ---- Animated Explainer Pipeline ----

--- a/tests/tools/test_openai_audio_tts.py
+++ b/tests/tools/test_openai_audio_tts.py
@@ -1,0 +1,121 @@
+import base64
+from pathlib import Path
+
+from tools.audio.openai_audio_tts import OpenAIAudioTTS
+from tools.audio.piper_tts import PiperTTS
+from tools.audio.tts_selector import TTSSelector
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def test_openai_audio_tts_posts_chat_audio_request(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_post(url, headers, json, timeout):
+        calls.append(
+            {
+                "url": url,
+                "headers": headers,
+                "json": json,
+                "timeout": timeout,
+            }
+        )
+        return FakeResponse(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "audio": {
+                                "data": base64.b64encode(b"fake wav bytes").decode("ascii"),
+                                "transcript": "Read this exactly.",
+                            }
+                        }
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr("requests.post", fake_post)
+
+    output_path = tmp_path / "sample.wav"
+    result = OpenAIAudioTTS().execute(
+        {
+            "text": "Read this exactly.",
+            "voice": "cedar",
+            "format": "wav",
+            "instructions": "Calm, confident product narration.",
+            "output_path": str(output_path),
+        }
+    )
+
+    assert result.success
+    assert output_path.read_bytes() == b"fake wav bytes"
+    assert result.data["provider"] == "openai_audio"
+    assert result.data["model"] == "gpt-audio-1.5"
+    assert result.data["voice"] == "cedar"
+    assert result.data["transcript"] == "Read this exactly."
+    assert result.data["timestamps"] is False
+
+    request = calls[0]
+    assert request["url"] == "https://api.openai.com/v1/chat/completions"
+    assert request["headers"]["Authorization"] == "Bearer test-key"
+    assert request["json"]["model"] == "gpt-audio-1.5"
+    assert request["json"]["modalities"] == ["text", "audio"]
+    assert request["json"]["audio"] == {"voice": "cedar", "format": "wav"}
+    assert request["json"]["messages"][1]["content"] == "Read this exactly."
+    assert "verbatim" in request["json"]["messages"][0]["content"]
+    assert "Calm, confident product narration." in request["json"]["messages"][0]["content"]
+
+
+def test_openai_audio_tts_supports_pcm16_extension(monkeypatch, tmp_path):
+    def fake_post(url, headers, json, timeout):
+        return FakeResponse(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "audio": {
+                                "data": base64.b64encode(b"pcm bytes").decode("ascii")
+                            }
+                        }
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr("requests.post", fake_post)
+
+    result = OpenAIAudioTTS().execute({"text": "Hello", "format": "pcm16", "output_path": str(tmp_path / "out.pcm")})
+
+    assert result.success
+    assert Path(result.data["output"]).suffix == ".pcm"
+
+
+def test_tts_selector_rank_respects_openai_audio_allowed_provider(monkeypatch):
+    monkeypatch.setattr(
+        TTSSelector,
+        "_providers",
+        lambda self: [PiperTTS(), OpenAIAudioTTS()],
+    )
+
+    result = TTSSelector().execute(
+        {
+            "operation": "rank",
+            "text": "Rank only OpenAI audio.",
+            "allowed_providers": ["openai_audio"],
+        }
+    )
+
+    assert result.success
+    assert [item["provider"] for item in result.data["rankings"]] == ["openai_audio"]

--- a/tests/tools/test_openai_audio_tts.py
+++ b/tests/tools/test_openai_audio_tts.py
@@ -2,6 +2,7 @@ import base64
 from pathlib import Path
 
 from tools.audio.openai_audio_tts import OpenAIAudioTTS
+from tools.audio.openai_tts import OpenAITTS
 from tools.audio.piper_tts import PiperTTS
 from tools.audio.tts_selector import TTSSelector
 
@@ -64,6 +65,8 @@ def test_openai_audio_tts_posts_chat_audio_request(monkeypatch, tmp_path):
     assert result.data["model"] == "gpt-audio-1.5"
     assert result.data["voice"] == "cedar"
     assert result.data["transcript"] == "Read this exactly."
+    assert result.data["instructions_applied"] is True
+    assert result.data["strict_script"] is True
     assert result.data["timestamps"] is False
 
     request = calls[0]
@@ -119,3 +122,36 @@ def test_tts_selector_rank_respects_openai_audio_allowed_provider(monkeypatch):
 
     assert result.success
     assert [item["provider"] for item in result.data["rankings"]] == ["openai_audio"]
+
+
+def test_tts_selector_can_prefer_openai_audio_tool(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    selector = TTSSelector()
+    candidates = [OpenAITTS(), OpenAIAudioTTS()]
+
+    tool, score = selector._select_best_tool(
+        {"preferred_tool": "openai_audio_tts", "text": "Read this."},
+        candidates,
+        selector._prepare_task_context({"text": "Read this."}),
+    )
+
+    assert tool.name == "openai_audio_tts"
+    assert score is None
+
+
+def test_tts_selector_routes_openai_to_audio_output_when_requested(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    selector = TTSSelector()
+    candidates = [OpenAITTS(), OpenAIAudioTTS()]
+
+    tool, _ = selector._select_best_tool(
+        {
+            "preferred_provider": "openai",
+            "prefer_audio_output": True,
+            "text": "Read this with delivery direction.",
+        },
+        candidates,
+        selector._prepare_task_context({"text": "Read this with delivery direction."}),
+    )
+
+    assert tool.name == "openai_audio_tts"

--- a/tests/tools/test_openai_tts.py
+++ b/tests/tools/test_openai_tts.py
@@ -1,0 +1,96 @@
+from tools.audio.openai_tts import OpenAITTS
+
+
+class FakeResponse:
+    def __init__(self, content=b"fake mp3"):
+        self.content = content
+
+    def raise_for_status(self):
+        return None
+
+
+def test_openai_tts_uses_current_voice_formats_and_instructions(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_post(url, headers, json, timeout):
+        calls.append({"url": url, "headers": headers, "json": json, "timeout": timeout})
+        return FakeResponse()
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr("requests.post", fake_post)
+
+    output_path = tmp_path / "speech.flac"
+    result = OpenAITTS().execute(
+        {
+            "text": "Read this line.",
+            "voice": "cedar",
+            "model": "gpt-4o-mini-tts",
+            "format": "flac",
+            "instructions": "Confident but not dramatic.",
+            "speed": 1.1,
+            "output_path": str(output_path),
+        }
+    )
+
+    assert result.success
+    assert output_path.read_bytes() == b"fake mp3"
+    request = calls[0]
+    assert request["url"] == "https://api.openai.com/v1/audio/speech"
+    assert request["headers"]["Authorization"] == "Bearer test-key"
+    call = request["json"]
+    assert call["model"] == "gpt-4o-mini-tts"
+    assert call["voice"] == "cedar"
+    assert call["response_format"] == "flac"
+    assert call["instructions"] == "Confident but not dramatic."
+    assert call["speed"] == 1.1
+    assert result.data["voice"] == "cedar"
+    assert result.data["instructions_applied"] is True
+    assert result.data["timestamps"] is False
+
+
+def test_openai_tts_skips_instructions_for_legacy_models(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_post(url, headers, json, timeout):
+        calls.append(json)
+        return FakeResponse()
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr("requests.post", fake_post)
+
+    result = OpenAITTS().execute(
+        {
+            "text": "Read this line.",
+            "voice": "nova",
+            "model": "tts-1",
+            "instructions": "This should not be sent.",
+            "output_path": str(tmp_path / "speech.mp3"),
+        }
+    )
+
+    assert result.success
+    assert "instructions" not in calls[0]
+    assert result.data["instructions_applied"] is False
+
+
+def test_openai_tts_supports_custom_voice_id(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_post(url, headers, json, timeout):
+        calls.append(json)
+        return FakeResponse()
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr("requests.post", fake_post)
+
+    result = OpenAITTS().execute(
+        {
+            "text": "Read this line.",
+            "voice_id": "voice_1234",
+            "output_path": str(tmp_path / "speech.mp3"),
+        }
+    )
+
+    assert result.success
+    assert calls[0]["voice"] == {"id": "voice_1234"}
+    assert result.data["voice"] == "voice_1234"

--- a/tools/audio/openai_audio_tts.py
+++ b/tools/audio/openai_audio_tts.py
@@ -205,6 +205,8 @@ class OpenAIAudioTTS(BaseTool):
                 "audio_duration_seconds": round(audio_duration, 2) if audio_duration else None,
                 "output": str(output_path),
                 "transcript": audio.get("transcript") or message.get("content"),
+                "instructions_applied": bool(inputs.get("instructions")),
+                "strict_script": bool(inputs.get("strict_script", True)),
                 "selected_provider": self.provider,
                 "selected_tool": self.name,
                 "timestamps": False,

--- a/tools/audio/openai_audio_tts.py
+++ b/tools/audio/openai_audio_tts.py
@@ -1,0 +1,250 @@
+"""OpenAI audio-output TTS provider.
+
+This provider uses audio-capable chat models such as gpt-audio-1.5. It is
+separate from openai_tts, which targets the dedicated Speech API.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+
+class OpenAIAudioTTS(BaseTool):
+    name = "openai_audio_tts"
+    version = "0.1.0"
+    tier = ToolTier.VOICE
+    capability = "tts"
+    provider = "openai_audio"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = ["python:requests"]
+    install_instructions = (
+        "Set the OPENAI_API_KEY environment variable:\n"
+        "  export OPENAI_API_KEY=your_key_here\n"
+        "This tool calls Chat Completions audio output with an audio-capable model "
+        "such as gpt-audio-1.5."
+    )
+    fallback = "openai_tts"
+    fallback_tools = ["openai_tts", "elevenlabs_tts", "piper_tts"]
+    agent_skills = ["openai-docs"]
+
+    capabilities = [
+        "text_to_speech",
+        "voice_selection",
+        "audio_output_chat_completions",
+        "instruction_directed_delivery",
+    ]
+    supports = {
+        "voice_cloning": False,
+        "multilingual": True,
+        "offline": False,
+        "native_audio": True,
+        "timestamps": False,
+        "audio_output_chat_completions": True,
+    }
+    best_for = [
+        "testing OpenAI's newest audio-output models for expressive narration",
+        "voiceover auditions that benefit from delivery instructions",
+        "spoken responses where natural delivery matters more than word-level timestamps",
+    ]
+    not_good_for = [
+        "word-level timestamp generation",
+        "fully offline production",
+        "voice clone matching",
+    ]
+
+    input_schema = {
+        "type": "object",
+        "required": ["text"],
+        "properties": {
+            "text": {
+                "type": "string",
+                "description": "Narration text to speak. In strict mode, the model is asked to read it verbatim.",
+            },
+            "model": {
+                "type": "string",
+                "default": "gpt-audio-1.5",
+                "description": "OpenAI audio-capable chat model.",
+            },
+            "voice": {
+                "type": "string",
+                "default": "alloy",
+                "description": "OpenAI audio voice name.",
+            },
+            "format": {
+                "type": "string",
+                "default": "wav",
+                "enum": ["wav", "mp3", "flac", "opus", "pcm16"],
+                "description": "Output audio format supported by Chat Completions audio output.",
+            },
+            "instructions": {
+                "type": "string",
+                "description": "Optional delivery direction, e.g. tone, pacing, emphasis, emotion, or accent.",
+            },
+            "strict_script": {
+                "type": "boolean",
+                "default": True,
+                "description": "Ask the model to speak the supplied text verbatim.",
+            },
+            "temperature": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 2,
+                "default": 0.6,
+                "description": "Sampling temperature for the audio-capable chat model.",
+            },
+            "output_path": {"type": "string"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=50, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
+    idempotency_key_fields = ["text", "voice", "model", "format", "instructions"]
+    side_effects = ["writes audio file to output_path", "calls OpenAI Chat Completions API"]
+    user_visible_verification = [
+        "Listen to generated audio for naturalness, exact wording, and tone",
+        "If subtitles are needed, align separately because this provider does not return word timestamps",
+    ]
+
+    _EXT_MAP = {
+        "wav": "wav",
+        "mp3": "mp3",
+        "flac": "flac",
+        "opus": "opus",
+        "pcm16": "pcm",
+    }
+
+    def get_status(self) -> ToolStatus:
+        if os.environ.get("OPENAI_API_KEY"):
+            return ToolStatus.AVAILABLE
+        return ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        # Audio-capable chat model pricing is token based and includes audio
+        # output tokens, so a character-only estimate would be misleading.
+        return 0.0
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        api_key = os.environ.get("OPENAI_API_KEY")
+        if not api_key:
+            return ToolResult(success=False, error="No OpenAI API key. " + self.install_instructions)
+
+        start = time.time()
+        try:
+            result = self._generate(inputs, api_key)
+        except Exception as exc:
+            return ToolResult(success=False, error=f"OpenAI audio TTS failed: {exc}")
+
+        result.duration_seconds = round(time.time() - start, 2)
+        result.cost_usd = self.estimate_cost(inputs)
+        return result
+
+    def _generate(self, inputs: dict[str, Any], api_key: str) -> ToolResult:
+        from tools.analysis.audio_probe import probe_duration
+
+        text = inputs["text"]
+        model = inputs.get("model", "gpt-audio-1.5")
+        voice = inputs.get("voice", "alloy")
+        fmt = inputs.get("format", "wav")
+        ext = self._EXT_MAP.get(fmt, fmt)
+        output_path = Path(inputs.get("output_path", f"openai_audio_tts.{ext}"))
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        response = requests.post(
+            "https://api.openai.com/v1/chat/completions",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json=self._request_payload(inputs),
+            timeout=180,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        message = payload["choices"][0]["message"]
+        audio = message.get("audio") or {}
+        audio_data = audio.get("data")
+        if not audio_data:
+            raise ValueError("OpenAI response did not include message.audio.data")
+
+        output_path.write_bytes(base64.b64decode(audio_data))
+        audio_duration = probe_duration(output_path)
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": self.provider,
+                "model": model,
+                "voice": voice,
+                "format": fmt,
+                "text_length": len(text),
+                "audio_duration_seconds": round(audio_duration, 2) if audio_duration else None,
+                "output": str(output_path),
+                "transcript": audio.get("transcript") or message.get("content"),
+                "selected_provider": self.provider,
+                "selected_tool": self.name,
+                "timestamps": False,
+            },
+            artifacts=[str(output_path)],
+            model=model,
+        )
+
+    def _request_payload(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        model = inputs.get("model", "gpt-audio-1.5")
+        voice = inputs.get("voice", "alloy")
+        fmt = inputs.get("format", "wav")
+        temperature = inputs.get("temperature", 0.6)
+        messages = [
+            {
+                "role": "system",
+                "content": self._system_prompt(inputs),
+            },
+            {
+                "role": "user",
+                "content": inputs["text"],
+            },
+        ]
+        return {
+            "model": model,
+            "modalities": ["text", "audio"],
+            "audio": {"voice": voice, "format": fmt},
+            "messages": messages,
+            "temperature": temperature,
+        }
+
+    @staticmethod
+    def _system_prompt(inputs: dict[str, Any]) -> str:
+        parts = [
+            "You are recording narration audio for a produced video.",
+        ]
+        if inputs.get("strict_script", True):
+            parts.append(
+                "Speak the user's script verbatim. Do not add, remove, summarize, or translate words."
+            )
+        if inputs.get("instructions"):
+            parts.append(f"Delivery direction: {inputs['instructions']}")
+        return " ".join(parts)

--- a/tools/audio/openai_tts.py
+++ b/tools/audio/openai_tts.py
@@ -23,7 +23,7 @@ from tools.base_tool import (
 
 class OpenAITTS(BaseTool):
     name = "openai_tts"
-    version = "0.1.0"
+    version = "0.2.0"
     tier = ToolTier.VOICE
     capability = "tts"
     provider = "openai"
@@ -32,7 +32,7 @@ class OpenAITTS(BaseTool):
     determinism = Determinism.STOCHASTIC
     runtime = ToolRuntime.API
 
-    dependencies = []
+    dependencies = ["python:requests"]
     install_instructions = (
         "Set the OPENAI_API_KEY environment variable:\n"
         "  export OPENAI_API_KEY=your_key_here\n"
@@ -45,16 +45,21 @@ class OpenAITTS(BaseTool):
     capabilities = [
         "text_to_speech",
         "voice_selection",
+        "instruction_directed_delivery",
+        "custom_voice_id",
     ]
     supports = {
         "voice_cloning": False,
         "multilingual": True,
         "offline": False,
         "native_audio": True,
+        "timestamps": False,
+        "custom_voice_id": True,
     }
     best_for = [
-        "general narration fallback",
-        "API-based production when ElevenLabs is unavailable",
+        "dedicated OpenAI Speech API narration",
+        "fast voiceover generation with 13 built-in voices",
+        "instruction-directed delivery with gpt-4o-mini-tts",
     ]
     not_good_for = [
         "voice clone matching",
@@ -68,22 +73,51 @@ class OpenAITTS(BaseTool):
             "text": {"type": "string"},
             "voice": {
                 "type": "string",
-                "default": "alloy",
-                "description": "OpenAI voice name",
+                "default": "marin",
+                "description": "OpenAI built-in voice name. For best quality, try marin or cedar.",
+                "enum": [
+                    "alloy",
+                    "ash",
+                    "ballad",
+                    "coral",
+                    "echo",
+                    "fable",
+                    "nova",
+                    "onyx",
+                    "sage",
+                    "shimmer",
+                    "verse",
+                    "marin",
+                    "cedar",
+                ],
+            },
+            "voice_id": {
+                "type": "string",
+                "description": "Optional custom OpenAI voice ID. When provided, it is sent as {'id': voice_id}.",
             },
             "model": {
                 "type": "string",
                 "default": "gpt-4o-mini-tts",
                 "description": "OpenAI speech model",
+                "enum": ["gpt-4o-mini-tts", "gpt-4o-mini-tts-2025-12-15", "tts-1", "tts-1-hd"],
             },
             "format": {
                 "type": "string",
                 "default": "mp3",
-                "enum": ["mp3", "wav", "pcm"],
+                "enum": ["mp3", "opus", "aac", "flac", "wav", "pcm"],
+                "description": "Speech API response format.",
             },
             "instructions": {
                 "type": "string",
-                "description": "Optional delivery instructions for the voice",
+                "maxLength": 4096,
+                "description": "Optional delivery instructions. Supported by gpt-4o-mini-tts, not by tts-1 or tts-1-hd.",
+            },
+            "speed": {
+                "type": "number",
+                "minimum": 0.25,
+                "maximum": 4.0,
+                "default": 1.0,
+                "description": "Speech speed. 1.0 is default.",
             },
             "output_path": {"type": "string"},
         },
@@ -93,9 +127,12 @@ class OpenAITTS(BaseTool):
         cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=50, network_required=True
     )
     retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
-    idempotency_key_fields = ["text", "voice", "model", "format"]
+    idempotency_key_fields = ["text", "voice", "voice_id", "model", "format", "instructions", "speed"]
     side_effects = ["writes audio file to output_path", "calls OpenAI API"]
-    user_visible_verification = ["Listen to generated audio for intelligibility and tone"]
+    user_visible_verification = [
+        "Listen to generated audio for intelligibility and tone",
+        "If subtitles are needed, align separately because this provider does not return word timestamps",
+    ]
 
     def get_status(self) -> ToolStatus:
         if os.environ.get("OPENAI_API_KEY"):
@@ -120,14 +157,13 @@ class OpenAITTS(BaseTool):
         return result
 
     def _generate(self, inputs: dict[str, Any]) -> ToolResult:
-        from openai import OpenAI
+        import requests
 
         from tools.analysis.audio_probe import probe_duration
 
-        client = OpenAI()
         text = inputs["text"]
         model = inputs.get("model", "gpt-4o-mini-tts")
-        voice = inputs.get("voice", "alloy")
+        voice = self._voice_payload(inputs)
         fmt = inputs.get("format", "mp3")
         output_path = Path(inputs.get("output_path", f"openai_tts.{fmt}"))
         output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -138,13 +174,22 @@ class OpenAITTS(BaseTool):
             "input": text,
             "response_format": fmt,
         }
-        if inputs.get("instructions"):
+        if inputs.get("instructions") and self._supports_instructions(model):
             kwargs["instructions"] = inputs["instructions"]
         if inputs.get("speed") and inputs["speed"] != 1.0:
             kwargs["speed"] = inputs["speed"]
 
-        with client.audio.speech.with_streaming_response.create(**kwargs) as response:
-            response.stream_to_file(output_path)
+        response = requests.post(
+            "https://api.openai.com/v1/audio/speech",
+            headers={
+                "Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}",
+                "Content-Type": "application/json",
+            },
+            json=kwargs,
+            timeout=180,
+        )
+        response.raise_for_status()
+        output_path.write_bytes(response.content)
 
         audio_duration = probe_duration(output_path)
 
@@ -153,12 +198,31 @@ class OpenAITTS(BaseTool):
             data={
                 "provider": self.provider,
                 "model": model,
-                "voice": voice,
+                "voice": self._voice_label(voice),
                 "format": fmt,
                 "text_length": len(text),
                 "audio_duration_seconds": round(audio_duration, 2) if audio_duration else None,
                 "output": str(output_path),
+                "instructions_applied": bool(inputs.get("instructions") and self._supports_instructions(model)),
+                "timestamps": False,
             },
             artifacts=[str(output_path)],
             model=model,
         )
+
+    @staticmethod
+    def _supports_instructions(model: str) -> bool:
+        return model.startswith("gpt-4o-mini-tts")
+
+    @staticmethod
+    def _voice_payload(inputs: dict[str, Any]) -> str | dict[str, str]:
+        voice_id = inputs.get("voice_id")
+        if voice_id:
+            return {"id": voice_id}
+        return inputs.get("voice", "marin")
+
+    @staticmethod
+    def _voice_label(voice: str | dict[str, str]) -> str:
+        if isinstance(voice, dict):
+            return voice.get("id", "")
+        return voice

--- a/tools/audio/tts_selector.py
+++ b/tools/audio/tts_selector.py
@@ -121,7 +121,7 @@ class TTSSelector(BaseTool):
         from lib.scoring import rank_providers
 
         task_context = self._prepare_task_context(inputs)
-        candidates = self._providers()
+        candidates = self._filter_candidates(self._providers(), inputs)
 
         # Rank mode — return scored provider rankings without generating
         if inputs.get("operation") == "rank":
@@ -164,9 +164,6 @@ class TTSSelector(BaseTool):
         from lib.scoring import rank_providers
 
         preferred = inputs.get("preferred_provider", "auto")
-        allowed = set(inputs.get("allowed_providers") or [])
-        if allowed:
-            candidates = [tool for tool in candidates if tool.provider in allowed]
 
         rankings = rank_providers(candidates, task_context)
 
@@ -185,6 +182,13 @@ class TTSSelector(BaseTool):
                 return tool_by_provider[score_item.provider], score_item
 
         return None, None
+
+    @staticmethod
+    def _filter_candidates(candidates: list[BaseTool], inputs: dict[str, Any]) -> list[BaseTool]:
+        allowed = set(inputs.get("allowed_providers") or [])
+        if not allowed:
+            return candidates
+        return [tool for tool in candidates if tool.provider in allowed or tool.name in allowed]
 
     def _prepare_task_context(self, inputs: dict[str, Any]) -> dict[str, Any]:
         from lib.scoring import normalize_task_context

--- a/tools/audio/tts_selector.py
+++ b/tools/audio/tts_selector.py
@@ -70,6 +70,15 @@ class TTSSelector(BaseTool):
                 "description": "Provider name or 'auto'. Valid values are discovered at runtime from the registry.",
                 "default": "auto",
             },
+            "preferred_tool": {
+                "type": "string",
+                "description": "Exact TTS tool name to prefer, e.g. openai_audio_tts.",
+            },
+            "prefer_audio_output": {
+                "type": "boolean",
+                "default": False,
+                "description": "For OpenAI routing, prefer the audio-output chat model path over the dedicated Speech API.",
+            },
             "allowed_providers": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -163,7 +172,13 @@ class TTSSelector(BaseTool):
         """Select the best TTS provider using scored ranking."""
         from lib.scoring import rank_providers
 
-        preferred = inputs.get("preferred_provider", "auto")
+        preferred_tool = inputs.get("preferred_tool")
+        if preferred_tool:
+            for tool in candidates:
+                if tool.name == preferred_tool and tool.get_status() == ToolStatus.AVAILABLE:
+                    return tool, None
+
+        preferred = self._preferred_provider(inputs)
 
         rankings = rank_providers(candidates, task_context)
 
@@ -182,6 +197,19 @@ class TTSSelector(BaseTool):
                 return tool_by_provider[score_item.provider], score_item
 
         return None, None
+
+    @staticmethod
+    def _preferred_provider(inputs: dict[str, Any]) -> str:
+        preferred = inputs.get("preferred_provider", "auto")
+        task_context = inputs.get("task_context") or {}
+        wants_audio_output = bool(
+            inputs.get("prefer_audio_output")
+            or task_context.get("prefer_audio_output")
+            or task_context.get("audio_output_chat_completions")
+        )
+        if preferred == "openai" and wants_audio_output:
+            return "openai_audio"
+        return preferred
 
     @staticmethod
     def _filter_candidates(candidates: list[BaseTool], inputs: dict[str, Any]) -> list[BaseTool]:


### PR DESCRIPTION
## Summary
- add `openai_audio_tts` for audio-output chat models such as `gpt-audio-1.5`
- refresh `openai_tts` to use the current Speech API REST surface and updated voice/model options
- document OpenAI provider options and keep `tts_selector` ranking constrained by allowed providers

## Tests
- `python -m pytest -q tests/tools/test_openai_tts.py tests/tools/test_openai_audio_tts.py tests/contracts/test_phase3_contracts.py`