### PR TITLE
Fix missing render_runtime in edit_decisions fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 *.egg-info/
 dist/
 build/
+venv/
 
 # Test/IDE
 .pytest_cache/

--- a/tests/qa/test_05_video_compose.py
+++ b/tests/qa/test_05_video_compose.py
@@ -97,6 +97,8 @@ print("\n--- Test 1: Compose from edit_decisions ---")
 r1 = tool.execute({
     "operation": "compose",
     "edit_decisions": {
+        "version": "1.0",
+        "render_runtime": "ffmpeg",
         "cuts": [
             {"source": CLIP_A, "in_seconds": 0, "out_seconds": 5},
             {"source": CLIP_B, "in_seconds": 0, "out_seconds": 5},
@@ -114,6 +116,8 @@ print("\n--- Test 2: Compose with subtitles ---")
 r2 = tool.execute({
     "operation": "compose",
     "edit_decisions": {
+        "version": "1.0",
+        "render_runtime": "ffmpeg",
         "cuts": [
             {"source": CLIP_A, "in_seconds": 0, "out_seconds": 5},
             {"source": CLIP_B, "in_seconds": 0, "out_seconds": 5},

--- a/tests/qa/test_08_end_to_end.py
+++ b/tests/qa/test_08_end_to_end.py
@@ -445,6 +445,7 @@ edit_decisions = {
         "enabled": True,
         "style": "clean-professional",
     },
+    "render_runtime": "ffmpeg",
 }
 
 try:


### PR DESCRIPTION
## Summary

Fixes #69 by adding the missing `render_runtime` field to `edit_decisions` fixtures.

The `edit_decisions` schema requires:

```json
"required": ["version", "cuts", "render_runtime"]
```

but the QA fixtures omitted `render_runtime`, causing pytest collection to fail with:

```text
CheckpointValidationError:
Artifact 'edit_decisions' failed schema validation:
'render_runtime' is a required property
```

## Changes

* Added `"render_runtime": "ffmpeg"` to `tests/qa/test_08_end_to_end.py`
* Added required `version` and `render_runtime` fields to `edit_decisions` payloads in `tests/qa/test_05_video_compose.py`

## Verification

Before:

```bash
python -m pytest --collect-only tests/qa/test_08_end_to_end.py
```

Result:

```text
CheckpointValidationError:
Artifact 'edit_decisions' failed schema validation:
'render_runtime' is a required property
```

After:

```bash
python -m pytest --collect-only tests/qa/test_08_end_to_end.py
```

Result:

```text
collected 0 items
no tests collected
```

Collection completes successfully without schema validation errors.
