### PR TITLE
Fixes #103: character-animation proposal-director fails runtime-presentation contract

### DIFF
--- a/skills/pipelines/character-animation/proposal-director.md
+++ b/skills/pipelines/character-animation/proposal-director.md
@@ -33,7 +33,7 @@ When both Remotion and HyperFrames are available:
 - FFmpeg: post-processing only. Do not pick FFmpeg as the primary runtime for
   character acting.
 
-Wait for user approval before locking `render_runtime`.
+Wait for user approval before locking `render_runtime` to `"remotion"` or `"hyperframes"`. You must record a `render_runtime_selection` decision in the decision log and present both composition runtimes if available.
 
 ## Sample-First Rule
 


### PR DESCRIPTION
"Updated the character-animation proposal-director to explicitly mention the lowercase runtime options and the render_runtime_selection decision, as required by the runtime-presentation contract test."