### PR TITLE
fix(reviewer): return success=False when QA finds issues

### DIFF
--- a/tools/character/character_animation.py
+++ b/tools/character/character_animation.py
@@ -889,7 +889,7 @@ class CharacterAnimationReviewer(BaseTool):
         }
         artifacts = _write_json(inputs.get("output_path"), report)
         return ToolResult(
-            success=True,
+            success=not issues,
             data={"character_qa_report": report},
             artifacts=artifacts,
             duration_seconds=round(time.time() - start, 2),


### PR DESCRIPTION
`CharacterAnimationReviewer.execute()` always returned `success=True` even when the QA check found issues — so the compose-director had no way to know the rig was broken.

**Reproduction**

```python
from tools.character.character_animation import CharacterAnimationReviewer

result = CharacterAnimationReviewer().execute({
    "rig_plan": {"characters": [{"id": "char1", "role": "lead"}]},  # missing joints
    "pose_library": {},
    "action_timeline": {},
    "review_level": "static",
})

print(result.success)                               # True  ← wrong
print(result.data["character_qa_report"]["status"]) # revise
```

Output before fix:
```
result.success          : True
report['status']        : revise
report['issues'] count  : 5
issues[0]               : Preview path is required for character animation QA.

Expected : result.success == False  (QA found issues)
Actual   : result.success == True   <- BUG
```

**Fix**

One-line change in `CharacterAnimationReviewer.execute()`:

```python
# before
return ToolResult(success=True, ...)

# after
return ToolResult(success=not issues, ...)
```

After fix:
```
With issues → success: False | status: revise
```

The `success` field now correctly reflects whether QA passed, so downstream agents and compose-director can gate on it.