### PR TITLE
[codex] Add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate Python
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - name: Install dependencies
+        run: make install-dev
+
+      - name: Run lint smoke checks
+        run: make lint
+
+      - name: Run test suite
+        run: make test

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ pydantic>=2.0
 jsonschema>=4.20
 python-dotenv>=1.0
 Pillow>=10.0
+numpy>=1.24
 requests>=2.31
 google-auth>=2.0       # service-account auth for Google TTS + Imagen (Vertex AI)

--- a/skills/pipelines/character-animation/proposal-director.md
+++ b/skills/pipelines/character-animation/proposal-director.md
@@ -33,6 +33,9 @@ When both Remotion and HyperFrames are available:
 - FFmpeg: post-processing only. Do not pick FFmpeg as the primary runtime for
   character acting.
 
+Present both Remotion and HyperFrames to the user before recommending one.
+Record the alternatives considered in the decision log as
+`render_runtime_selection`, including why `hyperframes` was accepted or rejected.
 Wait for user approval before locking `render_runtime`.
 
 ## Sample-First Rule

--- a/tests/contracts/test_phase3_contracts.py
+++ b/tests/contracts/test_phase3_contracts.py
@@ -143,7 +143,7 @@ class TestCapabilityMetadata:
         catalog = reg.capability_catalog()
         assert "tts" in catalog
         providers = {item["provider"] for item in catalog["tts"] if item["provider"] != "selector"}
-        assert providers == {"elevenlabs", "google_tts", "openai", "piper"}
+        assert providers == {"doubao", "elevenlabs", "google_tts", "openai", "piper"}
 
 
 # ---- Animated Explainer Pipeline ----


### PR DESCRIPTION
﻿## Summary

Adds a focused GitHub Actions CI workflow for OpenMontage pull requests and pushes to `main`.

The workflow:
- checks out the repository
- installs FFmpeg for media/QA tests
- sets up Python 3.11 with pip dependency caching
- installs development dependencies through `make install-dev`
- runs the existing lint smoke target with `make lint`
- runs the full pytest suite through `make test`

## Related issue

Closes #141

## Changes

- Added `.github/workflows/ci.yml`.
- Added `numpy` to core requirements because discovered tools import it during clean installs.
- Updated the TTS provider contract expectation so the current Doubao provider is represented in the catalog baseline.
- Added the missing character-animation `render_runtime_selection`/present-both runtime guidance required by the existing runtime presentation contract.

## Review guide alignment

I kept this separate from PR #155's tutorial, reviewer-guide, and Remotion changes per `docs/PR_REVIEW_GUIDE.md` scope-hygiene guidance. This PR is limited to CI plus the small baseline fixes needed so the new CI check is green on current `main`.

## Testing

- `python -c "from pathlib import Path; import yaml; data=yaml.safe_load(Path('.github/workflows/ci.yml').read_text()); print(data.get('name'))"`
- `python -m py_compile tools/base_tool.py tools/tool_registry.py tools/cost_tracker.py tools/analysis/composition_validator.py`
- `python -m pytest tests/contracts -q` -> 264 passed, 1 skipped
- `python -m pytest tests/tools -q` -> 77 passed
- `python -m pytest tests -q` -> 341 passed, 3 skipped

Note: local Windows environment does not have `make`, so I ran the underlying Python commands directly. The GitHub Actions runner uses Ubuntu, where `make` is available.
