### PR TITLE
fix(tests): carry render_runtime into e2e edit_decisions fixture (#69)

### DIFF
--- a/tests/qa/test_08_end_to_end.py
+++ b/tests/qa/test_08_end_to_end.py
@@ -424,6 +424,7 @@ for i, scene in enumerate(scene_plan["scenes"]):
 
 edit_decisions = {
     "version": "1.0",
+    "render_runtime": proposal_packet["production_plan"]["render_runtime"],
     "cuts": [
         {
             "id": f"cut_{scene['id']}",


### PR DESCRIPTION
## Summary
Fixes #69. `tests/qa/test_08_end_to_end.py` executes its pipeline at module-import time, so a single bad fixture breaks `pytest` collection for the whole suite. The Stage 5 `edit_decisions` fixture is missing the `render_runtime` field that `schemas/artifacts/edit_decisions.schema.json` marks as required.

## Problem
`schemas/artifacts/edit_decisions.schema.json` requires `render_runtime`:

```json
"required": ["version", "cuts", "render_runtime"],
```

but the fixture built one line before `write_checkpoint(... "edit_decisions" ...)` omits it (`tests/qa/test_08_end_to_end.py:425`):

```python
edit_decisions = {
    "version": "1.0",
    "cuts": [ ... ],
    "music": { ... },
    "subtitles": { ... },
}
```

So `--collect-only` aborts:

```
ERROR collecting tests/qa/test_08_end_to_end.py
lib.checkpoint.CheckpointValidationError: Artifact 'edit_decisions' failed schema validation: 'render_runtime' is a required property
```

## Solution
Add `render_runtime` to the fixture. Rather than hardcode an arbitrary runtime, I source it from the `proposal_packet` that the same test already builds:

```python
"render_runtime": proposal_packet["production_plan"]["render_runtime"],
```

That `production_plan` locks `"remotion"`, and the schema description plus `AGENT_GUIDE.md` state the runtime is locked at proposal and carried through `edit_decisions` **unchanged**. Sourcing it keeps the fixture internally consistent with the proposal it builds on, and the test stays correct if that proposal value ever changes.

Verified against the repo's own validator (no other change needed):

```
WITH render_runtime: PASS
WITHOUT render_runtime: fails -> 'render_runtime' is a required property
```

## Out of scope
- Other QA fixtures were not audited for the same drift; this PR fixes only the file called out in #69.
- No schema or runtime-selection logic is touched.

## Test plan
- [x] `python3 -m py_compile tests/qa/test_08_end_to_end.py`
- [x] Validated the fixed `edit_decisions` dict against `schemas/artifacts/edit_decisions.schema.json` via `schemas.artifacts.validate_artifact` — passes with the field, reproduces the reported error without it.
- [ ] CI / full `pytest --collect-only` to confirm collection exits 0.

## Related
- #69 — original report (missing `render_runtime` field, repro + root cause)

Made with [Cursor](https://cursor.com)