### PR TITLE
feat(tts): integrate Gemini API text-to-speech

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,10 @@
 FAL_KEY=                     # FLUX images, Google Veo video, Kling video, MiniMax video, Recraft images
                              # Get one at https://fal.ai/dashboard/keys
 
-# --- Google (one key unlocks image gen + TTS) ---
-GOOGLE_API_KEY=              # Google Imagen images, Google Cloud TTS (700+ voices, 50+ languages)
+# --- Google ---
+GOOGLE_API_KEY=              # Google Imagen images + latest Gemini API TTS key path
                              # Get one at https://aistudio.google.com/apikey
+GEMINI_API_KEY=              # Optional alias for Gemini API TTS; overrides GOOGLE_API_KEY when set
 
 # --- Voice ---
 ELEVENLABS_API_KEY=          # TTS narration, music generation, sound effects

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Turn your AI coding assistant into a full video production studio. Describe what
   <video src="https://github.com/user-attachments/assets/8daca07f-cdf8-4bec-89c3-9dc2176363fa" width="100%" controls></video>
 </div>
 
-> **"THE LAST BANANA"** — a 60-second Pixar-style animated short about a lonely banana who finds friendship with a kiwi. 6 Kling v3-generated motion clips (via fal.ai), Google Chirp3-HD narration, royalty-free piano music, TikTok-style word-level captions, and Remotion composition. Total cost: **$1.33**.
+> **"THE LAST BANANA"** — a 60-second Pixar-style animated short about a lonely banana who finds friendship with a kiwi. 6 Kling v3-generated motion clips (via fal.ai), Google Gemini narration, royalty-free piano music, TikTok-style word-level captions, and Remotion composition. Total cost: **$1.33**.
 
 <div align="center">
   <video src="https://github.com/user-attachments/assets/8a6d2cc3-7ad2-46f5-922f-a8e3e5848d9f" width="100%" controls></video>
@@ -173,7 +173,8 @@ SUNO_API_KEY=your-key          # Full songs, instrumentals, any genre
 ELEVENLABS_API_KEY=your-key    # Premium TTS, AI music, sound effects
 OPENAI_API_KEY=your-key        # OpenAI TTS, DALL-E 3 images
 XAI_API_KEY=your-key           # xAI Grok image edits/generation + Grok video generation
-GOOGLE_API_KEY=your-key        # Google Imagen images, Google TTS (700+ voices)
+GOOGLE_API_KEY=your-key        # Google Imagen images + Gemini API TTS
+GEMINI_API_KEY=your-key        # Optional Gemini API TTS alias
 
 # More video providers:
 HEYGEN_API_KEY=your-key        # HeyGen — VEO, Sora, Runway, Kling via single gateway
@@ -451,7 +452,7 @@ Each tool declares which Layer 3 skills it relies on. The agent reads Layer 1 to
 | Provider | Type | Notes |
 |----------|------|-------|
 | **ElevenLabs** | Cloud API | Premium voice quality |
-| **Google TTS** | Cloud API | 700+ voices, 50+ languages — best for localization |
+| **Google TTS** | Cloud API | Latest Gemini API TTS prompt control |
 | **OpenAI TTS** | Cloud API | Fast, affordable |
 | **Piper** | Local | Completely free, offline |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -389,7 +389,7 @@ All config is validated via Pydantic models in `lib/config_model.py`.
 | `HEYGEN_API_KEY` | heygen_video | Multi-provider video generation |
 | `PEXELS_API_KEY` | pexels_image, pexels_video | Stock media |
 | `PIXABAY_API_KEY` | pixabay_image, pixabay_video | Stock media |
-| `GOOGLE_API_KEY` | google_imagen, google_tts | Google Imagen images, Google Cloud TTS |
+| `GOOGLE_API_KEY` / `GEMINI_API_KEY` | google_imagen, google_tts | Google Imagen images and latest Gemini API TTS |
 | `RUNWAY_API_KEY` | runway_video | Runway Gen-3/Gen-4 direct |
 | `HIGGSFIELD_API_KEY` + `HIGGSFIELD_API_SECRET` | higgsfield_video | Higgsfield multi-model video |
 | `MODAL_LTX2_ENDPOINT_URL` | ltx_video_modal | Self-hosted LTX-2 |

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -253,6 +253,27 @@ Gemini API TTS supports prompt-directed single-speaker and two-speaker audio. Us
 }
 ```
 
+For repeatable narration auditions, prefer `delivery_preset` plus optional `duration_target_seconds` before hand-writing long prompt instructions. The duration target is prompt guidance, not a hard API speed parameter, so always listen to the sample and probe the final audio duration:
+
+```json
+{
+  "text": "遇到生产问题时，先让 Agent 汇总日志线索。",
+  "voice": "Kore",
+  "delivery_preset": "technical_briefing",
+  "duration_target_seconds": 5.2,
+  "prompt": "Mandarin narration, mature and steady, with clear product-demo pacing."
+}
+```
+
+Available delivery presets:
+
+| Preset | Use when |
+|--------|----------|
+| `technical_briefing` | Product demos, system explainers, and precise technical narration |
+| `compact_explainer` | A segment must stay tight without losing clarity |
+| `warm_opening` | Opening lines need a softer lead-in before the main problem statement |
+| `clear_cta` | Closing or action-oriented lines need faster, crisp emphasis |
+
 #### Google Imagen Pricing
 
 | Model | Price per image |

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -32,8 +32,9 @@ Everything you need to know about every provider in OpenMontage — setup instru
 PEXELS_API_KEY=              # Stock photos + videos
 PIXABAY_API_KEY=             # Stock photos + videos
 
-# GOOGLE (one key, two tools, generous free tier)
-GOOGLE_API_KEY=              # Google TTS + Google Imagen
+# GOOGLE
+GOOGLE_API_KEY=              # Gemini API TTS + Google Imagen
+GEMINI_API_KEY=              # Optional Gemini API TTS alias
 
 # VOICE + MUSIC
 ELEVENLABS_API_KEY=          # TTS, music, sound effects (10K chars/month free)
@@ -207,12 +208,12 @@ Doubao Speech 2.0 is billed by character package or usage in Volcengine. OpenMon
 
 ---
 
-### Google — TTS + Imagen (Shared Key)
+### Google — Gemini API TTS + Imagen
 
-> **One key, two tools.** Google Cloud TTS has 700+ voices in 50+ languages — the strongest localization option. Imagen 4 generates high-quality images.
+> **Latest Google TTS only.** OpenMontage uses Gemini API TTS, defaulting to `gemini-3.1-flash-tts-preview`. Imagen 4 uses the same Google API key family.
 
 **Tools unlocked:** `google_tts`, `google_imagen`
-**Env var:** `GOOGLE_API_KEY`
+**Env vars:** `GOOGLE_API_KEY` or `GEMINI_API_KEY` for Gemini API TTS.
 
 #### Setup
 
@@ -220,28 +221,37 @@ Doubao Speech 2.0 is billed by character package or usage in Volcengine. OpenMon
 2. Navigate to [aistudio.google.com/apikey](https://aistudio.google.com/apikey)
 3. Click **Create API Key**, select a Google Cloud project
 4. Copy the key
-5. Add to `.env`: `GOOGLE_API_KEY=AIza...`
+5. Add to `.env`: `GOOGLE_API_KEY=AIza...` or `GEMINI_API_KEY=AIza...`
 
-**For TTS specifically**, you also need to enable the Text-to-Speech API:
-1. Visit [console.cloud.google.com/apis/library/texttospeech.googleapis.com](https://console.cloud.google.com/apis/library/texttospeech.googleapis.com)
-2. Click **Enable**
-3. Make sure your API key's restrictions allow the Text-to-Speech API
+OpenMontage `google_tts` defaults to:
+
+```json
+{
+  "model": "gemini-3.1-flash-tts-preview",
+  "voice": "Kore"
+}
+```
+
+Gemini API returns 24 kHz PCM audio. OpenMontage writes a WAV file by default.
 
 **For Imagen**, enable the Generative Language API:
 1. Visit [console.cloud.google.com/apis/library/generativelanguage.googleapis.com](https://console.cloud.google.com/apis/library/generativelanguage.googleapis.com)
 2. Click **Enable**
 
-#### Google TTS Pricing
+#### Gemini API TTS
 
-| Voice Type | Free tier | Paid (per 1M chars) | Notes |
-|-----------|-----------|---------------------|-------|
-| **Standard** | 1M chars/month | $4.00 | Basic quality, fast |
-| **WaveNet** | 1M chars/month | $16.00 | Natural-sounding |
-| **Neural2** | 1M chars/month | $16.00 | Best quality |
-| **Studio** | — | $24.00 | Professional studio voices |
-| **Chirp** | — | $4.00 | Conversational style |
+Gemini API TTS supports prompt-directed single-speaker and two-speaker audio. Use `prompt` to describe tone, pace, accent, and emotion. Use `speaker_voice_configs` for dialogue:
 
-The free tiers apply *independently* — you get 1M Standard AND 1M WaveNet AND 1M Neural2 characters per month free. That's roughly 250+ minutes of narration per month at zero cost.
+```json
+{
+  "text": "Host: Welcome.\nGuest: Thanks for having me.",
+  "prompt": "Warm podcast conversation, natural pacing.",
+  "speaker_voice_configs": [
+    {"speaker": "Host", "voice": "Kore"},
+    {"speaker": "Guest", "voice": "Puck"}
+  ]
+}
+```
 
 #### Google Imagen Pricing
 
@@ -251,26 +261,22 @@ The free tiers apply *independently* — you get 1M Standard AND 1M WaveNet AND 
 | Imagen 4 Standard | $0.04 |
 | Imagen 4 Ultra | $0.06 |
 
-**Free tier for Imagen:** None. Paid tier only.
+#### Gemini API TTS Voice Options
 
-**New account bonus:** Google Cloud offers **$300 in free credits** for new accounts (90-day trial), applicable to both TTS and Imagen.
+Use Gemini prebuilt voice names such as:
 
-#### Google TTS Voice Types
+| Voice | Character |
+|-------|-----------|
+| `Kore` | Firm |
+| `Charon` | Informative |
+| `Aoede` | Breezy |
+| `Puck` | Upbeat |
+| `Orus` | Firm |
+| `Leda` | Youthful |
 
-Google TTS offers 700+ voices across 50+ languages. Voice names follow the pattern `{language}-{type}-{letter}`:
+**Recommended voices:** Start with `Kore` for firm narration, `Charon` for informative explainers, `Aoede` for breezy friendly narration, and `Puck` for upbeat dialogue.
 
-| Type | Example | Quality | Cost |
-|------|---------|---------|------|
-| **Chirp 3 HD** | `en-US-Chirp3-HD-Orus` | **Best (2024, most natural)** | **Mid — default** |
-| Standard | `en-US-Standard-A` | Good | Cheapest |
-| WaveNet | `en-US-WaveNet-D` | Very good | Mid |
-| Neural2 | `en-US-Neural2-D` | Excellent | Mid |
-| Studio | `en-US-Studio-O` | Professional | Highest |
-| Journey | `en-US-Journey-D` | Conversational (long-form) | Mid |
-
-**Recommended voices:** `en-US-Chirp3-HD-Orus` (male, rich/cinematic), `en-US-Chirp3-HD-Aoede` (female, warm). These are Google's newest tier — most natural-sounding, uses the v1beta1 endpoint automatically.
-
-**Languages include:** English (US, UK, AU, IN), Spanish, French, German, Italian, Portuguese, Japanese, Korean, Chinese (Mandarin, Cantonese), Arabic, Hindi, Russian, Dutch, Polish, Turkish, Vietnamese, Thai, Indonesian, and 30+ more.
+**Languages include:** Gemini API TTS supports automatic language detection across its supported TTS languages.
 
 ---
 

--- a/tests/contracts/test_phase3_contracts.py
+++ b/tests/contracts/test_phase3_contracts.py
@@ -114,6 +114,33 @@ class TestGoogleTTS:
             == "Kore"
         )
 
+    def test_delivery_preset_and_duration_target_become_prompt_guidance(self):
+        tool = GoogleTTS()
+        payload = tool._payload(
+            {
+                "text": "遇到生产问题时，先让 Agent 汇总日志线索。",
+                "delivery_preset": "technical_briefing",
+                "duration_target_seconds": 5.2,
+                "prompt": "Use a mature female Mandarin voice direction.",
+            },
+            voice_name="Kore",
+        )
+        text = payload["contents"][0]["parts"][0]["text"]
+        assert "focused technical product briefing" in text
+        assert "approximately 5.2 seconds" in text
+        assert "Use a mature female Mandarin voice direction." in text
+        assert text.endswith("遇到生产问题时，先让 Agent 汇总日志线索。")
+
+    def test_rejects_unknown_delivery_preset(self):
+        tool = GoogleTTS()
+        with pytest.raises(ValueError, match="delivery_preset"):
+            tool._validate_inputs({"text": "Hello", "delivery_preset": "sleepy_anchor"})
+
+    def test_rejects_non_positive_duration_target(self):
+        tool = GoogleTTS()
+        with pytest.raises(ValueError, match="duration_target_seconds"):
+            tool._validate_inputs({"text": "Hello", "duration_target_seconds": 0})
+
     def test_multi_speaker_payload_maps_speakers_to_voices(self):
         tool = GoogleTTS()
         payload = tool._payload(

--- a/tests/contracts/test_phase3_contracts.py
+++ b/tests/contracts/test_phase3_contracts.py
@@ -27,6 +27,7 @@ from tools.base_tool import ToolTier
 from tools.audio.music_gen import MusicGen
 from tools.tool_registry import ToolRegistry
 from tools.audio.elevenlabs_tts import ElevenLabsTTS
+from tools.audio.google_tts import GoogleTTS
 from tools.audio.openai_tts import OpenAITTS
 from tools.audio.piper_tts import PiperTTS
 from tools.audio.tts_selector import TTSSelector
@@ -72,6 +73,97 @@ class TestPiperTTS:
         tool = PiperTTS()
         assert "text_to_speech" in tool.capabilities
         assert "offline_generation" in tool.capabilities
+
+
+class TestGoogleTTS:
+    def test_identity(self):
+        tool = GoogleTTS()
+        info = tool.get_info()
+        assert info["name"] == "google_tts"
+        assert info["tier"] == "voice"
+        assert info["capability"] == "tts"
+        assert info["provider"] == "google_tts"
+
+    def test_gemini_prompt_model_supported(self):
+        tool = GoogleTTS()
+        assert tool._resolve_model({"model": "gemini"}) == "gemini-3.1-flash-tts-preview"
+        tool._validate_inputs({"text": "Hello", "model": "gemini-3.1-flash-tts-preview"})
+        assert "style_prompting" in tool.capabilities
+
+    def test_status_uses_gemini_api_key(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        tool = GoogleTTS()
+        assert tool.get_status().value == "available"
+
+    def test_gemini_api_payload_combines_prompt_and_voice(self):
+        tool = GoogleTTS()
+        payload = tool._payload(
+            {
+                "text": "Have a wonderful day!",
+                "prompt": "Say cheerfully:",
+            },
+            voice_name="Kore",
+        )
+        text = payload["contents"][0]["parts"][0]["text"]
+        assert text.startswith("Say cheerfully:")
+        assert text.endswith("Have a wonderful day!")
+        assert payload["generationConfig"]["responseModalities"] == ["AUDIO"]
+        assert (
+            payload["generationConfig"]["speechConfig"]["voiceConfig"]
+            ["prebuiltVoiceConfig"]["voiceName"]
+            == "Kore"
+        )
+
+    def test_multi_speaker_payload_maps_speakers_to_voices(self):
+        tool = GoogleTTS()
+        payload = tool._payload(
+            {
+                "text": "Host: Welcome.\nGuest: Thanks.",
+                "speaker_voice_configs": [
+                    {"speaker": "Host", "voice": "Kore"},
+                    {"speaker": "Guest", "voice": "Puck"},
+                ],
+            },
+            voice_name="Kore",
+        )
+        configs = (
+            payload["generationConfig"]["speechConfig"]["multiSpeakerVoiceConfig"]
+            ["speakerVoiceConfigs"]
+        )
+        assert configs[0]["speaker"] == "Host"
+        assert configs[1]["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Puck"
+
+    def test_rejects_more_than_two_speakers(self):
+        tool = GoogleTTS()
+        with pytest.raises(ValueError, match="at most two speakers"):
+            tool._validate_inputs(
+                {
+                    "text": "Dialogue",
+                    "speaker_voice_configs": [
+                        {"speaker": "A", "voice": "Kore"},
+                        {"speaker": "B", "voice": "Puck"},
+                        {"speaker": "C", "voice": "Aoede"},
+                    ],
+                }
+            )
+
+    def test_extract_gemini_audio_accepts_inline_data(self):
+        payload = {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {
+                                "inlineData": {
+                                    "data": "aGVsbG8=",
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+        assert GoogleTTS._extract_audio(payload) == b"hello"
 
 
 class TestMusicGen:
@@ -143,7 +235,7 @@ class TestCapabilityMetadata:
         catalog = reg.capability_catalog()
         assert "tts" in catalog
         providers = {item["provider"] for item in catalog["tts"] if item["provider"] != "selector"}
-        assert providers == {"elevenlabs", "google_tts", "openai", "piper"}
+        assert providers == {"doubao", "elevenlabs", "google_tts", "openai", "piper"}
 
 
 # ---- Animated Explainer Pipeline ----

--- a/tools/audio/google_tts.py
+++ b/tools/audio/google_tts.py
@@ -1,14 +1,11 @@
-"""Google Cloud Text-to-Speech provider tool.
-
-Google TTS offers 700+ voices across 50+ languages, including Standard,
-WaveNet, Neural2, Studio, and Journey voice types — strong for localization.
-"""
+"""Google Gemini API text-to-speech provider tool."""
 
 from __future__ import annotations
 
 import base64
 import os
 import time
+import wave
 from pathlib import Path
 from typing import Any
 
@@ -28,20 +25,19 @@ from tools.base_tool import (
 
 class GoogleTTS(BaseTool):
     name = "google_tts"
-    version = "0.1.0"
+    version = "0.4.0"
     tier = ToolTier.VOICE
     capability = "tts"
     provider = "google_tts"
     stability = ToolStability.BETA
     execution_mode = ExecutionMode.SYNC
-    determinism = Determinism.DETERMINISTIC
+    determinism = Determinism.STOCHASTIC
     runtime = ToolRuntime.API
 
     dependencies = []
     install_instructions = (
-        "Set GOOGLE_API_KEY to your Google Cloud API key with Text-to-Speech enabled.\n"
-        "  Enable the API at https://console.cloud.google.com/apis/library/texttospeech.googleapis.com\n"
-        "  Or use GOOGLE_APPLICATION_CREDENTIALS for service account auth."
+        "Set GOOGLE_API_KEY or GEMINI_API_KEY for Gemini API text-to-speech.\n"
+        "Get a key at https://aistudio.google.com/apikey"
     )
     fallback = "openai_tts"
     fallback_tools = ["openai_tts", "elevenlabs_tts", "piper_tts"]
@@ -50,62 +46,84 @@ class GoogleTTS(BaseTool):
     capabilities = [
         "text_to_speech",
         "voice_selection",
-        "ssml_support",
-        "multilingual",
+        "style_prompting",
+        "multi_speaker",
+        "gemini_api_tts",
     ]
     supports = {
         "voice_cloning": False,
         "multilingual": True,
         "offline": False,
         "native_audio": True,
-        "ssml": True,
+        "ssml": False,
+        "style_prompting": True,
+        "gemini_api_key_auth": True,
+        "multi_speaker": True,
     }
     best_for = [
-        "localization — 700+ voices across 50+ languages",
-        "affordable high-quality TTS (Neural2, WaveNet)",
-        "Google ecosystem integration",
+        "latest Gemini API TTS narration with API-key setup",
+        "prompt-directed tone, pace, accent, and emotion",
+        "single-speaker or two-speaker dialogue audio",
     ]
     not_good_for = [
         "voice cloning",
         "fully offline production",
     ]
 
+    DEFAULT_MODEL = "gemini-3.1-flash-tts-preview"
+    DEFAULT_VOICE = "Kore"
+    _MODELS = {
+        "gemini-3.1-flash-tts-preview",
+        "gemini-2.5-flash-preview-tts",
+        "gemini-2.5-pro-preview-tts",
+    }
+
     input_schema = {
         "type": "object",
         "required": ["text"],
         "properties": {
-            "text": {"type": "string", "description": "Text to convert to speech"},
+            "text": {
+                "type": "string",
+                "description": "Text to speak. For multi-speaker output, include speaker labels in the text.",
+            },
+            "prompt": {
+                "type": "string",
+                "description": "Natural-language direction for tone, pacing, accent, emotion, and delivery.",
+            },
+            "model": {
+                "type": "string",
+                "default": DEFAULT_MODEL,
+                "description": "Gemini TTS model.",
+            },
             "voice": {
                 "type": "string",
-                "default": "en-US-Chirp3-HD-Orus",
-                "description": "Voice name. Default tier is Chirp 3 HD (2024, most natural). Examples: en-US-Chirp3-HD-Orus (male, rich/cinematic), en-US-Chirp3-HD-Aoede (female, warm). Legacy tiers: en-US-Studio-O, en-US-Neural2-D, en-US-Journey-D.",
+                "default": DEFAULT_VOICE,
+                "description": "Gemini prebuilt voice, e.g. Kore, Charon, Aoede, Puck.",
             },
-            "language_code": {
-                "type": "string",
-                "default": "en-US",
-                "description": "BCP-47 language code (e.g. en-US, es-ES, ja-JP, fr-FR)",
-            },
-            "speaking_rate": {
-                "type": "number",
-                "default": 1.0,
-                "minimum": 0.25,
-                "maximum": 4.0,
-                "description": "Speaking speed. 1.0 = normal, 0.5 = half speed, 2.0 = double speed",
-            },
-            "pitch": {
-                "type": "number",
-                "default": 0.0,
-                "minimum": -20.0,
-                "maximum": 20.0,
-                "description": "Pitch adjustment in semitones. 0.0 = default",
-            },
-            "audio_encoding": {
-                "type": "string",
-                "default": "MP3",
-                "enum": ["MP3", "LINEAR16", "OGG_OPUS", "MULAW", "ALAW"],
-                "description": "Audio output encoding format",
+            "speaker_voice_configs": {
+                "type": "array",
+                "description": "Optional two-speaker voice map for dialogue.",
+                "items": {
+                    "type": "object",
+                    "required": ["speaker", "voice"],
+                    "properties": {
+                        "speaker": {"type": "string"},
+                        "voice": {"type": "string"},
+                    },
+                },
             },
             "output_path": {"type": "string"},
+        },
+    }
+
+    output_schema = {
+        "type": "object",
+        "properties": {
+            "output": {"type": "string"},
+            "audio_duration_seconds": {"type": ["number", "null"]},
+            "provider": {"type": "string"},
+            "model": {"type": "string"},
+            "voice": {"type": "string"},
         },
     }
 
@@ -113,124 +131,185 @@ class GoogleTTS(BaseTool):
         cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=50, network_required=True
     )
     retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
-    idempotency_key_fields = ["text", "voice", "language_code", "speaking_rate", "pitch"]
-    side_effects = ["writes audio file to output_path", "calls Google Cloud TTS API"]
-    user_visible_verification = ["Listen to generated audio for natural speech quality"]
-
-    # Extension mapping for audio encodings
-    _EXT_MAP = {
-        "MP3": "mp3",
-        "LINEAR16": "wav",
-        "OGG_OPUS": "ogg",
-        "MULAW": "wav",
-        "ALAW": "wav",
-    }
+    idempotency_key_fields = ["text", "prompt", "model", "voice", "speaker_voice_configs"]
+    side_effects = ["writes WAV audio file to output_path", "calls Gemini API"]
+    user_visible_verification = ["Listen to generated audio for natural speech quality and pacing"]
+    quality_score = 0.9
+    latency_p50_seconds = 6.0
 
     def _get_api_key(self) -> str | None:
-        return os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")
+        return os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
 
     def get_status(self) -> ToolStatus:
-        if self._get_api_key() or os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
-            return ToolStatus.AVAILABLE
-        return ToolStatus.UNAVAILABLE
-
-    # Voices requiring the v1beta1 endpoint (Chirp 3 HD, Journey)
-    _BETA_VOICE_PREFIXES = ("Chirp", "Journey")
-
-    def _needs_beta_api(self, voice: str) -> bool:
-        """Check if voice requires the v1beta1 endpoint."""
-        return any(prefix in voice for prefix in self._BETA_VOICE_PREFIXES)
+        return ToolStatus.AVAILABLE if self._get_api_key() else ToolStatus.UNAVAILABLE
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
-        text = inputs.get("text", "")
-        char_count = len(text)
-        voice = inputs.get("voice", "en-US-Chirp3-HD-Orus")
-        # Pricing per million characters (approximate)
-        if "Chirp3-HD" in voice:
-            rate_per_char = 0.000030  # $30/1M chars
-        elif "Studio" in voice:
-            rate_per_char = 0.000160  # $160/1M chars
-        elif "Neural2" in voice or "Journey" in voice:
-            rate_per_char = 0.000016  # $16/1M chars
-        elif "WaveNet" in voice:
-            rate_per_char = 0.000016  # $16/1M chars
-        else:
-            rate_per_char = 0.000004  # $4/1M chars (Standard)
-        return round(char_count * rate_per_char, 4)
+        # Gemini TTS pricing is model-specific and may change; this planning
+        # estimate is intentionally conservative until usage data is returned.
+        return round(len(inputs.get("text", "")) * 0.000030, 4)
 
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
         api_key = self._get_api_key()
         if not api_key:
-            return ToolResult(
-                success=False,
-                error="No Google API key found. " + self.install_instructions,
-            )
+            return ToolResult(success=False, error="No GOOGLE_API_KEY or GEMINI_API_KEY. " + self.install_instructions)
 
         start = time.time()
         try:
-            result = self._generate(inputs, api_key)
+            result = self._generate(inputs, api_key=api_key)
         except Exception as exc:
-            return ToolResult(success=False, error=f"Google TTS failed: {exc}")
+            return ToolResult(success=False, error=f"Google TTS failed: {self._safe_error(exc)}")
 
         result.duration_seconds = round(time.time() - start, 2)
-        result.cost_usd = self.estimate_cost(inputs)
+        result.cost_usd = result.cost_usd or self.estimate_cost(inputs)
         return result
 
-    def _generate(self, inputs: dict[str, Any], api_key: str) -> ToolResult:
+    def _generate(self, inputs: dict[str, Any], *, api_key: str) -> ToolResult:
         import requests
 
-        text = inputs["text"]
-        voice_name = inputs.get("voice", "en-US-Chirp3-HD-Orus")
-        language_code = inputs.get("language_code", "en-US")
-        speaking_rate = inputs.get("speaking_rate", 1.0)
-        pitch = inputs.get("pitch", 0.0)
-        audio_encoding = inputs.get("audio_encoding", "MP3")
-
-        payload = {
-            "input": {"text": text},
-            "voice": {
-                "languageCode": language_code,
-                "name": voice_name,
-            },
-            "audioConfig": {
-                "audioEncoding": audio_encoding,
-                "speakingRate": speaking_rate,
-                "pitch": pitch,
-            },
-        }
-
-        # Chirp 3 HD and Journey voices require the v1beta1 endpoint
-        api_version = "v1beta1" if self._needs_beta_api(voice_name) else "v1"
-        url = f"https://texttospeech.googleapis.com/{api_version}/text:synthesize"
+        self._validate_inputs(inputs)
+        model = self._resolve_model(inputs)
+        voice_name = inputs.get("voice") or self.DEFAULT_VOICE
+        output_path = Path(inputs.get("output_path", "google_tts.wav"))
 
         response = requests.post(
-            url,
-            headers={"Content-Type": "application/json"},
-            params={"key": api_key},
-            json=payload,
+            f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent",
+            headers={
+                "Content-Type": "application/json",
+                "x-goog-api-key": api_key,
+            },
+            json=self._payload(inputs, voice_name=voice_name),
             timeout=120,
         )
         response.raise_for_status()
 
-        audio_content = base64.b64decode(response.json()["audioContent"])
-
-        ext = self._EXT_MAP.get(audio_encoding, "mp3")
-        output_path = Path(inputs.get("output_path", f"tts_output.{ext}"))
+        pcm_audio = self._extract_audio(response.json())
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_bytes(audio_content)
+        self._write_pcm_as_wav(output_path, pcm_audio)
 
+        audio_duration = self._audio_duration(output_path)
         return ToolResult(
             success=True,
             data={
                 "provider": self.provider,
+                "model": model,
                 "voice": voice_name,
-                "language_code": language_code,
-                "text_length": len(text),
+                "speaker_voice_configs": inputs.get("speaker_voice_configs"),
+                "text_length": len(inputs.get("text", "")),
+                "prompt": inputs.get("prompt"),
                 "output": str(output_path),
-                "format": audio_encoding,
-                "speaking_rate": speaking_rate,
-                "pitch": pitch,
+                "format": "wav",
+                "audio_duration_seconds": round(audio_duration, 2) if audio_duration else None,
             },
             artifacts=[str(output_path)],
-            model=f"google-tts/{voice_name}",
+            model=f"google-gemini-tts/{model}/{voice_name}",
         )
+
+    def _payload(self, inputs: dict[str, Any], *, voice_name: str) -> dict[str, Any]:
+        speech_config = self._speech_config(inputs, voice_name=voice_name)
+        return {
+            "contents": [
+                {
+                    "parts": [
+                        {
+                            "text": self._prompted_text(inputs),
+                        }
+                    ]
+                }
+            ],
+            "generationConfig": {
+                "responseModalities": ["AUDIO"],
+                "speechConfig": speech_config,
+            },
+        }
+
+    def _speech_config(self, inputs: dict[str, Any], *, voice_name: str) -> dict[str, Any]:
+        speakers = inputs.get("speaker_voice_configs") or []
+        if speakers:
+            return {
+                "multiSpeakerVoiceConfig": {
+                    "speakerVoiceConfigs": [
+                        {
+                            "speaker": item["speaker"],
+                            "voiceConfig": {
+                                "prebuiltVoiceConfig": {
+                                    "voiceName": item["voice"],
+                                }
+                            },
+                        }
+                        for item in speakers
+                    ]
+                }
+            }
+        return {
+            "voiceConfig": {
+                "prebuiltVoiceConfig": {
+                    "voiceName": voice_name,
+                }
+            }
+        }
+
+    @staticmethod
+    def _prompted_text(inputs: dict[str, Any]) -> str:
+        text = inputs["text"]
+        prompt = inputs.get("prompt")
+        if not prompt:
+            return text
+        return f"{prompt.strip()}\n\n{text}"
+
+    @staticmethod
+    def _extract_audio(payload: dict[str, Any]) -> bytes:
+        try:
+            parts = payload["candidates"][0]["content"]["parts"]
+        except (KeyError, IndexError, TypeError) as exc:
+            raise RuntimeError(f"Gemini API response did not include audio content: {payload}") from exc
+
+        for part in parts:
+            inline_data = part.get("inlineData") or part.get("inline_data")
+            if inline_data and inline_data.get("data"):
+                return base64.b64decode(inline_data["data"])
+        raise RuntimeError(f"Gemini API response did not include inline audio data: {payload}")
+
+    @staticmethod
+    def _write_pcm_as_wav(path: Path, pcm_audio: bytes) -> None:
+        with wave.open(str(path), "wb") as wav_file:
+            wav_file.setnchannels(1)
+            wav_file.setsampwidth(2)
+            wav_file.setframerate(24000)
+            wav_file.writeframes(pcm_audio)
+
+    def _validate_inputs(self, inputs: dict[str, Any]) -> None:
+        if not inputs.get("text"):
+            raise ValueError("text is required")
+
+        model = self._resolve_model(inputs)
+        if model not in self._MODELS:
+            raise ValueError(f"Unsupported Gemini TTS model: {model}")
+
+        speakers = inputs.get("speaker_voice_configs") or []
+        if len(speakers) > 2:
+            raise ValueError("Gemini TTS supports at most two speakers.")
+        for item in speakers:
+            if not item.get("speaker") or not item.get("voice"):
+                raise ValueError("Each speaker_voice_configs item needs speaker and voice.")
+
+    def _resolve_model(self, inputs: dict[str, Any]) -> str:
+        model = inputs.get("model") or self.DEFAULT_MODEL
+        if model == "gemini":
+            return self.DEFAULT_MODEL
+        return model
+
+    @staticmethod
+    def _audio_duration(path: Path) -> float | None:
+        try:
+            from tools.analysis.audio_probe import probe_duration
+
+            return probe_duration(path)
+        except Exception:
+            return None
+
+    def _safe_error(self, exc: Exception) -> str:
+        message = str(exc)
+        api_key = self._get_api_key()
+        if api_key:
+            message = message.replace(api_key, "[redacted]")
+        return message

--- a/tools/audio/google_tts.py
+++ b/tools/audio/google_tts.py
@@ -49,6 +49,8 @@ class GoogleTTS(BaseTool):
         "style_prompting",
         "multi_speaker",
         "gemini_api_tts",
+        "delivery_presets",
+        "duration_guidance",
     ]
     supports = {
         "voice_cloning": False,
@@ -59,6 +61,8 @@ class GoogleTTS(BaseTool):
         "style_prompting": True,
         "gemini_api_key_auth": True,
         "multi_speaker": True,
+        "delivery_presets": True,
+        "duration_guidance": True,
     }
     best_for = [
         "latest Gemini API TTS narration with API-key setup",
@@ -72,6 +76,25 @@ class GoogleTTS(BaseTool):
 
     DEFAULT_MODEL = "gemini-3.1-flash-tts-preview"
     DEFAULT_VOICE = "Kore"
+    DELIVERY_PRESETS = {
+        "technical_briefing": (
+            "Deliver as a focused technical product briefing: confident, crisp, "
+            "direct, and calm. Keep Chinese technical terms clear, separate clauses "
+            "cleanly, and avoid theatrical emotion."
+        ),
+        "compact_explainer": (
+            "Deliver as a compact explainer: efficient pacing, short pauses, clear "
+            "articulation, and no dragged endings. Preserve intelligibility over speed."
+        ),
+        "warm_opening": (
+            "Deliver as a warm but professional opening: welcoming, steady, and "
+            "credible, with a natural first sentence rather than a hard sales tone."
+        ),
+        "clear_cta": (
+            "Deliver as a clear call to action: slightly faster, decisive, and easy "
+            "to follow, emphasizing the action words without sounding urgent."
+        ),
+    }
     _MODELS = {
         "gemini-3.1-flash-tts-preview",
         "gemini-2.5-flash-preview-tts",
@@ -89,6 +112,16 @@ class GoogleTTS(BaseTool):
             "prompt": {
                 "type": "string",
                 "description": "Natural-language direction for tone, pacing, accent, emotion, and delivery.",
+            },
+            "delivery_preset": {
+                "type": "string",
+                "enum": sorted(DELIVERY_PRESETS),
+                "description": "Reusable Gemini prompt preset for common narration styles.",
+            },
+            "duration_target_seconds": {
+                "type": "number",
+                "minimum": 0,
+                "description": "Approximate target duration. Gemini has no hard speed control, so this is encoded as prompt guidance.",
             },
             "model": {
                 "type": "string",
@@ -193,6 +226,8 @@ class GoogleTTS(BaseTool):
                 "provider": self.provider,
                 "model": model,
                 "voice": voice_name,
+                "delivery_preset": inputs.get("delivery_preset"),
+                "duration_target_seconds": inputs.get("duration_target_seconds"),
                 "speaker_voice_configs": inputs.get("speaker_voice_configs"),
                 "text_length": len(inputs.get("text", "")),
                 "prompt": inputs.get("prompt"),
@@ -248,13 +283,38 @@ class GoogleTTS(BaseTool):
             }
         }
 
-    @staticmethod
-    def _prompted_text(inputs: dict[str, Any]) -> str:
+    @classmethod
+    def _prompted_text(cls, inputs: dict[str, Any]) -> str:
         text = inputs["text"]
-        prompt = inputs.get("prompt")
-        if not prompt:
+        directions = cls._prompt_directions(inputs)
+        if not directions:
             return text
-        return f"{prompt.strip()}\n\n{text}"
+        return f"{' '.join(directions)}\n\n{text}"
+
+    @classmethod
+    def _prompt_directions(cls, inputs: dict[str, Any]) -> list[str]:
+        directions: list[str] = []
+        preset = inputs.get("delivery_preset")
+        if preset:
+            directions.append(cls.DELIVERY_PRESETS[preset])
+
+        duration_target = inputs.get("duration_target_seconds")
+        if duration_target:
+            directions.append(cls._duration_instruction(float(duration_target)))
+
+        prompt = inputs.get("prompt")
+        if prompt:
+            directions.append(prompt.strip())
+        return directions
+
+    @staticmethod
+    def _duration_instruction(target_seconds: float) -> str:
+        rounded = round(target_seconds, 1)
+        return (
+            f"Aim for approximately {rounded:g} seconds of audio. Use natural but "
+            "compact pacing; if exact timing conflicts with clarity, keep the speech "
+            "clear and close to the target duration."
+        )
 
     @staticmethod
     def _extract_audio(payload: dict[str, Any]) -> bytes:
@@ -284,6 +344,15 @@ class GoogleTTS(BaseTool):
         model = self._resolve_model(inputs)
         if model not in self._MODELS:
             raise ValueError(f"Unsupported Gemini TTS model: {model}")
+
+        preset = inputs.get("delivery_preset")
+        if preset and preset not in self.DELIVERY_PRESETS:
+            allowed = ", ".join(sorted(self.DELIVERY_PRESETS))
+            raise ValueError(f"Unsupported Google TTS delivery_preset: {preset}. Expected one of: {allowed}")
+
+        duration_target = inputs.get("duration_target_seconds")
+        if duration_target is not None and float(duration_target) <= 0:
+            raise ValueError("duration_target_seconds must be greater than 0.")
 
         speakers = inputs.get("speaker_voice_configs") or []
         if len(speakers) > 2:


### PR DESCRIPTION
## Summary
- Replace the Google TTS provider with Gemini API text-to-speech (`gemini-3.1-flash-tts-preview`)
- Support API-key auth via `GEMINI_API_KEY` / `GOOGLE_API_KEY`
- Add prompt-directed single-speaker and two-speaker payload support, writing Gemini PCM output as WAV
- Update provider docs, environment examples, and contract coverage for the Gemini API workflow

## Why
Google's Gemini API TTS docs show `gemini-3.1-flash-tts-preview` as a supported TTS model with `responseModalities: [\"AUDIO\"]`, prebuilt voice config, 24 kHz PCM output, and single/multi-speaker support. This keeps OpenMontage aligned with the current Google TTS path while preserving the existing provider contract and registry discovery style.

## Verification
- Real smoke test passed with `gemini-3.1-flash-tts-preview` / `Kore`, producing a 24 kHz mono WAV (`5.24s`)
- `.venv/bin/python -m pytest tests/contracts/test_phase3_contracts.py -q` -> 70 passed
- `.venv/bin/python -m compileall tools/audio/google_tts.py tests/contracts/test_phase3_contracts.py` -> passed
- `git diff --check` -> passed