### PR TITLE
chore: add .gitattributes to normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,51 @@
+# Normalize line endings across platforms.
+#
+# Default: treat every file as text, auto-detect, and store/check out with LF.
+# This keeps Windows, macOS, and Linux checkouts byte-consistent and prevents
+# CRLF drift from producing noisy whole-file diffs.
+* text=auto eol=lf
+
+# --- Source code -----------------------------------------------------------
+*.py    text eol=lf
+*.ts    text eol=lf
+*.tsx   text eol=lf
+*.js    text eol=lf
+*.jsx   text eol=lf
+*.mjs   text eol=lf
+*.json  text eol=lf
+*.yaml  text eol=lf
+*.yml   text eol=lf
+*.toml  text eol=lf
+*.md    text eol=lf
+*.mdc   text eol=lf
+*.txt   text eol=lf
+*.cfg   text eol=lf
+*.ini   text eol=lf
+
+# --- Newline-sensitive files (must stay LF) --------------------------------
+# A shell script checked out with CRLF has a broken shebang and will not run.
+*.sh        text eol=lf
+Makefile    text eol=lf
+.env.example text eol=lf
+
+# Windows batch files, if ever added, must keep CRLF.
+*.bat   text eol=crlf
+*.cmd   text eol=crlf
+
+# --- Binary assets (never normalize or diff) -------------------------------
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.webp  binary
+*.ico   binary
+*.mp4   binary
+*.mov   binary
+*.webm  binary
+*.mp3   binary
+*.wav   binary
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.otf   binary
+*.pdf   binary


### PR DESCRIPTION
## Summary

Adds a root `.gitattributes` to normalize line endings across platforms. Closes #187.

Without it, normalization depends on each contributor's local `core.autocrlf`. On Windows checkouts this can materialize text files — and shell scripts like `render-demo.sh` — with CRLF, which breaks script shebangs and produces noisy cross-platform diffs. This is the same class of Windows friction already seen in #172 and #148.

## What it does

- Defaults all text files to LF: `* text=auto eol=lf`
- Pins newline-sensitive files (`*.sh`, `Makefile`, `.env.example`) to LF explicitly
- Keeps `*.bat` / `*.cmd` as CRLF
- Marks image/video/audio/font assets as `binary` so Git never normalizes or diffs them

## Scope / safety

Only the policy file is added. Existing tracked files are **intentionally left unrenormalized** so the diff is a single new file and trivially reviewable. Maintainers can run `git add --renormalize .` in a separate commit whenever they want to apply it repo-wide.

Verified with `git check-attr`: `.sh` and `.md` resolve to `text` + `eol=lf`; `diagram.png` resolves to `binary` (untouched).