### PR TITLE
fix: repair contract drift and harden registry discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,96 @@
-# OpenMontage
+# CLAUDE.md
 
-**MANDATORY: Read [`AGENT_GUIDE.md`](AGENT_GUIDE.md) before responding to ANY user message.**
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-Do not act on the user's request until you have read AGENT_GUIDE.md.
-It contains routing rules that determine your first action based on what the user asked.
-Skipping it WILL cause you to take the wrong action.
+## Two modes — know which one you're in
 
-There are no instructions in this file. All instructions are in AGENT_GUIDE.md.
+This repo is used two completely different ways. Decide which before acting:
+
+1. **Operating the product (making a video).** The user wants a trailer, explainer, clip,
+   animation, etc. This goes through the agent-first pipeline system.
+   → **MANDATORY: Read [`AGENT_GUIDE.md`](AGENT_GUIDE.md) first.** It contains routing rules
+   (onboarding, reference-video entry point, Rule Zero) that determine your first action.
+   Skipping it WILL cause the wrong action. Do not improvise scripts to call tools directly.
+
+2. **Developing the codebase (writing tools, pipelines, skills, fixing the framework).**
+   That's what the rest of this file covers. `AGENT_GUIDE.md` is about *running* the product,
+   not *building* it — the developer commands below are not in that guide.
+
+When in doubt about a production request, default to mode 1 and read `AGENT_GUIDE.md`.
+
+## Architecture in one paragraph
+
+OpenMontage is **instruction-driven**: the AI agent is the orchestrator, and Python exists
+only for tools and persistence. There is **no Python orchestrator, reviewer, or stage handler** —
+orchestration, creative decisions, review, and stage transitions all live in instructions
+(YAML pipeline manifests + markdown skills) that the agent reads and follows. The production
+state machine is `idea → script → scene_plan → assets → edit → compose → publish`; each stage
+emits one canonical JSON artifact (validated against `schemas/artifacts/`) that becomes the
+contract for the next stage. See [`PROJECT_CONTEXT.md`](PROJECT_CONTEXT.md) and
+`docs/ARCHITECTURE.md` for the full picture.
+
+### Three knowledge layers (don't conflate them)
+
+- **Layer 1 — `tools/`** (Python `BaseTool` subclasses): *what* exists, availability, cost, runtime.
+  Discovered at runtime through `tools/tool_registry.py` — never hardcode tool lists.
+- **Layer 2 — `skills/`** (markdown): *how OpenMontage* uses those tools in a pipeline stage
+  (`skills/pipelines/<pipeline>/<stage>-director.md`) and meta policy (`skills/meta/`).
+- **Layer 3 — `.agents/skills/`** (markdown): *how the vendor technology works* — provider-specific
+  prompting and parameters. Each tool's `agent_skills[]` field bridges Layer 1 → Layer 3.
+
+### Things that bite if you don't know them
+
+- **Tool classes use PascalCase with NO `Tool` suffix** (`VideoCompose`, not `VideoComposeTool`).
+  Verify with `grep "^class " tools/<path>.py`.
+- **Tools are invoked via `.execute(params_dict)`**, returning a `ToolResult` (`.success`,
+  `.data`, `.error`) — not `.run()`.
+- **Selector pattern**: `tts_selector` / `image_selector` / `video_selector` auto-discover
+  providers from the registry by capability. Add a provider tool and it's available through the
+  selector with no selector code change.
+- **`video_compose` has three render runtimes** — FFmpeg, Remotion, HyperFrames — chosen at
+  proposal and locked in `edit_decisions.render_runtime`. Routing is automatic on that field;
+  silent runtime swaps are forbidden (see `AGENT_GUIDE.md`).
+- **`projects/`, `pipelines/`, and `music_library/` are gitignored** — all generated assets and
+  checkpoints are regenerable; never commit them.
+
+## Developer commands
+
+```bash
+make setup            # full install: pip deps + remotion-composer npm + Piper TTS + HyperFrames cache-warm
+make install          # python deps only (requirements.txt)
+make install-dev      # adds pytest + pytest-asyncio
+make install-gpu      # local-GPU video/image generation deps
+
+make test             # python -m pytest tests/ -v   (whole suite)
+make test-contracts   # contract tests only — the stage-artifact contracts
+make lint             # py_compile sanity check on core framework files
+make clean            # remove __pycache__ / *.pyc
+
+make preflight        # dump registry provider_menu() — what's configured/available
+make demo             # render zero-key Remotion demo videos (no API keys needed)
+make hyperframes-doctor   # validate the HyperFrames runtime (node/ffmpeg/npx)
+```
+
+Run a single test:
+
+```bash
+python -m pytest tests/contracts/test_phase1_contracts.py -v          # one file
+python -m pytest tests/contracts/test_phase1_contracts.py::test_name -v # one test
+python -m pytest tests/ -k "runtime_presentation" -v                   # by keyword
+```
+
+Test layout: `tests/contracts/` (stage-artifact contracts), `tests/tools/`, `tests/pipelines/`,
+`tests/styles/`, `tests/eval/`, `tests/qa/` (per-tool output inspection).
+
+## Extending the system
+
+- **New tool**: inherit `tools/base_tool.py` `BaseTool`, place it in the right capability package
+  (`tools/audio/`, `tools/video/`, `tools/analysis/`, …), set every contract field
+  (`capability`, `provider`, `supports`, `fallback_tools`, `agent_skills`, …), implement
+  `execute()` → `ToolResult`. Discovery is automatic via the registry; prefer the
+  selector-plus-provider pattern. Full checklist in `PROJECT_CONTEXT.md`.
+- **New pipeline**: add a YAML manifest in `pipeline_defs/` (validated by
+  `schemas/pipelines/pipeline_manifest.schema.json`) plus a director skill per stage under
+  `skills/pipelines/<name>/`, then contract tests in `tests/contracts/`.
+- **All code, comments, commits, and docs are English-only** (per the engineering standards).
+  User-facing video/UI strings are the only exception.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ pydantic>=2.0
 jsonschema>=4.20
 python-dotenv>=1.0
 Pillow>=10.0
+numpy>=1.24
 requests>=2.31

--- a/skills/pipelines/character-animation/proposal-director.md
+++ b/skills/pipelines/character-animation/proposal-director.md
@@ -20,20 +20,33 @@ Each option must include:
 - cost estimate,
 - honest limitation note.
 
-## Runtime Selection
+## Runtime Selection (required field — `render_runtime`)
 
-Read `skills/meta/animation-runtime-selector.md` before recommending a runtime.
+Read `skills/meta/animation-runtime-selector.md` and `skills/core/hyperframes.md`
+for the decision matrix, and `AGENT_GUIDE.md` → "Present Both Composition Runtimes
+(HARD RULE)" for the governance contract.
 
-When both Remotion and HyperFrames are available:
+**MANDATORY workflow — present both runtimes, don't silently default:**
 
-- Remotion: best when the final composition needs deterministic React-rendered
-  video, captions, audio, scene JSON, and final MP4 governance.
-- HyperFrames: best when the character scene is HTML/SVG/GSAP-heavy and benefits
-  from web-native authoring, lint, validate, and registry blocks.
-- FFmpeg: post-processing only. Do not pick FFmpeg as the primary runtime for
-  character acting.
+1. Query `video_compose.get_info()["render_engines"]`. If both `remotion` and
+   `hyperframes` are `True`, proceed to step 2.
+2. Present both runtimes to the user with brief-specific analysis:
+   - **Remotion** — best when the final composition needs deterministic
+     React-rendered video, captions, audio, scene JSON, and final MP4 governance.
+     One line on fit, one line on tradeoff.
+   - **HyperFrames** — best when the character scene is HTML/SVG/GSAP-heavy and
+     benefits from web-native authoring, lint, validate, and registry blocks.
+     One line on fit, one line on tradeoff.
+3. Recommend one with rationale tied to the brief's action complexity, rig style,
+   and approved tone. FFmpeg is post-processing only — never the primary runtime
+   for character acting.
+4. Wait for explicit user approval. Do NOT write `render_runtime` into
+   `proposal_packet.production_plan` before approval.
+5. Log a `render_runtime_selection` decision in `decision_log` with BOTH runtimes
+   in `options_considered` plus `ffmpeg` if it was a realistic option.
 
-Wait for user approval before locking `render_runtime`.
+A `render_runtime_selection` decision with only one option considered when both
+were available is a CRITICAL reviewer finding.
 
 ## Sample-First Rule
 

--- a/tests/contracts/test_phase2_contracts.py
+++ b/tests/contracts/test_phase2_contracts.py
@@ -174,10 +174,14 @@ class TestPhase2ErrorHandling:
         # Either succeeds (provider available) or fails gracefully
         assert isinstance(r, ToolResult)
 
-    def test_diagram_gen_empty_boxes(self):
+    def test_diagram_gen_empty_boxes(self, tmp_path):
         tool = DiagramGen()
         if tool.get_status() == ToolStatus.AVAILABLE:
-            r = tool.execute({"diagram_type": "boxes", "boxes": []})
+            r = tool.execute({
+                "diagram_type": "boxes",
+                "boxes": [],
+                "output_path": str(tmp_path / "empty.png"),
+            })
             assert isinstance(r, ToolResult)
 
 

--- a/tests/contracts/test_phase3_contracts.py
+++ b/tests/contracts/test_phase3_contracts.py
@@ -143,7 +143,7 @@ class TestCapabilityMetadata:
         catalog = reg.capability_catalog()
         assert "tts" in catalog
         providers = {item["provider"] for item in catalog["tts"] if item["provider"] != "selector"}
-        assert providers == {"elevenlabs", "google_tts", "openai", "piper"}
+        assert providers == {"doubao", "elevenlabs", "google_tts", "openai", "piper"}
 
 
 # ---- Animated Explainer Pipeline ----

--- a/tests/qa/test_08_end_to_end.py
+++ b/tests/qa/test_08_end_to_end.py
@@ -424,6 +424,7 @@ for i, scene in enumerate(scene_plan["scenes"]):
 
 edit_decisions = {
     "version": "1.0",
+    "render_runtime": "remotion",
     "cuts": [
         {
             "id": f"cut_{scene['id']}",

--- a/tools/video/green_screen_composite.py
+++ b/tools/video/green_screen_composite.py
@@ -16,7 +16,6 @@ import time
 from pathlib import Path
 from typing import Any
 
-import numpy as np
 from PIL import Image
 
 from tools.base_tool import (
@@ -248,6 +247,8 @@ class GreenScreenComposite(BaseTool):
 
     def _parse_hex_color(self, hex_str: str) -> np.ndarray:
         """Parse a hex color string like '#0E172A' to an RGB numpy array."""
+        import numpy as np
+
         hex_str = hex_str.lstrip("#")
         r = int(hex_str[0:2], 16)
         g = int(hex_str[2:4], 16)
@@ -318,6 +319,8 @@ class GreenScreenComposite(BaseTool):
         out_h: int,
     ) -> Image.Image:
         """Composite a single speaker frame over a background frame using the given layout."""
+        import numpy as np
+
         # Create alpha mask from speaker frame
         speaker_arr = np.array(speaker_img).astype(float)
         dist = np.sqrt(np.sum((speaker_arr - bg_color.astype(float)) ** 2, axis=2))


### PR DESCRIPTION
## Summary

Recent feature work — Doubao TTS (#57), the character-animation pipeline, and the `render_runtime` governance contract — introduced new contracts without updating the tests, skills, and schema payloads that depend on them. `pytest tests/` had **2 failures plus a collection-time crash**, and a test was overwriting the tracked `diagram.png`. This PR brings the suite back to green and hardens one robustness gap found along the way.

## Fixes

| Area | Change |
|---|---|
| `tests/contracts/test_phase3_contracts.py` | Stale assertion — add `doubao` to the expected TTS provider set (the provider auto-registers but the test wasn't updated). |
| `skills/pipelines/character-animation/proposal-director.md` | Governance gap — add the "present both runtimes" workflow + `render_runtime_selection` decision, matching the AGENT_GUIDE HARD RULE so the pipeline no longer silently defaults to Remotion. |
| `tools/video/green_screen_composite.py` | Robustness — defer the `numpy` import into the methods that use it (mirroring `green_screen_processor`), so a missing optional dep no longer crashes registry discovery for **every** tool. |
| `requirements.txt` | Declare `numpy`, a hard dependency of this CORE-tier tool. |
| `tests/qa/test_08_end_to_end.py` | Contract drift — add the now-required `render_runtime` field to the `edit_decisions` artifact, fixing the collection-time crash. |
| `tests/contracts/test_phase2_contracts.py` | Test hygiene — write the empty-boxes diagram to `tmp_path` instead of overwriting the tracked `diagram.png` at the repo root. |
| `CLAUDE.md` | Docs — add developer-facing guidance (usage modes, architecture, gotchas, `make`/`pytest` commands, extension checklists) on top of the existing AGENT_GUIDE.md pointer. |

## Testing

```
python -m pytest tests/
336 passed, 8 skipped in ~75s   (exit 0)
```

Previously: `334 passed, 2 failed` + 1 collection error (required `--ignore=tests/qa` to run at all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)