### PR TITLE
feat(tts): add MiniMax Speech provider

### DIFF
--- a/.agents/skills/minimax-tts/SKILL.md
+++ b/.agents/skills/minimax-tts/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: minimax-tts
+description: Generate expressive multilingual narration with MiniMax Speech T2A. Use when creating voiceovers with MiniMax/Hailuo voices, cloned MiniMax voices, or subtitle timing metadata from MiniMax Speech.
+---
+
+# MiniMax TTS
+
+Requires `MINIMAX_API_KEY` in `.env`.
+Set `MINIMAX_TTS_VOICE_ID` for the default voice, or pass `voice_id` to the tool.
+
+## Current API
+
+Use the MiniMax HTTP T2A endpoint for synchronous speech generation:
+
+```text
+POST https://api.minimax.io/v1/t2a_v2
+Authorization: Bearer ${MINIMAX_API_KEY}
+Content-Type: application/json
+```
+
+The HTTP endpoint is best for short and medium segments. It accepts up to 10,000 characters per request; for longer narration, split by scene or use MiniMax async T2A.
+
+## OpenMontage Usage
+
+Generate with the TTS selector:
+
+```python
+from tools.audio.tts_selector import TTSSelector
+
+result = TTSSelector().execute({
+    "preferred_provider": "minimax",
+    "text": "如果 AI 真的会改变未来，普通人到底该怎么参与？",
+    "voice_id": "Chinese (Mandarin)_Warm_Bestie",
+    "model": "speech-2.8-hd",
+    "output_path": "projects/my-video/assets/audio/minimax_sample.mp3",
+    "subtitle_enable": True,
+    "subtitle_type": "sentence",
+})
+```
+
+Or call the provider directly:
+
+```python
+from tools.audio.minimax_tts import MiniMaxTTS
+
+result = MiniMaxTTS().execute({
+    "text": "短样本试听文本。",
+    "voice_id": "Chinese (Mandarin)_Warm_Bestie",
+    "output_path": "projects/my-video/assets/audio/minimax_sample.mp3",
+})
+```
+
+The provider writes:
+
+- `output_path`: audio file decoded from MiniMax `hex` output, or downloaded from a returned URL
+- `metadata_path`: full MiniMax response JSON, defaulting to `<output_path>.json`
+
+## Voice Audition
+
+MiniMax's static system voice list does not include inline audio previews. For practical voice selection, generate a short audition pack with one fixed script:
+
+```bash
+python -m tools.audio.minimax_audition \
+  --output-dir projects/minimax-tts-audition/assets/audio/first-pass
+```
+
+This generates MP3 samples for a Mandarin shortlist and writes `AUDITION_REVIEW.md` with links to each audio file and metadata JSON.
+
+Pass explicit voices when comparing a narrower set:
+
+```bash
+python -m tools.audio.minimax_audition \
+  --voices "Chinese (Mandarin)_Reliable_Executive" "Chinese (Mandarin)_News_Anchor" \
+  --text "这个工具不是替你写一个结论，而是把排查过程变成可复盘的工作流。"
+```
+
+Or fetch account-available system voices first:
+
+```bash
+python -m tools.audio.minimax_audition \
+  --discover-voices \
+  --voice-type system \
+  --language-filter "Chinese (Mandarin)" \
+  --max-voices 8
+```
+
+## Recommended Workflow
+
+1. Generate a 10-15 second sample before a full paid narration.
+2. Ask the user to approve voice naturalness, pronunciation, and pace.
+3. Generate section-level narration after approval, especially for videos with visual beats.
+4. Keep the metadata JSON. It contains trace IDs, usage metadata, audio duration, and subtitle references when returned.
+5. Use `subtitle_enable: true` and `subtitle_type: "sentence"` first; switch to `word` only when fine-grained captions are needed.
+6. Keep `speed: 1.0` as the baseline. Compare short samples before changing speed or pitch.
+
+## Parameters
+
+- `voice_id`: MiniMax system, designed, or cloned voice ID. Defaults to `MINIMAX_TTS_VOICE_ID`.
+- `model`: defaults to `speech-2.8-hd`; use `speech-2.8-turbo` when latency matters more than maximum quality.
+- `language_boost`: defaults to `auto`; can be set to values such as `Chinese`, `English`, `Japanese`, or `Korean`.
+- `speed`: baseline `1.0`.
+- `format`: defaults to `mp3`; non-streaming also supports `wav` and `flac`.
+- `output_format`: defaults to `hex`; `url` returns a temporary MiniMax audio URL that the provider downloads.
+- `subtitle_enable`: defaults to `true`.
+- `subtitle_type`: defaults to `sentence`; `word` is available for word-level timing.
+
+## Troubleshooting
+
+- Authentication failure: check `MINIMAX_API_KEY` and Bearer authorization.
+- Missing or invalid voice: check `voice_id`/`MINIMAX_TTS_VOICE_ID` and whether the voice is authorized for the account.
+- Long text rejected: split narration into scene-level segments or use async T2A.
+- Missing subtitles: verify `subtitle_enable: true`, keep the metadata JSON, and confirm the selected model returned subtitle data.
+
+## Safety
+
+Never print or write the API key to logs, metadata, patches, or project artifacts. `.env.example` should contain only empty variable names.

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,9 @@ OPENAI_API_KEY=              # OpenAI TTS fallback and DALL-E image generation
 XAI_API_KEY=                 # Grok image generation/editing and Grok video generation
 DOUBAO_SPEECH_API_KEY=       # Volcengine Doubao Speech TTS (new console API Key)
 DOUBAO_SPEECH_VOICE_TYPE=    # Default Doubao speaker/voice type, e.g. zh_female_vv_uranus_bigtts
+MINIMAX_API_KEY=             # MiniMax Speech TTS, voice cloning, and voice design
+MINIMAX_TTS_VOICE_ID=        # Default MiniMax system/designed/cloned voice ID
+MINIMAX_TTS_MODEL=           # Optional MiniMax TTS model override, e.g. speech-2.8-hd
 # Piper local voices do not require env vars; install `piper-tts` via pip
 
 # --- Music ---

--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ ELEVENLABS_API_KEY=your-key    # Premium TTS, AI music, sound effects
 OPENAI_API_KEY=your-key        # OpenAI TTS, DALL-E 3 images
 XAI_API_KEY=your-key           # xAI Grok image edits/generation + Grok video generation
 GOOGLE_API_KEY=your-key        # Google Imagen images, Google TTS (700+ voices)
+DOUBAO_SPEECH_API_KEY=your-key # Doubao Speech Mandarin TTS
+MINIMAX_API_KEY=your-key       # MiniMax Speech TTS, voice cloning, voice design
 
 # More video providers:
 HEYGEN_API_KEY=your-key        # HeyGen — VEO, Sora, Runway, Kling via single gateway
@@ -368,7 +370,7 @@ Final video output -- only if self-review passes
 OpenMontage/
 ├── tools/              # 48 Python tools (the agent's hands)
 │   ├── video/          # 13 video gen tools + compose, stitch, trim
-│   ├── audio/          # 4 TTS providers + Suno/ElevenLabs music, mixing, enhancement
+│   ├── audio/          # 6 TTS providers + Suno/ElevenLabs music, mixing, enhancement
 │   ├── graphics/       # 9 image/graphics generation tools + diagrams, code snippets, math
 │   ├── enhancement/    # Upscale, bg remove, face enhance, color grade
 │   ├── analysis/       # Transcription, scene detect, frame sampling
@@ -446,13 +448,15 @@ Each tool declares which Layer 3 skills it relies on. The agent reads Layer 1 to
 </details>
 
 <details>
-<summary><strong>Text-to-Speech — 4 providers</strong></summary>
+<summary><strong>Text-to-Speech — 6 providers</strong></summary>
 
 | Provider | Type | Notes |
 |----------|------|-------|
 | **ElevenLabs** | Cloud API | Premium voice quality |
 | **Google TTS** | Cloud API | 700+ voices, 50+ languages — best for localization |
 | **OpenAI TTS** | Cloud API | Fast, affordable |
+| **Doubao Speech** | Cloud API | Strong Mandarin narration with timestamp metadata |
+| **MiniMax Speech** | Cloud API | Expressive multilingual voices, cloned voices, subtitle metadata |
 | **Piper** | Local | Completely free, offline |
 
 </details>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -152,7 +152,7 @@ Selectors route based on: user preference when explicitly set, then scored ranki
 
 **Analysis (4):** transcriber (WhisperX), scene_detect, frame_sampler, video_understand (CLIP/BLIP-2)
 
-**Audio (8):** elevenlabs_tts, google_tts, openai_tts, piper_tts, tts_selector, music_gen, audio_mixer, audio_enhance
+**Audio (10):** elevenlabs_tts, google_tts, openai_tts, piper_tts, doubao_tts, minimax_tts, tts_selector, music_gen, audio_mixer, audio_enhance
 
 **Avatar (2):** talking_head (SadTalker/MuseTalk), lip_sync (Wav2Lip)
 
@@ -385,6 +385,9 @@ All config is validated via Pydantic models in `lib/config_model.py`.
 | `ELEVENLABS_API_KEY` | elevenlabs_tts, music_gen | TTS, music, sound effects |
 | `OPENAI_API_KEY` | openai_tts, openai_image | TTS fallback, DALL-E 3 |
 | `XAI_API_KEY` | grok_image, grok_video | Grok image editing/generation, Grok video generation |
+| `DOUBAO_SPEECH_API_KEY` | doubao_tts | Volcengine Doubao Speech TTS |
+| `MINIMAX_API_KEY` | minimax_tts | MiniMax Speech TTS |
+| `MINIMAX_TTS_VOICE_ID` | minimax_tts | Default MiniMax TTS voice |
 | `FAL_KEY` | flux_image, kling_video, veo_video, minimax_video, recraft_image | fal.ai hosted models (FLUX, Veo, Kling, MiniMax, Recraft) |
 | `HEYGEN_API_KEY` | heygen_video | Multi-provider video generation |
 | `PEXELS_API_KEY` | pexels_image, pexels_video | Stock media |

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -41,6 +41,9 @@ OPENAI_API_KEY=              # OpenAI TTS + DALL-E 3 images
 XAI_API_KEY=                 # xAI Grok image generation/editing + Grok video generation
 DOUBAO_SPEECH_API_KEY=       # Volcengine Doubao Speech TTS (strong Mandarin narration)
 DOUBAO_SPEECH_VOICE_TYPE=    # Default Doubao speaker/voice type
+MINIMAX_API_KEY=             # MiniMax Speech TTS, voice cloning, and voice design
+MINIMAX_TTS_VOICE_ID=        # Default MiniMax system/designed/cloned voice ID
+MINIMAX_TTS_MODEL=           # Optional MiniMax TTS model override
 
 # MULTI-MODEL GATEWAY (one key, 6+ tools)
 FAL_KEY=                     # FLUX, Recraft, Kling, Veo, MiniMax video
@@ -204,6 +207,52 @@ Start with `speech_rate: 0` for natural Mandarin delivery. If the approved forma
 #### Pricing
 
 Doubao Speech 2.0 is billed by character package or usage in Volcengine. OpenMontage estimates cost from text length and prefers provider-returned usage metadata when available.
+
+---
+
+### MiniMax Speech - Expressive Multilingual TTS
+
+> **Expressive multilingual narration.** MiniMax Speech is useful for short and medium voiceover segments, cloned voices, and subtitle-aware narration across Chinese, English, and other supported languages.
+
+**Tools unlocked:** `minimax_tts`
+**Env vars:** `MINIMAX_API_KEY`, `MINIMAX_TTS_VOICE_ID`, `MINIMAX_TTS_MODEL`
+
+#### Setup
+
+1. Open the MiniMax platform and create an API key.
+2. Choose a system voice from the MiniMax voice list, or use a designed/cloned voice ID.
+3. Add to `.env`:
+   ```bash
+   MINIMAX_API_KEY=your-api-key
+   MINIMAX_TTS_VOICE_ID=your-voice-id
+   MINIMAX_TTS_MODEL=speech-2.8-hd
+   ```
+
+#### API Notes
+
+OpenMontage uses the synchronous HTTP T2A API:
+
+```text
+POST https://api.minimax.io/v1/t2a_v2
+Authorization: Bearer ${MINIMAX_API_KEY}
+```
+
+By default, OpenMontage requests MiniMax `hex` audio output, decodes it into `output_path`, and saves the full response JSON next to the audio file. Set `output_format: "url"` when you want MiniMax to return a temporary audio URL for OpenMontage to download.
+
+#### What It Is Best For
+
+- Expressive multilingual narration with current MiniMax Speech models
+- Short and medium narration segments under the HTTP T2A 10,000-character limit
+- Custom, designed, or cloned MiniMax voices
+- Sentence or word subtitle metadata for caption alignment
+
+#### Pacing
+
+Start with `speed: 1.0`, `pitch: 0`, and `language_boost: "auto"`. For Mandarin explainers, compare short samples before changing speed or pitch so the approved voice direction stays consistent.
+
+#### Pricing
+
+MiniMax Speech billing varies by plan and model. OpenMontage estimates cost from character count and prefers provider-returned `usage_characters` when available.
 
 ---
 

--- a/tests/contracts/test_phase3_contracts.py
+++ b/tests/contracts/test_phase3_contracts.py
@@ -29,6 +29,7 @@ from tools.tool_registry import ToolRegistry
 from tools.audio.elevenlabs_tts import ElevenLabsTTS
 from tools.audio.openai_tts import OpenAITTS
 from tools.audio.piper_tts import PiperTTS
+from tools.audio.minimax_tts import MiniMaxTTS
 from tools.audio.tts_selector import TTSSelector
 
 
@@ -72,6 +73,28 @@ class TestPiperTTS:
         tool = PiperTTS()
         assert "text_to_speech" in tool.capabilities
         assert "offline_generation" in tool.capabilities
+
+
+class TestMiniMaxTTS:
+    def test_identity(self):
+        tool = MiniMaxTTS()
+        info = tool.get_info()
+        assert info["name"] == "minimax_tts"
+        assert info["tier"] == "voice"
+        assert info["capability"] == "tts"
+        assert info["provider"] == "minimax"
+
+    def test_cost_estimate(self):
+        tool = MiniMaxTTS()
+        cost = tool.estimate_cost({"text": "Hello world, this is a test."})
+        assert cost > 0
+        assert cost < 0.01
+
+    def test_capabilities(self):
+        tool = MiniMaxTTS()
+        assert "text_to_speech" in tool.capabilities
+        assert "voice_selection" in tool.capabilities
+        assert "timestamp_alignment" in tool.capabilities
 
 
 class TestMusicGen:
@@ -143,7 +166,7 @@ class TestCapabilityMetadata:
         catalog = reg.capability_catalog()
         assert "tts" in catalog
         providers = {item["provider"] for item in catalog["tts"] if item["provider"] != "selector"}
-        assert providers == {"elevenlabs", "google_tts", "openai", "piper"}
+        assert providers == {"doubao", "elevenlabs", "google_tts", "minimax", "openai", "piper"}
 
 
 # ---- Animated Explainer Pipeline ----

--- a/tests/tools/test_minimax_tts.py
+++ b/tests/tools/test_minimax_tts.py
@@ -1,0 +1,243 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.audio.tts_selector import TTSSelector
+from tools.audio.minimax_tts import MiniMaxTTS
+from tools.base_tool import ToolStatus
+
+
+class FakeResponse:
+    def __init__(self, payload=None, content=b"", status_code=200):
+        self._payload = payload
+        self.content = content
+        self.status_code = status_code
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("not json")
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+def test_status_requires_api_key(monkeypatch):
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    assert MiniMaxTTS().get_status() == ToolStatus.UNAVAILABLE
+
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    assert MiniMaxTTS().get_status() == ToolStatus.AVAILABLE
+
+
+def test_execute_decodes_hex_audio_and_writes_metadata(monkeypatch, tmp_path):
+    post_calls = []
+
+    def fake_post(url, headers, json, timeout):
+        post_calls.append({"url": url, "headers": headers, "json": json, "timeout": timeout})
+        return FakeResponse(
+            {
+                "data": {"audio": b"audio-bytes".hex(), "status": 2, "subtitle_file": "subtitle-id"},
+                "extra_info": {
+                    "audio_length": 1234,
+                    "audio_sample_rate": 32000,
+                    "usage_characters": 12,
+                    "audio_format": "mp3",
+                    "audio_channel": 1,
+                },
+                "trace_id": "trace-123",
+                "base_resp": {"status_code": 0, "status_msg": "success"},
+            }
+        )
+
+    class FakeRequests:
+        post = staticmethod(fake_post)
+
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    monkeypatch.setitem(__import__("sys").modules, "requests", FakeRequests)
+
+    output_path = tmp_path / "sample.mp3"
+    result = MiniMaxTTS().execute(
+        {
+            "text": "hello minimax",
+            "voice_id": "voice-1",
+            "output_path": str(output_path),
+            "model": "speech-2.8-hd",
+        }
+    )
+
+    assert result.success
+    assert output_path.read_bytes() == b"audio-bytes"
+    metadata = json.loads(Path(result.data["metadata_path"]).read_text(encoding="utf-8"))
+    assert metadata["trace_id"] == "trace-123"
+    assert result.data["audio_duration_seconds"] == 1.23
+    assert result.data["subtitle_file"] == "subtitle-id"
+    assert result.cost_usd > 0
+
+    request = post_calls[0]
+    assert request["url"] == "https://api.minimax.io/v1/t2a_v2"
+    assert request["headers"]["Authorization"] == "Bearer test-key"
+    assert request["json"]["voice_setting"]["voice_id"] == "voice-1"
+    assert request["json"]["subtitle_enable"] is True
+    assert request["json"]["output_format"] == "hex"
+
+
+def test_tts_selector_routes_preferred_provider_to_minimax(monkeypatch, tmp_path):
+    def fake_post(url, headers, json, timeout):
+        assert url == "https://api.minimax.io/v1/t2a_v2"
+        return FakeResponse(
+            {
+                "data": {"audio": b"selector-audio".hex(), "status": 2},
+                "extra_info": {"audio_length": 1500, "usage_characters": 14},
+                "trace_id": "trace-selector",
+                "base_resp": {"status_code": 0, "status_msg": "success"},
+            }
+        )
+
+    class FakeRequests:
+        post = staticmethod(fake_post)
+
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    monkeypatch.setitem(__import__("sys").modules, "requests", FakeRequests)
+
+    output_path = tmp_path / "selector.mp3"
+    result = TTSSelector().execute(
+        {
+            "preferred_provider": "minimax",
+            "text": "hello selector",
+            "voice_id": "Chinese (Mandarin)_Reliable_Executive",
+            "output_path": str(output_path),
+        }
+    )
+
+    assert result.success
+    assert output_path.read_bytes() == b"selector-audio"
+    assert result.data["selected_tool"] == "minimax_tts"
+    assert result.data["selected_provider"] == "minimax"
+    assert result.data["trace_id"] == "trace-selector"
+
+
+def test_execute_downloads_url_audio(monkeypatch, tmp_path):
+    def fake_post(url, headers, json, timeout):
+        return FakeResponse(
+            {
+                "data": {"audio": "https://example.com/audio.mp3", "status": 2},
+                "extra_info": {},
+                "trace_id": "trace-url",
+                "base_resp": {"status_code": 0, "status_msg": "success"},
+            }
+        )
+
+    def fake_get(url, timeout):
+        assert url == "https://example.com/audio.mp3"
+        return FakeResponse(content=b"url-audio")
+
+    class FakeRequests:
+        post = staticmethod(fake_post)
+        get = staticmethod(fake_get)
+
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    monkeypatch.setitem(__import__("sys").modules, "requests", FakeRequests)
+
+    output_path = tmp_path / "url.mp3"
+    result = MiniMaxTTS().execute(
+        {
+            "text": "hello",
+            "voice_id": "voice-1",
+            "output_path": str(output_path),
+            "output_format": "url",
+        }
+    )
+
+    assert result.success
+    assert output_path.read_bytes() == b"url-audio"
+
+
+def test_list_voices_calls_get_voice(monkeypatch):
+    post_calls = []
+
+    def fake_post(url, headers, json, timeout):
+        post_calls.append({"url": url, "headers": headers, "json": json, "timeout": timeout})
+        return FakeResponse(
+            {
+                "system_voice": [
+                    {
+                        "voice_id": "Chinese (Mandarin)_Reliable_Executive",
+                        "voice_name": "Steady Executive",
+                    }
+                ],
+                "base_resp": {"status_code": 0, "status_msg": "success"},
+            }
+        )
+
+    class FakeRequests:
+        post = staticmethod(fake_post)
+
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    monkeypatch.setitem(__import__("sys").modules, "requests", FakeRequests)
+
+    payload = MiniMaxTTS().list_voices("system")
+
+    assert payload["system_voice"][0]["voice_id"] == "Chinese (Mandarin)_Reliable_Executive"
+    request = post_calls[0]
+    assert request["url"] == "https://api.minimax.io/v1/get_voice"
+    assert request["headers"]["Authorization"] == "Bearer test-key"
+    assert request["json"] == {"voice_type": "system"}
+
+
+def test_list_voices_rejects_unknown_voice_type(monkeypatch):
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+
+    with pytest.raises(ValueError, match="voice_type"):
+        MiniMaxTTS().list_voices("unknown")
+
+
+def test_rejects_text_above_http_limit(monkeypatch):
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    result = MiniMaxTTS().execute({"text": "x" * 10001, "voice_id": "voice-1"})
+
+    assert not result.success
+    assert "10000 characters" in result.error
+
+
+def test_minimax_error_redacts_api_key(monkeypatch):
+    def fake_post(url, headers, json, timeout):
+        return FakeResponse(
+            {
+                "data": None,
+                "base_resp": {
+                    "status_code": 1001,
+                    "status_msg": "invalid api key test-secret",
+                },
+            },
+            status_code=401,
+        )
+
+    class FakeRequests:
+        post = staticmethod(fake_post)
+
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-secret")
+    monkeypatch.setitem(__import__("sys").modules, "requests", FakeRequests)
+
+    result = MiniMaxTTS().execute({"text": "hello", "voice_id": "voice-1"})
+
+    assert not result.success
+    assert "test-secret" not in result.error
+    assert "[redacted]" in result.error
+
+
+def test_request_body_omits_optional_payloads_by_default():
+    body = MiniMaxTTS()._request_body(
+        {"text": "hello"},
+        voice_id="voice-1",
+        model="speech-2.8-hd",
+        output_format="hex",
+    )
+
+    assert body["stream"] is False
+    assert body["language_boost"] == "auto"
+    assert body["voice_setting"]["voice_id"] == "voice-1"
+    assert "pronunciation_dict" not in body
+    assert "voice_modify" not in body

--- a/tools/audio/minimax_audition.py
+++ b/tools/audio/minimax_audition.py
@@ -1,0 +1,229 @@
+"""Batch audition helper for MiniMax Speech voices.
+
+This module is intentionally a small CLI wrapper around MiniMaxTTS rather than
+a BaseTool. OpenMontage discovers provider tools automatically, and this helper
+exists only to make voice selection practical when MiniMax's static voice list
+does not include audio previews.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+from tools.audio.minimax_tts import MiniMaxTTS
+
+
+DEFAULT_MANDARIN_VOICES = [
+    "Chinese (Mandarin)_Reliable_Executive",
+    "Chinese (Mandarin)_News_Anchor",
+    "Chinese (Mandarin)_Male_Announcer",
+    "Chinese (Mandarin)_Radio_Host",
+    "Chinese (Mandarin)_Gentleman",
+    "Chinese (Mandarin)_Warm_Bestie",
+    "Chinese (Mandarin)_Sincere_Adult",
+    "Chinese (Mandarin)_Mature_Woman",
+]
+
+DEFAULT_TEXT = (
+    "这个工具不是替你写一个结论，而是把日志、链路、订单和上下文串起来，"
+    "让排查过程从凭经验，变成可复盘的工作流。"
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    text = load_text(args)
+    tool = MiniMaxTTS()
+    voices = list(resolve_voices(args, tool))
+    output_dir = resolve_output_dir(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    rows = []
+    failures = []
+
+    for index, voice_id in enumerate(voices, start=1):
+        stem = f"{index:02d}-{slugify(voice_id)}"
+        audio_path = output_dir / f"{stem}.{args.format}"
+        metadata_path = output_dir / f"{stem}.{args.format}.json"
+        result = tool.execute(
+            {
+                "text": text,
+                "voice_id": voice_id,
+                "model": args.model,
+                "language_boost": args.language_boost,
+                "speed": args.speed,
+                "vol": args.vol,
+                "pitch": args.pitch,
+                "format": args.format,
+                "sample_rate": args.sample_rate,
+                "bitrate": args.bitrate,
+                "channel": args.channel,
+                "subtitle_enable": args.subtitle_enable,
+                "subtitle_type": args.subtitle_type,
+                "output_path": str(audio_path),
+                "metadata_path": str(metadata_path),
+            }
+        )
+        if result.success:
+            rows.append(
+                {
+                    "voice_id": voice_id,
+                    "audio": audio_path,
+                    "metadata": metadata_path,
+                    "duration": result.data.get("audio_duration_seconds"),
+                    "trace_id": result.data.get("trace_id"),
+                }
+            )
+        else:
+            failures.append({"voice_id": voice_id, "error": result.error or "unknown error"})
+            if not args.continue_on_error:
+                break
+
+    review_path = output_dir / "AUDITION_REVIEW.md"
+    review_path.write_text(render_review(args, text, rows, failures), encoding="utf-8")
+    print(f"MiniMax audition review: {review_path}")
+    return 1 if failures else 0
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate a MiniMax Speech voice audition pack.")
+    parser.add_argument("--text", help="Short audition text. Defaults to a Mandarin product-narration sample.")
+    parser.add_argument("--text-file", type=Path, help="Read audition text from a UTF-8 text file.")
+    parser.add_argument(
+        "--voices",
+        nargs="+",
+        help="Voice IDs to audition. Defaults to a practical Mandarin shortlist.",
+    )
+    parser.add_argument("--output-dir", type=Path, help="Directory for generated audio and review markdown.")
+    parser.add_argument("--model", default="speech-2.8-hd")
+    parser.add_argument("--language-boost", default="Chinese")
+    parser.add_argument("--speed", type=float, default=1.0)
+    parser.add_argument("--vol", type=float, default=1.0)
+    parser.add_argument("--pitch", type=int, default=0)
+    parser.add_argument("--format", choices=["mp3", "wav", "flac"], default="mp3")
+    parser.add_argument("--sample-rate", type=int, default=32000)
+    parser.add_argument("--bitrate", type=int, default=128000)
+    parser.add_argument("--channel", type=int, choices=[1, 2], default=1)
+    parser.add_argument("--subtitle-enable", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--subtitle-type", choices=["sentence", "word"], default="sentence")
+    parser.add_argument(
+        "--discover-voices",
+        action="store_true",
+        help="Fetch account-available voices from MiniMax Get Voice before auditioning.",
+    )
+    parser.add_argument(
+        "--voice-type",
+        choices=["system", "voice_cloning", "voice_generation", "all"],
+        default="system",
+        help="Voice category to fetch when --discover-voices is set.",
+    )
+    parser.add_argument(
+        "--language-filter",
+        default="Chinese (Mandarin)",
+        help="Only audition discovered voices whose voice_id contains this text. Use an empty string to disable.",
+    )
+    parser.add_argument(
+        "--max-voices",
+        type=int,
+        default=8,
+        help="Maximum number of discovered voices to audition.",
+    )
+    parser.add_argument("--continue-on-error", action="store_true")
+    return parser.parse_args(argv)
+
+
+def load_text(args: argparse.Namespace) -> str:
+    if args.text_file:
+        return args.text_file.read_text(encoding="utf-8").strip()
+    return (args.text or DEFAULT_TEXT).strip()
+
+
+def resolve_voices(args: argparse.Namespace, tool: MiniMaxTTS) -> Iterable[str]:
+    if args.voices:
+        return args.voices
+    if not args.discover_voices:
+        return DEFAULT_MANDARIN_VOICES
+
+    payload = tool.list_voices(args.voice_type)
+    candidates = []
+    voice_keys = ["system_voice", "voice_cloning", "voice_generation"]
+    for key in voice_keys:
+        for item in payload.get(key, []) or []:
+            voice_id = item.get("voice_id")
+            if not voice_id:
+                continue
+            if args.language_filter and args.language_filter not in voice_id:
+                continue
+            candidates.append(voice_id)
+    return candidates[: args.max_voices]
+
+
+def resolve_output_dir(output_dir: Path | None) -> Path:
+    if output_dir:
+        return output_dir
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    return Path("projects/minimax-tts-audition/assets/audio") / stamp
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-").lower()
+    return slug or "voice"
+
+
+def render_review(
+    args: argparse.Namespace,
+    text: str,
+    rows: list[dict[str, object]],
+    failures: list[dict[str, str]],
+) -> str:
+    lines = [
+        "# MiniMax TTS Audition Review",
+        "",
+        "## Settings",
+        "",
+        f"- Model: `{args.model}`",
+        f"- Language boost: `{args.language_boost}`",
+        f"- Speed: `{args.speed}`",
+        f"- Pitch: `{args.pitch}`",
+        f"- Format: `{args.format}`",
+        f"- Subtitle type: `{args.subtitle_type}`",
+        "",
+        "## Audition Text",
+        "",
+        text,
+        "",
+        "## Voice Candidates",
+        "",
+        "| Voice ID | Duration | Audio | Metadata | Trace ID | Notes |",
+        "|---|---:|---|---|---|---|",
+    ]
+    for row in rows:
+        duration = row["duration"]
+        duration_text = f"{duration:.2f}s" if isinstance(duration, (int, float)) else ""
+        audio = Path(str(row["audio"]))
+        metadata = Path(str(row["metadata"]))
+        lines.append(
+            "| "
+            f"`{row['voice_id']}` | "
+            f"{duration_text} | "
+            f"[audio]({audio.name}) | "
+            f"[json]({metadata.name}) | "
+            f"`{row.get('trace_id') or ''}` |  |"
+        )
+
+    if failures:
+        lines.extend(["", "## Failures", ""])
+        for failure in failures:
+            lines.append(f"- `{failure['voice_id']}`: {failure['error']}")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/audio/minimax_tts.py
+++ b/tools/audio/minimax_tts.py
@@ -1,0 +1,458 @@
+"""MiniMax Speech text-to-speech provider tool."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+
+class MiniMaxTTS(BaseTool):
+    name = "minimax_tts"
+    version = "0.1.0"
+    tier = ToolTier.VOICE
+    capability = "tts"
+    provider = "minimax"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = []
+    install_instructions = (
+        "Set MINIMAX_API_KEY to a MiniMax platform API key.\n"
+        "Optional: set MINIMAX_TTS_VOICE_ID for the default voice and "
+        "MINIMAX_TTS_MODEL for the default speech model."
+    )
+    fallback = "doubao_tts"
+    fallback_tools = ["doubao_tts", "google_tts", "elevenlabs_tts", "openai_tts", "piper_tts"]
+    agent_skills = ["minimax-tts", "text-to-speech"]
+
+    capabilities = [
+        "text_to_speech",
+        "voice_selection",
+        "multilingual",
+        "voice_cloning",
+        "timestamp_alignment",
+    ]
+    supports = {
+        "voice_cloning": True,
+        "multilingual": True,
+        "offline": False,
+        "native_audio": True,
+        "timestamps": True,
+        "streaming": False,
+        "long_text_async": False,
+    }
+    best_for = [
+        "expressive multilingual narration",
+        "short and medium voiceover segments with subtitle metadata",
+        "custom or cloned MiniMax voices",
+    ]
+    not_good_for = [
+        "fully offline production",
+        "single-call long-form narration above 10000 characters",
+        "real-time playback; use the MiniMax WebSocket API for that workflow",
+    ]
+
+    input_schema = {
+        "type": "object",
+        "required": ["text"],
+        "properties": {
+            "text": {
+                "type": "string",
+                "description": "Text to convert to speech. MiniMax HTTP T2A accepts up to 10000 characters.",
+            },
+            "voice_id": {
+                "type": "string",
+                "description": "MiniMax system, designed, or cloned voice ID. Defaults to MINIMAX_TTS_VOICE_ID.",
+            },
+            "model": {
+                "type": "string",
+                "default": "speech-2.8-hd",
+                "enum": [
+                    "speech-2.8-hd",
+                    "speech-2.8-turbo",
+                    "speech-2.6-hd",
+                    "speech-2.6-turbo",
+                    "speech-02-hd",
+                    "speech-02-turbo",
+                    "speech-01-hd",
+                    "speech-01-turbo",
+                ],
+            },
+            "language_boost": {
+                "type": "string",
+                "default": "auto",
+                "description": "Language enhancement value such as auto, Chinese, English, Japanese, or Korean.",
+            },
+            "speed": {
+                "type": "number",
+                "default": 1.0,
+                "minimum": 0.5,
+                "maximum": 2.0,
+            },
+            "vol": {
+                "type": "number",
+                "default": 1.0,
+                "minimum": 0.1,
+                "maximum": 10.0,
+            },
+            "pitch": {
+                "type": "integer",
+                "default": 0,
+                "minimum": -12,
+                "maximum": 12,
+            },
+            "format": {
+                "type": "string",
+                "default": "mp3",
+                "enum": ["mp3", "wav", "flac"],
+            },
+            "sample_rate": {
+                "type": "integer",
+                "default": 32000,
+                "enum": [8000, 16000, 22050, 24000, 32000, 44100],
+            },
+            "bitrate": {
+                "type": "integer",
+                "default": 128000,
+            },
+            "channel": {
+                "type": "integer",
+                "default": 1,
+                "enum": [1, 2],
+            },
+            "output_format": {
+                "type": "string",
+                "default": "hex",
+                "enum": ["hex", "url"],
+                "description": "MiniMax non-streaming response format. hex embeds audio; url returns a temporary URL.",
+            },
+            "subtitle_enable": {
+                "type": "boolean",
+                "default": True,
+                "description": "Request subtitle timing metadata from MiniMax when supported.",
+            },
+            "subtitle_type": {
+                "type": "string",
+                "default": "sentence",
+                "enum": ["sentence", "word"],
+            },
+            "pronunciation_dict": {
+                "type": "object",
+                "description": "Optional MiniMax pronunciation dictionary payload.",
+            },
+            "voice_modify": {
+                "type": "object",
+                "description": "Optional MiniMax voice effects payload.",
+            },
+            "output_path": {"type": "string"},
+            "metadata_path": {
+                "type": "string",
+                "description": "Where to save the full MiniMax response JSON. Defaults next to output_path.",
+            },
+            "api_base": {
+                "type": "string",
+                "default": "https://api.minimax.io",
+                "description": "Override MiniMax API base URL.",
+            },
+        },
+    }
+
+    output_schema = {
+        "type": "object",
+        "properties": {
+            "output": {"type": "string"},
+            "metadata_path": {"type": "string"},
+            "trace_id": {"type": ["string", "null"]},
+            "audio_duration_seconds": {"type": ["number", "null"]},
+            "extra_info": {"type": ["object", "null"]},
+            "subtitle_file": {"type": ["string", "null"]},
+        },
+    }
+    artifact_schema = {
+        "type": "array",
+        "items": {"type": "string"},
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=50, network_required=True
+    )
+    retry_policy = RetryPolicy(
+        max_retries=2,
+        backoff_seconds=2.0,
+        retryable_errors=["timeout", "rate limit", "too many requests"],
+    )
+    idempotency_key_fields = ["text", "voice_id", "model", "speed", "format", "sample_rate"]
+    side_effects = [
+        "writes audio file to output_path",
+        "writes MiniMax response metadata JSON next to output_path",
+        "calls MiniMax Speech T2A HTTP API",
+    ]
+    user_visible_verification = [
+        "Listen to generated audio for tone, pronunciation, and pacing",
+        "Check subtitle metadata before caption alignment",
+    ]
+    quality_score = 0.87
+    latency_p50_seconds = 6.0
+
+    DEFAULT_API_BASE = "https://api.minimax.io"
+    T2A_PATH = "/v1/t2a_v2"
+    GET_VOICE_PATH = "/v1/get_voice"
+    DEFAULT_MODEL = "speech-2.8-hd"
+    DEFAULT_VOICE_ENV = "MINIMAX_TTS_VOICE_ID"
+    DEFAULT_MODEL_ENV = "MINIMAX_TTS_MODEL"
+
+    def get_status(self) -> ToolStatus:
+        if os.environ.get("MINIMAX_API_KEY"):
+            return ToolStatus.AVAILABLE
+        return ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        # MiniMax speech billing varies by plan/model. Use a conservative
+        # character-based estimate and prefer provider usage metadata when present.
+        return round(len(inputs.get("text", "")) * 0.00002, 4)
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        api_key = os.environ.get("MINIMAX_API_KEY")
+        if not api_key:
+            return ToolResult(success=False, error="No MiniMax API key. " + self.install_instructions)
+
+        voice_id = inputs.get("voice_id") or os.environ.get(self.DEFAULT_VOICE_ENV)
+        if not voice_id:
+            return ToolResult(
+                success=False,
+                error=(
+                    "No MiniMax voice_id provided. Pass voice_id or set "
+                    f"{self.DEFAULT_VOICE_ENV} in the environment."
+                ),
+            )
+
+        start = time.time()
+        try:
+            result = self._generate(inputs, api_key=api_key, voice_id=voice_id)
+        except Exception as exc:
+            return ToolResult(success=False, error=f"MiniMax TTS failed: {self._safe_error(exc)}")
+
+        result.duration_seconds = round(time.time() - start, 2)
+        if not result.cost_usd:
+            result.cost_usd = self.estimate_cost(inputs)
+        return result
+
+    def list_voices(self, voice_type: str = "all", *, api_key: str | None = None) -> dict[str, Any]:
+        """Return MiniMax voices available to the current account."""
+        import requests
+
+        key = api_key or os.environ.get("MINIMAX_API_KEY")
+        if not key:
+            raise RuntimeError("No MiniMax API key. " + self.install_instructions)
+        if voice_type not in {"system", "voice_cloning", "voice_generation", "all"}:
+            raise ValueError("voice_type must be one of: system, voice_cloning, voice_generation, all")
+
+        response = requests.post(
+            self._endpoint({}, path=self.GET_VOICE_PATH),
+            headers={
+                "Authorization": f"Bearer {key}",
+                "Content-Type": "application/json",
+            },
+            json={"voice_type": voice_type},
+            timeout=(10, 60),
+        )
+        payload = self._json_or_raise(response)
+        self._raise_for_minimax_error(response.status_code, payload)
+        return payload
+
+    def _generate(self, inputs: dict[str, Any], *, api_key: str, voice_id: str) -> ToolResult:
+        import requests
+
+        text = inputs["text"]
+        if len(text) > 10000:
+            raise ValueError("MiniMax HTTP T2A text must be 10000 characters or fewer.")
+
+        model = inputs.get("model") or os.environ.get(self.DEFAULT_MODEL_ENV) or self.DEFAULT_MODEL
+        fmt = inputs.get("format", "mp3")
+        output_format = inputs.get("output_format", "hex")
+        output_path = Path(inputs.get("output_path", f"minimax_tts.{fmt}"))
+        metadata_path = Path(
+            inputs.get("metadata_path") or output_path.with_suffix(output_path.suffix + ".json")
+        )
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        metadata_path.parent.mkdir(parents=True, exist_ok=True)
+
+        response = requests.post(
+            self._endpoint(inputs),
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json=self._request_body(inputs, voice_id=voice_id, model=model, output_format=output_format),
+            timeout=(10, 120),
+        )
+        payload = self._json_or_raise(response)
+        self._raise_for_minimax_error(response.status_code, payload)
+
+        audio_ref = (payload.get("data") or {}).get("audio")
+        if not audio_ref:
+            raise RuntimeError("MiniMax task completed but did not return data.audio")
+
+        if output_format == "url":
+            audio_response = requests.get(audio_ref, timeout=(10, 120))
+            audio_response.raise_for_status()
+            output_path.write_bytes(audio_response.content)
+        else:
+            output_path.write_bytes(bytes.fromhex(audio_ref))
+
+        metadata_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+        extra_info = payload.get("extra_info") or {}
+        audio_duration = self._duration_from_extra_info(extra_info) or self._audio_duration(output_path)
+        cost = self._cost_from_extra_info(extra_info) or self.estimate_cost(inputs)
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": self.provider,
+                "model": model,
+                "voice_id": voice_id,
+                "format": fmt,
+                "sample_rate": inputs.get("sample_rate", 32000),
+                "speed": inputs.get("speed", 1.0),
+                "language_boost": inputs.get("language_boost", "auto"),
+                "output_format": output_format,
+                "text_length": len(text),
+                "trace_id": payload.get("trace_id"),
+                "status": (payload.get("data") or {}).get("status"),
+                "audio_duration_seconds": round(audio_duration, 2) if audio_duration else None,
+                "output": str(output_path),
+                "metadata_path": str(metadata_path),
+                "extra_info": extra_info,
+                "subtitle_file": (payload.get("data") or {}).get("subtitle_file"),
+            },
+            artifacts=[str(output_path), str(metadata_path)],
+            cost_usd=cost,
+            model=model,
+        )
+
+    def _endpoint(self, inputs: dict[str, Any], *, path: str | None = None) -> str:
+        api_base = (inputs.get("api_base") or os.environ.get("MINIMAX_API_BASE") or self.DEFAULT_API_BASE).rstrip("/")
+        return f"{api_base}{path or self.T2A_PATH}"
+
+    def _request_body(
+        self,
+        inputs: dict[str, Any],
+        *,
+        voice_id: str,
+        model: str,
+        output_format: str,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "model": model,
+            "text": inputs["text"],
+            "stream": False,
+            "language_boost": inputs.get("language_boost", "auto"),
+            "output_format": output_format,
+            "voice_setting": {
+                "voice_id": voice_id,
+                "speed": inputs.get("speed", 1.0),
+                "vol": inputs.get("vol", 1.0),
+                "pitch": inputs.get("pitch", 0),
+            },
+            "audio_setting": {
+                "sample_rate": inputs.get("sample_rate", 32000),
+                "bitrate": inputs.get("bitrate", 128000),
+                "format": inputs.get("format", "mp3"),
+                "channel": inputs.get("channel", 1),
+            },
+            "subtitle_enable": bool(inputs.get("subtitle_enable", True)),
+            "subtitle_type": inputs.get("subtitle_type", "sentence"),
+        }
+        if inputs.get("pronunciation_dict"):
+            body["pronunciation_dict"] = inputs["pronunciation_dict"]
+        if inputs.get("voice_modify"):
+            body["voice_modify"] = inputs["voice_modify"]
+        return body
+
+    @staticmethod
+    def _json_or_raise(response: Any) -> dict[str, Any]:
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise RuntimeError(f"Non-JSON response from MiniMax API: HTTP {response.status_code}") from exc
+
+    def _raise_for_minimax_error(self, http_status: int, payload: dict[str, Any]) -> None:
+        base_resp = payload.get("base_resp") or {}
+        status_code = base_resp.get("status_code")
+        data_status = (payload.get("data") or {}).get("status")
+        if http_status < 400 and status_code in (0, "0", None) and data_status in (2, "2", None):
+            return
+
+        status_msg = base_resp.get("status_msg") or payload.get("message") or "unknown error"
+        hint = self._diagnostic_hint(str(status_msg))
+        raise RuntimeError(f"HTTP {http_status}, status_code {status_code}: {status_msg}{hint}")
+
+    @staticmethod
+    def _diagnostic_hint(message: str) -> str:
+        lowered = message.lower()
+        if "unauthorized" in lowered or "invalid api key" in lowered or "auth" in lowered:
+            return " (check MINIMAX_API_KEY and Bearer authorization)"
+        if "voice" in lowered and ("not found" in lowered or "invalid" in lowered or "permission" in lowered):
+            return " (check voice_id/MINIMAX_TTS_VOICE_ID and voice authorization)"
+        if "insufficient balance" in lowered or "balance" in lowered:
+            return " (check MiniMax Account > Billing > Balance and top up before generation)"
+        if "rate" in lowered or "quota" in lowered:
+            return " (check rate limit, balance, or remaining speech quota)"
+        if "text" in lowered and "10000" in lowered:
+            return " (split text into shorter segments or use MiniMax async T2A)"
+        return ""
+
+    @staticmethod
+    def _safe_error(exc: Exception) -> str:
+        api_key = os.environ.get("MINIMAX_API_KEY", "")
+        message = str(exc)
+        if api_key:
+            message = message.replace(api_key, "[redacted]")
+        return message
+
+    @staticmethod
+    def _duration_from_extra_info(extra_info: Any) -> float | None:
+        if not isinstance(extra_info, dict):
+            return None
+        audio_length = extra_info.get("audio_length")
+        if isinstance(audio_length, (int, float)) and audio_length > 0:
+            # MiniMax returns audio_length in milliseconds.
+            return float(audio_length) / 1000.0
+        return None
+
+    @staticmethod
+    def _audio_duration(path: Path) -> float | None:
+        try:
+            from tools.analysis.audio_probe import probe_duration
+
+            return probe_duration(path)
+        except Exception:
+            return None
+
+    @staticmethod
+    def _cost_from_extra_info(extra_info: Any) -> float | None:
+        if not isinstance(extra_info, dict):
+            return None
+        usage_characters = extra_info.get("usage_characters")
+        if not isinstance(usage_characters, (int, float)):
+            return None
+        return round(float(usage_characters) * 0.00002, 4)


### PR DESCRIPTION
## Summary
- add a MiniMax Speech HTTP T2A provider for OpenMontage TTS workflows
- add MiniMax voice discovery and a batch audition helper for practical voice selection
- document env setup, provider behavior, and MiniMax-specific agent usage

## Verification
- `python -m pytest tests/tools/test_minimax_tts.py tests/contracts/test_phase3_contracts.py -q` -> 75 passed
- registry discovery confirms `minimax_tts` is registered with capability `tts`
- `TTSSelector(preferred_provider="minimax")` is covered by a mocked end-to-end provider routing test
- real MiniMax `get_voice` call authenticated successfully and returned system voices; paid T2A generation could not be smoke-tested because the account returned `insufficient balance`

## Notes
- This PR covers HTTP T2A generation, metadata capture, voice discovery, and audition helpers.
- Async T2A, WebSocket streaming, voice cloning, and voice design remain future enhancements.