### PR TITLE
feat(audio): add ElevenLabs SFX generator and automatic timeline allocator

### DIFF
--- a/tests/tools/test_sfx.py
+++ b/tests/tools/test_sfx.py
@@ -1,0 +1,140 @@
+import json
+from pathlib import Path
+import pytest
+from unittest.mock import MagicMock, patch
+
+from tools.tool_registry import registry
+from tools.audio.sfx_gen import SFXGen
+from tools.audio.sfx_allocator import SFXAllocator
+from tools.base_tool import ToolResult, ToolStatus
+
+
+def test_sfx_tools_registered():
+    registry.discover()
+    assert "sfx_gen" in registry.list_all()
+    assert "sfx_allocator" in registry.list_all()
+    assert isinstance(registry.get("sfx_gen"), SFXGen)
+    assert isinstance(registry.get("sfx_allocator"), SFXAllocator)
+
+
+def test_sfx_allocator_parse_cues():
+    allocator = SFXAllocator()
+    
+    mock_script = {
+        "version": "1.0",
+        "title": "Test Title",
+        "total_duration_seconds": 30.0,
+        "sections": [
+            {
+                "id": "sec_1",
+                "text": "A flash of lightning [sfx: lightning strike] illuminates the sky.",
+                "start_seconds": 0.0,
+                "end_seconds": 10.0,
+                "enhancement_cues": []
+            },
+            {
+                "id": "sec_2",
+                "text": "Suddenly, a loud blast [sound: explosion] shatters the quiet night.",
+                "start_seconds": 10.0,
+                "end_seconds": 20.0,
+                "enhancement_cues": [
+                    {
+                        "type": "overlay",
+                        "description": "Sound of rain starting",
+                        "timestamp_seconds": 15.0
+                    }
+                ]
+            }
+        ]
+    }
+    
+    cues = allocator._parse_cues(mock_script)
+    assert len(cues) == 3
+    
+    # First cue from sec_1 bracket [sfx: lightning strike]
+    # "A flash of lightning " is 21 characters. Text len is 64. Ratio ~ 0.33
+    # start_seconds=0, end_seconds=10. expected ~ 3.3s
+    assert cues[0]["prompt"] == "lightning strike"
+    assert cues[0]["scene_id"] == "sec_1"
+    assert 2.0 <= cues[0]["start_seconds"] <= 4.5
+    
+    # Second cue from sec_2 bracket [sound: explosion]
+    # "Suddenly, a loud blast " is 23 characters. Text len is 68. Ratio ~ 0.34
+    # start_seconds=10, end_seconds=20. expected ~ 13.4s
+    assert cues[1]["prompt"] == "explosion"
+    assert cues[1]["scene_id"] == "sec_2"
+    assert 12.0 <= cues[1]["start_seconds"] <= 14.5
+    
+    # Third cue from sec_2 enhancement_cues
+    assert cues[2]["prompt"] == "rain starting"
+    assert cues[2]["scene_id"] == "sec_2"
+    assert cues[2]["start_seconds"] == 15.0
+
+
+@patch("tools.audio.sfx_allocator.registry")
+def test_sfx_allocator_execute(mock_registry, tmp_path):
+    project_id = "test_project"
+    project_dir = tmp_path / "projects" / project_id
+    project_dir.mkdir(parents=True)
+    artifacts_dir = project_dir / "artifacts"
+    artifacts_dir.mkdir()
+    
+    # Create mock script file
+    script_path = artifacts_dir / "script.json"
+    mock_script = {
+        "version": "1.0",
+        "title": "Test Title",
+        "total_duration_seconds": 10.0,
+        "sections": [
+            {
+                "id": "sec_1",
+                "text": "Pressing the button [sfx: high-pitch beep] triggers the flow.",
+                "start_seconds": 0.0,
+                "end_seconds": 5.0,
+            }
+        ]
+    }
+    with open(script_path, "w", encoding="utf-8") as f:
+        json.dump(mock_script, f)
+        
+    # Setup mock sfx_gen tool
+    mock_sfx_gen = MagicMock()
+    mock_sfx_gen.get_status.return_value = ToolStatus.AVAILABLE
+    mock_sfx_gen.execute.return_value = ToolResult(
+        success=True,
+        data={
+            "provider": "elevenlabs",
+            "prompt": "high-pitch beep",
+            "output": str(project_dir / "assets/audio/sfx/sfx_1.mp3")
+        },
+        cost_usd=0.01
+    )
+    
+    # Mock registry lookup
+    mock_registry.get.side_effect = lambda name: mock_sfx_gen if name == "sfx_gen" else None
+    
+    # Execute allocator
+    allocator = SFXAllocator()
+    with patch("tools.audio.sfx_allocator.Path", lambda *args: Path(tmp_path, *args)):
+        res = allocator.execute({
+            "project_id": project_id,
+            "sfx_volume_default": 0.5
+        })
+        
+    assert res.success
+    assert res.data["assets_generated"] == 1
+    assert len(res.data["sfx_allocated"]) == 1
+    assert res.data["sfx_allocated"][0]["asset_id"] == "sfx_1"
+    assert res.data["sfx_allocated"][0]["volume"] == 0.5
+    
+    # Verify manifest was written
+    manifest_path = artifacts_dir / "asset_manifest.json"
+    assert manifest_path.exists()
+    with open(manifest_path, encoding="utf-8") as f:
+        manifest_data = json.load(f)
+        
+    assert len(manifest_data["assets"]) == 1
+    assert manifest_data["assets"][0]["id"] == "sfx_1"
+    assert manifest_data["assets"][0]["type"] == "sfx"
+    assert manifest_data["assets"][0]["path"] == "assets/audio/sfx/sfx_1.mp3"
+    assert manifest_data["assets"][0]["cost_usd"] == 0.01

--- a/tools/audio/sfx_allocator.py
+++ b/tools/audio/sfx_allocator.py
@@ -1,0 +1,307 @@
+"""SFX placement and automatic generation engine."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Optional
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+from tools.tool_registry import registry
+
+
+class SFXAllocator(BaseTool):
+    name = "sfx_allocator"
+    version = "0.1.0"
+    tier = ToolTier.CORE
+    capability = "audio_processing"
+    provider = "openmontage"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.DETERMINISTIC
+    runtime = ToolRuntime.LOCAL
+
+    dependencies = []
+    install_instructions = "No external dependencies required."
+    agent_skills = ["ffmpeg", "elevenlabs", "sound-effects"]
+
+    capabilities = [
+        "allocate_sfx",
+        "parse_script_cues",
+        "generate_and_register_sfx",
+    ]
+
+    input_schema = {
+        "type": "object",
+        "required": ["project_id"],
+        "properties": {
+            "project_id": {
+                "type": "string",
+                "description": "The ID/name of the project directory under projects/",
+            },
+            "sfx_volume_default": {
+                "type": "number",
+                "minimum": 0.0,
+                "maximum": 1.0,
+                "default": 0.7,
+                "description": "Default volume for generated sound effects.",
+            },
+            "override_existing": {
+                "type": "boolean",
+                "default": False,
+                "description": "If true, regenerates and overwrites existing SFX files.",
+            },
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=100, network_required=True
+    )
+
+    def get_status(self) -> ToolStatus:
+        # Requires sfx_gen to be available
+        sfx_gen = registry.get("sfx_gen")
+        if sfx_gen and sfx_gen.get_status() == ToolStatus.AVAILABLE:
+            return ToolStatus.AVAILABLE
+        return ToolStatus.UNAVAILABLE
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        project_id = inputs["project_id"]
+        volume_default = inputs.get("sfx_volume_default", 0.7)
+        override = inputs.get("override_existing", False)
+
+        project_dir = Path("projects") / project_id
+        if not project_dir.exists():
+            return ToolResult(
+                success=False,
+                error=f"Project directory not found: {project_dir}",
+            )
+
+        artifacts_dir = project_dir / "artifacts"
+        script_path = artifacts_dir / "script.json"
+        manifest_path = artifacts_dir / "asset_manifest.json"
+        edit_decisions_path = artifacts_dir / "edit_decisions.json"
+
+        if not script_path.exists():
+            return ToolResult(
+                success=False,
+                error=f"Script artifact not found: {script_path}",
+            )
+
+        # 1. Load script
+        with open(script_path, encoding="utf-8") as f:
+            script_data = json.load(f)
+
+        # 2. Extract SFX cues
+        sfx_cues = self._parse_cues(script_data)
+        if not sfx_cues:
+            return ToolResult(
+                success=True,
+                data={
+                    "message": "No SFX cues found in script.",
+                    "sfx_allocated": [],
+                },
+            )
+
+        # 3. Load asset manifest
+        manifest_data = {"version": "1.0", "assets": [], "total_cost_usd": 0.0}
+        if manifest_path.exists():
+            try:
+                with open(manifest_path, encoding="utf-8") as f:
+                    manifest_data = json.load(f)
+            except Exception as e:
+                return ToolResult(
+                    success=False,
+                    error=f"Failed to load existing asset manifest: {e}",
+                )
+
+        # Ensure assets is a list
+        if "assets" not in manifest_data:
+            manifest_data["assets"] = []
+
+        sfx_gen_tool = registry.get("sfx_gen")
+        if not sfx_gen_tool:
+            return ToolResult(
+                success=False,
+                error="sfx_gen tool not found in registry.",
+            )
+
+        allocated_sfx = []
+        assets_generated = 0
+        total_sfx_cost = 0.0
+
+        # Create sfx asset directory
+        sfx_dir = project_dir / "assets" / "audio" / "sfx"
+        sfx_dir.mkdir(parents=True, exist_ok=True)
+
+        # 4. Generate and register sound effects
+        for idx, cue in enumerate(sfx_cues):
+            sfx_id = f"sfx_{idx + 1}"
+            prompt = cue["prompt"]
+            relative_path = f"assets/audio/sfx/{sfx_id}.mp3"
+            full_path = project_dir / relative_path
+
+            # Check if asset already exists in manifest
+            existing_asset = next(
+                (a for a in manifest_data["assets"] if a.get("id") == sfx_id), None
+            )
+
+            if existing_asset and not override and full_path.exists():
+                # Use existing asset
+                allocated_sfx.append({
+                    "asset_id": sfx_id,
+                    "start_seconds": cue["start_seconds"],
+                    "volume": volume_default,
+                })
+                continue
+
+            # Call sfx_gen tool to generate SFX
+            print(f"Generating SFX: '{prompt}' -> {relative_path}")
+            res = sfx_gen_tool.execute({
+                "prompt": prompt,
+                "output_path": str(full_path),
+            })
+
+            if not res.success:
+                return ToolResult(
+                    success=False,
+                    error=f"Failed to generate sound effect '{prompt}': {res.error}",
+                )
+
+            # Record cost
+            cost = res.cost_usd or 0.01
+            total_sfx_cost += cost
+
+            # Build asset manifest entry
+            asset_entry = {
+                "id": sfx_id,
+                "type": "sfx",
+                "path": relative_path,
+                "source_tool": "sfx_gen",
+                "scene_id": cue.get("scene_id", "unknown"),
+                "prompt": prompt,
+                "cost_usd": cost,
+                "provider": "elevenlabs",
+            }
+
+            # Update manifest_data
+            if existing_asset:
+                manifest_data["assets"] = [
+                    a if a.get("id") != sfx_id else asset_entry
+                    for a in manifest_data["assets"]
+                ]
+            else:
+                manifest_data["assets"].append(asset_entry)
+
+            assets_generated += 1
+            allocated_sfx.append({
+                "asset_id": sfx_id,
+                "start_seconds": cue["start_seconds"],
+                "volume": volume_default,
+            })
+
+        # Save asset manifest
+        if "total_cost_usd" in manifest_data:
+            manifest_data["total_cost_usd"] = round(
+                manifest_data["total_cost_usd"] + total_sfx_cost, 4
+            )
+        else:
+            manifest_data["total_cost_usd"] = round(total_sfx_cost, 4)
+
+        with open(manifest_path, "w", encoding="utf-8") as f:
+            json.dump(manifest_data, f, indent=2)
+
+        # 5. Load and update edit decisions
+        edit_decisions_updated = False
+        if edit_decisions_path.exists():
+            try:
+                with open(edit_decisions_path, encoding="utf-8") as f:
+                    edit_data = json.load(f)
+                
+                if "audio" not in edit_data:
+                    edit_data["audio"] = {}
+                
+                # Overwrite or append sfx
+                edit_data["audio"]["sfx"] = allocated_sfx
+                
+                with open(edit_decisions_path, "w", encoding="utf-8") as f:
+                    json.dump(edit_data, f, indent=2)
+                
+                edit_decisions_updated = True
+            except Exception as e:
+                print(f"Warning: Failed to update edit_decisions: {e}")
+
+        return ToolResult(
+            success=True,
+            data={
+                "message": f"Successfully allocated {len(allocated_sfx)} SFX cues.",
+                "assets_generated": assets_generated,
+                "total_cost_usd": total_sfx_cost,
+                "sfx_allocated": allocated_sfx,
+                "edit_decisions_updated": edit_decisions_updated,
+            },
+            artifacts=[str(manifest_path)] + ([str(edit_decisions_path)] if edit_decisions_updated else []),
+        )
+
+    def _parse_cues(self, script_data: dict[str, Any]) -> list[dict[str, Any]]:
+        """Parse script sections for SFX tags and return timestamped cues."""
+        cues = []
+        # Pattern: [sfx: thunder roll] or [sound: wind howling]
+        pattern = re.compile(r"\[(?:sfx|sound|bruitage):\s*([^\]]+)\]", re.IGNORECASE)
+
+        sections = script_data.get("sections", [])
+        for section in sections:
+            section_id = section.get("id", "unknown")
+            text = section.get("text", "")
+            start = section.get("start_seconds", 0.0)
+            end = section.get("end_seconds", start + 5.0)
+            duration = end - start
+
+            # Find all bracketed sfx tags
+            matches = list(pattern.finditer(text))
+            for match in matches:
+                prompt = match.group(1).strip()
+                # Compute absolute start time based on relative character position in text
+                char_idx = match.start()
+                text_len = len(text)
+                ratio = char_idx / text_len if text_len > 0 else 0.5
+                sfx_start = round(start + (duration * ratio), 2)
+
+                cues.append({
+                    "prompt": prompt,
+                    "start_seconds": sfx_start,
+                    "scene_id": section_id,
+                })
+
+            # Also check script section enhancement cues
+            enhancements = section.get("enhancement_cues", [])
+            for cue in enhancements:
+                desc = cue.get("description", "")
+                # If enhancement cue text describes a sound, e.g. "Sound of wind howling"
+                if "sound" in desc.lower() or "sfx" in desc.lower() or "bruit" in desc.lower():
+                    # Extract description after "sound of" or "sfx:" or keep description
+                    prompt = desc
+                    for prefix in ["sound of", "sound:", "sfx:", "bruit de", "bruitage:"]:
+                        if desc.lower().startswith(prefix):
+                            prompt = desc[len(prefix):].strip()
+                            break
+                    
+                    sfx_start = cue.get("timestamp_seconds", start)
+                    cues.append({
+                        "prompt": prompt,
+                        "start_seconds": sfx_start,
+                        "scene_id": section_id,
+                    })
+
+        return cues

--- a/tools/audio/sfx_gen.py
+++ b/tools/audio/sfx_gen.py
@@ -1,0 +1,158 @@
+"""Sound effect generation tool via ElevenLabs Sound Generation API."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+
+class SFXGen(BaseTool):
+    name = "sfx_gen"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "music_generation"  # part of music and SFX generation capability
+    provider = "elevenlabs"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = []  # checked dynamically via API key
+    install_instructions = (
+        "Set the ELEVENLABS_API_KEY environment variable:\n"
+        "  export ELEVENLABS_API_KEY=your_key_here\n"
+        "Get a key at https://elevenlabs.io"
+    )
+
+    agent_skills = ["elevenlabs", "sound-effects"]
+
+    capabilities = [
+        "generate_sfx",
+    ]
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "Sound effect description (e.g. 'heavy thunder clap', 'light sci-fi interface chime')",
+            },
+            "duration_seconds": {
+                "type": "number",
+                "minimum": 0.5,
+                "maximum": 30.0,
+                "description": "Duration in seconds (0.5 to 30s). Defaults to auto-calculation.",
+            },
+            "prompt_influence": {
+                "type": "number",
+                "minimum": 0.0,
+                "maximum": 1.0,
+                "default": 0.3,
+                "description": "How closely to follow the prompt (0.0 to 1.0).",
+            },
+            "loop": {
+                "type": "boolean",
+                "default": False,
+                "description": "Generate a seamlessly looping sound.",
+            },
+            "output_path": {"type": "string"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=50, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
+    idempotency_key_fields = ["prompt", "duration_seconds", "prompt_influence", "loop"]
+    side_effects = ["writes audio file to output_path", "calls ElevenLabs API"]
+    user_visible_verification = [
+        "Listen to the generated sound effect for prompt accuracy and audio quality",
+    ]
+
+    def get_status(self) -> ToolStatus:
+        if os.environ.get("ELEVENLABS_API_KEY"):
+            return ToolStatus.AVAILABLE
+        return ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        # ElevenLabs Sound Gen counts as ~200 characters per sound effect flat rate
+        return 0.01
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        api_key = os.environ.get("ELEVENLABS_API_KEY")
+        if not api_key:
+            return ToolResult(
+                success=False,
+                error="No ElevenLabs API key found. " + self.install_instructions,
+            )
+
+        start = time.time()
+        try:
+            result = self._generate(inputs, api_key)
+        except Exception as e:
+            return ToolResult(success=False, error=f"Sound effect generation failed: {e}")
+
+        result.duration_seconds = round(time.time() - start, 2)
+        result.cost_usd = self.estimate_cost(inputs)
+        return result
+
+    def _generate(self, inputs: dict[str, Any], api_key: str) -> ToolResult:
+        import requests
+
+        prompt = inputs["prompt"]
+        duration = inputs.get("duration_seconds")
+        influence = inputs.get("prompt_influence", 0.3)
+        loop = inputs.get("loop", False)
+
+        url = "https://api.elevenlabs.io/v1/sound-generation"
+
+        headers = {
+            "xi-api-key": api_key,
+            "Content-Type": "application/json",
+        }
+
+        payload: dict[str, Any] = {
+            "text": prompt,
+            "prompt_influence": influence,
+            "loop": loop,
+        }
+        if duration is not None:
+            payload["duration_seconds"] = duration
+
+        response = requests.post(
+            url, headers=headers, json=payload, timeout=90
+        )
+        response.raise_for_status()
+
+        output_path = Path(inputs.get("output_path", "sfx_output.mp3"))
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(response.content)
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": "elevenlabs",
+                "prompt": prompt,
+                "duration_seconds": duration,
+                "loop": loop,
+                "output": str(output_path),
+                "format": "mp3",
+            },
+            artifacts=[str(output_path)],
+        )


### PR DESCRIPTION
  I just added automated sound effects (SFX) generation and timeline placement. This allows us to write sfx    
  cues directly inside our scripts and have them generated and mixed into the video automatically.

  Here is what's included:

  • SFX Generation Tool ( sfx_gen.py ): Integrates with ElevenLabs' sound-generation API. It supports prompt   
  parameters, custom duration, loop generation, and prompt influence.
  • Timeline Placement Engine ( sfx_allocator.py ): Automatically scans script text sections for cues like     
  [sfx: description]  or  [sound: description] . It calculates the start time based on the character
  position of the tag inside the section, generates the MP3s, and updates both  asset_manifest.json  and       
  edit_decisions.json .
  • Tests ( test_sfx.py ): Added unit tests covering the auto-discovery, parser timing calculation, and full   
  pipeline execution (mocking the API calls). Tests are passing fine locally.

  Let me know if you have any questions or feedback!