### PR TITLE
feat(video): add experimental Google Flow bridge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,16 @@ VIDEO_GEN_LOCAL_ENABLED=     # Set to "true" for local video gen (needs GPU + di
 VIDEO_GEN_LOCAL_MODEL=       # Local model: wan2.1-1.3b, wan2.1-14b, hunyuan-1.5, ltx2-local, cogvideo-5b
 MODAL_LTX2_ENDPOINT_URL=    # Modal self-hosted LTX-2 endpoint (optional)
 
+# --- Experimental Google Flow browser bridge ---
+# Local-only, opt-in UI automation for a logged-in Google Flow web session.
+# Requires optional browser deps: pip install -r requirements-browser.txt
+GOOGLE_FLOW_ENABLED=false
+OPENMONTAGE_EXPERIMENTAL_GOOGLE_FLOW=
+GOOGLE_FLOW_BROWSER_PROFILE_DIR=~/.openmontage/google-flow-profile
+GOOGLE_FLOW_CDP_URL=
+GOOGLE_FLOW_URL=https://labs.google/fx/tools/flow
+GOOGLE_FLOW_HEADLESS=false
+
 # --- Stock Media ---
 PEXELS_API_KEY=              # Pexels stock footage/images (free)
 PIXABAY_API_KEY=             # Pixabay stock footage/images (free)

--- a/README.md
+++ b/README.md
@@ -406,13 +406,14 @@ Each tool declares which Layer 3 skills it relies on. The agent reads Layer 1 to
 > **Full setup guide with pricing and free tiers:** [`docs/PROVIDERS.md`](docs/PROVIDERS.md)
 
 <details>
-<summary><strong>Video Generation — 14 providers</strong></summary>
+<summary><strong>Video Generation Providers</strong></summary>
 
 | Provider | Type | Notes |
 |----------|------|-------|
 | **Kling** | Cloud API | High quality, fast |
 | **Runway Gen-4** | Cloud API | Cinematic quality, Gen-3 Alpha Turbo / Gen-4 Turbo / Gen-4 Aleph |
 | **Google Veo 3** | Cloud API | Long-form, cinematic. Via fal.ai or HeyGen. |
+| **Google Flow** | Experimental local browser | Uses a dedicated logged-in Flow UI profile only when explicitly selected |
 | **Grok Imagine Video** | Cloud API | Strong reference-image video and xAI-native short-form generation |
 | **Higgsfield** | Cloud API | Multi-model orchestrator with Soul ID for character consistency |
 | **MiniMax** | Cloud API | Cost-effective |
@@ -426,6 +427,17 @@ Each tool declares which Layer 3 skills it relies on. The agent reads Layer 1 to
 | **Wikimedia Commons** | Stock | Free/open stock footage and archival video |
 
 </details>
+
+> Google Flow support is experimental and local-only. It automates the public
+> Flow web UI through Playwright so you can use an already logged-in Google AI
+> Pro / Flow session, but it is never selected by `auto` routing. The dedicated
+> local browser profile stores the browser session on your machine, while
+> OpenMontage does not write cookies, tokens, storage snapshots, HARs, DOM dumps,
+> or screenshots into project artifacts. Install
+> `requirements-browser.txt`, set `GOOGLE_FLOW_ENABLED=true` plus
+> `OPENMONTAGE_EXPERIMENTAL_GOOGLE_FLOW=1`, then pass
+> `preferred_provider="google_flow"` and `confirm_browser_automation=true` for
+> any generation run.
 
 <details>
 <summary><strong>Image Generation — 10 tools/providers</strong></summary>

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -20,8 +20,9 @@ Everything you need to know about every provider in OpenMontage — setup instru
 | 8 | **$12/month** | Runway | Gen-4 video — highest quality AI video |
 | 9 | **pay-as-you-go** | HeyGen | Avatar videos, multi-model video gateway |
 | 10 | **pay-as-you-go** | Suno | Full song generation with vocals and lyrics |
-| 11 | **$0 + GPU** | Local video gen | WAN 2.1, Hunyuan, CogVideo, LTX — free, offline |
-| 12 | **$0 + GPU** | Local Diffusion | Stable Diffusion images — free, offline |
+| 11 | **Existing Google web credits** | Google Flow browser bridge | Experimental local UI automation for logged-in Flow sessions |
+| 12 | **$0 + GPU** | Local video gen | WAN 2.1, Hunyuan, CogVideo, LTX — free, offline |
+| 13 | **$0 + GPU** | Local Diffusion | Stable Diffusion images — free, offline |
 
 ### Environment Variable Summary
 
@@ -49,6 +50,14 @@ FAL_KEY=                     # FLUX, Recraft, Kling, Veo, MiniMax video
 HEYGEN_API_KEY=              # HeyGen avatar video gateway
 RUNWAY_API_KEY=              # Runway Gen-4 video (direct)
 SUNO_API_KEY=                # Suno music generation
+
+# EXPERIMENTAL LOCAL BROWSER BRIDGE
+GOOGLE_FLOW_ENABLED=false
+OPENMONTAGE_EXPERIMENTAL_GOOGLE_FLOW=
+GOOGLE_FLOW_BROWSER_PROFILE_DIR=~/.openmontage/google-flow-profile
+GOOGLE_FLOW_CDP_URL=
+GOOGLE_FLOW_URL=https://labs.google/fx/tools/flow
+GOOGLE_FLOW_HEADLESS=false
 
 # LOCAL (no keys needed — just GPU + install)
 VIDEO_GEN_LOCAL_ENABLED=     # Set to "true" for local video gen
@@ -254,6 +263,86 @@ The free tiers apply *independently* — you get 1M Standard AND 1M WaveNet AND 
 **Free tier for Imagen:** None. Paid tier only.
 
 **New account bonus:** Google Cloud offers **$300 in free credits** for new accounts (90-day trial), applicable to both TTS and Imagen.
+
+---
+
+### Google Flow - Experimental Browser Bridge
+
+> **Local-only, opt-in UI automation.** This provider uses a dedicated Chrome
+> profile and the public Google Flow web UI. It is useful only when you
+> explicitly want OpenMontage to spend credits from a logged-in Google AI Pro /
+> Flow session. It is not an official Google API integration.
+
+**Tools unlocked:** `google_flow_video`
+**Runtime:** local browser automation
+**Default profile:** `~/.openmontage/google-flow-profile`
+
+#### Setup
+
+1. Install optional browser dependencies:
+   ```bash
+   pip install -r requirements-browser.txt
+   python -m playwright install chromium
+   ```
+2. Add explicit opt-in flags to `.env`:
+   ```bash
+   GOOGLE_FLOW_ENABLED=true
+   OPENMONTAGE_EXPERIMENTAL_GOOGLE_FLOW=1
+   GOOGLE_FLOW_BROWSER_PROFILE_DIR=~/.openmontage/google-flow-profile
+   ```
+3. Open the login flow through the tool:
+   ```python
+   from tools.video.google_flow_video import GoogleFlowVideo
+   GoogleFlowVideo().execute({"operation": "open_login"})
+   ```
+4. Sign in manually in the dedicated browser profile, then verify:
+   ```python
+   GoogleFlowVideo().execute({"operation": "check_auth"})
+   ```
+
+#### Required Generation Flags
+
+Generation must be explicitly selected on every call:
+
+```python
+GoogleFlowVideo().execute({
+    "operation": "text_to_video",
+    "preferred_provider": "google_flow",
+    "confirm_browser_automation": True,
+    "prompt": "A short vertical travel clip...",
+    "aspect_ratio": "9:16",
+    "output_path": "projects/demo/assets/video/flow.mp4",
+})
+```
+
+The `video_selector` will not auto-select this provider. It can route to Flow
+only when `preferred_provider="google_flow"` is supplied.
+
+#### Security And Support Notes
+
+- This bridge automates the visible Flow UI only. It must not scrape hidden
+  tokens, bypass CAPTCHA, bypass account limits, or call private endpoints.
+- Browser state lives in the dedicated local Chrome profile. OpenMontage does
+  not write cookies, storage state, HAR files, screenshots, DOM dumps, tokens,
+  auth headers, or account identifiers into repo artifacts.
+- `GOOGLE_FLOW_URL` must point at an expected Google Flow HTTPS host
+  (`labs.google`, `labs.google.com`, or `flow.google.com`) so the dedicated
+  Google-account profile is not navigated to arbitrary origins.
+- `GOOGLE_FLOW_CDP_URL`, when used for an already-running browser, must point
+  at a localhost debugging endpoint. CDP mode uses that existing local browser
+  context instead of launching the default dedicated profile.
+- Redacted errors are returned when the UI changes, login expires, generation
+  times out, or a download fails.
+- Live tests are opt-in only:
+  ```bash
+  GOOGLE_FLOW_E2E=1 GOOGLE_FLOW_ENABLED=true OPENMONTAGE_EXPERIMENTAL_GOOGLE_FLOW=1 pytest tests/tools/test_google_flow_video.py -k live
+  ```
+
+#### Pricing
+
+OpenMontage reports `$0.00` API cost for this tool because there is no
+OpenMontage-metered API call. The real cost is whatever Google Flow or Google
+AI Pro credits your logged-in account consumes in the web UI.
 
 #### Google TTS Voice Types
 
@@ -744,7 +833,7 @@ How many providers cover each capability:
 | Capability | Cloud Providers | Local Providers | Free Options |
 |-----------|----------------|-----------------|--------------|
 | **Image Generation** | FLUX, Grok, Google Imagen, DALL-E 3, Recraft | Local Diffusion | Pexels, Pixabay (stock) |
-| **Video Generation** | Grok, Kling, Runway, Veo, Higgsfield, MiniMax, HeyGen | WAN, Hunyuan, CogVideo, LTX | Pexels, Pixabay (stock) |
+| **Video Generation** | Grok, Kling, Runway, Veo, Higgsfield, MiniMax, HeyGen, Google Flow browser bridge (experimental) | WAN, Hunyuan, CogVideo, LTX | Pexels, Pixabay (stock) |
 | **Text-to-Speech** | ElevenLabs, Google TTS, OpenAI | Piper | Piper, Google free tier, ElevenLabs free tier |
 | **Music Generation** | ElevenLabs, Suno | — | ElevenLabs free tier |
 | **Post-Production** | — | FFmpeg (compose, stitch, trim, mix, enhance, grade) | All free |

--- a/requirements-browser.txt
+++ b/requirements-browser.txt
@@ -1,0 +1,5 @@
+# Optional browser automation dependencies.
+# Install only when using local browser bridges such as Google Flow:
+#   pip install -r requirements-browser.txt
+#   python -m playwright install chromium
+playwright>=1.49

--- a/tests/tools/test_google_flow_video.py
+++ b/tests/tools/test_google_flow_video.py
@@ -1,0 +1,431 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tools.base_tool import (
+    BaseTool,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+from tools.video.google_flow_browser_bridge import (
+    GoogleFlowBridgeError,
+    GoogleFlowBrowserBridge,
+    redact_payload,
+    redact_text,
+)
+from tools.video.google_flow_video import GoogleFlowVideo
+from tools.video.video_selector import VideoSelector
+
+
+def enable_flow(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GOOGLE_FLOW_ENABLED", "true")
+    monkeypatch.setenv("OPENMONTAGE_EXPERIMENTAL_GOOGLE_FLOW", "1")
+    monkeypatch.setattr(GoogleFlowVideo, "_playwright_available", staticmethod(lambda: True))
+    monkeypatch.setattr(GoogleFlowVideo, "_playwright_chromium_available", staticmethod(lambda: True))
+
+
+def disable_flow(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GOOGLE_FLOW_ENABLED", "false")
+    monkeypatch.delenv("OPENMONTAGE_EXPERIMENTAL_GOOGLE_FLOW", raising=False)
+    monkeypatch.setattr(GoogleFlowVideo, "_playwright_available", staticmethod(lambda: False))
+    monkeypatch.setattr(GoogleFlowVideo, "_playwright_chromium_available", staticmethod(lambda: False))
+
+
+def assert_no_secret_leaks(value: Any) -> None:
+    blob = json.dumps(value, default=str) if not isinstance(value, str) else value
+    forbidden = [
+        "SID=secret",
+        "Bearer secret",
+        "ya29.secret",
+        "user@example.com",
+        "/Users/tester/.openmontage/google-flow-profile",
+        "google-flow-profile/Default",
+        "Authorization",
+        "Cookie:",
+    ]
+    for needle in forbidden:
+        assert needle not in blob
+
+
+class FakeBridge:
+    instances: list["FakeBridge"] = []
+    mode = "success"
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.closed = False
+        self.profile_dir = kwargs.get("profile_dir")
+        self.__class__.instances.append(self)
+
+    def open_login(self, *, keep_open: bool = True) -> dict[str, Any]:
+        return {
+            "authenticated": False,
+            "flow_url": "https://labs.google/fx/tools/flow",
+            "profile_dir": "/Users/tester/.openmontage/google-flow-profile",
+            "account": "user@example.com",
+            "browser_open": keep_open,
+        }
+
+    def check_auth(self) -> dict[str, Any]:
+        if self.mode == "logged_out":
+            return {"authenticated": False, "account": "user@example.com"}
+        return {"authenticated": True, "account": "user@example.com"}
+
+    def generate_video(self, **kwargs: Any) -> dict[str, Any]:
+        if self.mode != "success":
+            raise GoogleFlowBridgeError(
+                "Cookie: SID=secret Authorization: Bearer secret user@example.com "
+                "/Users/tester/.openmontage/google-flow-profile",
+                code=self.mode,
+                retryable=self.mode in {"timeout", "ui_changed", "download_failed"},
+                details={
+                    "Authorization": "Bearer secret",
+                    "profile_dir": "/Users/tester/.openmontage/google-flow-profile",
+                    "account": "user@example.com",
+                },
+            )
+        output = Path(kwargs["output_path"])
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_bytes(b"fake-mp4")
+        return {
+            "output_path": str(output),
+            "flow_url": "https://labs.google/fx/tools/flow",
+            "Cookie": "SID=secret",
+            "Authorization": "Bearer secret",
+            "account": "user@example.com",
+            "profile_dir": "/Users/tester/.openmontage/google-flow-profile",
+        }
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeVideoProvider(BaseTool):
+    tier = ToolTier.GENERATE
+    capability = "video_generation"
+    stability = ToolStability.EXPERIMENTAL
+    runtime = ToolRuntime.HYBRID
+    capabilities = ["text_to_video"]
+    input_schema = {"type": "object", "properties": {"prompt": {"type": "string"}}}
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        provider: str,
+        requires_explicit_preference: bool = False,
+        quality_score: float = 0.5,
+    ) -> None:
+        self.name = name
+        self.provider = provider
+        self.supports = {
+            "text_to_video": True,
+            "requires_explicit_preference": requires_explicit_preference,
+        }
+        self.quality_score = quality_score
+        self.best_for = ["social video", provider]
+
+    def get_status(self) -> ToolStatus:
+        return ToolStatus.AVAILABLE
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        return ToolResult(success=True, data={"selected": self.provider})
+
+
+def test_google_flow_provider_metadata() -> None:
+    tool = GoogleFlowVideo()
+    info = tool.get_info()
+    assert info["name"] == "google_flow_video"
+    assert info["provider"] == "google_flow"
+    assert info["capability"] == "video_generation"
+    assert info["stability"] == "experimental"
+    assert info["runtime"] == "hybrid"
+    assert tool.supports["requires_explicit_preference"] is True
+    assert tool.supports["requires_browser_automation_confirmation"] is True
+    assert tool.supports["stores_browser_session"] is True
+    assert tool.supports["stores_repo_auth_artifacts"] is False
+    assert "playwright-recording" in tool.agent_skills
+
+
+def test_status_is_gated_by_two_env_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    tool = GoogleFlowVideo()
+    monkeypatch.setattr(GoogleFlowVideo, "_playwright_available", staticmethod(lambda: True))
+    monkeypatch.setattr(GoogleFlowVideo, "_playwright_chromium_available", staticmethod(lambda: True))
+
+    monkeypatch.delenv("GOOGLE_FLOW_ENABLED", raising=False)
+    monkeypatch.delenv("OPENMONTAGE_EXPERIMENTAL_GOOGLE_FLOW", raising=False)
+    assert tool.get_status() == ToolStatus.UNAVAILABLE
+
+    monkeypatch.setenv("GOOGLE_FLOW_ENABLED", "true")
+    assert tool.get_status() == ToolStatus.UNAVAILABLE
+
+    monkeypatch.setenv("OPENMONTAGE_EXPERIMENTAL_GOOGLE_FLOW", "1")
+    assert tool.get_status() == ToolStatus.AVAILABLE
+
+
+def test_status_requires_playwright(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GOOGLE_FLOW_ENABLED", "true")
+    monkeypatch.setenv("OPENMONTAGE_EXPERIMENTAL_GOOGLE_FLOW", "1")
+    monkeypatch.setattr(GoogleFlowVideo, "_playwright_available", staticmethod(lambda: False))
+    monkeypatch.setattr(GoogleFlowVideo, "_playwright_chromium_available", staticmethod(lambda: True))
+    assert GoogleFlowVideo().get_status() == ToolStatus.UNAVAILABLE
+
+
+def test_status_requires_playwright_chromium(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GOOGLE_FLOW_ENABLED", "true")
+    monkeypatch.setenv("OPENMONTAGE_EXPERIMENTAL_GOOGLE_FLOW", "1")
+    monkeypatch.setattr(GoogleFlowVideo, "_playwright_available", staticmethod(lambda: True))
+    monkeypatch.setattr(GoogleFlowVideo, "_playwright_chromium_available", staticmethod(lambda: False))
+    assert GoogleFlowVideo().get_status() == ToolStatus.UNAVAILABLE
+
+
+def test_registry_discovers_google_flow_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    disable_flow(monkeypatch)
+    from tools.tool_registry import ToolRegistry
+
+    registry = ToolRegistry()
+    registry.discover()
+    tool = registry.get("google_flow_video")
+    assert isinstance(tool, GoogleFlowVideo)
+
+    summary = registry.provider_menu_summary()
+    video_cap = next(item for item in summary["capabilities"] if item["capability"] == "video_generation")
+    assert "google_flow" in video_cap["unavailable_providers"]
+
+
+def test_selector_auto_skips_explicit_only_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    flow = FakeVideoProvider(
+        name="fake_google_flow_video",
+        provider="google_flow",
+        requires_explicit_preference=True,
+        quality_score=1.0,
+    )
+    fallback = FakeVideoProvider(
+        name="fake_regular_video",
+        provider="regular",
+        requires_explicit_preference=False,
+        quality_score=0.1,
+    )
+    selector = VideoSelector()
+    monkeypatch.setattr(selector, "_providers", lambda: [flow, fallback])
+
+    result = selector.execute({"prompt": "make a travel short", "preferred_provider": "auto"})
+
+    assert result.success
+    assert result.data["selected_provider"] == "regular"
+    assert result.data["selected_tool"] == "fake_regular_video"
+
+
+def test_selector_explicit_preference_can_route_to_flow(monkeypatch: pytest.MonkeyPatch) -> None:
+    flow = FakeVideoProvider(
+        name="fake_google_flow_video",
+        provider="google_flow",
+        requires_explicit_preference=True,
+        quality_score=1.0,
+    )
+    fallback = FakeVideoProvider(name="fake_regular_video", provider="regular")
+    selector = VideoSelector()
+    monkeypatch.setattr(selector, "_providers", lambda: [flow, fallback])
+
+    result = selector.execute({"prompt": "make a travel short", "preferred_provider": "google_flow"})
+
+    assert result.success
+    assert result.data["selected_provider"] == "google_flow"
+    assert result.data["selected_tool"] == "fake_google_flow_video"
+
+
+def test_selector_rank_auto_skips_explicit_only_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    flow = FakeVideoProvider(
+        name="fake_google_flow_video",
+        provider="google_flow",
+        requires_explicit_preference=True,
+        quality_score=1.0,
+    )
+    fallback = FakeVideoProvider(name="fake_regular_video", provider="regular")
+    selector = VideoSelector()
+    monkeypatch.setattr(selector, "_providers", lambda: [flow, fallback])
+
+    result = selector.execute({"prompt": "make a travel short", "operation": "rank"})
+
+    assert result.success
+    ranked_providers = [item["provider"] for item in result.data["rankings"]]
+    assert "google_flow" not in ranked_providers
+    assert "regular" in ranked_providers
+
+
+def test_selector_rank_explicit_preference_includes_flow(monkeypatch: pytest.MonkeyPatch) -> None:
+    flow = FakeVideoProvider(
+        name="fake_google_flow_video",
+        provider="google_flow",
+        requires_explicit_preference=True,
+        quality_score=1.0,
+    )
+    fallback = FakeVideoProvider(name="fake_regular_video", provider="regular")
+    selector = VideoSelector()
+    monkeypatch.setattr(selector, "_providers", lambda: [flow, fallback])
+
+    result = selector.execute(
+        {
+            "prompt": "make a travel short",
+            "operation": "rank",
+            "preferred_provider": "google_flow",
+        }
+    )
+
+    assert result.success
+    ranked_providers = [item["provider"] for item in result.data["rankings"]]
+    assert "google_flow" in ranked_providers
+
+
+def test_generation_requires_explicit_provider_and_confirmation(monkeypatch: pytest.MonkeyPatch) -> None:
+    enable_flow(monkeypatch)
+    tool = GoogleFlowVideo()
+
+    missing_preference = tool.execute({"prompt": "x", "confirm_browser_automation": True})
+    assert not missing_preference.success
+    assert "preferred_provider" in (missing_preference.error or "")
+
+    missing_confirmation = tool.execute({"prompt": "x", "preferred_provider": "google_flow"})
+    assert not missing_confirmation.success
+    assert "confirm_browser_automation" in (missing_confirmation.error or "")
+
+
+def test_mocked_bridge_success_and_safe_shutdown(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    enable_flow(monkeypatch)
+    FakeBridge.instances = []
+    FakeBridge.mode = "success"
+    monkeypatch.setattr("tools.video.google_flow_video.GoogleFlowBrowserBridge", FakeBridge)
+    output_path = tmp_path / "flow.mp4"
+
+    result = GoogleFlowVideo().execute(
+        {
+            "prompt": "A vertical travel opener",
+            "operation": "text_to_video",
+            "preferred_provider": "google_flow",
+            "confirm_browser_automation": True,
+            "aspect_ratio": "9:16",
+            "output_path": str(output_path),
+        }
+    )
+
+    assert result.success
+    assert result.data["provider"] == "google_flow"
+    assert result.data["output_path"] == str(output_path)
+    assert result.artifacts == [str(output_path)]
+    assert FakeBridge.instances[-1].closed is True
+    assert_no_secret_leaks(result.data)
+
+
+@pytest.mark.parametrize("mode", ["logged_out", "timeout", "ui_changed", "download_failed"])
+def test_mocked_bridge_failures_are_categorized_and_redacted(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mode: str,
+) -> None:
+    enable_flow(monkeypatch)
+    FakeBridge.instances = []
+    FakeBridge.mode = mode
+    monkeypatch.setattr("tools.video.google_flow_video.GoogleFlowBrowserBridge", FakeBridge)
+
+    result = GoogleFlowVideo().execute(
+        {
+            "prompt": "A vertical travel opener",
+            "operation": "text_to_video",
+            "preferred_provider": "google_flow",
+            "confirm_browser_automation": True,
+            "output_path": str(tmp_path / "flow.mp4"),
+        }
+    )
+
+    assert not result.success
+    assert result.data["error_code"] == mode
+    assert FakeBridge.instances[-1].closed is True
+    assert_no_secret_leaks(result.error)
+    assert_no_secret_leaks(result.data)
+
+
+def test_check_auth_does_not_require_generation_confirmation(monkeypatch: pytest.MonkeyPatch) -> None:
+    enable_flow(monkeypatch)
+    FakeBridge.instances = []
+    FakeBridge.mode = "logged_out"
+    monkeypatch.setattr("tools.video.google_flow_video.GoogleFlowBrowserBridge", FakeBridge)
+
+    result = GoogleFlowVideo().execute({"operation": "check_auth"})
+
+    assert result.success
+    assert result.data["authenticated"] is False
+    assert FakeBridge.instances[-1].closed is True
+    assert_no_secret_leaks(result.data)
+
+
+def test_open_login_can_leave_browser_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    enable_flow(monkeypatch)
+    FakeBridge.instances = []
+    FakeBridge.mode = "logged_out"
+    monkeypatch.setattr("tools.video.google_flow_video.GoogleFlowBrowserBridge", FakeBridge)
+
+    result = GoogleFlowVideo().execute({"operation": "open_login", "keep_open": True})
+
+    assert result.success
+    assert FakeBridge.instances[-1].closed is False
+    assert_no_secret_leaks(result.data)
+
+
+def test_redaction_removes_browser_session_material() -> None:
+    profile = "/Users/tester/.openmontage/google-flow-profile"
+    raw = (
+        "Cookie: SID=secret Authorization: Bearer secret ya29.secret "
+        "user@example.com /Users/tester/.openmontage/google-flow-profile/Default"
+    )
+    redacted = redact_text(raw, profile_dir=profile)
+    assert_no_secret_leaks(redacted)
+    assert "[REDACTED]" in redacted
+
+    payload = {
+        "headers": {"Authorization": "Bearer secret", "Cookie": "SID=secret"},
+        "account": "user@example.com",
+        "profile_dir": profile,
+        "safe": "output.mp4",
+    }
+    cleaned = redact_payload(payload, profile_dir=profile)
+    assert cleaned["safe"] == "output.mp4"
+    assert_no_secret_leaks(cleaned)
+
+
+def test_bridge_rejects_non_flow_urls() -> None:
+    with pytest.raises(GoogleFlowBridgeError) as exc:
+        GoogleFlowBrowserBridge(flow_url="https://example.com/fake-flow")
+    assert exc.value.code == "validation"
+
+
+def test_bridge_rejects_remote_cdp_urls() -> None:
+    with pytest.raises(GoogleFlowBridgeError) as exc:
+        GoogleFlowBrowserBridge(cdp_url="http://198.51.100.10:9222")
+    assert exc.value.code == "validation"
+
+
+def test_execute_returns_tool_result_for_invalid_flow_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    enable_flow(monkeypatch)
+    monkeypatch.setenv("GOOGLE_FLOW_URL", "https://example.com/fake-flow")
+
+    result = GoogleFlowVideo().execute({"operation": "check_auth"})
+
+    assert not result.success
+    assert "validation" in (result.error or "")
+
+
+@pytest.mark.skipif(os.environ.get("GOOGLE_FLOW_E2E") != "1", reason="live Flow E2E is opt-in")
+def test_live_google_flow_check_auth() -> None:
+    result = GoogleFlowVideo().execute({"operation": "check_auth"})
+    assert result.success
+    assert "authenticated" in result.data

--- a/tools/video/google_flow_browser_bridge.py
+++ b/tools/video/google_flow_browser_bridge.py
@@ -1,0 +1,512 @@
+"""Local browser bridge for Google Flow.
+
+This module intentionally drives the public Flow web UI through Playwright.
+It stores browser session state only in the dedicated local Chrome profile and
+does not call private Google endpoints or write browser artifacts into the
+OpenMontage project tree.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+DEFAULT_FLOW_URL = "https://labs.google/fx/tools/flow"
+DEFAULT_PROFILE_DIR = "~/.openmontage/google-flow-profile"
+ALLOWED_FLOW_HOSTS = {"labs.google", "labs.google.com", "flow.google.com"}
+
+
+_SENSITIVE_PATTERNS = [
+    re.compile(r"(?i)\b(cookie|set-cookie|authorization|x-client-data)\s*[:=]\s*[^\n\r,;]+"),
+    re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]+"),
+    re.compile(r"\bya29\.[A-Za-z0-9._-]+"),
+    re.compile(r"\bAIza[0-9A-Za-z_-]{20,}"),
+    re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"),
+    re.compile(r"\b(?:SID|HSID|SSID|SAPISID|APISID|__Secure-[A-Za-z0-9_-]+)=[^;\s]+"),
+    re.compile(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b"),
+]
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def redact_text(value: object, *, profile_dir: str | Path | None = None) -> str:
+    """Remove auth/session/account material from public errors and metadata."""
+    text = str(value)
+    for pattern in _SENSITIVE_PATTERNS:
+        text = pattern.sub("[REDACTED]", text)
+
+    candidates: list[str] = []
+    configured = profile_dir or os.environ.get("GOOGLE_FLOW_BROWSER_PROFILE_DIR") or DEFAULT_PROFILE_DIR
+    if configured:
+        expanded = str(Path(str(configured)).expanduser())
+        candidates.extend({expanded, str(configured), str(Path(expanded).parent)})
+
+    for candidate in sorted({c for c in candidates if c}, key=len, reverse=True):
+        text = text.replace(candidate, "[REDACTED_PROFILE_PATH]")
+    return text
+
+
+def redact_payload(value: Any, *, profile_dir: str | Path | None = None) -> Any:
+    """Recursively redact values before returning ToolResult data."""
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            key_lower = key_text.lower()
+            is_sensitive_key = (
+                key_lower in {
+                    "cookie",
+                    "set-cookie",
+                    "authorization",
+                    "auth_header",
+                    "auth_headers",
+                    "token",
+                    "access_token",
+                    "refresh_token",
+                    "id_token",
+                    "account",
+                    "email",
+                    "profile_dir",
+                    "profile_path",
+                    "browser_profile",
+                }
+                or key_lower.endswith("_token")
+            )
+            if is_sensitive_key:
+                redacted["redacted_sensitive_field"] = "[REDACTED]"
+            else:
+                redacted[key_text] = redact_payload(item, profile_dir=profile_dir)
+        return redacted
+    if isinstance(value, list):
+        return [redact_payload(item, profile_dir=profile_dir) for item in value]
+    if isinstance(value, tuple):
+        return tuple(redact_payload(item, profile_dir=profile_dir) for item in value)
+    if isinstance(value, str):
+        return redact_text(value, profile_dir=profile_dir)
+    return value
+
+
+@dataclass
+class GoogleFlowBridgeError(RuntimeError):
+    """Public, categorized bridge failure."""
+
+    message: str
+    code: str = "ui_changed"
+    retryable: bool = False
+    details: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        RuntimeError.__init__(self, self.message)
+
+    def public_message(self, *, profile_dir: str | Path | None = None) -> str:
+        return redact_text(self.message, profile_dir=profile_dir)
+
+    def public_details(self, *, profile_dir: str | Path | None = None) -> dict[str, Any]:
+        return redact_payload(self.details or {}, profile_dir=profile_dir)
+
+
+class GoogleFlowBrowserBridge:
+    """Small Playwright/CDP wrapper around the Google Flow UI."""
+
+    def __init__(
+        self,
+        *,
+        profile_dir: str | Path | None = None,
+        flow_url: str | None = None,
+        cdp_url: str | None = None,
+        headless: bool | None = None,
+        timeout_seconds: int = 900,
+    ) -> None:
+        self.profile_dir = Path(profile_dir or os.environ.get("GOOGLE_FLOW_BROWSER_PROFILE_DIR") or DEFAULT_PROFILE_DIR).expanduser()
+        self.flow_url = self._validate_flow_url(flow_url or os.environ.get("GOOGLE_FLOW_URL") or DEFAULT_FLOW_URL)
+        self.cdp_url = self._validate_cdp_url(cdp_url or os.environ.get("GOOGLE_FLOW_CDP_URL") or None)
+        self.headless = _env_bool("GOOGLE_FLOW_HEADLESS", False) if headless is None else headless
+        self.timeout_seconds = int(timeout_seconds)
+        self._playwright: Any = None
+        self._context: Any = None
+        self._browser: Any = None
+        self._owns_context = False
+
+    @staticmethod
+    def _validate_flow_url(flow_url: str) -> str:
+        parsed = urlparse(flow_url)
+        host = (parsed.hostname or "").lower()
+        if parsed.scheme != "https" or host not in ALLOWED_FLOW_HOSTS:
+            allowed = ", ".join(sorted(ALLOWED_FLOW_HOSTS))
+            raise GoogleFlowBridgeError(
+                f"GOOGLE_FLOW_URL must use https and one of these hosts: {allowed}.",
+                code="validation",
+            )
+        return flow_url
+
+    @staticmethod
+    def _validate_cdp_url(cdp_url: str | None) -> str | None:
+        if not cdp_url:
+            return None
+        parsed = urlparse(cdp_url)
+        host = (parsed.hostname or "").lower()
+        if parsed.scheme not in {"http", "https", "ws", "wss"} or host not in {"localhost", "127.0.0.1", "::1"}:
+            raise GoogleFlowBridgeError(
+                "GOOGLE_FLOW_CDP_URL must point to a localhost browser debugging endpoint.",
+                code="validation",
+            )
+        return cdp_url
+
+    def close(self) -> None:
+        """Close only resources owned by this bridge."""
+        if self._context is not None and self._owns_context:
+            try:
+                self._context.close()
+            except Exception:
+                pass
+        if self._playwright is not None:
+            try:
+                self._playwright.stop()
+            except Exception:
+                pass
+        self._context = None
+        self._browser = None
+        self._playwright = None
+        self._owns_context = False
+
+    def open_login(self, *, keep_open: bool = True) -> dict[str, Any]:
+        page = self._new_page()
+        self._goto_flow(page)
+        status = self._auth_state(page)
+        return redact_payload(
+            {
+                "flow_url": page.url,
+                "authenticated": status["authenticated"],
+                "browser_open": keep_open,
+                "profile_configured": True,
+                "message": "Sign in to Google Flow in the opened browser profile, then rerun check_auth.",
+            },
+            profile_dir=self.profile_dir,
+        )
+
+    def check_auth(self) -> dict[str, Any]:
+        page = self._new_page()
+        self._goto_flow(page)
+        return redact_payload(self._auth_state(page), profile_dir=self.profile_dir)
+
+    def generate_video(
+        self,
+        *,
+        prompt: str,
+        output_path: str | Path,
+        operation: str = "text_to_video",
+        image_paths: list[str | Path] | None = None,
+        aspect_ratio: str | None = None,
+        duration: str | int | None = None,
+        model_variant: str | None = None,
+    ) -> dict[str, Any]:
+        if not prompt.strip():
+            raise GoogleFlowBridgeError("Google Flow prompt is required.", code="validation")
+
+        output = Path(output_path).expanduser()
+        output.parent.mkdir(parents=True, exist_ok=True)
+
+        normalized_images = [Path(p).expanduser() for p in image_paths or []]
+        missing = [str(path) for path in normalized_images if not path.exists()]
+        if missing:
+            raise GoogleFlowBridgeError(
+                f"Reference image file not found: {missing[0]}",
+                code="validation",
+            )
+
+        page = self._new_page()
+        self._goto_flow(page)
+        auth = self._auth_state(page)
+        if not auth["authenticated"]:
+            raise GoogleFlowBridgeError(
+                "Google Flow browser session is logged out. Run open_login first.",
+                code="logged_out",
+            )
+
+        try:
+            self._submit_prompt(
+                page,
+                prompt=prompt,
+                operation=operation,
+                image_paths=normalized_images,
+                aspect_ratio=aspect_ratio,
+                duration=duration,
+                model_variant=model_variant,
+            )
+            downloaded = self._wait_for_download(page, output)
+        except GoogleFlowBridgeError:
+            raise
+        except Exception as exc:
+            raise GoogleFlowBridgeError(
+                f"Google Flow UI automation failed: {redact_text(exc, profile_dir=self.profile_dir)}",
+                code="ui_changed",
+                retryable=True,
+            ) from exc
+
+        return redact_payload(
+            {
+                "output_path": str(downloaded),
+                "source": "google_flow_ui_download",
+                "flow_url": page.url,
+                "browser_profile": "dedicated_google_flow_profile",
+            },
+            profile_dir=self.profile_dir,
+        )
+
+    def _start_playwright(self) -> Any:
+        if self._playwright is not None:
+            return self._playwright
+        try:
+            from playwright.sync_api import sync_playwright
+        except ImportError as exc:
+            raise GoogleFlowBridgeError(
+                "Playwright is not installed. Install optional browser dependencies with requirements-browser.txt.",
+                code="missing_dependency",
+            ) from exc
+        self._playwright = sync_playwright().start()
+        return self._playwright
+
+    def _ensure_context(self) -> Any:
+        if self._context is not None:
+            return self._context
+
+        pw = self._start_playwright()
+        if self.cdp_url:
+            try:
+                self._browser = pw.chromium.connect_over_cdp(self.cdp_url)
+                if self._browser.contexts:
+                    self._context = self._browser.contexts[0]
+                    self._owns_context = False
+                else:
+                    self._context = self._browser.new_context(accept_downloads=True)
+                    self._owns_context = True
+            except Exception as exc:
+                raise GoogleFlowBridgeError(
+                    f"Failed to connect to GOOGLE_FLOW_CDP_URL: {redact_text(exc, profile_dir=self.profile_dir)}",
+                    code="browser_start_failed",
+                    retryable=True,
+                ) from exc
+        else:
+            try:
+                self.profile_dir.mkdir(parents=True, exist_ok=True)
+                self._context = pw.chromium.launch_persistent_context(
+                    str(self.profile_dir),
+                    accept_downloads=True,
+                    headless=self.headless,
+                    args=["--disable-blink-features=AutomationControlled"],
+                )
+                self._owns_context = True
+            except Exception as exc:
+                raise GoogleFlowBridgeError(
+                    f"Failed to launch dedicated Google Flow browser profile: {redact_text(exc, profile_dir=self.profile_dir)}",
+                    code="browser_start_failed",
+                    retryable=True,
+                ) from exc
+
+        try:
+            self._context.set_default_timeout(15_000)
+        except Exception:
+            pass
+        return self._context
+
+    def _new_page(self) -> Any:
+        context = self._ensure_context()
+        try:
+            if context.pages:
+                return context.pages[0]
+        except Exception:
+            pass
+        return context.new_page()
+
+    def _goto_flow(self, page: Any) -> None:
+        try:
+            page.goto(self.flow_url, wait_until="domcontentloaded", timeout=60_000)
+        except Exception as exc:
+            raise GoogleFlowBridgeError(
+                f"Failed to open Google Flow: {redact_text(exc, profile_dir=self.profile_dir)}",
+                code="navigation_failed",
+                retryable=True,
+            ) from exc
+
+    def _auth_state(self, page: Any) -> dict[str, Any]:
+        logged_out = False
+        try:
+            logged_out = "accounts.google." in page.url or "ServiceLogin" in page.url
+        except Exception:
+            logged_out = False
+
+        sign_in_re = re.compile(r"sign\s*in|log\s*in", re.I)
+        for locator_factory in (
+            lambda: page.get_by_role("button", name=sign_in_re),
+            lambda: page.get_by_role("link", name=sign_in_re),
+            lambda: page.get_by_text(sign_in_re),
+        ):
+            try:
+                if locator_factory().first.is_visible(timeout=1000):
+                    logged_out = True
+                    break
+            except Exception:
+                continue
+
+        return {
+            "authenticated": not logged_out,
+            "flow_url": redact_text(page.url, profile_dir=self.profile_dir),
+            "auth_mode": "browser_session",
+        }
+
+    def _submit_prompt(
+        self,
+        page: Any,
+        *,
+        prompt: str,
+        operation: str,
+        image_paths: list[Path],
+        aspect_ratio: str | None,
+        duration: str | int | None,
+        model_variant: str | None,
+    ) -> None:
+        if operation == "image_to_video":
+            self._upload_images(page, image_paths)
+
+        prompt_box = self._first_visible(
+            page,
+            [
+                lambda: page.get_by_role("textbox", name=re.compile(r"prompt|describe|idea", re.I)),
+                lambda: page.locator("textarea"),
+                lambda: page.locator('[contenteditable="true"]'),
+                lambda: page.locator('input[type="text"]'),
+            ],
+            description="prompt box",
+        )
+        try:
+            prompt_box.first.fill(prompt)
+        except Exception:
+            prompt_box.first.click()
+            page.keyboard.insert_text(prompt)
+
+        for value in (aspect_ratio, duration, model_variant):
+            if value:
+                self._click_text_if_available(page, str(value))
+
+        generate_button = self._first_visible(
+            page,
+            [
+                lambda: page.get_by_role("button", name=re.compile(r"generate|create|make", re.I)),
+                lambda: page.get_by_text(re.compile(r"generate|create|make video", re.I)),
+            ],
+            description="generate button",
+        )
+        generate_button.first.click()
+
+    def _upload_images(self, page: Any, image_paths: list[Path]) -> None:
+        if not image_paths:
+            raise GoogleFlowBridgeError("image_to_video requires a local image path.", code="validation")
+
+        file_inputs = page.locator('input[type="file"]')
+        try:
+            if file_inputs.count() == 0:
+                self._click_text_if_available(page, "Image")
+                file_inputs = page.locator('input[type="file"]')
+            file_inputs.first.set_input_files([str(path) for path in image_paths])
+        except Exception as exc:
+            raise GoogleFlowBridgeError(
+                f"Could not upload local image to Google Flow UI: {redact_text(exc, profile_dir=self.profile_dir)}",
+                code="ui_changed",
+                retryable=True,
+            ) from exc
+
+    def _wait_for_download(self, page: Any, output_path: Path) -> Path:
+        deadline = time.time() + self.timeout_seconds
+        download_re = re.compile(r"download|save", re.I)
+        failure_re = re.compile(r"failed|error|try again|unable", re.I)
+
+        while time.time() < deadline:
+            try:
+                error_text = page.get_by_text(failure_re).first
+                if error_text.is_visible(timeout=1000):
+                    raise GoogleFlowBridgeError(
+                        f"Google Flow reported a generation/download error: {error_text.inner_text(timeout=1000)}",
+                        code="download_failed",
+                        retryable=True,
+                    )
+            except GoogleFlowBridgeError:
+                raise
+            except Exception:
+                pass
+
+            try:
+                download_button = page.get_by_role("button", name=download_re).first
+                if not download_button.is_visible(timeout=1000):
+                    download_button = page.get_by_text(download_re).first
+                if download_button.is_visible(timeout=1000):
+                    try:
+                        with page.expect_download(timeout=30_000) as download_info:
+                            download_button.click()
+                        download = download_info.value
+                    except Exception as exc:
+                        raise GoogleFlowBridgeError(
+                            f"Google Flow download action failed: {redact_text(exc, profile_dir=self.profile_dir)}",
+                            code="download_failed",
+                            retryable=True,
+                        ) from exc
+                    download.save_as(str(output_path))
+                    return output_path
+            except GoogleFlowBridgeError:
+                raise
+            except Exception:
+                pass
+
+            try:
+                page.wait_for_timeout(5000)
+            except Exception:
+                time.sleep(5)
+
+        raise GoogleFlowBridgeError(
+            "Timed out waiting for Google Flow to finish generation and expose a download button.",
+            code="timeout",
+            retryable=True,
+        )
+
+    def _first_visible(self, page: Any, factories: list[Any], *, description: str) -> Any:
+        last_error: Exception | None = None
+        for factory in factories:
+            try:
+                locator = factory()
+                if locator.first.is_visible(timeout=2000):
+                    return locator
+            except Exception as exc:
+                last_error = exc
+                continue
+        detail = f": {last_error}" if last_error else ""
+        raise GoogleFlowBridgeError(
+            f"Google Flow UI changed; could not find {description}{redact_text(detail, profile_dir=self.profile_dir)}",
+            code="ui_changed",
+            retryable=True,
+        )
+
+    def _click_text_if_available(self, page: Any, value: str) -> bool:
+        escaped = re.escape(value)
+        candidates = [
+            lambda: page.get_by_role("button", name=re.compile(escaped, re.I)),
+            lambda: page.get_by_text(re.compile(escaped, re.I)),
+        ]
+        for factory in candidates:
+            try:
+                locator = factory().first
+                if locator.is_visible(timeout=1000):
+                    locator.click()
+                    return True
+            except Exception:
+                continue
+        return False

--- a/tools/video/google_flow_video.py
+++ b/tools/video/google_flow_video.py
@@ -1,0 +1,371 @@
+"""Experimental Google Flow video provider via a local browser session."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+from tools.video.google_flow_browser_bridge import (
+    DEFAULT_PROFILE_DIR,
+    GoogleFlowBridgeError,
+    GoogleFlowBrowserBridge,
+    redact_payload,
+    redact_text,
+)
+
+
+def _env_true(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _truthy_input(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "on", "confirmed"}
+
+
+class GoogleFlowVideo(BaseTool):
+    name = "google_flow_video"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "video_generation"
+    provider = "google_flow"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.HYBRID
+
+    dependencies = ["python:playwright"]
+    install_instructions = (
+        "Experimental local browser bridge. Install optional browser deps with "
+        "`pip install -r requirements-browser.txt` and `python -m playwright install chromium`, "
+        "then set GOOGLE_FLOW_ENABLED=true and OPENMONTAGE_EXPERIMENTAL_GOOGLE_FLOW=1."
+    )
+    agent_skills = ["ai-video-gen", "playwright-recording"]
+
+    capabilities = ["text_to_video", "image_to_video", "check_auth", "open_login", "browser_session"]
+    supports = {
+        "text_to_video": True,
+        "image_to_video": True,
+        "local_image_upload": True,
+        "check_auth": True,
+        "open_login": True,
+        "browser_session": True,
+        "uses_subscription_credits": True,
+        "requires_explicit_preference": True,
+        "requires_browser_automation_confirmation": True,
+        "private_api": False,
+        "stores_browser_session": True,
+        "stores_cookies_in_browser_profile": True,
+        "stores_storage_state_in_browser_profile": True,
+        "stores_repo_auth_artifacts": False,
+        "stores_har": False,
+        "stores_screenshots": False,
+        "dedicated_profile_default": True,
+        "cdp_url_localhost_only": True,
+    }
+    best_for = [
+        "local-only use of a logged-in Google Flow UI session",
+        "spending Google AI Pro or Flow web credits when the user explicitly opts in",
+        "experimental video generation workflows where official API coverage is unavailable",
+    ]
+    not_good_for = [
+        "unattended production runs",
+        "auto-selected provider routing",
+        "bypassing CAPTCHA, rate limits, or account protections",
+    ]
+    fallback_tools = ["veo_video", "runway_video", "seedance_video", "kling_video"]
+    quality_score = 0.65
+    historical_success_rate = 0.45
+    latency_p50_seconds = 180.0
+
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "prompt": {"type": "string"},
+            "operation": {
+                "type": "string",
+                "enum": ["text_to_video", "image_to_video", "check_auth", "open_login"],
+                "default": "text_to_video",
+            },
+            "preferred_provider": {
+                "type": "string",
+                "description": "Must be google_flow for generation operations.",
+            },
+            "confirm_browser_automation": {
+                "type": "boolean",
+                "description": "Must be true for generation operations.",
+                "default": False,
+            },
+            "reference_image_path": {"type": "string"},
+            "image_path": {"type": "string"},
+            "reference_image_paths": {"type": "array", "items": {"type": "string"}},
+            "aspect_ratio": {"type": "string", "enum": ["16:9", "9:16", "1:1"], "default": "16:9"},
+            "duration": {"type": "string"},
+            "model_variant": {"type": "string", "default": "flow"},
+            "output_path": {"type": "string"},
+            "keep_open": {
+                "type": "boolean",
+                "description": "For open_login only. Leave the browser session open for manual sign-in.",
+                "default": True,
+            },
+        },
+    }
+    output_schema = {
+        "type": "object",
+        "properties": {
+            "output_path": {"type": "string"},
+            "provider": {"type": "string"},
+            "operation": {"type": "string"},
+            "auth_mode": {"type": "string"},
+            "experimental_surface": {"type": "boolean"},
+        },
+    }
+    resource_profile = ResourceProfile(cpu_cores=2, ram_mb=2048, vram_mb=0, disk_mb=2048, network_required=True)
+    retry_policy = RetryPolicy(max_retries=0)
+    idempotency_key_fields = ["prompt", "operation", "aspect_ratio", "duration"]
+    side_effects = [
+        "opens a local browser profile",
+        "submits prompts through the Google Flow UI",
+        "uses credits from the logged-in Google account",
+        "writes downloaded video to output_path",
+    ]
+    user_visible_verification = [
+        "Run check_auth before generation",
+        "Watch the downloaded clip for motion quality and watermarks",
+        "Confirm the browser session is the intended Google account before spending Flow credits",
+    ]
+
+    @staticmethod
+    def _playwright_available() -> bool:
+        try:
+            import playwright.sync_api  # noqa: F401
+        except ImportError:
+            return False
+        return True
+
+    @staticmethod
+    def _playwright_chromium_available() -> bool:
+        try:
+            from playwright.sync_api import sync_playwright
+
+            with sync_playwright() as playwright:
+                return Path(playwright.chromium.executable_path).exists()
+        except Exception:
+            return False
+
+    @staticmethod
+    def _opt_in_enabled() -> bool:
+        return _env_true("GOOGLE_FLOW_ENABLED") and os.environ.get("OPENMONTAGE_EXPERIMENTAL_GOOGLE_FLOW") == "1"
+
+    def get_status(self) -> ToolStatus:
+        if not self._opt_in_enabled():
+            return ToolStatus.UNAVAILABLE
+        if not self._playwright_available():
+            return ToolStatus.UNAVAILABLE
+        if not self._playwright_chromium_available():
+            return ToolStatus.UNAVAILABLE
+        return ToolStatus.AVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        # Flow consumes account/subscription credits in the browser UI, not an
+        # OpenMontage-metered API bill. Surface as metadata, not USD.
+        return 0.0
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        operation = inputs.get("operation", "text_to_video")
+        if operation in {"check_auth", "open_login"}:
+            return 10.0
+        return 240.0
+
+    def dry_run(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "tool": self.name,
+            "status": self.get_status().value,
+            "playwright_available": self._playwright_available(),
+            "chromium_available": self._playwright_chromium_available(),
+            "would_execute": bool(
+                self.get_status() == ToolStatus.AVAILABLE
+                and inputs.get("preferred_provider") == "google_flow"
+                and _truthy_input(inputs.get("confirm_browser_automation"))
+            ),
+            "estimated_cost_usd": 0.0,
+            "credits_source": "google_ai_pro_or_flow_web_credits",
+            "experimental_surface": True,
+            "requires_explicit_preference": True,
+            "requires_browser_automation_confirmation": True,
+        }
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        start = time.time()
+        operation = str(inputs.get("operation", "text_to_video"))
+        profile_dir = inputs.get("profile_dir") or os.environ.get("GOOGLE_FLOW_BROWSER_PROFILE_DIR") or DEFAULT_PROFILE_DIR
+
+        if not self._opt_in_enabled():
+            return ToolResult(
+                success=False,
+                error=(
+                    "Google Flow bridge is disabled. Set GOOGLE_FLOW_ENABLED=true and "
+                    "OPENMONTAGE_EXPERIMENTAL_GOOGLE_FLOW=1 to opt in."
+                ),
+            )
+
+        if not self._playwright_available():
+            return ToolResult(
+                success=False,
+                error="Playwright is not installed. " + self.install_instructions,
+            )
+        if not self._playwright_chromium_available():
+            return ToolResult(
+                success=False,
+                error="Playwright Chromium is not installed. Run `python -m playwright install chromium`.",
+            )
+
+        bridge = None
+        close_bridge = True
+        try:
+            bridge = GoogleFlowBrowserBridge(profile_dir=profile_dir)
+            if operation == "open_login":
+                keep_open = _truthy_input(inputs.get("keep_open", True))
+                close_bridge = not keep_open
+                data = bridge.open_login(keep_open=keep_open)
+                return ToolResult(
+                    success=True,
+                    data=self._public_metadata(data, operation=operation),
+                    duration_seconds=round(time.time() - start, 2),
+                )
+
+            if operation == "check_auth":
+                data = bridge.check_auth()
+                return ToolResult(
+                    success=True,
+                    data=self._public_metadata(data, operation=operation),
+                    duration_seconds=round(time.time() - start, 2),
+                )
+
+            validation_error = self._validate_generation_inputs(inputs)
+            if validation_error:
+                return ToolResult(success=False, error=validation_error)
+
+            prompt = str(inputs.get("prompt") or "")
+            output_path = Path(str(inputs.get("output_path") or "google_flow_output.mp4")).expanduser()
+            image_paths = self._image_paths(inputs)
+            model_variant = str(inputs.get("model_variant") or "flow")
+            data = bridge.generate_video(
+                prompt=prompt,
+                operation=operation,
+                image_paths=image_paths,
+                aspect_ratio=inputs.get("aspect_ratio"),
+                duration=inputs.get("duration"),
+                model_variant=model_variant,
+                output_path=output_path,
+            )
+            public = self._public_metadata(
+                {
+                    "provider": "google_flow",
+                    "model": f"google-flow/{model_variant}",
+                    "prompt": prompt,
+                    "operation": operation,
+                    "output": str(output_path),
+                    "output_path": str(output_path),
+                    "format": "mp4",
+                    "auth_mode": "browser_session",
+                    "credits_source": "google_ai_pro_or_flow_web_credits",
+                    "consumes_subscription_credits": True,
+                    "experimental_surface": True,
+                    "browser_automation_confirmed": True,
+                    **data,
+                },
+                operation=operation,
+            )
+            artifact = public.get("output_path")
+            return ToolResult(
+                success=True,
+                data=public,
+                artifacts=[artifact] if isinstance(artifact, str) else [],
+                cost_usd=0.0,
+                duration_seconds=round(time.time() - start, 2),
+                model=public.get("model"),
+            )
+        except GoogleFlowBridgeError as exc:
+            return ToolResult(
+                success=False,
+                error=(
+                    f"Google Flow browser bridge failed ({exc.code}): "
+                    f"{exc.public_message(profile_dir=profile_dir)}"
+                ),
+                data={
+                    "provider": "google_flow",
+                    "error_code": exc.code,
+                    "retryable": exc.retryable,
+                    "details": exc.public_details(profile_dir=profile_dir),
+                },
+                duration_seconds=round(time.time() - start, 2),
+            )
+        except Exception as exc:
+            return ToolResult(
+                success=False,
+                error=f"Google Flow browser bridge failed: {redact_text(exc, profile_dir=profile_dir)}",
+                data={"provider": "google_flow", "error_code": "unexpected"},
+                duration_seconds=round(time.time() - start, 2),
+            )
+        finally:
+            if close_bridge and bridge is not None:
+                bridge.close()
+
+    def _validate_generation_inputs(self, inputs: dict[str, Any]) -> str | None:
+        if inputs.get("preferred_provider") != "google_flow":
+            return (
+                "Google Flow requires explicit provider preference. "
+                "Set preferred_provider='google_flow'."
+            )
+        if not _truthy_input(inputs.get("confirm_browser_automation")):
+            return (
+                "Google Flow requires explicit browser automation confirmation. "
+                "Set confirm_browser_automation=true."
+            )
+        operation = str(inputs.get("operation", "text_to_video"))
+        if operation not in {"text_to_video", "image_to_video"}:
+            return f"Unsupported Google Flow operation: {operation}"
+        if not str(inputs.get("prompt") or "").strip():
+            return "Google Flow generation requires a prompt."
+        if operation == "image_to_video" and not self._image_paths(inputs):
+            return "image_to_video requires image_path, reference_image_path, or reference_image_paths."
+        return None
+
+    @staticmethod
+    def _image_paths(inputs: dict[str, Any]) -> list[Path]:
+        paths: list[Path] = []
+        for key in ("image_path", "reference_image_path"):
+            if inputs.get(key):
+                paths.append(Path(str(inputs[key])).expanduser())
+        for value in inputs.get("reference_image_paths") or []:
+            paths.append(Path(str(value)).expanduser())
+        return paths
+
+    @staticmethod
+    def _public_metadata(data: dict[str, Any], *, operation: str) -> dict[str, Any]:
+        merged = {
+            "provider": "google_flow",
+            "operation": operation,
+            "auth_mode": "browser_session",
+            "experimental_surface": True,
+            **data,
+        }
+        return redact_payload(merged)

--- a/tools/video/video_selector.py
+++ b/tools/video/video_selector.py
@@ -142,6 +142,7 @@ class VideoSelector(BaseTool):
 
         # Rank mode — return scored provider rankings without generating
         if inputs.get("operation") == "rank":
+            candidates = self._exclude_explicit_only_auto_candidates(inputs, candidates)
             rankings = rank_providers(candidates, task_context)
             return ToolResult(
                 success=True,
@@ -220,6 +221,8 @@ class VideoSelector(BaseTool):
         if preferred == "auto" and env_hint in env_map:
             preferred = env_map[env_hint]
 
+        candidates = self._exclude_explicit_only_auto_candidates(inputs, candidates)
+
         rankings = rank_providers(candidates, task_context)
 
         # Build tool lookup: provider → tool (first available per provider)
@@ -241,6 +244,18 @@ class VideoSelector(BaseTool):
                 return tool_by_provider[score.provider], score
 
         return None, None
+
+    @staticmethod
+    def _exclude_explicit_only_auto_candidates(
+        inputs: dict[str, object],
+        candidates: list[BaseTool],
+    ) -> list[BaseTool]:
+        if inputs.get("preferred_provider", "auto") != "auto":
+            return candidates
+        return [
+            tool for tool in candidates
+            if not getattr(tool, "supports", {}).get("requires_explicit_preference")
+        ]
 
     def _prepare_task_context(self, inputs: dict[str, object]) -> dict[str, object]:
         from lib.scoring import normalize_task_context


### PR DESCRIPTION
## Summary
- Add `google_flow_video`, an experimental video-generation provider that drives the visible Google Flow web UI through a local Playwright browser session.
- Add `google_flow_browser_bridge` for login checks, prompt submission, download polling, redaction, safe shutdown, and URL safety checks.
- Keep Flow explicitly opt-in: it requires `GOOGLE_FLOW_ENABLED=true`, `OPENMONTAGE_EXPERIMENTAL_GOOGLE_FLOW=1`, `preferred_provider="google_flow"`, and `confirm_browser_automation=true`; `video_selector` skips explicit-only providers in auto and rank modes.
- Document optional browser setup in `requirements-browser.txt`, `.env.example`, README, and `docs/PROVIDERS.md`.

## Experimental / Local-Only Warning
This is not an official Google Flow API integration. It automates only the visible Flow browser UI, uses the local logged-in browser session, and must not bypass CAPTCHA, rate limits, account protections, or private endpoints. Browser session state is stored only in the dedicated local Chrome profile by default; OpenMontage does not write cookies, tokens, storage snapshots, HARs, DOM dumps, or screenshots into repo/project artifacts. CDP mode is limited to localhost debugging endpoints.

## Testing
- `pytest tests/tools/test_google_flow_video.py` -> 21 passed, 1 skipped (`GOOGLE_FLOW_E2E` live smoke skipped)
- `pytest tests/contracts/test_phase3_contracts.py tests/tools/test_hyperframes_compose.py` -> 105 passed
- `python -c "from tools.tool_registry import registry; import json; registry.discover(); print(json.dumps(registry.provider_menu_summary(), indent=2))"` -> passed; `google_flow` appears as unavailable by default under `video_generation`
- `git diff --check && python -m py_compile tools/video/google_flow_browser_bridge.py tools/video/google_flow_video.py tools/video/video_selector.py tests/tools/test_google_flow_video.py` -> passed
- Subagent focused review -> no blocker findings after fixes

## Live Flow E2E
Live Flow generation/check-auth tests remain opt-in and were not run. To run them locally, provide a logged-in browser profile and use:

```bash
GOOGLE_FLOW_E2E=1 GOOGLE_FLOW_ENABLED=true OPENMONTAGE_EXPERIMENTAL_GOOGLE_FLOW=1 pytest tests/tools/test_google_flow_video.py -k live
```
