### PR TITLE
feat(tts): add Azure AI Speech provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,11 @@ OPENAI_API_KEY=              # OpenAI TTS fallback and DALL-E image generation
 XAI_API_KEY=                 # Grok image generation/editing and Grok video generation
 DOUBAO_SPEECH_API_KEY=       # Volcengine Doubao Speech TTS (new console API Key)
 DOUBAO_SPEECH_VOICE_TYPE=    # Default Doubao speaker/voice type, e.g. zh_female_vv_uranus_bigtts
+AZURE_SPEECH_KEY=            # Azure AI Speech TTS
+AZURE_SPEECH_REGION=         # Azure Speech region, e.g. eastus
+AZURE_SPEECH_ENDPOINT=       # Optional custom Azure Speech endpoint
+# Optional Azure timing metadata support:
+#   pip install azure-cognitiveservices-speech
 # Piper local voices do not require env vars; install `piper-tts` via pip
 
 # --- Music ---

--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ ELEVENLABS_API_KEY=your-key    # Premium TTS, AI music, sound effects
 OPENAI_API_KEY=your-key        # OpenAI TTS, DALL-E 3 images
 XAI_API_KEY=your-key           # xAI Grok image edits/generation + Grok video generation
 GOOGLE_API_KEY=your-key        # Google Imagen images, Google TTS (700+ voices)
+AZURE_SPEECH_KEY=your-key      # Azure AI Speech TTS
+AZURE_SPEECH_REGION=eastus     # Azure Speech region
+# Optional for Azure word-boundary timing: pip install azure-cognitiveservices-speech
 
 # More video providers:
 HEYGEN_API_KEY=your-key        # HeyGen — VEO, Sora, Runway, Kling via single gateway
@@ -446,10 +449,11 @@ Each tool declares which Layer 3 skills it relies on. The agent reads Layer 1 to
 </details>
 
 <details>
-<summary><strong>Text-to-Speech — 4 providers</strong></summary>
+<summary><strong>Text-to-Speech — 5 providers</strong></summary>
 
 | Provider | Type | Notes |
 |----------|------|-------|
+| **Azure AI Speech** | Cloud API | SSML-directed enterprise TTS, strong multilingual and Mandarin coverage |
 | **ElevenLabs** | Cloud API | Premium voice quality |
 | **Google TTS** | Cloud API | 700+ voices, 50+ languages — best for localization |
 | **OpenAI TTS** | Cloud API | Fast, affordable |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -152,7 +152,7 @@ Selectors route based on: user preference when explicitly set, then scored ranki
 
 **Analysis (4):** transcriber (WhisperX), scene_detect, frame_sampler, video_understand (CLIP/BLIP-2)
 
-**Audio (8):** elevenlabs_tts, google_tts, openai_tts, piper_tts, tts_selector, music_gen, audio_mixer, audio_enhance
+**Audio (9):** azure_tts, elevenlabs_tts, google_tts, openai_tts, piper_tts, tts_selector, music_gen, audio_mixer, audio_enhance
 
 **Avatar (2):** talking_head (SadTalker/MuseTalk), lip_sync (Wav2Lip)
 
@@ -384,6 +384,7 @@ All config is validated via Pydantic models in `lib/config_model.py`.
 |----------|---------|---------|
 | `ELEVENLABS_API_KEY` | elevenlabs_tts, music_gen | TTS, music, sound effects |
 | `OPENAI_API_KEY` | openai_tts, openai_image | TTS fallback, DALL-E 3 |
+| `AZURE_SPEECH_KEY` + `AZURE_SPEECH_REGION` | azure_tts | Azure AI Speech TTS; optional `azure-cognitiveservices-speech` package enables word-boundary timing metadata |
 | `XAI_API_KEY` | grok_image, grok_video | Grok image editing/generation, Grok video generation |
 | `FAL_KEY` | flux_image, kling_video, veo_video, minimax_video, recraft_image | fal.ai hosted models (FLUX, Veo, Kling, MiniMax, Recraft) |
 | `HEYGEN_API_KEY` | heygen_video | Multi-provider video generation |

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -41,6 +41,8 @@ OPENAI_API_KEY=              # OpenAI TTS + DALL-E 3 images
 XAI_API_KEY=                 # xAI Grok image generation/editing + Grok video generation
 DOUBAO_SPEECH_API_KEY=       # Volcengine Doubao Speech TTS (strong Mandarin narration)
 DOUBAO_SPEECH_VOICE_TYPE=    # Default Doubao speaker/voice type
+AZURE_SPEECH_KEY=            # Azure AI Speech TTS
+AZURE_SPEECH_REGION=         # Azure Speech region, e.g. eastus
 
 # MULTI-MODEL GATEWAY (one key, 6+ tools)
 FAL_KEY=                     # FLUX, Recraft, Kling, Veo, MiniMax video
@@ -204,6 +206,100 @@ Start with `speech_rate: 0` for natural Mandarin delivery. If the approved forma
 #### Pricing
 
 Doubao Speech 2.0 is billed by character package or usage in Volcengine. OpenMontage estimates cost from text length and prefers provider-returned usage metadata when available.
+
+---
+
+### Azure AI Speech — Enterprise TTS
+
+> **SSML-directed production voice.** Azure AI Speech is a strong option for enterprise narration, multilingual localization, and Chinese voiceovers that need stable REST generation plus fine SSML control.
+
+**Tools unlocked:** `azure_tts`
+**Env vars:** `AZURE_SPEECH_KEY`, `AZURE_SPEECH_REGION`
+
+Optional:
+
+- `AZURE_SPEECH_ENDPOINT` for a custom Speech endpoint
+- `AZURE_SPEECH_AUTH_TOKEN` for token-based auth
+- `azure-cognitiveservices-speech` Python package for word-boundary timing metadata
+
+#### Setup
+
+1. Create an Azure AI Speech resource in the Azure portal.
+2. Copy the resource key and region.
+3. Add to `.env`:
+   ```bash
+   AZURE_SPEECH_KEY=your-key
+   AZURE_SPEECH_REGION=eastus
+   ```
+4. Use `operation: list_voices` to fetch available voices before choosing a production voice.
+
+For subtitle or visual cue timing, install the optional SDK:
+
+```bash
+pip install azure-cognitiveservices-speech
+```
+
+#### API Notes
+
+OpenMontage uses the Azure AI Speech REST endpoint by default:
+
+```text
+POST https://{region}.tts.speech.microsoft.com/cognitiveservices/v1
+Ocp-Apim-Subscription-Key: ${AZURE_SPEECH_KEY}
+Content-Type: application/ssml+xml
+X-Microsoft-OutputFormat: audio-24khz-160kbitrate-mono-mp3
+```
+
+For custom voice deployments, pass `deployment_id`; OpenMontage appends it as
+`deploymentId` on the synthesis request. If you provide `ssml`, OpenMontage
+sends it directly. Otherwise it builds SSML from `text`, `voice`, `style`,
+`style_degree`, `role`, `rate`, `pitch`, `volume`, and optional sentence
+silence.
+
+#### REST vs SDK Mode
+
+Use the default REST mode for normal narration:
+
+```json
+{
+  "preferred_provider": "azure",
+  "text": "System narration",
+  "voice": "zh-CN-YunxiNeural"
+}
+```
+
+Use SDK mode when subtitles, karaoke text, or cue-aligned visuals need spoken
+timing metadata:
+
+```json
+{
+  "preferred_provider": "azure",
+  "text": "系统问题分析助手可以串联日志、TID 和代码上下文。",
+  "voice": "zh-CN-YunxiNeural",
+  "enable_word_boundaries": true
+}
+```
+
+Setting `enable_word_boundaries: true` or `backend: "sdk"` uses the optional
+Azure Speech SDK. The output metadata includes `boundaries` and `words` with
+`audio_offset_seconds`, `duration_seconds`, `text_offset`, and `word_length`.
+
+#### What It Is Best For
+
+- Enterprise-grade TTS with stable REST generation
+- Mandarin and multilingual narration that needs SSML control
+- Voice catalog discovery before TTS Segment Lab auditions
+- Styles and roles through `mstts:express-as`, when supported by the selected voice
+
+#### Timing Note
+
+REST mode is intentionally lightweight and does not return word-boundary events.
+SDK mode adds those events when `azure-cognitiveservices-speech` is installed.
+
+#### Pricing
+
+Azure AI Speech is billed by character usage and voice class. OpenMontage uses a
+conservative character estimate; Azure billing remains the source of truth.
 
 ---
 
@@ -723,6 +819,7 @@ These tools require only FFmpeg or Python packages — no GPU, no API key.
 | **Pixabay** | `PIXABAY_API_KEY` | `pixabay_image`, `pixabay_video` | Free |
 | **Piper** | — (install only) | `piper_tts` | Free |
 | **Google** | `GOOGLE_API_KEY` | `google_tts`, `google_imagen` | Free tier + paid |
+| **Azure AI Speech** | `AZURE_SPEECH_KEY` + `AZURE_SPEECH_REGION` | `azure_tts` | Free tier + paid |
 | **ElevenLabs** | `ELEVENLABS_API_KEY` | `elevenlabs_tts`, `music_gen` | Free tier + paid |
 | **fal.ai** | `FAL_KEY` | `flux_image`, `recraft_image`, `kling_video`, `veo_video`, `minimax_video` | Pay-as-you-go |
 | **OpenAI** | `OPENAI_API_KEY` | `openai_tts`, `openai_image` | Paid only |
@@ -745,7 +842,7 @@ How many providers cover each capability:
 |-----------|----------------|-----------------|--------------|
 | **Image Generation** | FLUX, Grok, Google Imagen, DALL-E 3, Recraft | Local Diffusion | Pexels, Pixabay (stock) |
 | **Video Generation** | Grok, Kling, Runway, Veo, Higgsfield, MiniMax, HeyGen | WAN, Hunyuan, CogVideo, LTX | Pexels, Pixabay (stock) |
-| **Text-to-Speech** | ElevenLabs, Google TTS, OpenAI | Piper | Piper, Google free tier, ElevenLabs free tier |
+| **Text-to-Speech** | Azure AI Speech, ElevenLabs, Google TTS, OpenAI | Piper | Piper, Google free tier, ElevenLabs free tier |
 | **Music Generation** | ElevenLabs, Suno | — | ElevenLabs free tier |
 | **Post-Production** | — | FFmpeg (compose, stitch, trim, mix, enhance, grade) | All free |
 | **Analysis** | — | WhisperX, Scene Detect, Frame Sampler, CLIP/BLIP-2 | All free |

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -283,6 +283,15 @@ timing metadata:
 Setting `enable_word_boundaries: true` or `backend: "sdk"` uses the optional
 Azure Speech SDK. The output metadata includes `boundaries` and `words` with
 `audio_offset_seconds`, `duration_seconds`, `text_offset`, and `word_length`.
+If the SDK is unavailable and `require_word_boundaries` is not set, OpenMontage
+falls back to REST synthesis so voice auditions still produce audio; metadata
+records `word_boundary_fallback: "rest_without_word_boundaries"` plus a warning.
+Set `require_word_boundaries: true` when missing timing metadata should block
+the run.
+
+Use `operation: "preflight"` before large batches to confirm credentials,
+region/endpoint configuration, SDK availability, and whether REST fallback will
+be used.
 
 #### What It Is Best For
 
@@ -295,6 +304,8 @@ Azure Speech SDK. The output metadata includes `boundaries` and `words` with
 
 REST mode is intentionally lightweight and does not return word-boundary events.
 SDK mode adds those events when `azure-cognitiveservices-speech` is installed.
+For TTS Segment Lab auditions, prefer fallback unless the review specifically
+depends on word-level timing.
 
 #### Pricing
 

--- a/skills/pipelines/explainer/asset-director.md
+++ b/skills/pipelines/explainer/asset-director.md
@@ -92,6 +92,14 @@ For each script section:
 
 **Pronunciation guide**: If the script contains technical terms, jargon, or names with non-obvious pronunciation, include a pronunciation map in the TTS request.
 
+**Azure timing option**: When Azure AI Speech is selected and the video needs
+subtitle timing, karaoke captions, or cue-aligned visual reveals, set
+`enable_word_boundaries: true` on the TTS request. This uses the optional Azure
+Speech SDK and returns `words`/`boundaries` metadata for downstream subtitle and
+visual-timing work. If the SDK is missing, report the install command
+(`pip install azure-cognitiveservices-speech`) and either install it with user
+approval or fall back to REST-only narration.
+
 ### Step 4: Generate Visual Assets
 
 Process asset tasks grouped by tool for efficiency:

--- a/tests/contracts/test_phase3_contracts.py
+++ b/tests/contracts/test_phase3_contracts.py
@@ -24,6 +24,7 @@ from lib.checkpoint import STAGES
 from schemas.artifacts import list_schemas
 from styles.playbook_loader import load_playbook, list_playbooks, validate_playbook
 from tools.base_tool import ToolTier
+from tools.audio.azure_tts import AzureTTS
 from tools.audio.music_gen import MusicGen
 from tools.tool_registry import ToolRegistry
 from tools.audio.elevenlabs_tts import ElevenLabsTTS
@@ -102,13 +103,14 @@ class TestNewToolsRegistry:
 
     def test_voice_tier_tools(self):
         reg = ToolRegistry()
+        reg.register(AzureTTS())
         reg.register(ElevenLabsTTS())
         reg.register(OpenAITTS())
         reg.register(PiperTTS())
         voice_tools = reg.get_by_tier(ToolTier.VOICE)
-        assert len(voice_tools) == 3
+        assert len(voice_tools) == 4
         names = {t.name for t in voice_tools}
-        assert names == {"elevenlabs_tts", "openai_tts", "piper_tts"}
+        assert names == {"azure_tts", "elevenlabs_tts", "openai_tts", "piper_tts"}
 
 
 class TestCapabilityMetadata:
@@ -123,16 +125,19 @@ class TestCapabilityMetadata:
 
     def test_provider_specific_tts_tools_register(self):
         reg = ToolRegistry()
+        reg.register(AzureTTS())
         reg.register(ElevenLabsTTS())
         reg.register(OpenAITTS())
         reg.register(PiperTTS())
         reg.register(TTSSelector())
         assert {tool.name for tool in reg.get_by_capability("tts")} == {
+            "azure_tts",
             "elevenlabs_tts",
             "openai_tts",
             "piper_tts",
             "tts_selector",
         }
+        assert {tool.name for tool in reg.get_by_provider("azure")} == {"azure_tts"}
         assert {tool.name for tool in reg.get_by_provider("elevenlabs")} == {"elevenlabs_tts"}
 
     def test_registry_catalog_views(self):
@@ -143,7 +148,7 @@ class TestCapabilityMetadata:
         catalog = reg.capability_catalog()
         assert "tts" in catalog
         providers = {item["provider"] for item in catalog["tts"] if item["provider"] != "selector"}
-        assert providers == {"elevenlabs", "google_tts", "openai", "piper"}
+        assert providers == {"azure", "doubao", "elevenlabs", "google_tts", "openai", "piper"}
 
 
 # ---- Animated Explainer Pipeline ----

--- a/tests/tools/test_azure_tts.py
+++ b/tests/tools/test_azure_tts.py
@@ -159,6 +159,35 @@ def test_word_boundaries_require_optional_sdk(monkeypatch, tmp_path):
     monkeypatch.setenv("AZURE_SPEECH_KEY", "test-key")
     monkeypatch.setenv("AZURE_SPEECH_REGION", "eastus")
 
+    def fake_post(url, *, headers, data, timeout):
+        return FakeResponse(content=b"rest-audio", headers={"X-RequestId": "req-fallback"})
+
+    def missing_sdk(module_name):
+        if module_name == "azure.cognitiveservices.speech":
+            raise ImportError("missing sdk")
+        raise AssertionError(module_name)
+
+    monkeypatch.setattr("tools.audio.azure_tts.importlib.import_module", missing_sdk)
+    monkeypatch.setitem(sys.modules, "requests", SimpleNamespace(post=fake_post))
+
+    result = AzureTTS().execute({
+        "text": "需要时间戳。",
+        "enable_word_boundaries": True,
+        "output_path": str(tmp_path / "timed.mp3"),
+    })
+
+    assert result.success
+    assert result.data["backend"] == "rest"
+    assert result.data["word_boundary_fallback"] == "rest_without_word_boundaries"
+    assert result.data["words"] == []
+    assert "pip install azure-cognitiveservices-speech" in result.data["warnings"][0]
+    assert (tmp_path / "timed.mp3").read_bytes() == b"rest-audio"
+
+
+def test_word_boundaries_can_be_required(monkeypatch, tmp_path):
+    monkeypatch.setenv("AZURE_SPEECH_KEY", "test-key")
+    monkeypatch.setenv("AZURE_SPEECH_REGION", "eastus")
+
     def missing_sdk(module_name):
         if module_name == "azure.cognitiveservices.speech":
             raise ImportError("missing sdk")
@@ -169,11 +198,26 @@ def test_word_boundaries_require_optional_sdk(monkeypatch, tmp_path):
     result = AzureTTS().execute({
         "text": "需要时间戳。",
         "enable_word_boundaries": True,
+        "require_word_boundaries": True,
         "output_path": str(tmp_path / "timed.mp3"),
     })
 
     assert not result.success
     assert "pip install azure-cognitiveservices-speech" in result.error
+
+
+def test_preflight_reports_sdk_fallback(monkeypatch):
+    monkeypatch.setenv("AZURE_SPEECH_KEY", "test-key")
+    monkeypatch.setenv("AZURE_SPEECH_REGION", "eastus")
+    monkeypatch.setattr("tools.audio.azure_tts.AzureTTS._sdk_available", staticmethod(lambda: False))
+
+    result = AzureTTS().execute({"operation": "preflight", "enable_word_boundaries": True})
+
+    assert result.success
+    assert result.data["status"] == "available"
+    assert result.data["sdk_available"] is False
+    assert result.data["rest_fallback_available"] is True
+    assert "fall back to REST" in result.data["warnings"][0]
 
 
 def test_sdk_backend_writes_word_boundary_metadata(monkeypatch, tmp_path):

--- a/tests/tools/test_azure_tts.py
+++ b/tests/tools/test_azure_tts.py
@@ -1,0 +1,256 @@
+import json
+import sys
+from datetime import timedelta
+from pathlib import Path
+from enum import Enum
+from types import SimpleNamespace
+
+from tools.audio.azure_tts import AzureTTS
+from tools.base_tool import ToolStatus
+
+
+class FakeResponse:
+    def __init__(self, *, content=b"", payload=None, headers=None):
+        self.content = content
+        self._payload = payload
+        self.headers = headers or {}
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def test_status_requires_key_and_region(monkeypatch):
+    tool = AzureTTS()
+    monkeypatch.delenv("AZURE_SPEECH_KEY", raising=False)
+    monkeypatch.delenv("SPEECH_KEY", raising=False)
+    monkeypatch.delenv("AZURE_SPEECH_REGION", raising=False)
+    monkeypatch.delenv("SPEECH_REGION", raising=False)
+    monkeypatch.delenv("AZURE_SPEECH_ENDPOINT", raising=False)
+    assert tool.get_status() == ToolStatus.UNAVAILABLE
+
+    monkeypatch.setenv("AZURE_SPEECH_KEY", "test-key")
+    monkeypatch.setenv("AZURE_SPEECH_REGION", "eastus")
+    assert tool.get_status() == ToolStatus.AVAILABLE
+
+
+def test_builds_ssml_with_style_prosody_and_silence():
+    tool = AzureTTS()
+    ssml = tool._build_ssml({
+        "text": "你好，研发同学。",
+        "voice": "zh-CN-YunxiNeural",
+        "language_code": "zh-CN",
+        "style": "chat",
+        "style_degree": 1.2,
+        "role": "YoungAdultMale",
+        "rate": "+8%",
+        "pitch": "+1st",
+        "volume": "medium",
+        "sentence_silence_ms": 180,
+    })
+
+    assert 'xml:lang="zh-CN"' in ssml
+    assert '<voice name="zh-CN-YunxiNeural">' in ssml
+    assert '<mstts:silence type="Sentenceboundary" value="180ms"/>' in ssml
+    assert '<mstts:express-as style="chat" styledegree="1.2" role="YoungAdultMale">' in ssml
+    assert '<prosody rate="+8%" pitch="+1st" volume="medium">' in ssml
+
+
+def test_synthesize_writes_audio_and_metadata(monkeypatch, tmp_path):
+    calls = {}
+
+    def fake_post(url, *, headers, data, timeout):
+        calls["url"] = url
+        calls["headers"] = headers
+        calls["data"] = data.decode("utf-8")
+        calls["timeout"] = timeout
+        return FakeResponse(content=b"mp3-bytes", headers={"X-RequestId": "req-123"})
+
+    monkeypatch.setenv("AZURE_SPEECH_KEY", "test-key")
+    monkeypatch.setenv("AZURE_SPEECH_REGION", "eastus")
+    monkeypatch.setitem(sys.modules, "requests", SimpleNamespace(post=fake_post))
+
+    output = tmp_path / "voice.mp3"
+    result = AzureTTS().execute({
+        "text": "系统问题分析助手可以串联日志和代码上下文。",
+        "voice": "zh-CN-YunxiNeural",
+        "style": "chat",
+        "rate": "+5%",
+        "output_path": str(output),
+    })
+
+    assert result.success
+    assert output.read_bytes() == b"mp3-bytes"
+    assert calls["url"] == "https://eastus.tts.speech.microsoft.com/cognitiveservices/v1"
+    assert calls["headers"]["Ocp-Apim-Subscription-Key"] == "test-key"
+    assert calls["headers"]["X-Microsoft-OutputFormat"] == "audio-24khz-160kbitrate-mono-mp3"
+    assert "mstts:express-as" in calls["data"]
+
+    metadata = json.loads((tmp_path / "voice.mp3.json").read_text(encoding="utf-8"))
+    assert metadata["provider"] == "azure"
+    assert metadata["request_id"] == "req-123"
+    assert metadata["output"] == str(output)
+
+
+def test_list_voices_filters_locale(monkeypatch):
+    def fake_get(url, *, headers, timeout):
+        assert url == "https://eastus.tts.speech.microsoft.com/cognitiveservices/voices/list"
+        assert headers["Ocp-Apim-Subscription-Key"] == "test-key"
+        return FakeResponse(payload=[
+            {"ShortName": "zh-CN-XiaoxiaoNeural", "Locale": "zh-CN"},
+            {"ShortName": "en-US-JennyNeural", "Locale": "en-US"},
+        ])
+
+    monkeypatch.setenv("AZURE_SPEECH_KEY", "test-key")
+    monkeypatch.setenv("AZURE_SPEECH_REGION", "eastus")
+    monkeypatch.setitem(sys.modules, "requests", SimpleNamespace(get=fake_get))
+
+    result = AzureTTS().execute({"operation": "list_voices", "language_code": "zh-CN"})
+
+    assert result.success
+    assert result.data["voice_count"] == 1
+    assert result.data["voices"][0]["ShortName"] == "zh-CN-XiaoxiaoNeural"
+
+
+def test_custom_endpoint_and_deployment_id(monkeypatch, tmp_path):
+    calls = {}
+
+    def fake_post(url, *, headers, data, timeout):
+        calls["url"] = url
+        return FakeResponse(content=b"audio")
+
+    monkeypatch.setenv("AZURE_SPEECH_KEY", "test-key")
+    monkeypatch.setenv("AZURE_SPEECH_ENDPOINT", "https://example.cognitiveservices.azure.com")
+    monkeypatch.setitem(sys.modules, "requests", SimpleNamespace(post=fake_post))
+
+    result = AzureTTS().execute({
+        "text": "custom voice",
+        "deployment_id": "deploy-1",
+        "output_path": str(tmp_path / "custom.mp3"),
+    })
+
+    assert result.success
+    assert calls["url"] == "https://example.cognitiveservices.azure.com/cognitiveservices/v1?deploymentId=deploy-1"
+
+
+def test_full_synthesis_endpoint_is_not_duplicated(monkeypatch, tmp_path):
+    calls = {}
+
+    def fake_post(url, *, headers, data, timeout):
+        calls["url"] = url
+        return FakeResponse(content=b"audio")
+
+    monkeypatch.setenv("AZURE_SPEECH_KEY", "test-key")
+    monkeypatch.setitem(sys.modules, "requests", SimpleNamespace(post=fake_post))
+
+    result = AzureTTS().execute({
+        "text": "endpoint",
+        "endpoint": "https://eastus.tts.speech.microsoft.com/cognitiveservices/v1",
+        "output_path": str(tmp_path / "endpoint.mp3"),
+    })
+
+    assert result.success
+    assert calls["url"] == "https://eastus.tts.speech.microsoft.com/cognitiveservices/v1"
+
+
+def test_word_boundaries_require_optional_sdk(monkeypatch, tmp_path):
+    monkeypatch.setenv("AZURE_SPEECH_KEY", "test-key")
+    monkeypatch.setenv("AZURE_SPEECH_REGION", "eastus")
+
+    def missing_sdk(module_name):
+        if module_name == "azure.cognitiveservices.speech":
+            raise ImportError("missing sdk")
+        raise AssertionError(module_name)
+
+    monkeypatch.setattr("tools.audio.azure_tts.importlib.import_module", missing_sdk)
+
+    result = AzureTTS().execute({
+        "text": "需要时间戳。",
+        "enable_word_boundaries": True,
+        "output_path": str(tmp_path / "timed.mp3"),
+    })
+
+    assert not result.success
+    assert "pip install azure-cognitiveservices-speech" in result.error
+
+
+def test_sdk_backend_writes_word_boundary_metadata(monkeypatch, tmp_path):
+    class BoundaryType(Enum):
+        Word = 0
+
+    class Signal:
+        def __init__(self):
+            self.callback = None
+
+        def connect(self, callback):
+            self.callback = callback
+
+    class FakeSpeechConfig:
+        def __init__(self, subscription=None, region=None, endpoint=None):
+            self.subscription = subscription
+            self.region = region
+            self.endpoint = endpoint
+            self.authorization_token = None
+            self.speech_synthesis_voice_name = None
+            self.output_format = None
+
+        def set_speech_synthesis_output_format(self, fmt):
+            self.output_format = fmt
+
+    class FakeAudioOutputConfig:
+        def __init__(self, filename):
+            self.filename = filename
+
+    class FakeSynthesizer:
+        def __init__(self, speech_config, audio_config):
+            self.speech_config = speech_config
+            self.audio_config = audio_config
+            self.synthesis_word_boundary = Signal()
+
+        def speak_ssml_async(self, ssml):
+            output_path = self.audio_config.filename
+            callback = self.synthesis_word_boundary.callback
+            if callback:
+                callback(SimpleNamespace(
+                    boundary_type=BoundaryType.Word,
+                    text="系统",
+                    audio_offset=5_000_000,
+                    duration=timedelta(milliseconds=200),
+                    text_offset=0,
+                    word_length=2,
+                ))
+            Path(output_path).write_bytes(b"sdk-audio")
+            return SimpleNamespace(get=lambda: SimpleNamespace(reason="completed"))
+
+    fake_sdk = SimpleNamespace(
+        SpeechConfig=FakeSpeechConfig,
+        SpeechSynthesizer=FakeSynthesizer,
+        ResultReason=SimpleNamespace(SynthesizingAudioCompleted="completed"),
+        CancellationDetails=lambda result: "cancelled",
+        SpeechSynthesisOutputFormat=SimpleNamespace(Audio24Khz160KBitRateMonoMp3="fmt"),
+        audio=SimpleNamespace(AudioOutputConfig=FakeAudioOutputConfig),
+    )
+
+    monkeypatch.setenv("AZURE_SPEECH_KEY", "test-key")
+    monkeypatch.setenv("AZURE_SPEECH_REGION", "eastus")
+    monkeypatch.setitem(sys.modules, "azure.cognitiveservices.speech", fake_sdk)
+
+    output = tmp_path / "sdk.mp3"
+    result = AzureTTS().execute({
+        "text": "系统问题分析助手。",
+        "backend": "sdk",
+        "voice": "zh-CN-YunxiNeural",
+        "output_path": str(output),
+    })
+
+    assert result.success
+    assert output.read_bytes() == b"sdk-audio"
+    assert result.data["backend"] == "sdk"
+    assert result.data["word_boundary_count"] == 1
+    assert result.data["words"][0]["audio_offset_seconds"] == 0.5
+    assert result.data["words"][0]["duration_seconds"] == 0.2
+
+    metadata = json.loads((tmp_path / "sdk.mp3.json").read_text(encoding="utf-8"))
+    assert metadata["words"][0]["text"] == "系统"

--- a/tools/audio/azure_tts.py
+++ b/tools/audio/azure_tts.py
@@ -88,8 +88,8 @@ class AzureTTS(BaseTool):
             "operation": {
                 "type": "string",
                 "default": "synthesize",
-                "enum": ["synthesize", "list_voices"],
-                "description": "Use list_voices to fetch the Azure voice catalog without generating audio.",
+                "enum": ["synthesize", "list_voices", "preflight"],
+                "description": "Use list_voices to fetch the Azure voice catalog, or preflight to inspect credentials and optional SDK availability.",
             },
             "text": {"type": "string", "description": "Text to convert to speech"},
             "backend": {
@@ -102,6 +102,11 @@ class AzureTTS(BaseTool):
                 "type": "boolean",
                 "default": False,
                 "description": "Use Azure Speech SDK to capture word-boundary timing metadata for subtitles and visual cue alignment. Requires azure-cognitiveservices-speech.",
+            },
+            "require_word_boundaries": {
+                "type": "boolean",
+                "default": False,
+                "description": "Fail instead of falling back to REST when word-boundary metadata was requested but the optional SDK is unavailable.",
             },
             "ssml": {
                 "type": "string",
@@ -248,6 +253,8 @@ class AzureTTS(BaseTool):
             operation = inputs.get("operation", "synthesize")
             if operation == "list_voices":
                 result = self._list_voices(inputs)
+            elif operation == "preflight":
+                result = self._preflight(inputs)
             elif self._should_use_sdk(inputs):
                 result = self._synthesize_with_sdk(inputs)
             else:
@@ -264,6 +271,14 @@ class AzureTTS(BaseTool):
         try:
             speechsdk = importlib.import_module("azure.cognitiveservices.speech")
         except ImportError:
+            if self._can_fallback_to_rest(inputs):
+                result = self._synthesize(inputs)
+                self._mark_word_boundary_fallback(
+                    result,
+                    "Azure word-boundary timing requires the optional Speech SDK: "
+                    "pip install azure-cognitiveservices-speech",
+                )
+                return result
             return ToolResult(
                 success=False,
                 error=(
@@ -408,9 +423,68 @@ class AzureTTS(BaseTool):
             model="azure-tts/voices-list",
         )
 
+    def _preflight(self, inputs: dict[str, Any]) -> ToolResult:
+        region = self._get_region(inputs)
+        endpoint = self._get_endpoint(inputs)
+        has_key = bool(self._get_key())
+        has_token = bool(self._get_auth_token())
+        sdk_available = self._sdk_available()
+        wants_word_boundaries = bool(inputs.get("enable_word_boundaries"))
+        can_synthesize = bool((has_key or has_token) and (region or endpoint))
+        warnings = []
+        if wants_word_boundaries and not sdk_available:
+            if self._can_fallback_to_rest(inputs):
+                warnings.append(
+                    "Azure Speech SDK is unavailable; synthesis can fall back to REST without word-boundary metadata."
+                )
+            else:
+                warnings.append(
+                    "Azure Speech SDK is unavailable and word-boundary metadata is required."
+                )
+        return ToolResult(
+            success=True,
+            data={
+                "provider": self.provider,
+                "operation": "preflight",
+                "status": "available" if can_synthesize else "unavailable",
+                "has_key": has_key,
+                "has_auth_token": has_token,
+                "region": region,
+                "endpoint": self._safe_endpoint(inputs),
+                "sdk_available": sdk_available,
+                "word_boundaries_requested": wants_word_boundaries,
+                "rest_fallback_available": self._can_fallback_to_rest(inputs),
+                "warnings": warnings,
+            },
+            model="azure-tts/preflight",
+        )
+
     @staticmethod
     def _should_use_sdk(inputs: dict[str, Any]) -> bool:
         return inputs.get("backend") == "sdk" or bool(inputs.get("enable_word_boundaries"))
+
+    @staticmethod
+    def _can_fallback_to_rest(inputs: dict[str, Any]) -> bool:
+        return inputs.get("backend") != "sdk" and not bool(inputs.get("require_word_boundaries"))
+
+    @staticmethod
+    def _sdk_available() -> bool:
+        try:
+            return importlib.util.find_spec("azure.cognitiveservices.speech") is not None
+        except (ImportError, ValueError):
+            return False
+
+    @staticmethod
+    def _mark_word_boundary_fallback(result: ToolResult, reason: str) -> None:
+        if result.data is None:
+            result.data = {}
+        warnings = list(result.data.get("warnings") or [])
+        warnings.append(reason)
+        result.data["warnings"] = warnings
+        result.data["word_boundaries_requested"] = True
+        result.data["word_boundary_fallback"] = "rest_without_word_boundaries"
+        result.data["boundaries"] = []
+        result.data["words"] = []
 
     def _sdk_speech_config(self, speechsdk: Any, inputs: dict[str, Any]) -> Any:
         endpoint = self._get_endpoint(inputs)

--- a/tools/audio/azure_tts.py
+++ b/tools/audio/azure_tts.py
@@ -1,0 +1,617 @@
+"""Azure AI Speech text-to-speech provider tool."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import time
+import xml.sax.saxutils
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+
+class AzureTTS(BaseTool):
+    name = "azure_tts"
+    version = "0.1.0"
+    tier = ToolTier.VOICE
+    capability = "tts"
+    provider = "azure"
+    stability = ToolStability.BETA
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.DETERMINISTIC
+    runtime = ToolRuntime.API
+
+    dependencies = []
+    install_instructions = (
+        "Set AZURE_SPEECH_KEY and AZURE_SPEECH_REGION for Azure AI Speech.\n"
+        "Optional: set AZURE_SPEECH_ENDPOINT for a custom endpoint, or "
+        "AZURE_SPEECH_AUTH_TOKEN for token-based auth.\n"
+        "For word-boundary timing metadata, install the optional SDK:\n"
+        "  pip install azure-cognitiveservices-speech"
+    )
+    fallback = "doubao_tts"
+    fallback_tools = ["doubao_tts", "google_tts", "elevenlabs_tts", "openai_tts", "piper_tts"]
+    agent_skills = ["text-to-speech"]
+
+    capabilities = [
+        "text_to_speech",
+        "voice_selection",
+        "ssml_support",
+        "multilingual",
+        "expressive_style_control",
+        "custom_voice_endpoint",
+        "voice_catalog",
+        "word_boundary_timestamps",
+    ]
+    supports = {
+        "voice_cloning": False,
+        "custom_voice": True,
+        "multilingual": True,
+        "offline": False,
+        "native_audio": True,
+        "ssml": True,
+        "style": True,
+        "prosody": True,
+        "word_boundary_events": True,
+        "sdk_optional": True,
+    }
+    best_for = [
+        "production Mandarin narration with enterprise-grade availability",
+        "SSML-directed pacing, pitch, volume, style, and role",
+        "voice catalog discovery before TTS Segment Lab auditions",
+        "word-boundary timing metadata for subtitles and visual cue alignment when the optional SDK is installed",
+    ]
+    not_good_for = [
+        "fully offline production",
+        "word-level timestamps without the optional Azure Speech SDK",
+        "voice cloning through this generic REST provider",
+    ]
+
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "operation": {
+                "type": "string",
+                "default": "synthesize",
+                "enum": ["synthesize", "list_voices"],
+                "description": "Use list_voices to fetch the Azure voice catalog without generating audio.",
+            },
+            "text": {"type": "string", "description": "Text to convert to speech"},
+            "backend": {
+                "type": "string",
+                "default": "auto",
+                "enum": ["auto", "rest", "sdk"],
+                "description": "auto/rest uses lightweight REST by default. sdk uses the optional Azure Speech SDK for word-boundary metadata.",
+            },
+            "enable_word_boundaries": {
+                "type": "boolean",
+                "default": False,
+                "description": "Use Azure Speech SDK to capture word-boundary timing metadata for subtitles and visual cue alignment. Requires azure-cognitiveservices-speech.",
+            },
+            "ssml": {
+                "type": "string",
+                "description": "Raw SSML. When provided, OpenMontage sends it directly and ignores text/prosody/style fields.",
+            },
+            "voice": {
+                "type": "string",
+                "default": "zh-CN-YunxiNeural",
+                "description": "Azure voice name, for example zh-CN-XiaoxiaoNeural, zh-CN-YunxiNeural, en-US-JennyNeural.",
+            },
+            "language_code": {
+                "type": "string",
+                "default": "zh-CN",
+                "description": "SSML xml:lang and optional voice catalog locale filter.",
+            },
+            "style": {
+                "type": "string",
+                "description": "Optional mstts:express-as style, for example chat, cheerful, customerservice, newscast, sad.",
+            },
+            "style_degree": {
+                "type": "number",
+                "minimum": 0.01,
+                "maximum": 2.0,
+                "description": "Optional mstts:express-as styledegree. Azure commonly supports 0.01 to 2.",
+            },
+            "role": {
+                "type": "string",
+                "description": "Optional mstts:express-as role, for example YoungAdultMale or SeniorFemale.",
+            },
+            "rate": {
+                "type": "string",
+                "description": "Optional SSML prosody rate, for example +8%, -10%, fast, medium, slow.",
+            },
+            "pitch": {
+                "type": "string",
+                "description": "Optional SSML prosody pitch, for example +2st, -5%, high, medium, low.",
+            },
+            "volume": {
+                "type": "string",
+                "description": "Optional SSML prosody volume, for example +2dB, soft, medium, loud.",
+            },
+            "sentence_silence_ms": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Optional sentence boundary silence using mstts:silence, in milliseconds.",
+            },
+            "audio_format": {
+                "type": "string",
+                "default": "audio-24khz-160kbitrate-mono-mp3",
+                "description": "Azure X-Microsoft-OutputFormat value. Custom values are passed through.",
+            },
+            "region": {
+                "type": "string",
+                "description": "Azure Speech region. Defaults to AZURE_SPEECH_REGION or SPEECH_REGION.",
+            },
+            "endpoint": {
+                "type": "string",
+                "description": "Optional Azure Speech endpoint override. Defaults to AZURE_SPEECH_ENDPOINT.",
+            },
+            "deployment_id": {
+                "type": "string",
+                "description": "Optional custom voice deployment id. Appended as deploymentId query parameter.",
+            },
+            "output_path": {"type": "string"},
+            "metadata_path": {
+                "type": "string",
+                "description": "Where to save provider metadata. Defaults next to output_path.",
+            },
+        },
+    }
+
+    output_schema = {
+        "type": "object",
+        "properties": {
+            "output": {"type": "string"},
+            "metadata_path": {"type": "string"},
+            "voice": {"type": "string"},
+            "language_code": {"type": "string"},
+            "format": {"type": "string"},
+            "voices": {"type": "array"},
+            "words": {"type": "array"},
+            "boundaries": {"type": "array"},
+        },
+    }
+    artifact_schema = {"type": "array", "items": {"type": "string"}}
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=50, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout", "429", "503"])
+    idempotency_key_fields = [
+        "text", "ssml", "voice", "language_code", "style", "rate", "audio_format",
+        "backend", "enable_word_boundaries",
+    ]
+    side_effects = [
+        "writes audio file to output_path",
+        "writes Azure request metadata JSON next to output_path",
+        "calls Azure AI Speech REST API",
+        "optionally calls Azure Speech SDK when word-boundary timing is requested",
+    ]
+    user_visible_verification = [
+        "Listen to generated audio for naturalness, pronunciation, and pacing",
+        "Use operation=list_voices before choosing a production voice",
+    ]
+    quality_score = 0.86
+    latency_p50_seconds = 3.0
+
+    DEFAULT_REGION_ENV = "AZURE_SPEECH_REGION"
+    DEFAULT_KEY_ENV = "AZURE_SPEECH_KEY"
+    DEFAULT_TOKEN_ENV = "AZURE_SPEECH_AUTH_TOKEN"
+    DEFAULT_VOICE = "zh-CN-YunxiNeural"
+    DEFAULT_LANGUAGE = "zh-CN"
+    DEFAULT_FORMAT = "audio-24khz-160kbitrate-mono-mp3"
+
+    _EXT_MAP = {
+        "mp3": "mp3",
+        "riff": "wav",
+        "wav": "wav",
+        "raw": "pcm",
+        "ogg": "ogg",
+        "opus": "opus",
+        "webm": "webm",
+    }
+
+    def get_status(self) -> ToolStatus:
+        if (self._get_key() or self._get_auth_token()) and (self._get_region({}) or self._get_endpoint({})):
+            return ToolStatus.AVAILABLE
+        return ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        # Azure Speech bills neural TTS by characters. Keep this conservative;
+        # provider account billing remains the source of truth.
+        text = inputs.get("text") or inputs.get("ssml") or ""
+        return round(len(text) * 0.000016, 4)
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        if not (self._get_key() or self._get_auth_token()):
+            return ToolResult(success=False, error="No Azure Speech key/token. " + self.install_instructions)
+        if not (self._get_region(inputs) or self._get_endpoint(inputs)):
+            return ToolResult(success=False, error="No Azure Speech region or endpoint. " + self.install_instructions)
+
+        start = time.time()
+        try:
+            operation = inputs.get("operation", "synthesize")
+            if operation == "list_voices":
+                result = self._list_voices(inputs)
+            elif self._should_use_sdk(inputs):
+                result = self._synthesize_with_sdk(inputs)
+            else:
+                result = self._synthesize(inputs)
+        except Exception as exc:
+            return ToolResult(success=False, error=f"Azure TTS failed: {self._safe_error(exc)}")
+
+        result.duration_seconds = round(time.time() - start, 2)
+        if not result.cost_usd:
+            result.cost_usd = self.estimate_cost(inputs)
+        return result
+
+    def _synthesize_with_sdk(self, inputs: dict[str, Any]) -> ToolResult:
+        try:
+            speechsdk = importlib.import_module("azure.cognitiveservices.speech")
+        except ImportError:
+            return ToolResult(
+                success=False,
+                error=(
+                    "Azure word-boundary timing requires the optional Speech SDK: "
+                    "pip install azure-cognitiveservices-speech"
+                ),
+            )
+
+        text = inputs.get("text")
+        ssml = inputs.get("ssml")
+        if not text and not ssml:
+            return ToolResult(success=False, error="Azure TTS SDK synthesize requires text or ssml.")
+
+        audio_format = inputs.get("audio_format", self.DEFAULT_FORMAT)
+        output_path = Path(inputs.get("output_path", f"azure_tts.{self._extension_for_format(audio_format)}"))
+        metadata_path = Path(inputs.get("metadata_path") or output_path.with_suffix(output_path.suffix + ".json"))
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        metadata_path.parent.mkdir(parents=True, exist_ok=True)
+
+        speech_config = self._sdk_speech_config(speechsdk, inputs)
+        speech_config.speech_synthesis_voice_name = inputs.get("voice", self.DEFAULT_VOICE)
+        speech_config.set_speech_synthesis_output_format(self._sdk_output_format(speechsdk, audio_format))
+
+        audio_config = speechsdk.audio.AudioOutputConfig(filename=str(output_path))
+        synthesizer = speechsdk.SpeechSynthesizer(
+            speech_config=speech_config,
+            audio_config=audio_config,
+        )
+
+        boundaries: list[dict[str, Any]] = []
+
+        def on_word_boundary(evt: Any) -> None:
+            boundaries.append(self._word_boundary_payload(evt))
+
+        synthesizer.synthesis_word_boundary.connect(on_word_boundary)
+
+        ssml_body = ssml or self._build_ssml(inputs)
+        result = synthesizer.speak_ssml_async(ssml_body).get()
+        reason = getattr(result, "reason", None)
+        if reason != speechsdk.ResultReason.SynthesizingAudioCompleted:
+            details = getattr(result, "cancellation_details", None) or speechsdk.CancellationDetails(result)
+            return ToolResult(success=False, error=f"Azure Speech SDK synthesis failed: {details}")
+
+        words = [item for item in boundaries if item.get("boundary_type") == "Word"]
+        metadata = {
+            "provider": self.provider,
+            "operation": "synthesize",
+            "backend": "sdk",
+            "voice": inputs.get("voice", self.DEFAULT_VOICE),
+            "language_code": inputs.get("language_code", self.DEFAULT_LANGUAGE),
+            "format": audio_format,
+            "output": str(output_path),
+            "ssml_generated": not bool(ssml),
+            "region": self._get_region(inputs),
+            "endpoint": self._safe_endpoint(inputs),
+            "deployment_id": inputs.get("deployment_id"),
+            "text_length": len(text or ssml_body),
+            "word_boundary_count": len(words),
+            "boundaries": boundaries,
+            "words": words,
+        }
+        metadata_path.write_text(json.dumps(metadata, ensure_ascii=False, indent=2), encoding="utf-8")
+
+        return ToolResult(
+            success=True,
+            data={**metadata, "metadata_path": str(metadata_path)},
+            artifacts=[str(output_path), str(metadata_path)],
+            model=f"azure-tts-sdk/{inputs.get('voice', self.DEFAULT_VOICE)}",
+        )
+
+    def _synthesize(self, inputs: dict[str, Any]) -> ToolResult:
+        import requests
+
+        text = inputs.get("text")
+        ssml = inputs.get("ssml")
+        if not text and not ssml:
+            return ToolResult(success=False, error="Azure TTS synthesize requires text or ssml.")
+
+        audio_format = inputs.get("audio_format", self.DEFAULT_FORMAT)
+        output_path = Path(inputs.get("output_path", f"azure_tts.{self._extension_for_format(audio_format)}"))
+        metadata_path = Path(inputs.get("metadata_path") or output_path.with_suffix(output_path.suffix + ".json"))
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        metadata_path.parent.mkdir(parents=True, exist_ok=True)
+
+        ssml_body = ssml or self._build_ssml(inputs)
+        response = requests.post(
+            self._synthesize_url(inputs),
+            headers=self._synthesize_headers(audio_format),
+            data=ssml_body.encode("utf-8"),
+            timeout=(10, 120),
+        )
+        response.raise_for_status()
+        output_path.write_bytes(response.content)
+
+        metadata = {
+            "provider": self.provider,
+            "operation": "synthesize",
+            "backend": "rest",
+            "voice": inputs.get("voice", self.DEFAULT_VOICE),
+            "language_code": inputs.get("language_code", self.DEFAULT_LANGUAGE),
+            "format": audio_format,
+            "output": str(output_path),
+            "ssml_generated": not bool(ssml),
+            "region": self._get_region(inputs),
+            "endpoint": self._safe_endpoint(inputs),
+            "deployment_id": inputs.get("deployment_id"),
+            "text_length": len(text or ssml_body),
+            "request_id": response.headers.get("X-RequestId") or response.headers.get("x-requestid"),
+        }
+        metadata_path.write_text(json.dumps(metadata, ensure_ascii=False, indent=2), encoding="utf-8")
+
+        return ToolResult(
+            success=True,
+            data={**metadata, "metadata_path": str(metadata_path)},
+            artifacts=[str(output_path), str(metadata_path)],
+            model=f"azure-tts/{inputs.get('voice', self.DEFAULT_VOICE)}",
+        )
+
+    def _list_voices(self, inputs: dict[str, Any]) -> ToolResult:
+        import requests
+
+        response = requests.get(
+            self._voices_url(inputs),
+            headers=self._auth_headers(),
+            timeout=(10, 60),
+        )
+        response.raise_for_status()
+        voices = response.json()
+        locale = inputs.get("language_code")
+        if locale:
+            voices = [voice for voice in voices if voice.get("Locale") == locale]
+        return ToolResult(
+            success=True,
+            data={
+                "provider": self.provider,
+                "operation": "list_voices",
+                "backend": "rest",
+                "language_code": locale,
+                "voices": voices,
+                "voice_count": len(voices),
+            },
+            model="azure-tts/voices-list",
+        )
+
+    @staticmethod
+    def _should_use_sdk(inputs: dict[str, Any]) -> bool:
+        return inputs.get("backend") == "sdk" or bool(inputs.get("enable_word_boundaries"))
+
+    def _sdk_speech_config(self, speechsdk: Any, inputs: dict[str, Any]) -> Any:
+        endpoint = self._get_endpoint(inputs)
+        key = self._get_key()
+        token = self._get_auth_token()
+        region = self._get_region(inputs)
+
+        if endpoint:
+            speech_config = speechsdk.SpeechConfig(endpoint=endpoint, subscription=key)
+        else:
+            speech_config = speechsdk.SpeechConfig(subscription=key, region=region)
+        if token:
+            speech_config.authorization_token = token
+        return speech_config
+
+    @staticmethod
+    def _sdk_output_format(speechsdk: Any, audio_format: str) -> Any:
+        normalized = audio_format.replace("-", "_").replace(".", "_")
+        candidates = {
+            "audio_16khz_32kbitrate_mono_mp3": "Audio16Khz32KBitRateMonoMp3",
+            "audio_16khz_64kbitrate_mono_mp3": "Audio16Khz64KBitRateMonoMp3",
+            "audio_16khz_128kbitrate_mono_mp3": "Audio16Khz128KBitRateMonoMp3",
+            "audio_24khz_48kbitrate_mono_mp3": "Audio24Khz48KBitRateMonoMp3",
+            "audio_24khz_96kbitrate_mono_mp3": "Audio24Khz96KBitRateMonoMp3",
+            "audio_24khz_160kbitrate_mono_mp3": "Audio24Khz160KBitRateMonoMp3",
+            "riff_16khz_16bit_mono_pcm": "Riff16Khz16BitMonoPcm",
+            "riff_24khz_16bit_mono_pcm": "Riff24Khz16BitMonoPcm",
+            "riff_48khz_16bit_mono_pcm": "Riff48Khz16BitMonoPcm",
+            "ogg_24khz_16bit_mono_opus": "Ogg24Khz16BitMonoOpus",
+            "webm_24khz_16bit_mono_opus": "Webm24Khz16BitMonoOpus",
+        }
+        enum_name = candidates.get(normalized.lower(), "Audio24Khz160KBitRateMonoMp3")
+        return getattr(speechsdk.SpeechSynthesisOutputFormat, enum_name)
+
+    @staticmethod
+    def _word_boundary_payload(evt: Any) -> dict[str, Any]:
+        boundary_type = getattr(evt, "boundary_type", "")
+        if hasattr(boundary_type, "name"):
+            boundary_type = boundary_type.name
+        audio_offset_ticks = AzureTTS._ticks(getattr(evt, "audio_offset", 0))
+        duration_ticks = AzureTTS._ticks(getattr(evt, "duration", 0))
+        return {
+            "boundary_type": str(boundary_type),
+            "text": getattr(evt, "text", ""),
+            "audio_offset_ticks": audio_offset_ticks,
+            "audio_offset_seconds": audio_offset_ticks / 10_000_000,
+            "duration_ticks": duration_ticks,
+            "duration_seconds": duration_ticks / 10_000_000,
+            "text_offset": getattr(evt, "text_offset", None),
+            "word_length": getattr(evt, "word_length", None),
+        }
+
+    @staticmethod
+    def _ticks(value: Any) -> int:
+        if hasattr(value, "total_seconds"):
+            return int(value.total_seconds() * 10_000_000)
+        return int(value or 0)
+
+    def _build_ssml(self, inputs: dict[str, Any]) -> str:
+        text = xml.sax.saxutils.escape(inputs["text"])
+        language = xml.sax.saxutils.escape(inputs.get("language_code", self.DEFAULT_LANGUAGE))
+        voice = xml.sax.saxutils.escape(inputs.get("voice", self.DEFAULT_VOICE))
+        content = text
+
+        silence = self._silence_tag(inputs)
+        if self._has_prosody(inputs):
+            attrs = self._attrs({
+                "rate": inputs.get("rate"),
+                "pitch": inputs.get("pitch"),
+                "volume": inputs.get("volume"),
+            })
+            content = f"<prosody{attrs}>{content}</prosody>"
+
+        if self._has_express_as(inputs):
+            attrs = self._attrs({
+                "style": inputs.get("style"),
+                "styledegree": inputs.get("style_degree"),
+                "role": inputs.get("role"),
+            })
+            content = f"<mstts:express-as{attrs}>{content}</mstts:express-as>"
+
+        return (
+            f'<speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis" '
+            f'xmlns:mstts="https://www.w3.org/2001/mstts" xml:lang="{language}">'
+            f'<voice name="{voice}">{silence}{content}</voice>'
+            f"</speak>"
+        )
+
+    @staticmethod
+    def _attrs(values: dict[str, Any]) -> str:
+        attrs = []
+        for key, value in values.items():
+            if value is None or value == "":
+                continue
+            escaped = xml.sax.saxutils.escape(str(value), {'"': "&quot;"})
+            attrs.append(f'{key}="{escaped}"')
+        return (" " + " ".join(attrs)) if attrs else ""
+
+    @staticmethod
+    def _has_prosody(inputs: dict[str, Any]) -> bool:
+        return any(inputs.get(key) for key in ("rate", "pitch", "volume"))
+
+    @staticmethod
+    def _has_express_as(inputs: dict[str, Any]) -> bool:
+        return any(inputs.get(key) for key in ("style", "style_degree", "role"))
+
+    @staticmethod
+    def _silence_tag(inputs: dict[str, Any]) -> str:
+        value = inputs.get("sentence_silence_ms")
+        if value is None:
+            return ""
+        return f'<mstts:silence type="Sentenceboundary" value="{int(value)}ms"/>'
+
+    def _synthesize_headers(self, audio_format: str) -> dict[str, str]:
+        headers = {
+            "Content-Type": "application/ssml+xml",
+            "X-Microsoft-OutputFormat": audio_format,
+            "User-Agent": "OpenMontage",
+        }
+        headers.update(self._auth_headers())
+        return headers
+
+    def _auth_headers(self) -> dict[str, str]:
+        token = self._get_auth_token()
+        if token:
+            return {"Authorization": f"Bearer {token}"}
+        return {"Ocp-Apim-Subscription-Key": self._get_key() or ""}
+
+    def _synthesize_url(self, inputs: dict[str, Any]) -> str:
+        url = self._synthesis_endpoint(inputs)
+        deployment_id = inputs.get("deployment_id")
+        if deployment_id:
+            separator = "&" if "?" in url else "?"
+            url = f"{url}{separator}{urlencode({'deploymentId': deployment_id})}"
+        return url
+
+    def _voices_url(self, inputs: dict[str, Any]) -> str:
+        endpoint = self._get_endpoint(inputs)
+        if endpoint:
+            endpoint = endpoint.rstrip("/")
+            if endpoint.endswith("/cognitiveservices/voices/list"):
+                return endpoint
+            if endpoint.endswith("/cognitiveservices/v1"):
+                return endpoint.rsplit("/cognitiveservices/v1", 1)[0] + "/cognitiveservices/voices/list"
+            return endpoint + "/cognitiveservices/voices/list"
+        return self._endpoint_base(inputs, service="tts") + "/cognitiveservices/voices/list"
+
+    def _synthesis_endpoint(self, inputs: dict[str, Any]) -> str:
+        endpoint = self._get_endpoint(inputs)
+        if endpoint:
+            endpoint = endpoint.rstrip("/")
+            if endpoint.endswith("/cognitiveservices/v1"):
+                return endpoint
+            return endpoint + "/cognitiveservices/v1"
+        return self._endpoint_base(inputs, service="tts") + "/cognitiveservices/v1"
+
+    def _endpoint_base(self, inputs: dict[str, Any], *, service: str) -> str:
+        endpoint = self._get_endpoint(inputs)
+        if endpoint:
+            return endpoint.rstrip("/")
+        region = self._get_region(inputs)
+        if service == "tts":
+            return f"https://{region}.tts.speech.microsoft.com"
+        return f"https://{region}.api.cognitive.microsoft.com"
+
+    @staticmethod
+    def _get_key() -> str | None:
+        return os.environ.get("AZURE_SPEECH_KEY") or os.environ.get("SPEECH_KEY")
+
+    @staticmethod
+    def _get_auth_token() -> str | None:
+        return os.environ.get("AZURE_SPEECH_AUTH_TOKEN") or os.environ.get("SPEECH_AUTH_TOKEN")
+
+    @staticmethod
+    def _get_region(inputs: dict[str, Any]) -> str | None:
+        return inputs.get("region") or os.environ.get("AZURE_SPEECH_REGION") or os.environ.get("SPEECH_REGION")
+
+    @staticmethod
+    def _get_endpoint(inputs: dict[str, Any]) -> str | None:
+        return inputs.get("endpoint") or os.environ.get("AZURE_SPEECH_ENDPOINT") or os.environ.get("SPEECH_ENDPOINT")
+
+    def _safe_endpoint(self, inputs: dict[str, Any]) -> str | None:
+        endpoint = self._get_endpoint(inputs)
+        if endpoint:
+            return endpoint.rstrip("/")
+        region = self._get_region(inputs)
+        return f"https://{region}.tts.speech.microsoft.com" if region else None
+
+    @classmethod
+    def _extension_for_format(cls, audio_format: str) -> str:
+        lowered = audio_format.lower()
+        for needle, ext in cls._EXT_MAP.items():
+            if needle in lowered:
+                return ext
+        return "audio"
+
+    @staticmethod
+    def _safe_error(exc: Exception) -> str:
+        message = str(exc)
+        for env_name in ("AZURE_SPEECH_KEY", "SPEECH_KEY", "AZURE_SPEECH_AUTH_TOKEN", "SPEECH_AUTH_TOKEN"):
+            value = os.environ.get(env_name)
+            if value:
+                message = message.replace(value, "[redacted]")
+        return message


### PR DESCRIPTION
## Summary

Adds an Azure AI Speech text-to-speech provider for OpenMontage.

Highlights:
- REST synthesis via Azure AI Speech with `AZURE_SPEECH_KEY` and `AZURE_SPEECH_REGION`
- `operation=list_voices` for voice catalog discovery
- SSML generation with voice, style, role, rate, pitch, volume, and sentence silence controls
- Custom endpoint and custom voice deployment support
- Optional SDK mode for word-boundary timing metadata when `azure-cognitiveservices-speech` is installed
- TTS selector compatibility through the existing capability/provider registry
- Documentation and provider contract coverage

## Validation

Passed:

```bash
.venv/bin/python -m pytest -q tests/tools/test_azure_tts.py tests/contracts/test_phase3_contracts.py
# 71 passed
```

Also validated manually with a live Azure Speech resource:
- provider status: `available`
- `operation=list_voices` for `zh-CN`: 49 voices returned
- direct SDK synthesis succeeded
- SDK word-boundary metadata returned 13 boundaries / 11 words for a Chinese sample
- `tts_selector` routed `preferred_provider=azure` to `azure_tts` and generated audio

Full-suite note:

```bash
.venv/bin/python -m pytest -q
```

currently stops during collection in `tests/qa/test_08_end_to_end.py` because its fixture does not include the now-required `render_runtime` property for `edit_decisions`. That appears unrelated to this Azure provider change.