### PR TITLE
docs(readme): swap 'Into the Abyss' for 'The Library at Alexandria'

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ Turn your AI coding assistant into a full video production studio. Describe what
 > **"THE LAST BANANA"** — a 60-second Pixar-style animated short about a lonely banana who finds friendship with a kiwi. 6 Kling v3-generated motion clips (via fal.ai), Google Chirp3-HD narration, royalty-free piano music, TikTok-style word-level captions, and Remotion composition. Total cost: **$1.33**.
 
 <div align="center">
+  <video src="https://github.com/user-attachments/assets/e03b5d1f-1199-4093-9f31-a43aa9da2c68" width="100%" controls></video>
+</div>
+
+> **"The Library at Alexandria"** — a 70-second history elegy on what humanity lost in a single night. Five hand-authored scenes — an illuminated manuscript page, cascading scroll-tags, a Burning Counter ticking 700,000 → 0 inside a candle's flame, a charred vellum fragment with surviving Greek, and an empty void — set to OpenAI 'ash' narration and a free Pixabay strings score. Total cost: **$0.02**. Built through OpenMontage's atelier (bespoke) composition mode — every scene crafted from scratch, no shared components.
+
+<div align="center">
   <video src="https://github.com/user-attachments/assets/8a6d2cc3-7ad2-46f5-922f-a8e3e5848d9f" width="100%" controls></video>
 </div>
 
@@ -68,12 +74,6 @@ Turn your AI coding assistant into a full video production studio. Describe what
 </div>
 
 > **"Mori no Seishin"** — a Ghibli-style anime animation of a forest spirit's journey through ancient woods. 12 FLUX-generated images with parallax crossfade, drift and pan camera motion, firefly and petal particles, cinematic vignette lighting, and ambient forest soundtrack. Total cost: **$0.15**. Still images brought to life through Remotion's animation engine.
-
-<div align="center">
-  <video src="https://github.com/user-attachments/assets/9cf633d9-c264-4961-bfd0-b1db188654aa" width="100%" controls></video>
-</div>
-
-> **"Into the Abyss"** — a deep ocean exploration rendered in anime style. Bioluminescent gardens, coral cathedrals, and creatures of light — 12 FLUX-generated images with sparkle and mist particle overlays, light-ray effects, smooth camera motion, and ambient oceanic soundtrack. Total cost: **$0.15**. Zero video generation APIs needed.
 
 <p align="center">
   <a href="https://www.youtube.com/@OpenMontage?sub_confirmation=1"><strong>Subscribe to @OpenMontage on YouTube</strong></a> to see new videos as they ship — every video includes the full prompt, pipeline, tools used, and cost so you can reproduce it yourself.


### PR DESCRIPTION
## Summary

Adds the new atelier-mode bespoke piece (**The Library at Alexandria**) to the README showcase block, placed right after THE LAST BANANA (Pixar). Removes the prior **Into the Abyss** anime piece to keep the section focused.

The Alexandria piece is the canonical worked example of the atelier (bespoke) composition mode that landed in #203 — every scene crafted from scratch with no shared components, signature device appears in only one of five scenes (the climax) per the scene-distinctness rule in `skills/meta/bespoke-composition.md`.

## Changes

- `README.md` — one block added (Alexandria), one block removed (Abyss). Net +/-: identical line count.

## Checklist

- [x] Single logical concern.
- [x] No unrelated files.

---

**Editorial correction (post-merge):** I briefly edited this PR's title/body to claim it also covered a Star History chart + badge polish. That was wrong — those changes never landed in this PR. They are in a separate PR cut from latest main.