### PR TITLE
docs(readme): add Star History chart + polish Repository of the Day badge

### DIFF
--- a/.github/assets/repo-of-the-day-dark.svg
+++ b/.github/assets/repo-of-the-day-dark.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="340" height="68" viewBox="0 0 340 68" role="img" aria-label="#1 Repository of the Day on GitHub Trending">
+  <!-- Card -->
+  <rect x="1.5" y="1.5" width="337" height="65" rx="12" ry="12" fill="#0D1117" stroke="#A78BFA" stroke-width="1.6"/>
+
+  <!-- Laurel + "1" emblem -->
+  <g transform="translate(22 14)">
+    <g fill="none" stroke="#A78BFA" stroke-width="1.5" stroke-linecap="round">
+      <path d="M 4 34 C -2 26 -2 14 6 6"/>
+      <path d="M 4 30 C 0 30 -3 27 -3 24"/>
+      <path d="M 1 24 C -2 23 -4 20 -3 17"/>
+      <path d="M 0 18 C -2 16 -3 13 -1 10"/>
+      <path d="M 2 12 C 0 10 0 7 3 5"/>
+    </g>
+    <g fill="none" stroke="#A78BFA" stroke-width="1.5" stroke-linecap="round">
+      <path d="M 36 34 C 42 26 42 14 34 6"/>
+      <path d="M 36 30 C 40 30 43 27 43 24"/>
+      <path d="M 39 24 C 42 23 44 20 43 17"/>
+      <path d="M 40 18 C 42 16 43 13 41 10"/>
+      <path d="M 38 12 C 40 10 40 7 37 5"/>
+    </g>
+    <text x="20" y="30" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="28" font-weight="400" fill="#A78BFA">1</text>
+  </g>
+
+  <g transform="translate(96 0)" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif">
+    <text x="0" y="28" font-size="11" font-weight="700" letter-spacing="1.8" fill="#7E74A6">GITHUB TRENDING</text>
+    <text x="0" y="52" font-size="20" font-weight="800" fill="#C4B5FD">#1 Repository Of The Day</text>
+  </g>
+</svg>

--- a/.github/assets/repo-of-the-day-light.svg
+++ b/.github/assets/repo-of-the-day-light.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="340" height="68" viewBox="0 0 340 68" role="img" aria-label="#1 Repository of the Day on GitHub Trending">
+  <!-- Card -->
+  <rect x="1.5" y="1.5" width="337" height="65" rx="12" ry="12" fill="#FFFFFF" stroke="#7C3AED" stroke-width="1.6"/>
+
+  <!-- Laurel + "1" emblem -->
+  <g transform="translate(22 14)">
+    <!-- Left laurel branch -->
+    <g fill="none" stroke="#7C3AED" stroke-width="1.5" stroke-linecap="round">
+      <path d="M 4 34 C -2 26 -2 14 6 6"/>
+      <path d="M 4 30 C 0 30 -3 27 -3 24"/>
+      <path d="M 1 24 C -2 23 -4 20 -3 17"/>
+      <path d="M 0 18 C -2 16 -3 13 -1 10"/>
+      <path d="M 2 12 C 0 10 0 7 3 5"/>
+    </g>
+    <!-- Right laurel branch (mirror) -->
+    <g fill="none" stroke="#7C3AED" stroke-width="1.5" stroke-linecap="round">
+      <path d="M 36 34 C 42 26 42 14 34 6"/>
+      <path d="M 36 30 C 40 30 43 27 43 24"/>
+      <path d="M 39 24 C 42 23 44 20 43 17"/>
+      <path d="M 40 18 C 42 16 43 13 41 10"/>
+      <path d="M 38 12 C 40 10 40 7 37 5"/>
+    </g>
+    <!-- "1" inside -->
+    <text x="20" y="30" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="28" font-weight="400" fill="#7C3AED">1</text>
+  </g>
+
+  <!-- Right side text block -->
+  <g transform="translate(96 0)" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif">
+    <text x="0" y="28" font-size="11" font-weight="700" letter-spacing="1.8" fill="#94A3B8">GITHUB TRENDING</text>
+    <text x="0" y="52" font-size="20" font-weight="800" fill="#7C3AED">#1 Repository Of The Day</text>
+  </g>
+</svg>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,12 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/trending"><img src="https://img.shields.io/badge/%F0%9F%8F%86%20%231%20on%20GitHub%20Trending-Repository%20of%20the%20Day-8957E5?style=for-the-badge&labelColor=1a1a2e" alt="#1 on GitHub Trending — Repository of the Day"></a>
+  <a href="https://github.com/trending">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/%F0%9F%8F%86_Repository_of_the_Day-%231_on_GitHub_Trending-F6B543?style=for-the-badge&labelColor=0D1117&color=F6B543">
+      <img alt="🏆 Repository of the Day — #1 on GitHub Trending" src="https://img.shields.io/badge/%F0%9F%8F%86_Repository_of_the_Day-%231_on_GitHub_Trending-D9892A?style=for-the-badge&labelColor=0D1117&color=D9892A" height="48">
+    </picture>
+  </a>
 </p>
 
 <p align="center"><strong>Follow The Build</strong></p>
@@ -657,6 +662,18 @@ make test-contracts
 # Run all tests
 make test
 ```
+
+---
+
+## Star History
+
+<a href="https://www.star-history.com/?repos=calesthio%2FOpenMontage&type=date&legend=top-left">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=calesthio/OpenMontage&type=date&theme=dark&legend=top-left" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=calesthio/OpenMontage&type=date&legend=top-left" />
+    <img alt="Star History Chart" src="https://api.star-history.com/image?repos=calesthio/OpenMontage&type=date&legend=top-left" />
+  </picture>
+</a>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@
 <p align="center">
   <a href="https://github.com/trending">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/%F0%9F%8F%86_Repository_of_the_Day-%231_on_GitHub_Trending-F6B543?style=for-the-badge&labelColor=0D1117&color=F6B543">
-      <img alt="🏆 Repository of the Day — #1 on GitHub Trending" src="https://img.shields.io/badge/%F0%9F%8F%86_Repository_of_the_Day-%231_on_GitHub_Trending-D9892A?style=for-the-badge&labelColor=0D1117&color=D9892A" height="48">
+      <source media="(prefers-color-scheme: dark)" srcset=".github/assets/repo-of-the-day-dark.svg">
+      <img alt="🏆 #1 Repository of the Day on GitHub Trending" src=".github/assets/repo-of-the-day-light.svg" height="60">
     </picture>
   </a>
 </p>


### PR DESCRIPTION
## Summary

Two small README polish changes:

1. **Star History** — added before the License section, matching the pattern in [calesthio/Crucix](https://github.com/calesthio/Crucix). Dark-mode-aware via `<picture>` + `<source>` with `prefers-color-scheme` variants.
2. **Repository of the Day badge** — replaced the stretched shields.io banner with a **bordered SVG card** that matches the deer-flow / Trendshift design language: laurel-wreath "1" emblem on the left, two lines of restrained text on the right, small (340×68) rounded card with a thin purple stroke. Light + dark variants served via `<picture>`.

## Design notes

OpenMontage isn't listed on [Trendshift](https://trendshift.io) (deer-flow's actual badge provider), so a real Trendshift badge isn't available. The two SVGs under `.github/assets/repo-of-the-day-{light,dark}.svg` are original, matching the deer-flow design *intent* (small bordered pill, laurel emblem, restrained palette) without copying Trendshift's branded asset. If we later register OpenMontage on Trendshift, swap the `<img>`/`<source>` `src` to `https://trendshift.io/api/badge/repositories/<id>` and delete the SVGs.

- **Light variant**: white bg, #7C3AED purple stroke + headline
- **Dark variant**: #0D1117 bg, #A78BFA lavender stroke, #C4B5FD headline

## Changes

- `README.md` — Star History added, Repository-of-the-Day badge swapped to local SVG (+18 / -1 lines)
- `.github/assets/repo-of-the-day-light.svg` — new (32 lines)
- `.github/assets/repo-of-the-day-dark.svg` — new (28 lines)

## Process correction (from history)

This started as commit `72bcb5e` pushed in error to the already-merged branch `docs/readme-add-alexandria-remove-abyss` after PR #209 was merged. Re-issued cleanly here on a fresh branch from latest main. PR #209's title/body were restored to accurately describe what actually merged there (only the Alexandria swap).

## Checklist

- [x] Localized, cosmetic only.
- [x] No unrelated files.