### PR TITLE
feat: add EvoLink video provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@
 # --- Image + video gateway ---
 FAL_KEY=                     # FLUX images, Google Veo video, Kling video, MiniMax video, Recraft images
                              # Get one at https://fal.ai/dashboard/keys
+EVOLINK_API_KEY=             # EvoLink Seedance 2.0 video generation
+                             # Get one at https://evolink.ai/dashboard/keys
 
 # --- Google (one key unlocks image gen + TTS) ---
 GOOGLE_API_KEY=              # Google Imagen images, Google Cloud TTS (700+ voices, 50+ languages)

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ This repo is built for agentic operation. If you're an OpenClaw-style agent, her
 
 # Image + video gateway:
 FAL_KEY=your-key               # FLUX images + Google Veo, Kling, MiniMax video + Recraft images
+EVOLINK_API_KEY=your-key       # EvoLink Seedance 2.0 video generation
 
 # Free stock media:
 PEXELS_API_KEY=your-key        # Free stock footage and images
@@ -410,13 +411,14 @@ Each tool declares which Layer 3 skills it relies on. The agent reads Layer 1 to
 > **Full setup guide with pricing and free tiers:** [`docs/PROVIDERS.md`](docs/PROVIDERS.md)
 
 <details>
-<summary><strong>Video Generation — 14 providers</strong></summary>
+<summary><strong>Video Generation — 15 providers</strong></summary>
 
 | Provider | Type | Notes |
 |----------|------|-------|
 | **Kling** | Cloud API | High quality, fast |
 | **Runway Gen-4** | Cloud API | Cinematic quality, Gen-3 Alpha Turbo / Gen-4 Turbo / Gen-4 Aleph |
 | **Google Veo 3** | Cloud API | Long-form, cinematic. Via fal.ai or HeyGen. |
+| **EvoLink** | Cloud API | Seedance 2.0 text-to-video and image-to-video via one EvoLink key |
 | **Grok Imagine Video** | Cloud API | Strong reference-image video and xAI-native short-form generation |
 | **Higgsfield** | Cloud API | Multi-model orchestrator with Soul ID for character consistency |
 | **MiniMax** | Cloud API | Cost-effective |

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -15,13 +15,14 @@ Everything you need to know about every provider in OpenMontage — setup instru
 | 3 | **$0** | ElevenLabs | Premium TTS + music + SFX (10K chars/month free) |
 | 4 | **$0** | Piper (local install) | Fully offline TTS — no API key, no cost, no network |
 | 5 | **~$0.03/image** | fal.ai | FLUX images + Kling/Veo/MiniMax video + Recraft — broad single-key image + video coverage |
-| 6 | **~$0.04/image** | OpenAI | DALL-E 3 images + OpenAI TTS |
-| 7 | **~$0.04/image** | Google Imagen | Imagen 4 images (shares the Google API key) |
-| 8 | **$12/month** | Runway | Gen-4 video — highest quality AI video |
-| 9 | **pay-as-you-go** | HeyGen | Avatar videos, multi-model video gateway |
-| 10 | **pay-as-you-go** | Suno | Full song generation with vocals and lyrics |
-| 11 | **$0 + GPU** | Local video gen | WAN 2.1, Hunyuan, CogVideo, LTX — free, offline |
-| 12 | **$0 + GPU** | Local Diffusion | Stable Diffusion images — free, offline |
+| 6 | **pay-as-you-go** | EvoLink | Seedance 2.0 text-to-video and image-to-video via one EvoLink key |
+| 7 | **~$0.04/image** | OpenAI | DALL-E 3 images + OpenAI TTS |
+| 8 | **~$0.04/image** | Google Imagen | Imagen 4 images (shares the Google API key) |
+| 9 | **$12/month** | Runway | Gen-4 video — highest quality AI video |
+| 10 | **pay-as-you-go** | HeyGen | Avatar videos, multi-model video gateway |
+| 11 | **pay-as-you-go** | Suno | Full song generation with vocals and lyrics |
+| 12 | **$0 + GPU** | Local video gen | WAN 2.1, Hunyuan, CogVideo, LTX — free, offline |
+| 13 | **$0 + GPU** | Local Diffusion | Stable Diffusion images — free, offline |
 
 ### Environment Variable Summary
 
@@ -44,6 +45,7 @@ DOUBAO_SPEECH_VOICE_TYPE=    # Default Doubao speaker/voice type
 
 # MULTI-MODEL GATEWAY (one key, 6+ tools)
 FAL_KEY=                     # FLUX, Recraft, Kling, Veo, MiniMax video
+EVOLINK_API_KEY=             # EvoLink Seedance 2.0 video generation
 
 # VIDEO
 HEYGEN_API_KEY=              # HeyGen avatar video gateway
@@ -130,6 +132,29 @@ No subscription — pure pay-as-you-go, no minimum spend.
 | WAN 2.5 | $0.05/sec | 20 seconds |
 
 **Free tier:** None — but $0 to start, you only pay for what you use.
+
+---
+
+### EvoLink — Seedance 2.0 Video Gateway
+
+> **Best if you already use EvoLink for AI model access.** One key unlocks
+> Seedance 2.0 text-to-video and image-to-video through EvoLink's async task API.
+
+**Tools unlocked:** `evolink_video`
+**Env var:** `EVOLINK_API_KEY`
+
+#### Setup
+
+1. Go to [evolink.ai/dashboard/keys](https://evolink.ai/dashboard/keys)
+2. Create or copy an API key
+3. Add to `.env`: `EVOLINK_API_KEY=your-key-here`
+
+#### What it's best for
+
+- Seedance 2.0 short-form text-to-video
+- First-frame image-to-video with a publicly accessible image URL
+- Optional synchronized audio and web-search enhanced prompts
+- Teams that want to route production through EvoLink rather than a model-specific key
 
 ---
 
@@ -725,6 +750,7 @@ These tools require only FFmpeg or Python packages — no GPU, no API key.
 | **Google** | `GOOGLE_API_KEY` | `google_tts`, `google_imagen` | Free tier + paid |
 | **ElevenLabs** | `ELEVENLABS_API_KEY` | `elevenlabs_tts`, `music_gen` | Free tier + paid |
 | **fal.ai** | `FAL_KEY` | `flux_image`, `recraft_image`, `kling_video`, `veo_video`, `minimax_video` | Pay-as-you-go |
+| **EvoLink** | `EVOLINK_API_KEY` | `evolink_video` | Pay-as-you-go |
 | **OpenAI** | `OPENAI_API_KEY` | `openai_tts`, `openai_image` | Paid only |
 | **xAI** | `XAI_API_KEY` | `grok_image`, `grok_video` | Paid only |
 | **Runway** | `RUNWAY_API_KEY` | `runway_video` | Free trial + paid |

--- a/tests/tools/test_evolink_video.py
+++ b/tests/tools/test_evolink_video.py
@@ -1,0 +1,161 @@
+"""Unit coverage for the EvoLink video provider."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import ToolStatus
+from tools.tool_registry import ToolRegistry
+from tools.video.evolink_video import EvoLinkVideo
+from tools.video.video_selector import VideoSelector
+
+
+def test_evolink_video_identity():
+    tool = EvoLinkVideo()
+    info = tool.get_info()
+
+    assert info["name"] == "evolink_video"
+    assert info["tier"] == "generate"
+    assert info["capability"] == "video_generation"
+    assert info["provider"] == "evolink"
+    assert "text_to_video" in info["capabilities"]
+    assert "image_to_video" in info["capabilities"]
+
+
+def test_evolink_video_status_uses_evolink_api_key(monkeypatch):
+    monkeypatch.delenv("EVOLINK_API_KEY", raising=False)
+    assert EvoLinkVideo().get_status() == ToolStatus.UNAVAILABLE
+
+    monkeypatch.setenv("EVOLINK_API_KEY", "test-key")
+    assert EvoLinkVideo().get_status() == ToolStatus.AVAILABLE
+
+
+def test_evolink_text_payload_maps_to_current_api_fields():
+    payload = EvoLinkVideo()._build_payload(
+        {
+            "prompt": "A cinematic product reveal",
+            "duration": "4",
+            "resolution": "480p",
+            "aspect_ratio": "9:16",
+            "generate_audio": False,
+            "web_search": True,
+        }
+    )
+
+    assert payload == {
+        "model": "seedance-2.0-text-to-video",
+        "prompt": "A cinematic product reveal",
+        "duration": 4,
+        "quality": "480p",
+        "aspect_ratio": "9:16",
+        "generate_audio": False,
+        "content_filter": True,
+        "model_params": {"web_search": True},
+    }
+
+
+def test_evolink_image_payload_accepts_selector_reference_alias():
+    payload = EvoLinkVideo()._build_payload(
+        {
+            "prompt": "Animate this first frame",
+            "operation": "image_to_video",
+            "model_variant": "fast",
+            "reference_image_url": "https://example.com/start.png",
+            "end_image_url": "https://example.com/end.png",
+        }
+    )
+
+    assert payload["model"] == "seedance-2.0-fast-image-to-video"
+    assert payload["image_urls"] == [
+        "https://example.com/start.png",
+        "https://example.com/end.png",
+    ]
+
+
+def test_video_selector_discovers_evolink_provider():
+    reg = ToolRegistry()
+    reg.register(EvoLinkVideo())
+    reg.register(VideoSelector())
+
+    providers = {tool.provider for tool in reg.get_by_capability("video_generation")}
+    assert "evolink" in providers
+
+
+def test_evolink_execute_submits_polls_and_downloads(monkeypatch, tmp_path):
+    monkeypatch.setenv("EVOLINK_API_KEY", "test-key")
+    monkeypatch.setattr("tools.video.evolink_video.time.sleep", lambda _: None)
+
+    calls: list[tuple[str, str, dict[str, Any] | None]] = []
+
+    class FakeResponse:
+        def __init__(
+            self,
+            payload: dict[str, Any] | None = None,
+            content: bytes = b"",
+        ) -> None:
+            self._payload = payload or {}
+            self.content = content
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return self._payload
+
+    def fake_post(url: str, **kwargs: Any) -> FakeResponse:
+        calls.append(("post", url, kwargs.get("json")))
+        return FakeResponse(
+            {
+                "id": "task-unified-123-test",
+                "status": "pending",
+                "model": "seedance-2.0-text-to-video",
+            }
+        )
+
+    def fake_get(url: str, **kwargs: Any) -> FakeResponse:
+        calls.append(("get", url, None))
+        if url.endswith("/v1/tasks/task-unified-123-test"):
+            return FakeResponse(
+                {
+                    "id": "task-unified-123-test",
+                    "status": "completed",
+                    "results": ["https://cdn.example.com/video.mp4"],
+                    "usage": {"credits_reserved": 1},
+                }
+            )
+        return FakeResponse(content=b"fake mp4 bytes")
+
+    monkeypatch.setattr("requests.post", fake_post)
+    monkeypatch.setattr("requests.get", fake_get)
+
+    output_path = tmp_path / "evolink.mp4"
+    result = EvoLinkVideo().execute(
+        {
+            "prompt": "A clean motion graphics title card",
+            "duration": 4,
+            "resolution": "480p",
+            "generate_audio": False,
+            "output_path": str(output_path),
+        }
+    )
+
+    assert result.success
+    assert result.model == "seedance-2.0-text-to-video"
+    assert result.data["provider"] == "evolink"
+    assert result.data["task_id"] == "task-unified-123-test"
+    assert result.artifacts == [str(output_path)]
+    assert Path(output_path).read_bytes() == b"fake mp4 bytes"
+    assert calls[0] == (
+        "post",
+        "https://api.evolink.ai/v1/videos/generations",
+        {
+            "model": "seedance-2.0-text-to-video",
+            "prompt": "A clean motion graphics title card",
+            "duration": 4,
+            "quality": "480p",
+            "aspect_ratio": "16:9",
+            "generate_audio": False,
+            "content_filter": True,
+        },
+    )

--- a/tools/video/evolink_video.py
+++ b/tools/video/evolink_video.py
@@ -1,0 +1,313 @@
+"""EvoLink video generation provider.
+
+Wraps EvoLink's asynchronous video task API in OpenMontage's synchronous
+BaseTool contract so the capability selectors can discover and rank it.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+
+class EvoLinkVideo(BaseTool):
+    name = "evolink_video"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "video_generation"
+    provider = "evolink"
+    stability = ToolStability.BETA
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = []
+    install_instructions = (
+        "Set EVOLINK_API_KEY to your EvoLink API key.\n"
+        "  Get one at https://evolink.ai/dashboard/keys"
+    )
+    agent_skills = ["ai-video-gen", "seedance-2-0"]
+
+    capabilities = ["text_to_video", "image_to_video"]
+    supports = {
+        "text_to_video": True,
+        "image_to_video": True,
+        "reference_image": True,
+        "native_audio": True,
+        "cinematic_quality": True,
+        "camera_direction": True,
+        "lip_sync": True,
+        "aspect_ratio": True,
+        "web_search": True,
+    }
+    best_for = [
+        "single EvoLink key access to premium video generation models",
+        "Seedance 2.0 text-to-video and first-frame image-to-video clips",
+        "cinematic short clips with optional synchronized audio",
+        "web-search enhanced video prompts when current information matters",
+    ]
+    not_good_for = ["offline generation", "local image paths that are not publicly reachable URLs"]
+    fallback_tools = ["seedance_video", "veo_video", "kling_video", "minimax_video"]
+    quality_score = 0.92
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+            "prompt": {"type": "string"},
+            "operation": {
+                "type": "string",
+                "enum": ["text_to_video", "image_to_video"],
+                "default": "text_to_video",
+            },
+            "model_variant": {
+                "type": "string",
+                "enum": ["standard", "fast"],
+                "default": "standard",
+            },
+            "duration": {
+                "type": "integer",
+                "minimum": 4,
+                "maximum": 15,
+                "default": 5,
+            },
+            "aspect_ratio": {
+                "type": "string",
+                "enum": ["16:9", "9:16", "1:1", "4:3", "3:4", "21:9", "adaptive"],
+                "default": "16:9",
+            },
+            "resolution": {
+                "type": "string",
+                "enum": ["480p", "720p", "1080p"],
+                "default": "720p",
+            },
+            "quality": {
+                "type": "string",
+                "enum": ["480p", "720p", "1080p"],
+                "description": "Alias for resolution; EvoLink calls this field quality.",
+            },
+            "generate_audio": {"type": "boolean", "default": True},
+            "content_filter": {"type": "boolean", "default": True},
+            "web_search": {
+                "type": "boolean",
+                "default": False,
+                "description": "Enable EvoLink's Seedance web search extension for text-to-video.",
+            },
+            "image_url": {
+                "type": "string",
+                "description": "First-frame image URL for image_to_video.",
+            },
+            "reference_image_url": {
+                "type": "string",
+                "description": (
+                    "Alias accepted by OpenMontage selectors for the first-frame image URL."
+                ),
+            },
+            "end_image_url": {
+                "type": "string",
+                "description": "Optional last-frame image URL for image_to_video.",
+            },
+            "output_path": {"type": "string"},
+            "poll_interval_seconds": {"type": "integer", "minimum": 2, "default": 5},
+            "timeout_seconds": {"type": "integer", "minimum": 30, "default": 900},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=512, vram_mb=0, disk_mb=500, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
+    idempotency_key_fields = [
+        "prompt",
+        "operation",
+        "model_variant",
+        "duration",
+        "aspect_ratio",
+        "resolution",
+    ]
+    side_effects = ["writes video file to output_path", "calls EvoLink API"]
+    user_visible_verification = [
+        "Watch generated clip for motion quality, prompt fidelity, and audio sync"
+    ]
+
+    def get_status(self) -> ToolStatus:
+        if os.environ.get("EVOLINK_API_KEY"):
+            return ToolStatus.AVAILABLE
+        return ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        duration = self._normalize_duration(inputs.get("duration", 5))
+        quality = inputs.get("quality") or inputs.get("resolution", "720p")
+        variant = inputs.get("model_variant", "standard")
+        rates = {
+            "standard": {"480p": 0.092, "720p": 0.199, "1080p": 0.496},
+            "fast": {"480p": 0.074, "720p": 0.161, "1080p": 0.496},
+        }
+        rate = rates.get(variant, rates["standard"]).get(quality, 0.199)
+        return round(duration * rate, 2)
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        duration = self._normalize_duration(inputs.get("duration", 5))
+        return 90.0 + duration * 10.0
+
+    @staticmethod
+    def _normalize_duration(value: Any) -> int:
+        try:
+            duration = int(value)
+        except (TypeError, ValueError):
+            duration = 5
+        return min(15, max(4, duration))
+
+    @staticmethod
+    def _model_name(operation: str, variant: str) -> str:
+        prefix = "seedance-2.0-fast" if variant == "fast" else "seedance-2.0"
+        suffix = "image-to-video" if operation == "image_to_video" else "text-to-video"
+        return f"{prefix}-{suffix}"
+
+    def _build_payload(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        operation = inputs.get("operation", "text_to_video")
+        if operation not in {"text_to_video", "image_to_video"}:
+            raise ValueError(f"EvoLink video does not support operation: {operation}")
+
+        variant = inputs.get("model_variant", "standard")
+        payload: dict[str, Any] = {
+            "model": self._model_name(operation, variant),
+            "prompt": inputs["prompt"],
+            "duration": self._normalize_duration(inputs.get("duration", 5)),
+            "quality": inputs.get("quality") or inputs.get("resolution", "720p"),
+            "aspect_ratio": inputs.get("aspect_ratio", "16:9"),
+            "generate_audio": inputs.get("generate_audio", True),
+            "content_filter": inputs.get("content_filter", True),
+        }
+
+        if operation == "text_to_video" and inputs.get("web_search"):
+            payload["model_params"] = {"web_search": True}
+
+        if operation == "image_to_video":
+            first_frame = inputs.get("image_url") or inputs.get("reference_image_url")
+            if not first_frame:
+                raise ValueError("image_to_video requires image_url or reference_image_url")
+            image_urls = [first_frame]
+            if inputs.get("end_image_url"):
+                image_urls.append(inputs["end_image_url"])
+            payload["image_urls"] = image_urls
+
+        return payload
+
+    @staticmethod
+    def _extract_result_url(task_data: dict[str, Any]) -> str:
+        results = task_data.get("results") or []
+        if not results:
+            raise RuntimeError(f"EvoLink task completed without result URLs: {task_data}")
+        first = results[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected EvoLink result payload: {results}")
+        return first
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        api_key = os.environ.get("EVOLINK_API_KEY")
+        if not api_key:
+            return ToolResult(
+                success=False,
+                error="EVOLINK_API_KEY not set. " + self.install_instructions,
+            )
+
+        import requests
+        from tools.video._shared import probe_output
+
+        start = time.time()
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        try:
+            payload = self._build_payload(inputs)
+            submit_resp = requests.post(
+                "https://api.evolink.ai/v1/videos/generations",
+                headers=headers,
+                json=payload,
+                timeout=60,
+            )
+            submit_resp.raise_for_status()
+            task_data = submit_resp.json()
+            task_id = task_data["id"]
+
+            timeout_seconds = int(inputs.get("timeout_seconds", 900))
+            poll_interval = int(inputs.get("poll_interval_seconds", 5))
+            deadline = time.time() + timeout_seconds
+
+            while time.time() < deadline:
+                status_resp = requests.get(
+                    f"https://api.evolink.ai/v1/tasks/{task_id}",
+                    headers={"Authorization": headers["Authorization"]},
+                    timeout=30,
+                )
+                status_resp.raise_for_status()
+                task_data = status_resp.json()
+                status = task_data.get("status")
+                if status == "completed":
+                    break
+                if status == "failed":
+                    error = task_data.get("error") or {}
+                    detail = error.get("message") or error or "failed"
+                    return ToolResult(
+                        success=False,
+                        error=f"EvoLink video generation failed: {detail}",
+                    )
+                time.sleep(min(poll_interval, max(0.0, deadline - time.time())))
+            else:
+                return ToolResult(
+                    success=False,
+                    error=f"EvoLink video generation timed out after {timeout_seconds}s",
+                )
+
+            video_url = self._extract_result_url(task_data)
+            video_response = requests.get(video_url, timeout=120)
+            video_response.raise_for_status()
+
+            output_path = Path(inputs.get("output_path", "evolink_output.mp4"))
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(video_response.content)
+
+        except Exception as exc:
+            return ToolResult(success=False, error=f"EvoLink video generation failed: {exc}")
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": "evolink",
+                "model": payload["model"],
+                "prompt": inputs["prompt"],
+                "operation": inputs.get("operation", "text_to_video"),
+                "task_id": task_id,
+                "result_url": video_url,
+                "aspect_ratio": payload.get("aspect_ratio"),
+                "resolution": payload.get("quality"),
+                "generate_audio": payload.get("generate_audio"),
+                "output": str(output_path),
+                "output_path": str(output_path),
+                "format": "mp4",
+                "usage": task_data.get("usage"),
+                **probe_output(output_path),
+            },
+            artifacts=[str(output_path)],
+            cost_usd=self.estimate_cost(inputs),
+            duration_seconds=round(time.time() - start, 2),
+            model=payload["model"],
+        )


### PR DESCRIPTION
## Summary

Adds `evolink_video`, a video generation provider backed by EvoLink's async video task API.

The tool follows the existing OpenMontage `BaseTool` provider pattern and is auto-discoverable by `video_selector` via `capability = \"video_generation\"`. It supports:

- Seedance 2.0 text-to-video
- Seedance 2.0 image-to-video using public image URLs
- standard/fast model variants
- duration, quality/resolution, aspect ratio, audio toggle, content filter, and web search fields
- submit -> poll `GET /v1/tasks/{task_id}` -> download MP4 workflow

Also documents `EVOLINK_API_KEY` in `.env.example`, `README.md`, and `docs/PROVIDERS.md`, and adds unit coverage for metadata, status, payload mapping, selector registration, and the mocked submit/poll/download path.

## Validation

```bash
env -u all_proxy -u http_proxy -u https_proxy -u ALL_PROXY -u HTTP_PROXY -u HTTPS_PROXY \
  /tmp/openmontage-evolink-venv/bin/python -m pytest tests/tools/test_evolink_video.py -q
```

Result:

```text
......                                                                   [100%]
6 passed in 0.76s
```

```bash
env -u all_proxy -u http_proxy -u https_proxy -u ALL_PROXY -u HTTP_PROXY -u HTTPS_PROXY \
  /tmp/openmontage-evolink-venv/bin/python -m compileall tools/video/evolink_video.py tests/tools/test_evolink_video.py
```

Result:

```text
Compiling 'tests/tools/test_evolink_video.py'...
```

Live EvoLink tool-path smoke test through `EvoLinkVideo.execute()`:

```text
success= True
error= None
model= seedance-2.0-text-to-video
cost_estimate= 0.37
duration_seconds= 209.32
artifacts= ['/tmp/openmontage-evolink-real.mp4']
task_id= task-unified-1781671188-fib1epbg
file_size_bytes= 504418
video_width= 864
video_height= 496
video_codec= h264
```

Additional output probe:

```bash
ffprobe -v error -select_streams v:0 \
  -show_entries stream=codec_name,width,height \
  -show_entries format=duration,size \
  -of default=noprint_wrappers=1 /tmp/openmontage-evolink-real.mp4
```

Result:

```text
codec_name=h264
width=864
height=496
duration=4.041667
size=504418
```