### PR TITLE
feat(stickman): add custom 30s stickman fight cinematic composition

### DIFF
--- a/remotion-composer/src/Root.tsx
+++ b/remotion-composer/src/Root.tsx
@@ -16,6 +16,7 @@ import { ProductReveal, ProductRevealProps } from "./components/ProductReveal";
 import { CaptionOverlay, WordCaption } from "./components/CaptionOverlay";
 import { CollageBurst, CollageBurstProps } from "./CollageBurst";
 import { LyricOverlay, LyricOverlayProps } from "./LyricOverlay";
+import { StickmanFight } from "./stickman/StickmanFight";
 
 // ---------------------------------------------------------------------------
 // Theme System — prevents every video from looking like dark fintech
@@ -329,6 +330,14 @@ export const Root: React.FC = () => {
           fadeOutSeconds: 1.5,
           overlay: true,
         } as EndTagProps}
+      />
+      <Composition
+        id="StickmanFight"
+        component={StickmanFight}
+        durationInFrames={30 * 30}
+        fps={30}
+        width={1920}
+        height={1080}
       />
     </>
   );

--- a/remotion-composer/src/stickman/StickmanFight.tsx
+++ b/remotion-composer/src/stickman/StickmanFight.tsx
@@ -1,0 +1,391 @@
+import React from "react";
+import {
+  AbsoluteFill,
+  useCurrentFrame,
+  useVideoConfig,
+  interpolate,
+  Easing,
+  random,
+} from "remotion";
+import { POSES, lerpPose, Pose } from "./poses";
+import {
+  KEYFRAMES,
+  SHAKE_EVENTS,
+  FLASH_EVENTS,
+  IMPACT_BURSTS,
+  TEXT_CARDS,
+  WIDTH,
+  HEIGHT,
+  Keyframe,
+} from "./timeline";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const easeFns: Record<string, (t: number) => number> = {
+  linear: Easing.linear,
+  easeInOut: Easing.inOut(Easing.ease),
+  easeOut: Easing.out(Easing.cubic),
+  easeIn: Easing.in(Easing.cubic),
+  snap: Easing.out(Easing.back(1.2)),
+};
+
+function findSurroundingKeyframes(timeSec: number): [Keyframe, Keyframe, number] {
+  for (let i = 0; i < KEYFRAMES.length - 1; i++) {
+    const a = KEYFRAMES[i];
+    const b = KEYFRAMES[i + 1];
+    if (timeSec >= a.t && timeSec <= b.t) {
+      const span = b.t - a.t || 1;
+      const raw = (timeSec - a.t) / span;
+      const fn = easeFns[b.ease] ?? Easing.linear;
+      return [a, b, fn(Math.min(1, Math.max(0, raw)))];
+    }
+  }
+  const last = KEYFRAMES[KEYFRAMES.length - 1];
+  return [last, last, 0];
+}
+
+function lerpNum(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+// ---------------------------------------------------------------------------
+// Stick figure rig
+// ---------------------------------------------------------------------------
+
+interface FighterProps {
+  pose: Pose;
+  hip: [number, number];
+  facing: 1 | -1;
+  color: string;
+  highlightColor: string;
+}
+
+const Fighter: React.FC<FighterProps> = ({ pose, hip, facing, color, highlightColor }) => {
+  const [hipX, hipY] = hip;
+  const headRadius = 26;
+  const torsoLength = 95;
+
+  // Torso end point (shoulders), rotated by torsoLean around the hip.
+  const torsoAngleRad = (pose.torsoLean * Math.PI) / 180;
+  const shoulderX = -Math.sin(torsoAngleRad) * torsoLength;
+  const shoulderY = -Math.cos(torsoAngleRad) * torsoLength;
+
+  const headAngleRad = ((pose.torsoLean + pose.headTilt) * Math.PI) / 180;
+  const headCx = shoulderX + Math.sin(headAngleRad) * (headRadius + 4) + pose.headOffsetX;
+  const headCy = shoulderY - Math.cos(headAngleRad) * (headRadius + 4) + pose.headOffsetY;
+
+  const limb = (point: { x: number; y: number }) => ({
+    x: point.x * facing,
+    y: point.y,
+  });
+
+  const armL = limb(pose.armL);
+  const armR = limb(pose.armR);
+  const legL = limb(pose.legL);
+  const legR = limb(pose.legR);
+
+  const stroke = color;
+  const strokeWidth = 11;
+
+  return (
+    <g
+      transform={`translate(${hipX + pose.hipOffsetX * facing}, ${
+        hipY + pose.hipOffsetY
+      }) scale(${pose.scaleX}, ${pose.scaleY})`}
+    >
+      {/* Legs */}
+      <line x1={0} y1={0} x2={legL.x} y2={legL.y} stroke={stroke} strokeWidth={strokeWidth} strokeLinecap="round" />
+      <line x1={0} y1={0} x2={legR.x} y2={legR.y} stroke={stroke} strokeWidth={strokeWidth} strokeLinecap="round" />
+
+      {/* Torso */}
+      <line x1={0} y1={0} x2={shoulderX} y2={shoulderY} stroke={stroke} strokeWidth={strokeWidth + 2} strokeLinecap="round" />
+
+      {/* Arms */}
+      <line x1={shoulderX} y1={shoulderY} x2={shoulderX + armL.x} y2={shoulderY + armL.y} stroke={stroke} strokeWidth={strokeWidth} strokeLinecap="round" />
+      <line x1={shoulderX} y1={shoulderY} x2={shoulderX + armR.x} y2={shoulderY + armR.y} stroke={stroke} strokeWidth={strokeWidth} strokeLinecap="round" />
+
+      {/* Head */}
+      <circle cx={headCx} cy={headCy} r={headRadius} fill={highlightColor} stroke={stroke} strokeWidth={strokeWidth - 3} />
+    </g>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Background arena
+// ---------------------------------------------------------------------------
+
+const Arena: React.FC<{ groundY: number }> = ({ groundY }) => {
+  return (
+    <>
+      <defs>
+        <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#1b1037" />
+          <stop offset="55%" stopColor="#3a1d5c" />
+          <stop offset="100%" stopColor="#7c2f5e" />
+        </linearGradient>
+        <linearGradient id="ground" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#241433" />
+          <stop offset="100%" stopColor="#0c0716" />
+        </linearGradient>
+        <radialGradient id="moonGlow" cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stopColor="#fff7d6" stopOpacity={0.9} />
+          <stop offset="100%" stopColor="#fff7d6" stopOpacity={0} />
+        </radialGradient>
+      </defs>
+      <rect x={-400} y={-400} width={WIDTH + 800} height={HEIGHT + 800} fill="url(#sky)" />
+      <circle cx={WIDTH * 0.78} cy={HEIGHT * 0.18} r={220} fill="url(#moonGlow)" />
+      <circle cx={WIDTH * 0.78} cy={HEIGHT * 0.18} r={70} fill="#fff7d6" opacity={0.85} />
+      {/* distant mountains */}
+      <polygon
+        points={`-200,${groundY} 250,${groundY - 220} 600,${groundY - 80} 1000,${groundY - 260} 1450,${groundY - 100} 1900,${groundY - 240} 2200,${groundY}`}
+        fill="#190f2b"
+        opacity={0.8}
+      />
+      {/* ground */}
+      <rect x={-400} y={groundY} width={WIDTH + 800} height={HEIGHT - groundY + 400} fill="url(#ground)" />
+      {/* ground line glow */}
+      <rect x={-400} y={groundY - 4} width={WIDTH + 800} height={8} fill="#ff7a59" opacity={0.55} />
+    </>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Particle burst (impact)
+// ---------------------------------------------------------------------------
+
+const ImpactParticles: React.FC<{ x: number; y: number; progress: number; scale: number; color: string }> = ({
+  x,
+  y,
+  progress,
+  scale,
+  color,
+}) => {
+  const count = 14;
+  const particles = Array.from({ length: count }).map((_, i) => {
+    const angle = (i / count) * Math.PI * 2 + random(`angle-${i}`) * 0.6;
+    const dist = interpolate(progress, [0, 1], [0, 90 + 140 * scale]);
+    const px = x + Math.cos(angle) * dist;
+    const py = y + Math.sin(angle) * dist;
+    const opacity = interpolate(progress, [0, 0.15, 1], [1, 1, 0]);
+    const size = interpolate(progress, [0, 1], [10 * scale, 1]);
+    return { px, py, opacity, size, key: i };
+  });
+
+  return (
+    <>
+      {particles.map((p) => (
+        <circle key={p.key} cx={p.px} cy={p.py} r={Math.max(0, p.size)} fill={color} opacity={Math.max(0, p.opacity)} />
+      ))}
+    </>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Speed lines (for high-impact moments)
+// ---------------------------------------------------------------------------
+
+const SpeedLines: React.FC<{ opacity: number }> = ({ opacity }) => {
+  if (opacity <= 0) return null;
+  const lines = Array.from({ length: 18 }).map((_, i) => {
+    const cx = WIDTH / 2;
+    const cy = HEIGHT / 2;
+    const angle = (i / 18) * Math.PI * 2;
+    const innerR = 200;
+    const outerR = 1400;
+    const x1 = cx + Math.cos(angle) * innerR;
+    const y1 = cy + Math.sin(angle) * innerR;
+    const x2 = cx + Math.cos(angle) * outerR;
+    const y2 = cy + Math.sin(angle) * outerR;
+    return { x1, y1, x2, y2, key: i };
+  });
+  return (
+    <svg
+      width={WIDTH}
+      height={HEIGHT}
+      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+      style={{ position: "absolute", inset: 0, pointerEvents: "none" }}
+    >
+      {lines.map((l) => (
+        <line key={l.key} x1={l.x1} y1={l.y1} x2={l.x2} y2={l.y2} stroke="#ffffff" strokeWidth={3} opacity={opacity * 0.5} />
+      ))}
+    </svg>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Text card overlay
+// ---------------------------------------------------------------------------
+
+const TextCardOverlay: React.FC<{ frame: number; fps: number }> = ({ frame, fps }) => {
+  const t = frame / fps;
+  return (
+    <>
+      {TEXT_CARDS.map((card, i) => {
+        if (t < card.from || t > card.to) return null;
+        const fadeIn = interpolate(t, [card.from, card.from + 0.35], [0, 1], {
+          extrapolateLeft: "clamp",
+          extrapolateRight: "clamp",
+        });
+        const fadeOut = interpolate(t, [card.to - 0.4, card.to], [1, 0], {
+          extrapolateLeft: "clamp",
+          extrapolateRight: "clamp",
+        });
+        const opacity = Math.min(fadeIn, fadeOut);
+        const scale = interpolate(t, [card.from, card.from + 0.35], [0.85, 1], {
+          extrapolateLeft: "clamp",
+          extrapolateRight: "clamp",
+        });
+        const fontSize = card.size === "huge" ? 200 : 96;
+        return (
+          <AbsoluteFill
+            key={i}
+            style={{
+              alignItems: "center",
+              justifyContent: "center",
+              opacity,
+            }}
+          >
+            <div
+              style={{
+                fontFamily: "Arial Black, Impact, sans-serif",
+                fontWeight: 900,
+                fontSize,
+                letterSpacing: 12,
+                color: "#fff7e0",
+                textShadow:
+                  "0 0 30px rgba(255,150,60,0.9), 0 0 60px rgba(255,90,30,0.6), 0 6px 0 rgba(0,0,0,0.5)",
+                transform: `scale(${scale})`,
+              }}
+            >
+              {card.text}
+            </div>
+          </AbsoluteFill>
+        );
+      })}
+    </>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Main composition
+// ---------------------------------------------------------------------------
+
+export const StickmanFight: React.FC = () => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const t = frame / fps;
+
+  const [kfA, kfB, progress] = findSurroundingKeyframes(t);
+
+  const poseA = lerpPose(POSES[kfA.poseA], POSES[kfB.poseA], progress);
+  const poseB = lerpPose(POSES[kfA.poseB], POSES[kfB.poseB], progress);
+
+  const hipA: [number, number] = [
+    lerpNum(kfA.hipA[0], kfB.hipA[0], progress),
+    lerpNum(kfA.hipA[1], kfB.hipA[1], progress),
+  ];
+  const hipB: [number, number] = [
+    lerpNum(kfA.hipB[0], kfB.hipB[0], progress),
+    lerpNum(kfA.hipB[1], kfB.hipB[1], progress),
+  ];
+
+  const camZoom = lerpNum(kfA.camera.zoom, kfB.camera.zoom, progress);
+  const camX = lerpNum(kfA.camera.x, kfB.camera.x, progress);
+  const camY = lerpNum(kfA.camera.y, kfB.camera.y, progress);
+
+  // Camera shake
+  let shakeX = 0;
+  let shakeY = 0;
+  for (const ev of SHAKE_EVENTS) {
+    if (t >= ev.time && t <= ev.time + ev.duration) {
+      const localT = (t - ev.time) / ev.duration;
+      const decay = 1 - localT;
+      const seedX = random(`shakeX-${ev.time}-${frame}`);
+      const seedY = random(`shakeY-${ev.time}-${frame}`);
+      shakeX += (seedX - 0.5) * 2 * ev.intensity * decay;
+      shakeY += (seedY - 0.5) * 2 * ev.intensity * decay;
+    }
+  }
+
+  // Flash overlay
+  let flashOpacity = 0;
+  let flashColor = "#ffffff";
+  for (const ev of FLASH_EVENTS) {
+    if (t >= ev.time && t <= ev.time + ev.duration) {
+      const localT = (t - ev.time) / ev.duration;
+      const o = interpolate(localT, [0, 0.25, 1], [ev.peakOpacity, ev.peakOpacity, 0]);
+      if (o > flashOpacity) {
+        flashOpacity = o;
+        flashColor = ev.color;
+      }
+    }
+  }
+
+  // Speed-line opacity for the biggest hits
+  let speedLineOpacity = 0;
+  for (const ev of FLASH_EVENTS) {
+    if (ev.peakOpacity >= 0.6 && t >= ev.time && t <= ev.time + ev.duration * 1.5) {
+      const localT = (t - ev.time) / (ev.duration * 1.5);
+      speedLineOpacity = Math.max(speedLineOpacity, interpolate(localT, [0, 1], [1, 0]));
+    }
+  }
+
+  const groundY = HEIGHT * 0.66;
+
+  return (
+    <AbsoluteFill style={{ backgroundColor: "#0c0716", overflow: "hidden" }}>
+      <svg
+        width={WIDTH}
+        height={HEIGHT}
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        style={{ position: "absolute", inset: 0 }}
+      >
+        <g
+          transform={`translate(${WIDTH / 2}, ${HEIGHT / 2}) scale(${camZoom}) translate(${
+            -WIDTH / 2 + camX + shakeX
+          }, ${-HEIGHT / 2 + camY + shakeY})`}
+        >
+          <Arena groundY={groundY} />
+          <Fighter pose={poseA} hip={hipA} facing={kfB.facingA} color="#f5f1e8" highlightColor="#ffe9c2" />
+          <Fighter pose={poseB} hip={hipB} facing={kfB.facingB} color="#9be8ff" highlightColor="#dffaff" />
+
+          {/* Impact particle bursts */}
+          {IMPACT_BURSTS.map((burst, i) => {
+            if (t < burst.time || t > burst.time + burst.duration) return null;
+            const progressBurst = (t - burst.time) / burst.duration;
+            return (
+              <ImpactParticles
+                key={i}
+                x={burst.x}
+                y={burst.y}
+                progress={progressBurst}
+                scale={burst.scale}
+                color={burst.color}
+              />
+            );
+          })}
+        </g>
+      </svg>
+
+      <SpeedLines opacity={speedLineOpacity} />
+
+      {/* Flash */}
+      {flashOpacity > 0 && (
+        <AbsoluteFill style={{ backgroundColor: flashColor, opacity: flashOpacity }} />
+      )}
+
+      {/* Vignette */}
+      <AbsoluteFill
+        style={{
+          background:
+            "radial-gradient(ellipse at center, rgba(0,0,0,0) 55%, rgba(0,0,0,0.55) 100%)",
+          pointerEvents: "none",
+        }}
+      />
+
+      <TextCardOverlay frame={frame} fps={fps} />
+    </AbsoluteFill>
+  );
+};

--- a/remotion-composer/src/stickman/poses.ts
+++ b/remotion-composer/src/stickman/poses.ts
@@ -1,0 +1,313 @@
+// Pose library for the stickman fight cinematic.
+// Coordinates are local to each fighter's hip origin.
+// x: positive = "facing direction" (multiplied by facing sign in the renderer)
+// y: positive = downward (SVG convention)
+
+export interface LimbPoint {
+  x: number;
+  y: number;
+}
+
+export interface Pose {
+  torsoLean: number; // degrees, rotates torso+head around hip
+  headTilt: number; // additional head rotation
+  headOffsetX: number;
+  headOffsetY: number;
+  armL: LimbPoint;
+  armR: LimbPoint;
+  legL: LimbPoint;
+  legR: LimbPoint;
+  scaleX: number;
+  scaleY: number;
+  hipOffsetX: number; // local lunge offset
+  hipOffsetY: number; // local jump/crouch offset
+}
+
+export const BASE_POSE: Pose = {
+  torsoLean: 0,
+  headTilt: 0,
+  headOffsetX: 0,
+  headOffsetY: 0,
+  armL: { x: 35, y: 95 },
+  armR: { x: -35, y: 95 },
+  legL: { x: 35, y: 110 },
+  legR: { x: -35, y: 110 },
+  scaleX: 1,
+  scaleY: 1,
+  hipOffsetX: 0,
+  hipOffsetY: 0,
+};
+
+function pose(overrides: Partial<Pose>): Pose {
+  return { ...BASE_POSE, ...overrides };
+}
+
+export const POSES: Record<string, Pose> = {
+  offstage: pose({}),
+
+  idle_guard: pose({
+    armL: { x: 80, y: -110 },
+    armR: { x: -45, y: -85 },
+    legL: { x: 35, y: 110 },
+    legR: { x: -30, y: 112 },
+  }),
+
+  on_guard_tense: pose({
+    torsoLean: 4,
+    armL: { x: 90, y: -120 },
+    armR: { x: -50, y: -95 },
+    legL: { x: 45, y: 108 },
+    legR: { x: -25, y: 114 },
+    hipOffsetY: -4,
+  }),
+
+  jab: pose({
+    torsoLean: 10,
+    armL: { x: 175, y: -110 },
+    armR: { x: -45, y: -90 },
+    legL: { x: 60, y: 104 },
+    legR: { x: -15, y: 116 },
+    hipOffsetX: 18,
+  }),
+
+  dodge_lean: pose({
+    torsoLean: -22,
+    headTilt: -18,
+    headOffsetY: -6,
+    armL: { x: 70, y: -100 },
+    armR: { x: -55, y: -90 },
+    legL: { x: 55, y: 108 },
+    legR: { x: -45, y: 114 },
+    hipOffsetX: -14,
+  }),
+
+  hit_recoil_face: pose({
+    torsoLean: -28,
+    headTilt: -42,
+    headOffsetX: -10,
+    headOffsetY: -10,
+    armL: { x: -70, y: -55 },
+    armR: { x: 95, y: -35 },
+    legL: { x: 50, y: 105 },
+    legR: { x: -25, y: 116 },
+    scaleX: 1.05,
+    scaleY: 0.94,
+    hipOffsetX: -16,
+  }),
+
+  kick_round: pose({
+    torsoLean: -18,
+    headTilt: -6,
+    armL: { x: -80, y: -95 },
+    armR: { x: 85, y: -75 },
+    legL: { x: -10, y: 116 },
+    legR: { x: 165, y: 10 },
+    hipOffsetY: -22,
+  }),
+
+  block: pose({
+    torsoLean: 6,
+    armL: { x: 75, y: -95 },
+    armR: { x: 60, y: -125 },
+    legL: { x: 45, y: 108 },
+    legR: { x: -35, y: 114 },
+  }),
+
+  block_recoil: pose({
+    torsoLean: -8,
+    armL: { x: 65, y: -90 },
+    armR: { x: 50, y: -118 },
+    legL: { x: 55, y: 105 },
+    legR: { x: -45, y: 116 },
+    hipOffsetX: -10,
+    scaleX: 1.02,
+    scaleY: 0.98,
+  }),
+
+  hit_recoil_body_heavy: pose({
+    torsoLean: -38,
+    headTilt: -20,
+    headOffsetX: -14,
+    armL: { x: -90, y: -40 },
+    armR: { x: 110, y: -20 },
+    legL: { x: 70, y: 95 },
+    legR: { x: 100, y: 75 },
+    scaleX: 1.12,
+    scaleY: 0.85,
+    hipOffsetX: -85,
+    hipOffsetY: -10,
+  }),
+
+  stagger: pose({
+    torsoLean: -12,
+    headTilt: -10,
+    armL: { x: 25, y: 80 },
+    armR: { x: -30, y: 85 },
+    legL: { x: 50, y: 108 },
+    legR: { x: -55, y: 112 },
+    hipOffsetX: -30,
+    hipOffsetY: -4,
+  }),
+
+  jump_kick_attacker: pose({
+    torsoLean: 14,
+    headTilt: 6,
+    armL: { x: -60, y: -120 },
+    armR: { x: -90, y: -90 },
+    legL: { x: -40, y: 70 },
+    legR: { x: 175, y: -10 },
+    hipOffsetX: 60,
+    hipOffsetY: -150,
+  }),
+
+  jump_kick_defender: pose({
+    torsoLean: -16,
+    headTilt: -10,
+    armL: { x: -90, y: -85 },
+    armR: { x: -60, y: -120 },
+    legL: { x: 165, y: -5 },
+    legR: { x: -40, y: 75 },
+    hipOffsetX: -60,
+    hipOffsetY: -150,
+  }),
+
+  land_stagger: pose({
+    torsoLean: -6,
+    armL: { x: 60, y: -60 },
+    armR: { x: -60, y: -55 },
+    legL: { x: 70, y: 100 },
+    legR: { x: -70, y: 100 },
+    hipOffsetY: -6,
+  }),
+
+  flurry_jab_a: pose({
+    torsoLean: 12,
+    armL: { x: 180, y: -125 },
+    armR: { x: -50, y: -90 },
+    legL: { x: 55, y: 106 },
+    legR: { x: -20, y: 116 },
+    hipOffsetX: 16,
+  }),
+
+  flurry_jab_b: pose({
+    torsoLean: 10,
+    armR: { x: 180, y: -90 },
+    armL: { x: -50, y: -125 },
+    legL: { x: 55, y: 106 },
+    legR: { x: -20, y: 116 },
+    hipOffsetX: 16,
+  }),
+
+  flurry_recoil: pose({
+    torsoLean: -22,
+    headTilt: -30,
+    headOffsetX: -8,
+    headOffsetY: -8,
+    armL: { x: -55, y: -50 },
+    armR: { x: 80, y: -30 },
+    legL: { x: 55, y: 104 },
+    legR: { x: -35, y: 116 },
+    scaleX: 1.03,
+    scaleY: 0.96,
+    hipOffsetX: -18,
+  }),
+
+  kneel: pose({
+    torsoLean: 35,
+    headTilt: 18,
+    headOffsetY: 30,
+    armL: { x: 40, y: 40 },
+    armR: { x: -10, y: 60 },
+    legL: { x: 5, y: 60 },
+    legR: { x: -75, y: 100 },
+    hipOffsetY: 70,
+  }),
+
+  powerup: pose({
+    torsoLean: -4,
+    headTilt: -12,
+    headOffsetY: -8,
+    armL: { x: 110, y: -210 },
+    armR: { x: -110, y: -210 },
+    legL: { x: 45, y: 108 },
+    legR: { x: -45, y: 108 },
+    scaleX: 1.06,
+    scaleY: 1.1,
+    hipOffsetY: -10,
+  }),
+
+  uppercut: pose({
+    torsoLean: -14,
+    headTilt: -10,
+    armL: { x: 70, y: -240 },
+    armR: { x: -55, y: -85 },
+    legL: { x: 55, y: 105 },
+    legR: { x: -20, y: 118 },
+    hipOffsetX: 22,
+    hipOffsetY: -28,
+  }),
+
+  ko_fly: pose({
+    torsoLean: -65,
+    headTilt: -50,
+    headOffsetX: -20,
+    armL: { x: -120, y: -10 },
+    armR: { x: 130, y: 20 },
+    legL: { x: 110, y: 40 },
+    legR: { x: 140, y: 90 },
+    scaleX: 0.95,
+    scaleY: 0.92,
+    hipOffsetX: -160,
+    hipOffsetY: -120,
+  }),
+
+  ko_ground: pose({
+    torsoLean: 82,
+    headTilt: 70,
+    headOffsetX: -40,
+    headOffsetY: 30,
+    armL: { x: -130, y: 30 },
+    armR: { x: 90, y: 60 },
+    legL: { x: 130, y: 30 },
+    legR: { x: 150, y: 70 },
+    hipOffsetX: -200,
+    hipOffsetY: 120,
+  }),
+
+  victory_pose: pose({
+    torsoLean: 0,
+    headTilt: 6,
+    headOffsetY: -6,
+    armL: { x: 130, y: -230 },
+    armR: { x: -130, y: -230 },
+    legL: { x: 50, y: 110 },
+    legR: { x: -50, y: 110 },
+    scaleX: 1.04,
+    scaleY: 1.06,
+  }),
+};
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+function lerpPoint(a: LimbPoint, b: LimbPoint, t: number): LimbPoint {
+  return { x: lerp(a.x, b.x, t), y: lerp(a.y, b.y, t) };
+}
+
+export function lerpPose(a: Pose, b: Pose, t: number): Pose {
+  return {
+    torsoLean: lerp(a.torsoLean, b.torsoLean, t),
+    headTilt: lerp(a.headTilt, b.headTilt, t),
+    headOffsetX: lerp(a.headOffsetX, b.headOffsetX, t),
+    headOffsetY: lerp(a.headOffsetY, b.headOffsetY, t),
+    armL: lerpPoint(a.armL, b.armL, t),
+    armR: lerpPoint(a.armR, b.armR, t),
+    legL: lerpPoint(a.legL, b.legL, t),
+    legR: lerpPoint(a.legR, b.legR, t),
+    scaleX: lerp(a.scaleX, b.scaleX, t),
+    scaleY: lerp(a.scaleY, b.scaleY, t),
+    hipOffsetX: lerp(a.hipOffsetX, b.hipOffsetX, t),
+    hipOffsetY: lerp(a.hipOffsetY, b.hipOffsetY, t),
+  };
+}

--- a/remotion-composer/src/stickman/timeline.ts
+++ b/remotion-composer/src/stickman/timeline.ts
@@ -1,0 +1,406 @@
+// Fight choreography timeline for the 30-second stickman cinematic.
+// All times are in seconds. FPS = 30.
+
+export const FPS = 30;
+export const DURATION_SECONDS = 30;
+export const WIDTH = 1920;
+export const HEIGHT = 1080;
+
+export type Easing = "linear" | "easeInOut" | "easeOut" | "easeIn" | "snap";
+
+export interface CameraState {
+  zoom: number;
+  x: number;
+  y: number;
+}
+
+export interface Keyframe {
+  t: number;
+  poseA: string;
+  poseB: string;
+  hipA: [number, number];
+  hipB: [number, number];
+  facingA: 1 | -1;
+  facingB: 1 | -1;
+  camera: CameraState;
+  ease: Easing;
+}
+
+// Canvas center is (WIDTH/2, HEIGHT*0.62) for the "ground line".
+const GROUND_Y = HEIGHT * 0.66;
+
+export const KEYFRAMES: Keyframe[] = [
+  // Intro: both fighters off-screen
+  {
+    t: 0,
+    poseA: "offstage",
+    poseB: "offstage",
+    hipA: [-300, GROUND_Y],
+    hipB: [WIDTH + 300, GROUND_Y],
+    facingA: 1,
+    facingB: -1,
+    camera: { zoom: 1.0, x: 0, y: 0 },
+    ease: "linear",
+  },
+  // Walk-in to center stage
+  {
+    t: 2.6,
+    poseA: "idle_guard",
+    poseB: "idle_guard",
+    hipA: [WIDTH * 0.36, GROUND_Y],
+    hipB: [WIDTH * 0.64, GROUND_Y],
+    facingA: 1,
+    facingB: -1,
+    camera: { zoom: 1.0, x: 0, y: 0 },
+    ease: "easeOut",
+  },
+  // On guard, tense beat, slow push-in
+  {
+    t: 3.3,
+    poseA: "on_guard_tense",
+    poseB: "on_guard_tense",
+    hipA: [WIDTH * 0.36, GROUND_Y],
+    hipB: [WIDTH * 0.64, GROUND_Y],
+    facingA: 1,
+    facingB: -1,
+    camera: { zoom: 1.12, x: 0, y: -10 },
+    ease: "easeInOut",
+  },
+  // A jabs forward
+  {
+    t: 3.9,
+    poseA: "jab",
+    poseB: "dodge_lean",
+    hipA: [WIDTH * 0.36, GROUND_Y],
+    hipB: [WIDTH * 0.66, GROUND_Y],
+    facingA: 1,
+    facingB: -1,
+    camera: { zoom: 1.18, x: -40, y: -20 },
+    ease: "snap",
+  },
+  // B counters, lands hit on A's face (impact)
+  {
+    t: 4.6,
+    poseA: "hit_recoil_face",
+    poseB: "jab",
+    hipA: [WIDTH * 0.34, GROUND_Y],
+    hipB: [WIDTH * 0.64, GROUND_Y],
+    facingA: 1,
+    facingB: -1,
+    camera: { zoom: 1.35, x: 60, y: -30 },
+    ease: "snap",
+  },
+  // Recover, reset to guard, camera pulls back
+  {
+    t: 6.0,
+    poseA: "idle_guard",
+    poseB: "idle_guard",
+    hipA: [WIDTH * 0.36, GROUND_Y],
+    hipB: [WIDTH * 0.64, GROUND_Y],
+    facingA: 1,
+    facingB: -1,
+    camera: { zoom: 1.05, x: 0, y: 0 },
+    ease: "easeInOut",
+  },
+  // A throws a round kick, B blocks
+  {
+    t: 7.2,
+    poseA: "kick_round",
+    poseB: "block",
+    hipA: [WIDTH * 0.37, GROUND_Y],
+    hipB: [WIDTH * 0.64, GROUND_Y],
+    facingA: 1,
+    facingB: -1,
+    camera: { zoom: 1.2, x: 30, y: -10 },
+    ease: "snap",
+  },
+  // Block recoil, brief reset
+  {
+    t: 7.7,
+    poseA: "idle_guard",
+    poseB: "block_recoil",
+    hipA: [WIDTH * 0.36, GROUND_Y],
+    hipB: [WIDTH * 0.65, GROUND_Y],
+    facingA: 1,
+    facingB: -1,
+    camera: { zoom: 1.1, x: 0, y: 0 },
+    ease: "easeOut",
+  },
+  // B spinning back-kick, lands heavy on A's body (big impact + knockback)
+  {
+    t: 8.6,
+    poseA: "hit_recoil_body_heavy",
+    poseB: "kick_round",
+    hipA: [WIDTH * 0.30, GROUND_Y - 6],
+    hipB: [WIDTH * 0.62, GROUND_Y],
+    facingA: 1,
+    facingB: -1,
+    camera: { zoom: 1.45, x: -80, y: -30 },
+    ease: "snap",
+  },
+  // Slow-motion stagger, dramatic hold
+  {
+    t: 11.0,
+    poseA: "stagger",
+    poseB: "idle_guard",
+    hipA: [WIDTH * 0.27, GROUND_Y],
+    hipB: [WIDTH * 0.62, GROUND_Y],
+    facingA: 1,
+    facingB: -1,
+    camera: { zoom: 1.5, x: -120, y: -40 },
+    ease: "easeInOut",
+  },
+  // Both charge to center, camera whips to wide
+  {
+    t: 12.6,
+    poseA: "idle_guard",
+    poseB: "idle_guard",
+    hipA: [WIDTH * 0.42, GROUND_Y],
+    hipB: [WIDTH * 0.58, GROUND_Y],
+    facingA: 1,
+    facingB: -1,
+    camera: { zoom: 1.0, x: 0, y: 0 },
+    ease: "easeIn",
+  },
+  // Mid-air clash (both jump-kick into each other) - massive impact
+  {
+    t: 13.7,
+    poseA: "jump_kick_attacker",
+    poseB: "jump_kick_defender",
+    hipA: [WIDTH * 0.46, GROUND_Y],
+    hipB: [WIDTH * 0.54, GROUND_Y],
+    facingA: 1,
+    facingB: -1,
+    camera: { zoom: 1.4, x: 0, y: -60 },
+    ease: "snap",
+  },
+  // Both land, stagger back, dramatic pause
+  {
+    t: 15.2,
+    poseA: "land_stagger",
+    poseB: "land_stagger",
+    hipA: [WIDTH * 0.38, GROUND_Y],
+    hipB: [WIDTH * 0.62, GROUND_Y],
+    facingA: 1,
+    facingB: -1,
+    camera: { zoom: 1.08, x: 0, y: 0 },
+    ease: "easeOut",
+  },
+  // Hold the pause
+  {
+    t: 16.3,
+    poseA: "idle_guard",
+    poseB: "idle_guard",
+    hipA: [WIDTH * 0.38, GROUND_Y],
+    hipB: [WIDTH * 0.62, GROUND_Y],
+    facingA: 1,
+    facingB: -1,
+    camera: { zoom: 1.1, x: 0, y: -10 },
+    ease: "easeInOut",
+  },
+  // B flurry jab 1
+  {
+    t: 16.8,
+    poseA: "flurry_recoil",
+    poseB: "flurry_jab_b",
+    hipA: [WIDTH * 0.36, GROUND_Y],
+    hipB: [WIDTH * 0.63, GROUND_Y],
+    facingA: 1,
+    facingB: -1,
+    camera: { zoom: 1.25, x: 50, y: -20 },
+    ease: "snap",
+  },
+  // B flurry jab 2
+  {
+    t: 17.3,
+    poseA: "flurry_recoil",
+    poseB: "flurry_jab_a",
+    hipA: [WIDTH * 0.355, GROUND_Y],
+    hipB: [WIDTH * 0.63, GROUND_Y],
+    facingA: 1,
+    facingB: -1,
+    camera: { zoom: 1.3, x: 60, y: -25 },
+    ease: "snap",
+  },
+  // B flurry jab 3 (final, hardest)
+  {
+    t: 17.8,
+    poseA: "hit_recoil_face",
+    poseB: "flurry_jab_b",
+    hipA: [WIDTH * 0.34, GROUND_Y],
+    hipB: [WIDTH * 0.63, GROUND_Y],
+    facingA: 1,
+    facingB: -1,
+    camera: { zoom: 1.4, x: 70, y: -30 },
+    ease: "snap",
+  },
+  // A staggers down to one knee
+  {
+    t: 19.2,
+    poseA: "kneel",
+    poseB: "idle_guard",
+    hipA: [WIDTH * 0.34, GROUND_Y],
+    hipB: [WIDTH * 0.62, GROUND_Y],
+    facingA: 1,
+    facingB: -1,
+    camera: { zoom: 1.2, x: -40, y: 20 },
+    ease: "easeOut",
+  },
+  // Hold the kneel - dramatic low-angle beat
+  {
+    t: 20.6,
+    poseA: "kneel",
+    poseB: "idle_guard",
+    hipA: [WIDTH * 0.34, GROUND_Y],
+    hipB: [WIDTH * 0.62, GROUND_Y],
+    facingA: 1,
+    facingB: -1,
+    camera: { zoom: 1.25, x: -40, y: 30 },
+    ease: "linear",
+  },
+  // A rises with a power-up surge
+  {
+    t: 21.8,
+    poseA: "powerup",
+    poseB: "idle_guard",
+    hipA: [WIDTH * 0.36, GROUND_Y],
+    hipB: [WIDTH * 0.62, GROUND_Y],
+    facingA: 1,
+    facingB: -1,
+    camera: { zoom: 1.15, x: 0, y: -10 },
+    ease: "easeOut",
+  },
+  // A unleashes the finishing uppercut - massive flash
+  {
+    t: 22.7,
+    poseA: "uppercut",
+    poseB: "ko_fly",
+    hipA: [WIDTH * 0.40, GROUND_Y],
+    hipB: [WIDTH * 0.66, GROUND_Y - 40],
+    facingA: 1,
+    facingB: -1,
+    camera: { zoom: 1.6, x: 80, y: -60 },
+    ease: "snap",
+  },
+  // B flies and lands
+  {
+    t: 24.6,
+    poseA: "victory_pose",
+    poseB: "ko_ground",
+    hipA: [WIDTH * 0.40, GROUND_Y],
+    hipB: [WIDTH * 0.78, GROUND_Y + 30],
+    facingA: 1,
+    facingB: -1,
+    camera: { zoom: 1.0, x: 0, y: 0 },
+    ease: "easeOut",
+  },
+  // Final hero shot - victory pose, slow zoom out
+  {
+    t: 30,
+    poseA: "victory_pose",
+    poseB: "ko_ground",
+    hipA: [WIDTH * 0.40, GROUND_Y],
+    hipB: [WIDTH * 0.78, GROUND_Y + 30],
+    facingA: 1,
+    facingB: -1,
+    camera: { zoom: 0.92, x: -20, y: 10 },
+    ease: "easeInOut",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// One-off effects: shake, flash, particle bursts, text cards
+// ---------------------------------------------------------------------------
+
+export interface ShakeEvent {
+  time: number;
+  duration: number;
+  intensity: number;
+}
+
+export const SHAKE_EVENTS: ShakeEvent[] = [
+  { time: 4.6, duration: 0.3, intensity: 10 },
+  { time: 7.2, duration: 0.18, intensity: 5 },
+  { time: 8.6, duration: 0.45, intensity: 18 },
+  { time: 13.7, duration: 0.5, intensity: 24 },
+  { time: 16.8, duration: 0.18, intensity: 8 },
+  { time: 17.3, duration: 0.18, intensity: 8 },
+  { time: 17.8, duration: 0.35, intensity: 14 },
+  { time: 22.7, duration: 0.7, intensity: 30 },
+];
+
+export interface FlashEvent {
+  time: number;
+  duration: number;
+  peakOpacity: number;
+  color: string;
+}
+
+export const FLASH_EVENTS: FlashEvent[] = [
+  { time: 4.6, duration: 0.18, peakOpacity: 0.35, color: "#ffffff" },
+  { time: 8.6, duration: 0.22, peakOpacity: 0.5, color: "#ffe9c2" },
+  { time: 13.7, duration: 0.28, peakOpacity: 0.7, color: "#ffffff" },
+  { time: 17.8, duration: 0.18, peakOpacity: 0.4, color: "#ffffff" },
+  { time: 22.7, duration: 0.45, peakOpacity: 1.0, color: "#fff6e0" },
+];
+
+export interface ImpactBurst {
+  time: number;
+  duration: number;
+  x: number; // canvas-relative x at the moment of impact
+  y: number;
+  scale: number;
+  color: string;
+}
+
+export const IMPACT_BURSTS: ImpactBurst[] = [
+  { time: 4.6, duration: 0.5, x: WIDTH * 0.38, y: GROUND_Y - 220, scale: 1.0, color: "#ffd28a" },
+  { time: 8.6, duration: 0.6, x: WIDTH * 0.34, y: GROUND_Y - 90, scale: 1.4, color: "#ffb27a" },
+  { time: 13.7, duration: 0.7, x: WIDTH * 0.5, y: GROUND_Y - 160, scale: 1.8, color: "#ffffff" },
+  { time: 17.8, duration: 0.5, x: WIDTH * 0.37, y: GROUND_Y - 220, scale: 1.1, color: "#ffd28a" },
+  { time: 22.7, duration: 0.9, x: WIDTH * 0.5, y: GROUND_Y - 280, scale: 2.4, color: "#fff2cf" },
+];
+
+export interface TextCard {
+  text: string;
+  subtext?: string;
+  from: number;
+  to: number;
+  size: "title" | "huge";
+}
+
+export const TEXT_CARDS: TextCard[] = [
+  { text: "ROUND ONE", from: 0, to: 2.6, size: "title" },
+  { text: "K.O.!", from: 22.7, to: 25.0, size: "huge" },
+  { text: "VICTORY", from: 26.5, to: 30, size: "title" },
+];
+
+// SFX timeline reference (consumed by the audio synthesis script, not the renderer)
+export interface SfxEvent {
+  time: number;
+  type:
+    | "bell"
+    | "whoosh"
+    | "hit_light"
+    | "hit_block"
+    | "hit_heavy"
+    | "hit_clash"
+    | "hit_ko"
+    | "powerup";
+}
+
+export const SFX_EVENTS: SfxEvent[] = [
+  { time: 0.05, type: "bell" },
+  { time: 3.9, type: "whoosh" },
+  { time: 4.6, type: "hit_light" },
+  { time: 7.2, type: "hit_block" },
+  { time: 8.6, type: "hit_heavy" },
+  { time: 12.6, type: "whoosh" },
+  { time: 13.7, type: "hit_clash" },
+  { time: 16.8, type: "hit_light" },
+  { time: 17.3, type: "hit_light" },
+  { time: 17.8, type: "hit_heavy" },
+  { time: 21.8, type: "powerup" },
+  { time: 22.7, type: "hit_ko" },
+  { time: 29.3, type: "bell" },
+];


### PR DESCRIPTION
## Summary
- Adds a new `StickmanFight` Remotion composition (1920x1080, 30fps, 900 frames / 30s) featuring two stick-figure fighters in a choreographed cinematic fight scene.
- Built as a custom composition rather than using the existing `character-animation` pipeline, since that pipeline currently produces generic rounded "blob" characters not suited for fight choreography.

## What was added
- `src/stickman/poses.ts` - a 22-pose library (guard, jab, dodge, kicks, blocks, knockdowns, uppercut, KO, victory, etc.) with deep pose interpolation (`lerpPose`) for smooth blending between poses.
- `src/stickman/timeline.ts` - keyframed choreography data: camera moves (zoom/pan), shake events, flash events, impact particle bursts, text cards ("ROUND ONE", "K.O.!", "VICTORY"), and an SFX event schedule.
- `src/stickman/StickmanFight.tsx` - the composition itself: SVG stick-figure rig driven by the pose data, an arena/background, a camera transform wrapper (zoom/pan/shake), impact VFX overlays (flash, particles, speed lines, vignette), and title card overlays.
- Registers the new `StickmanFight` composition in `Root.tsx`.

## Notes for reviewers
- This composition is self-contained (no new dependencies, no external API calls) and renders entirely from local pose/timeline data.
- Audio/SFX for this composition are intended to be generated separately (e.g. via ffmpeg-synthesized SFX) and muxed in during render/export; this PR only adds the visual composition.
- Verified locally: rendered the full 900-frame composition successfully with `npx remotion render StickmanFight`.

Generated with [Claude Code](https://claude.com/claude-code).