### PR TITLE
fix: use --props=<path> equals form for Remotion render on Windows

### DIFF
--- a/tools/video/video_compose.py
+++ b/tools/video/video_compose.py
@@ -1352,7 +1352,12 @@ class VideoCompose(BaseTool):
             str(composer_dir / "src" / "index.tsx"),
             composition_id,
             str(output_path),
-            "--props", str(props_path),
+            # Use the `--props=<path>` equals form rather than two separate
+            # args. On Windows, passing `--props` and the path separately makes
+            # Remotion mis-parse the value (quote escaping differs), failing
+            # with "neither valid JSON nor a file path". The equals form is the
+            # API Remotion recommends for file paths and is cross-platform safe.
+            f"--props={props_path}",
         ]
 
         # Apply media profile dimensions


### PR DESCRIPTION
## Summary

On Windows, `video_compose` can fail when rendering with Remotion because `--props` and the JSON file path are passed as **two separate** CLI arguments. Due to how Windows escapes command-line quotes, Remotion mis-parses the value and aborts with:

> You passed --props but it was neither valid JSON nor a file path to a valid JSON file.

## Fix

Switch to the `--props=<path>` equals form that Remotion recommends for file paths, in `tools/video/video_compose.py`:

```diff
-            "--props", str(props_path),
+            f"--props={props_path}",
```

The equals form sidesteps the Windows quote-escaping issue and behaves identically on macOS/Linux, so it's a safe cross-platform change. The rest of the render path (temp props file, composer dir, command order) is unchanged.

## Testing

- `python -m py_compile tools/video/video_compose.py` passes.
- `pytest tests/contracts/` — 250 passed; the pre-existing failures are unrelated to this change (they reproduce identically on a clean checkout and concern tool-registry/provider availability, not the render command). No test asserts on the `--props` argument.

Fixes #172