### PR TITLE
Fixes #69: add missing render_runtime to edit_decisions fixture in test_08

### DIFF
--- a/tests/qa/test_08_end_to_end.py
+++ b/tests/qa/test_08_end_to_end.py
@@ -424,6 +424,7 @@ for i, scene in enumerate(scene_plan["scenes"]):
 
 edit_decisions = {
     "version": "1.0",
+    "render_runtime": "remotion",
     "cuts": [
         {
             "id": f"cut_{scene['id']}",


### PR DESCRIPTION
This PR fixes Issue #69. The test_08_end_to_end.py automated test was crashing because the mock edit_decisions test fixture was missing the render_runtime field, which is marked as strictly required in schemas/artifacts/edit_decisions.schema.json.

I added "render_runtime": "remotion" to the mock dictionary to align it with the proposal_packet output earlier in the test, which allows the test suite to pass schema validation successfully.