### PR TITLE
chore: add issue templates and a pull-request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,69 @@
+name: Bug report
+description: Report a reproducible problem with OpenMontage
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill in the fields below so it can be reproduced and triaged quickly.
+        For questions or help, use [GitHub Discussions](https://github.com/calesthio/OpenMontage/discussions) instead.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A clear, one-paragraph description of the bug.
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: e.g. Windows 11, macOS 14.5, Ubuntu 24.04
+    validations:
+      required: true
+  - type: input
+    id: pipeline
+    attributes:
+      label: Pipeline
+      description: Which pipeline were you running, if any?
+      placeholder: e.g. cinematic, explainer, character-animation
+    validations:
+      required: false
+  - type: input
+    id: runtime
+    attributes:
+      label: Runtime / renderer
+      placeholder: e.g. remotion, hyperframes
+    validations:
+      required: false
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The exact commands or actions that trigger the bug.
+      placeholder: |
+        1. Run `...`
+        2. ...
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or error output
+      description: Paste any error messages or tracebacks. This is automatically formatted as code.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & troubleshooting
+    url: https://github.com/calesthio/OpenMontage/discussions/categories/q-a
+    about: Ask setup, pipeline, or troubleshooting questions in Discussions.
+  - name: Ideas & feature brainstorming
+    url: https://github.com/calesthio/OpenMontage/discussions/categories/ideas
+    about: Propose and discuss new pipelines, tools, or integrations.
+  - name: Show and Tell
+    url: https://github.com/calesthio/OpenMontage/discussions/categories/show-and-tell
+    about: Share videos, prompts, or workflows you've built.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Suggest a new tool, pipeline, integration, or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea? If it's open-ended or you want to discuss direction first, consider posting in
+        [Discussions → Ideas](https://github.com/calesthio/OpenMontage/discussions/categories/ideas).
+        Use this form for a concrete, actionable request.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve, or what is missing today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the tool, pipeline, or change you'd like.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you've thought about.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links, mockups, references, or examples.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+<!--
+Thanks for contributing to OpenMontage! Please fill in the sections below.
+Keep PRs focused — one logical change per PR is easier to review and merge.
+-->
+
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+## Related issue
+
+<!-- Link the issue this closes, e.g. "Closes #123". Use "Refs #123" if it only relates. -->
+Closes #
+
+## Changes
+
+<!-- Bullet the notable changes. -->
+-
+
+## Testing
+
+<!-- How did you verify this? Commands run, manual steps, platforms checked. -->
+-
+
+## Checklist
+
+- [ ] The change is focused on a single logical concern.
+- [ ] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
+- [ ] I updated docs/README if behavior or usage changed.
+- [ ] No unrelated files (build artifacts, local config) are included in the diff.


### PR DESCRIPTION
## Summary

Adds GitHub issue templates and a pull-request template. Closes #189.

The repo had no `.github` issue or PR templates, so bug reports arrived with inconsistent detail and general questions landed on the issue tracker instead of the project's existing GitHub Discussions.

## What's added

- **`ISSUE_TEMPLATE/bug_report.yml`** — structured form capturing OS, pipeline, runtime, repro steps, expected vs actual, and logs (mirrors the fields the best existing reports like #172 already include).
- **`ISSUE_TEMPLATE/feature_request.yml`** — problem / proposed solution / alternatives / context.
- **`ISSUE_TEMPLATE/config.yml`** — disables blank issues and routes questions, ideas, and show-and-tell to the existing Discussions categories (Q&A, Ideas, Show and Tell).
- **`PULL_REQUEST_TEMPLATE.md`** — summary, linked issue, testing done, and a short checklist.

## Scope / safety

Purely additive — no source code touched. All three YAML forms were validated with a YAML parser. The Discussions URLs point at the categories already linked from the README.