### PR TITLE
docs: resolve orphaned skill AGENTS.md scope and stale gsap README (#61)

### DIFF
--- a/.agents/skills/flux-best-practices/SKILL.md
+++ b/.agents/skills/flux-best-practices/SKILL.md
@@ -11,6 +11,8 @@ metadata:
 
 Use this skill when generating prompts for any BFL FLUX model to ensure optimal image quality and accurate prompt interpretation.
 
+> **Extended reference:** [`AGENTS.md`](AGENTS.md) in this directory is the long-form upstream FLUX guide (vendored from Black Forest Labs). It is supplementary reference material scoped to this skill only — `SKILL.md` is the loadable entry point and the authority. It does not override or extend the repository-root `AGENTS.md` / `AGENT_GUIDE.md`.
+
 ## When to Use
 
 - Creating prompts for FLUX.2 or FLUX.1 models

--- a/.agents/skills/gsap/README.md
+++ b/.agents/skills/gsap/README.md
@@ -1,5 +1,7 @@
 # GSAP Skills in OpenMontage
 
+> **Scope:** This directory has no `SKILL.md` — it is **not** a loadable skill. This file is a navigation map for the eight loadable `gsap-*` skills that live in sibling directories (`gsap-core`, `gsap-timeline`, …). Read it to find the right `gsap-*` skill; the agent loads those, not this README.
+
 Eight Layer 3 skills teaching the agent correct GSAP (GreenSock Animation Platform) usage. Sourced from [greensock/gsap-skills](https://github.com/greensock/gsap-skills), MIT licensed.
 
 ## Why GSAP is in this repo
@@ -7,7 +9,7 @@ Eight Layer 3 skills teaching the agent correct GSAP (GreenSock Animation Platfo
 OpenMontage doesn't use GSAP directly today — Remotion compositions are driven by `useCurrentFrame()` + `interpolate()` + `spring()`. GSAP becomes relevant in two concrete scenarios:
 
 1. **Advanced text / SVG / motion-path animation inside a Remotion component.** GSAP's plugin family (SplitText, MorphSVG, DrawSVG, MotionPath, CustomEase) solves problems that are painful to hand-roll with primitive `interpolate()` calls. When you need per-character reveals, curved camera paths over SVG, or morphing between two arbitrary shapes — reach for GSAP.
-2. **HyperFrames composition (future)**. If the parallel HyperFrames engine gets wired in (see `DESIGN.md` / earlier discussion), GSAP is its native animation runtime via the Frame Adapter pattern — timelines are paused and registered on `window.__timelines`, and the engine seeks them frame-by-frame. GSAP timeline authoring becomes a day-1 skill.
+2. **HyperFrames composition.** HyperFrames is a production composition runtime in OpenMontage (rendered via `hyperframes_compose`; see `skills/core/hyperframes.md` and `AGENT_GUIDE.md`). GSAP is its native animation runtime via the Frame Adapter pattern — timelines are paused and registered on `window.__timelines`, and the engine seeks them frame-by-frame. GSAP timeline authoring is a day-1 skill for HyperFrames scenes.
 
 ## When to read which
 
@@ -31,7 +33,7 @@ These skills don't fire automatically. Trigger points:
 
 - **`skills/meta/animation-runtime-selector.md`** — the dispatcher meta skill. When authoring any animated scene, read this first; it routes you to the right Layer 3 skill based on what kind of motion you need.
 - **Pipeline asset-director skills** — `animated-explainer`, `animation`, and `cinematic` pipelines reference these skills where applicable (SplitText for text, MorphSVG for logos, MotionPath for camera moves).
-- **Future `hyperframes_compose` tool** — if added, will declare `agent_skills: ["gsap-timeline", "gsap-core"]` so the agent auto-reads them before authoring a HyperFrames composition.
+- **`hyperframes_compose` tool** — declares `agent_skills: ["gsap-timeline", "gsap-core"]` so the agent auto-reads them before authoring a HyperFrames composition.
 
 ## Running GSAP deterministically inside Remotion
 

--- a/.agents/skills/vercel-composition-patterns/SKILL.md
+++ b/.agents/skills/vercel-composition-patterns/SKILL.md
@@ -19,6 +19,8 @@ boolean prop proliferation by using compound components, lifting state, and
 composing internals. These patterns make codebases easier for both humans and AI
 agents to work with as they scale.
 
+> **Extended reference:** [`AGENTS.md`](AGENTS.md) in this directory is the long-form upstream guide (vendored from Vercel). It is supplementary reference material scoped to this skill only — `SKILL.md` is the loadable entry point and the authority. It does not override or extend the repository-root `AGENTS.md` / `AGENT_GUIDE.md`.
+
 ## When to Apply
 
 Reference these guidelines when:

--- a/.agents/skills/vercel-react-best-practices/SKILL.md
+++ b/.agents/skills/vercel-react-best-practices/SKILL.md
@@ -11,6 +11,8 @@ metadata:
 
 Comprehensive performance optimization guide for React and Next.js applications, maintained by Vercel. Contains 65 rules across 8 categories, prioritized by impact to guide automated refactoring and code generation.
 
+> **Extended reference:** [`AGENTS.md`](AGENTS.md) in this directory is the long-form upstream guide (vendored from Vercel). It is supplementary reference material scoped to this skill only — `SKILL.md` is the loadable entry point and the authority. It does not override or extend the repository-root `AGENTS.md` / `AGENT_GUIDE.md`.
+
 ## When to Apply
 
 Reference these guidelines when:


### PR DESCRIPTION
## Summary

Four files under `.agents/skills/` were unreferenced housekeeping debt with undefined authority scope or stale content. This PR resolves both without deleting any vendored reference material.

## Related issue

Closes #61

## Changes

**Orphaned skill-level `AGENTS.md` files** — each sits beside a loadable `SKILL.md` but was referenced by nothing (SKILL.md, `skills/INDEX.md`, `AGENT_GUIDE.md`, or any pipeline manifest), so its relationship to the repo-root `AGENTS.md` was undefined:
- Added an **Extended reference** note to each parent `SKILL.md` (`flux-best-practices`, `vercel-composition-patterns`, `vercel-react-best-practices`) stating the `AGENTS.md` is supplementary upstream reference scoped to that skill, that `SKILL.md` is the loadable entry point and authority, and that it does not override/extend the root `AGENTS.md` / `AGENT_GUIDE.md`. Preserves the vendored content while removing the ambiguity.

**Stale `gsap/README.md`** — described HyperFrames as a "future" engine, contradicting every other artifact (HyperFrames is a production runtime; `hyperframes_compose` is a registered tool):
- Rewrote the HyperFrames references to present-tense production reality.
- Added a scope note: this directory has no `SKILL.md` and is **not** a loadable skill — it is a navigation map for the sibling `gsap-*` skills, clarifying why it is not loadable via `agent_skills[]`.

## Testing

- Documentation-only change; no code paths affected.
- Verified each orphaned `AGENTS.md` is unreferenced (`grep` across `*.md`) before scoping it.
- Verified HyperFrames is treated as production in `AGENT_GUIDE.md`, `skills/core/hyperframes.md`, and that `hyperframes_compose` is registered in `tools/tool_registry.py` / `tools/video/video_compose.py` before de-staling.

## Checklist

- [x] The change is focused on a single logical concern.
- [ ] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable. (docs-only; no tests apply)
- [x] I updated docs/README if behavior or usage changed.
- [x] No unrelated files (build artifacts, local config) are included in the diff.
