### PR TITLE
chore: gitignore downloaded voice models (*.onnx)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ __pycache__/
 dist/
 build/
 
+# Local model downloads (e.g. Piper TTS voices, fetched at runtime — not source)
+*.onnx
+*.onnx.json
+
 # Test/IDE
 .pytest_cache/
 .mypy_cache/


### PR DESCRIPTION
## What

Add `*.onnx` / `*.onnx.json` to `.gitignore` so Piper TTS voice models downloaded at runtime (e.g. `en_US-lessac-medium.onnx`, ~60MB) don't get accidentally committed to the repo root.

## Note

This PR originally also added `numpy>=1.24` to `requirements.txt` (it's imported by `tools/video/green_screen_composite.py` and was missing, crashing `registry.discover()` on a clean install). That fix landed independently on `main` in the meantime, so after rebasing onto latest `main` this PR is now scoped to just the voice-model gitignore. No `.onnx` files are tracked today, so this is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)