### PR TITLE
test(contracts): include doubao in expected TTS providers

### DIFF
--- a/tests/contracts/test_phase3_contracts.py
+++ b/tests/contracts/test_phase3_contracts.py
@@ -143,7 +143,7 @@ class TestCapabilityMetadata:
         catalog = reg.capability_catalog()
         assert "tts" in catalog
         providers = {item["provider"] for item in catalog["tts"] if item["provider"] != "selector"}
-        assert providers == {"elevenlabs", "google_tts", "openai", "piper"}
+        assert providers == {"doubao", "elevenlabs", "google_tts", "openai", "piper"}
 
 
 # ---- Animated Explainer Pipeline ----


### PR DESCRIPTION
## Summary

The Doubao TTS provider added in #57 makes `test_registry_catalog_views` fail — the expected provider set was never updated to include it, so the assertion sees a 5-provider catalog where it expects 4.

```
AssertionError: assert {'elevenlabs', 'piper', 'openai', 'doubao', 'google_tts'} == {'piper', 'elevenlabs', 'openai', 'google_tts'}
Extra items in the left set: 'doubao'
```

One-line fix: add `'doubao'` to the expected set in [test_phase3_contracts.py:146](https://github.com/calesthio/OpenMontage/blob/main/tests/contracts/test_phase3_contracts.py#L146).

## Test plan

- [x] `pytest tests/contracts/test_phase3_contracts.py::TestCapabilityMetadata::test_registry_catalog_views` — passes
- [x] Full `pytest tests/contracts/` — 257 passed, 7 skipped, 1 unrelated failure (character-animation runtime-contract gap, separate issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)