### PR TITLE
fix: resolve skill loading warnings and correct video-toolkit naming

### DIFF
--- a/.agents/skills/synthetic-screen-recording/SKILL.md
+++ b/.agents/skills/synthetic-screen-recording/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: synthetic-screen-recording
+description: Synthetic terminal-style screen recording guidance for Remotion `TerminalScene`.
+license: MIT
+---
+
 # Synthetic Screen Recording (Remotion TerminalScene)
 
 **Decision this skill answers:** When the user wants a screen-recording-looking demo of a terminal, CLI tool, or coding workflow — do I **capture the real desktop** (OS screen recording via `screen_recorder`, Windows-MCP, Cap, or Playwright), or do I **synthesize it in Remotion** with the `TerminalScene` component?

--- a/.agents/skills/video-toolkit/SKILL.md
+++ b/.agents/skills/video-toolkit/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: video_toolkit
+name: video-toolkit
 description: Create professional videos autonomously using claude-code-video-toolkit — AI voiceovers, image generation, music, talking heads, and Remotion rendering.
 metadata:
   openclaw:

--- a/.claude/skills/video_toolkit/SKILL.md
+++ b/.claude/skills/video_toolkit/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: video_toolkit
+name: video-toolkit
 description: Create professional videos autonomously using claude-code-video-toolkit — AI voiceovers, image generation, music, talking heads, and Remotion rendering.
 metadata:
   openclaw:

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ remotion-composer/public/*
 remotion-composer/public/demo-props/test-*
 remotion-composer/public/demo-props/talking-head-*
 remotion-composer/public/demo-props/caption-burn-*
+
+venv/

--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -646,7 +646,7 @@ The `.agents/skills/` directory is large. When you're not coming in through a to
 | **Avatar / lip-sync** | `avatar-video`, `heygen`, `create-video`, `faceswap`, `video-translate`, `speech-to-text`, `agents` |
 | **Capture** | `playwright-recording` (browser flows), `ffmpeg` (post) |
 | **Visualization** | `beautiful-mermaid`, `d3-viz`, `manim-composer`, `manimce-best-practices`, `manimgl-best-practices` |
-| **Media editing** | `video-edit`, `video-download`, `video-understand`, `video_toolkit`, `visual-style` |
+| **Media editing** | `video-edit`, `video-download`, `video-understand`, `video-toolkit`, `visual-style` |
 
 **When in doubt, read the category's meta routing file first:**
 - Picking an animation runtime? → `skills/meta/animation-runtime-selector.md` routes between Remotion primitives, GSAP plugins, framer-motion, Lottie, Manim, D3.

--- a/skills/INDEX.md
+++ b/skills/INDEX.md
@@ -78,7 +78,7 @@ Key capability families to look for in the output:
 
 | Skill | File | Trigger | Agent Skills (Layer 3) |
 |-------|------|---------|----------------------|
-| FFmpeg | `core/ffmpeg.md` | Video encoding, filtering, composition | `ffmpeg`, `video_toolkit` |
+| FFmpeg | `core/ffmpeg.md` | Video encoding, filtering, composition | `ffmpeg`, `video-toolkit` |
 | Remotion | `core/remotion.md` | React-based composition, Phase 3+ | `remotion-best-practices`, `remotion` |
 | HyperFrames | `core/hyperframes.md` | HTML/CSS/GSAP composition runtime — kinetic typography, product promos, website-to-video, registry blocks | `hyperframes`, `hyperframes-cli`, `hyperframes-registry`, `website-to-hyperframes`, `gsap-core`, `gsap-timeline` |
 | WhisperX | `core/whisperx.md` | Transcription with word-level timestamps | `speech-to-text` |
@@ -89,10 +89,10 @@ Key capability families to look for in the output:
 
 | Skill | File | Trigger | Agent Skills (Layer 3) |
 |-------|------|---------|----------------------|
-| Video Editing | `creative/video-editing.md` | Cut decisions, pacing, rhythm | `ffmpeg`, `video_toolkit` |
+| Video Editing | `creative/video-editing.md` | Cut decisions, pacing, rhythm | `ffmpeg`, `video-toolkit` |
 | Enhancement Strategy | `creative/enhancement-strategy.md` | Overlay placement and density | `ffmpeg` |
 | Data Visualization | `creative/data-visualization.md` | Chart type selection, animation, label placement | `d3-viz`, `remotion-best-practices` |
-| Video Stitching | `creative/video-stitching.md` | Multi-clip assembly, AI clip chaining, spatial composition | `ffmpeg`, `video_toolkit` |
+| Video Stitching | `creative/video-stitching.md` | Multi-clip assembly, AI clip chaining, spatial composition | `ffmpeg`, `video-toolkit` |
 | Video Gen Prompting | `creative/video-gen-prompting.md` | Universal video generation prompt vocabulary; **canonical 5-aspect spec** (Subject / Motion / Scene / Spatial / Camera); ~200 cinematography primitives | `ai-video-gen`, `ltx2`, `create-video` |
 | â†³ Seedance Prompting | `creative/prompting/seedance-prompting.md` | **Preferred premium default.** Seedance 2.0 8-component structure, multi-shot, lip-sync, reference-to-video | `seedance-2-0`, `ai-video-gen` |
 | â†³ Grok Prompting | `creative/prompting/grok-prompting.md` | Grok image/video prompting, edit flows, reference-image video | `grok-media` |
@@ -301,7 +301,7 @@ Claude Code accesses them via symlinks in `.claude/skills/`.
 | Category | Installed Skills | Source |
 |----------|-----------------|--------|
 | **Video Composition** | `remotion-best-practices`, `remotion`, `hyperframes`, `hyperframes-cli`, `hyperframes-registry`, `website-to-hyperframes` | `remotion-dev/skills`, `digitalsamba/claude-code-video-toolkit`, `heygen-com/hyperframes` |
-| **Video Processing** | `ffmpeg`, `video_toolkit` | `digitalsamba/claude-code-video-toolkit` |
+| **Video Processing** | `ffmpeg`, `video-toolkit` | `digitalsamba/claude-code-video-toolkit` |
 | **TTS & Audio** | `text-to-speech`, `speech-to-text`, `music`, `sound-effects`, `elevenlabs`, `agents`, `setup-api-key` | `elevenlabs/skills`, `digitalsamba/claude-code-video-toolkit` |
 | **Image Generation** | `flux-best-practices`, `bfl-api`, `grok-media` | `black-forest-labs/skills`, local OpenMontage skill |
 | **Math Animation** | `manimce-best-practices`, `manimgl-best-practices`, `manim-composer` | `adithya-s-k/manim_skill` |

--- a/tools/audio/audio_mixer.py
+++ b/tools/audio/audio_mixer.py
@@ -38,7 +38,7 @@ class AudioMixer(BaseTool):
         "FFmpeg is required. pydub is optional for advanced mixing:\n"
         "pip install pydub"
     )
-    agent_skills = ["ffmpeg", "video_toolkit"]
+    agent_skills = ["ffmpeg", "video-toolkit"]
 
     capabilities = ["mix", "duck", "fade", "normalize", "extract_audio", "segmented_music"]
 

--- a/tools/video/showcase_card.py
+++ b/tools/video/showcase_card.py
@@ -35,7 +35,7 @@ class ShowcaseCard(BaseTool):
 
     dependencies = ["cmd:ffmpeg", "cmd:ffprobe"]
     install_instructions = "Install FFmpeg: https://ffmpeg.org/download.html"
-    agent_skills = ["ffmpeg", "video_toolkit"]
+    agent_skills = ["ffmpeg", "video-toolkit"]
 
     capabilities = ["create_showcase_card"]
 

--- a/tools/video/video_stitch.py
+++ b/tools/video/video_stitch.py
@@ -43,7 +43,7 @@ class VideoStitch(BaseTool):
         "macOS: brew install ffmpeg\n"
         "Linux: sudo apt install ffmpeg"
     )
-    agent_skills = ["ffmpeg", "video_toolkit"]
+    agent_skills = ["ffmpeg", "video-toolkit"]
 
     capabilities = [
         "validate_clips",

--- a/tools/video/video_trimmer.py
+++ b/tools/video/video_trimmer.py
@@ -42,7 +42,7 @@ class VideoTrimmer(BaseTool):
         "macOS: brew install ffmpeg\n"
         "Linux: sudo apt install ffmpeg"
     )
-    agent_skills = ["ffmpeg", "video_toolkit"]
+    agent_skills = ["ffmpeg", "video-toolkit"]
 
     capabilities = ["cut", "trim", "speed_adjust", "concat"]
 


### PR DESCRIPTION
    ### Summary                                                                                                              
    This PR fixes a warning when loading skills and resolves inconsistent naming for the `video-toolkit` skill across the    
  repository's code and documentation files.                                                                                 
                                                                                                                             
    Please review this Pull Request for merging: @calesthio   , @claude  .                                                   
  
    ### Key Changes
    1. **Fix Skill Loading Warnings**:
       - Added missing YAML frontmatter delimited by `---` to `.agents/skills/synthetic-screen-recording/SKILL.md` to prevent
  loading warnings.
    2. **Rename Skill References**:
       - The directory name on disk is `.agents/skills/video-toolkit/` (kebab-case), but it was referenced in several files  
  as `video_toolkit` (snake_case).
       - Updated references from `video_toolkit` to `video-toolkit` in the following files:
         - `AGENT_GUIDE.md`
         - `skills/INDEX.md`
         - `tools/audio/audio_mixer.py`
         - `tools/video/showcase_card.py`
         - `tools/video/video_stitch.py`
         - `tools/video/video_trimmer.py`
    3. **Ignore Local Virtual Environments**:
       - Added `venv/` to `.gitignore` to prevent tracking local environments.
  
    ### Verification
    - Checked that the skill loader successfully reads both skills without throwing `missing YAML frontmatter` warnings or   
  resolving errors.
