### PR TITLE
feat(Explainer): graceful enter/exit transitions for scene text

### DIFF
--- a/remotion-composer/src/Explainer.tsx
+++ b/remotion-composer/src/Explainer.tsx
@@ -528,9 +528,45 @@ const BackgroundVideoLayer: React.FC<{
   );
 };
 
+// Per-scene text transition — graceful fade + slide + scale on entry AND exit.
+// Without this, scene text/components pop in and vanish abruptly at cut boundaries.
+// Only the text/component layer animates; background video/image stays steady.
+const SceneTextTransition: React.FC<{ children: React.ReactNode; durationInFrames: number }> = ({
+  children,
+  durationInFrames,
+}) => {
+  const frame = useCurrentFrame();
+  const fadeIn = Math.min(18, Math.max(9, Math.floor(durationInFrames * 0.26)));
+  const outStart = Math.max(fadeIn + 1, durationInFrames - 22);
+  const stops = [0, fadeIn, outStart, durationInFrames];
+  const opacity = interpolate(frame, stops, [0, 1, 1, 0], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+  });
+  const translateY = interpolate(frame, stops, [80, 0, 0, -60], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+  });
+  const scale = interpolate(frame, stops, [0.88, 1, 1, 1.08], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+  });
+  return (
+    <AbsoluteFill style={{ opacity, transform: `translateY(${translateY}px) scale(${scale})` }}>
+      {children}
+    </AbsoluteFill>
+  );
+};
+
 const SceneRenderer: React.FC<{ cut: Cut; theme: ThemeConfig }> = ({ cut, theme }) => {
-  // Wrap component with background video or image if specified
+  const { fps } = useVideoConfig();
+  const sceneDuration = Math.round((cut.out_seconds - cut.in_seconds) * fps);
+  // Wrap component with background video or image if specified.
+  // Text/component content gets an enter/exit transition; background stays steady.
   const maybeWrapWithBg = (element: React.ReactElement) => {
+    const content = (
+      <SceneTextTransition durationInFrames={sceneDuration}>{element}</SceneTextTransition>
+    );
     if (cut.backgroundVideo) {
       return (
         <BackgroundVideoLayer
@@ -538,7 +574,7 @@ const SceneRenderer: React.FC<{ cut: Cut; theme: ThemeConfig }> = ({ cut, theme 
           startFrom={cut.backgroundVideoStart ?? 0}
           overlayOpacity={cut.backgroundOverlay ?? 0.55}
         >
-          {element}
+          {content}
         </BackgroundVideoLayer>
       );
     }
@@ -548,11 +584,11 @@ const SceneRenderer: React.FC<{ cut: Cut; theme: ThemeConfig }> = ({ cut, theme 
           src={cut.backgroundImage}
           overlayOpacity={cut.backgroundOverlay ?? 0.55}
         >
-          {element}
+          {content}
         </BackgroundImageLayer>
       );
     }
-    return element;
+    return content;
   };
 
   // Resolve the scene element based on cut type, then wrap with backgroundImage if set


### PR DESCRIPTION
## What
Adds a `SceneTextTransition` wrapper so every scene's text/component gets a graceful **enter and exit** animation (fade + slide + subtle scale), instead of popping in and vanishing abruptly at cut boundaries.

## Why
Currently scene components have entrance springs but **no exit** — text snaps in, then disappears instantly when the next cut starts. On real explainer videos this reads as jarring, especially between back-to-back text scenes.

## How
- New `SceneTextTransition` component drives `opacity` (0→1→1→0), `translateY` (slide up on enter / drift up on exit) and `scale` (0.88→1→1.08) from the cut's own duration, with clamped interpolation.
- `SceneRenderer.maybeWrapWithBg` now wraps inner content in `SceneTextTransition` **before** the background layer — only the text/component layer animates; `backgroundVideo` / `backgroundImage` stay steady.
- Timing auto-scales per cut (`fadeIn ≈ duration*0.26`, exit starts ~22 frames before end), so short and long cuts both transition cleanly.

## Scope / Safety
- Single file, ~40 lines added. No API/schema change — `cuts` props untouched.
- Applies uniformly to all scene types (text_card / callout / comparison / hero_title / charts…) since they all flow through `maybeWrapWithBg`.
- Verified by rendering full explainer videos (1080p, mixed text + background-video cuts).

Happy to gate this behind a prop (e.g. `cut.transition: "none"`) if you'd prefer opt-in rather than default-on.
