### PR TITLE
fix: defer composition runtime choice to Present Both gate in reference-analyst

### DIFF
--- a/skills/meta/video-reference-analyst.md
+++ b/skills/meta/video-reference-analyst.md
@@ -126,16 +126,18 @@ REFERENCE NEEDS          YOUR CAPABILITIES          GAP
 Video clips (sci-fi)     Video gen: 0/12 configured BLOCKED without key
 Narration (deep male)    TTS: ElevenLabs available  READY
 Background music         Music: MusicGen available  READY
-Composition engine       Remotion: available        READY (preferred)
-                         FFmpeg: available          READY (fallback only)
+Composition engine       Remotion: available        READY
+                         HyperFrames: available     READY
+                         FFmpeg: available          READY (standalone ops)
 ```
 
-**Composition engine priority:** Remotion is the **default** composition engine for
-ALL final renders — video clips, images, animated scenes, mixed content. It embeds
-video natively via `<OffthreadVideo>` and handles transitions, overlays, and profile
-scaling in a single React render pass. FFmpeg is only used when Remotion is
-unavailable, or for standalone operations (trim, transcode, subtitle burn) outside
-the composition pipeline. **Never default to FFmpeg when Remotion is available.**
+**Composition engine selection:** Remotion and HyperFrames are parallel, non-ranked
+composition runtimes — do NOT pre-lock either one here. When both are available, the
+"Present Both Composition Runtimes (HARD RULE)" gate in `AGENT_GUIDE.md` governs the
+choice: present both options to the user with tradeoffs at the proposal stage and wait
+for explicit approval before locking `render_runtime`. Silently picking a default is
+forbidden. FFmpeg is not a composition runtime in this flow — it is reserved for
+standalone operations (trim, transcode, subtitle burn) outside the composition pipeline.
 
 Be honest about gaps. If video generation is needed but unavailable, say so clearly:
 


### PR DESCRIPTION
## Summary

The `video-reference-analyst` skill is the first thing that runs in any reference-led flow. Its Step 2 capability audit hard-coded Remotion as the **default** composition engine ("Remotion is the default ... Never default to FFmpeg when Remotion is available"), which silently locked the runtime before the user was ever offered a choice.

This contradicts the **Present Both Composition Runtimes (HARD RULE)** in `AGENT_GUIDE.md` (L117), which forbids silently picking a default and treats Remotion and HyperFrames as parallel, non-ranked runtimes. The audit also omitted HyperFrames entirely, so it was never surfaced as an option in the reference-led path.

## Related issue

Closes #60

## Changes

- Add HyperFrames to the audited composition-runtime list in the capability-audit table.
- Remove the "Remotion is the default / preferred" and "Never default to FFmpeg" framing.
- Defer engine selection to the AGENT_GUIDE "Present Both" gate instead of pre-locking a runtime.
- Keep FFmpeg scoped to standalone ops (trim, transcode, subtitle burn), not composition.

## Testing

- Documentation-only change to `skills/meta/video-reference-analyst.md`; no code paths affected.
- Verified the new guidance matches the `AGENT_GUIDE.md` "Present Both Composition Runtimes (HARD RULE)" wording (L117–131).

## Checklist

- [x] The change is focused on a single logical concern.
- [ ] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable. (docs-only; no tests apply)
- [x] I updated docs/README if behavior or usage changed.
- [x] No unrelated files (build artifacts, local config) are included in the diff.
