### PR TITLE
Add edge-tts provider for free Chinese voiceover MVP (no API key)

### DIFF
--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -11,17 +11,18 @@ Everything you need to know about every provider in OpenMontage — setup instru
 | Step | Cost | What to set up | What it unlocks |
 |------|------|----------------|-----------------|
 | 1 | **$0** | Pexels + Pixabay | Stock photos and videos — enough to produce basic videos |
-| 2 | **$0** | Google API key | TTS with 700+ voices (1M chars/month free) + $300 new account credit |
-| 3 | **$0** | ElevenLabs | Premium TTS + music + SFX (10K chars/month free) |
-| 4 | **$0** | Piper (local install) | Fully offline TTS — no API key, no cost, no network |
-| 5 | **~$0.03/image** | fal.ai | FLUX images + Kling/Veo/MiniMax video + Recraft — broad single-key image + video coverage |
-| 6 | **~$0.04/image** | OpenAI | DALL-E 3 images + OpenAI TTS |
-| 7 | **~$0.04/image** | Google Imagen | Imagen 4 images (shares the Google API key) |
-| 8 | **$12/month** | Runway | Gen-4 video — highest quality AI video |
-| 9 | **pay-as-you-go** | HeyGen | Avatar videos, multi-model video gateway |
-| 10 | **pay-as-you-go** | Suno | Full song generation with vocals and lyrics |
-| 11 | **$0 + GPU** | Local video gen | WAN 2.1, Hunyuan, CogVideo, LTX — free, offline |
-| 12 | **$0 + GPU** | Local Diffusion | Stable Diffusion images — free, offline |
+| 2 | **$0** | edge-tts | Free Chinese TTS via Microsoft Edge — no API key, pip install edge-tts |
+| 3 | **$0** | Google API key | TTS with 700+ voices (1M chars/month free) + $300 new account credit |
+| 4 | **$0** | ElevenLabs | Premium TTS + music + SFX (10K chars/month free) |
+| 5 | **$0** | Piper (local install) | Fully offline TTS — no API key, no cost, no network |
+| 6 | **~$0.03/image** | fal.ai | FLUX images + Kling/Veo/MiniMax video + Recraft — broad single-key image + video coverage |
+| 7 | **~$0.04/image** | OpenAI | DALL-E 3 images + OpenAI TTS |
+| 8 | **~$0.04/image** | Google Imagen | Imagen 4 images (shares the Google API key) |
+| 9 | **$12/month** | Runway | Gen-4 video — highest quality AI video |
+| 10 | **pay-as-you-go** | HeyGen | Avatar videos, multi-model video gateway |
+| 11 | **pay-as-you-go** | Suno | Full song generation with vocals and lyrics |
+| 12 | **$0 + GPU** | Local video gen | WAN 2.1, Hunyuan, CogVideo, LTX — free, offline |
+| 13 | **$0 + GPU** | Local Diffusion | Stable Diffusion images — free, offline |
 
 ### Environment Variable Summary
 
@@ -158,6 +159,55 @@ No subscription — pure pay-as-you-go, no minimum spend.
 | Scale | $330/mo | 2,000,000 | Priority support |
 
 **Free tier:** 10,000 characters/month (roughly 2-3 minutes of narration). API access included. Music generation and sound effects also available on free tier with limited credits.
+
+---
+
+### Edge-TTS — Free Chinese Voiceover (MVP/Testing)
+
+> **Best if you need free Chinese TTS with no API key for demos and testing.**
+> Not a production SLA-backed API — use Doubao, Google TTS, or ElevenLabs for formal publishing.
+
+**Tools unlocked:** `edge_tts`
+**Env var:** None (no API key required)
+
+#### Setup
+
+```bash
+pip install edge-tts
+```
+
+No API key, no registration, no configuration. It uses Microsoft Edge's free TTS service.
+
+#### Recommended Chinese Voices
+
+| Voice | Gender | Style |
+|-------|--------|-------|
+| `zh-CN-XiaoxiaoNeural` | Female | Default, natural (recommended) |
+| `zh-CN-YunxiNeural` | Male | Calm, warm |
+| `zh-CN-XiaoyiNeural` | Female | Expressive, lively |
+| `zh-CN-YunjianNeural` | Male | Deep, authoritative |
+| `zh-HK-HiuGaaiNeural` | Female | Cantonese |
+
+#### Usage
+
+```python
+from tools.audio.tts_selector import TTSSelector
+
+result = TTSSelector().execute({
+    "preferred_provider": "edge_tts",
+    "text": "深圳的城市公园里，也藏着一个热闹的自然世界。",
+    "voice": "zh-CN-XiaoxiaoNeural",
+    "output_path": "projects/my-video/assets/audio/narration.mp3",
+    "subtitle_path": "projects/my-video/assets/subtitles/narration.srt",
+})
+```
+
+#### Limitations
+
+- **Online only:** requires internet connection.
+- **Free, no SLA:** this scrapes Microsoft Edge's undocumented TTS endpoint. It may break or be rate-limited at any time.
+- **Expressive range:** limited compared to ElevenLabs or Doubao.
+- **For production Chinese videos**, prefer `doubao_tts`, `google_tts`, or manual voiceover.
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Pillow>=10.0
 numpy>=1.24
 requests>=2.31
 google-auth>=2.0       # service-account auth for Google TTS + Imagen (Vertex AI)
+edge-tts>=7.0          # free Chinese TTS for MVP/testing (no API key)

--- a/skills/pipelines/explainer/proposal-director.md
+++ b/skills/pipelines/explainer/proposal-director.md
@@ -320,6 +320,11 @@ For each stage in the pipeline manifest (`animated-explainer.yaml`), specify:
 4. **Why this provider** — explain the choice ("ElevenLabs for narration because voice quality is critical for this topic" or "Piper TTS because running local-only and free")
 5. **Fallback if unavailable** — what happens if the primary tool is down
 
+**Chinese narration policy:**
+- For Chinese videos, prefer `doubao_tts` or `google_tts` for production-quality narration (requires API key).
+- Use `edge_tts` as a free MVP/testing provider when no paid TTS key is configured.
+- Do NOT silently fallback to `piper_tts` for Chinese narration — it is English-oriented. If no Chinese-capable TTS is available, surface this to the user explicitly rather than defaulting to English TTS.
+
 **Tool selection rationale must be honest:**
 - If using a free/local tool because the cloud tool is unavailable, say so
 - If using a cloud tool when a local alternative exists, explain the quality tradeoff
@@ -333,7 +338,9 @@ For each meaningful choice, present the tradeoff:
 TRADEOFF: TTS Provider
 ├── Premium: ElevenLabs ($0.18-0.30) — natural voice, emotional delivery
 ├── Standard: OpenAI TTS ($0.05-0.15) — good quality, less expressive
-└── Free: Piper local ($0.00) — robotic but works offline
+├── Chinese Production: Doubao ($0.00/cost) — best Mandarin, needs API key
+├── Chinese MVP: edge-tts ($0.00, no key) — free Chinese via Microsoft Edge, experimental
+└── Free local: Piper ($0.00) — English-oriented, robotic, offline
 
 TRADEOFF: Visual Assets
 ├── Premium: AI video clips ($0.10-0.50/clip) — motion, dynamic

--- a/tools/audio/edge_tts.py
+++ b/tools/audio/edge_tts.py
@@ -1,0 +1,244 @@
+"""Edge-TTS provider: free online TTS via Microsoft Edge TTS service.
+
+No API key required. Uses the same service powering Microsoft Edge's
+"Read Aloud" feature, providing natural-sounding Chinese voices.
+
+Warning: This is a free experimental online workflow, not an official
+production SLA-backed API. For formal publishing, prefer manual voiceover,
+Doubao, Google TTS, Azure TTS, ElevenLabs, or OpenAI TTS depending on
+budget and usage rights.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+
+class EdgeTTS(BaseTool):
+    name = "edge_tts"
+    version = "0.1.0"
+    tier = ToolTier.VOICE
+    capability = "tts"
+    provider = "edge_tts"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.DETERMINISTIC
+    runtime = ToolRuntime.API
+
+    dependencies = ["python:edge-tts"]
+    install_instructions = (
+        "Install edge-tts:\n"
+        "  pip install edge-tts\n"
+        "\n"
+        "No API key required. edge-tts uses Microsoft Edge's free TTS service.\n"
+        "\n"
+        "Recommended Chinese voices:\n"
+        "  zh-CN-XiaoxiaoNeural  (female, default)\n"
+        "  zh-CN-YunxiNeural     (male)\n"
+        "  zh-CN-XiaoyiNeural    (female, expressive)\n"
+        "  zh-HK-HiuGaaiNeural   (Cantonese, female)"
+    )
+    agent_skills = ["text-to-speech"]
+
+    capabilities = [
+        "text_to_speech",
+        "multilingual",
+        "subtitle_output",
+    ]
+    supports = {
+        "voice_cloning": False,
+        "multilingual": True,
+        "offline": False,
+        "native_audio": True,
+        "subtitles": True,
+    }
+    best_for = [
+        "free Chinese voiceover for MVP/testing",
+        "no-API-key Chinese narration",
+        "quick prototyping with natural voices",
+    ]
+    not_good_for = [
+        "production SLA-backed publishing",
+        "best-in-class expressive voice quality",
+        "fully offline production",
+        "voice clone matching",
+    ]
+    fallback_tools = ["doubao_tts", "google_tts", "openai_tts", "piper_tts"]
+
+    input_schema = {
+        "type": "object",
+        "required": ["text"],
+        "properties": {
+            "text": {"type": "string", "description": "Text to convert to speech"},
+            "voice": {
+                "type": "string",
+                "default": "zh-CN-XiaoxiaoNeural",
+                "description": "Edge TTS voice name (e.g. zh-CN-XiaoxiaoNeural, zh-CN-YunxiNeural)",
+            },
+            "rate": {
+                "type": "string",
+                "default": "+0%",
+                "description": "Speaking rate adjustment (e.g. +0%, -20%, +50%)",
+            },
+            "volume": {
+                "type": "string",
+                "default": "+0%",
+                "description": "Volume adjustment (e.g. +0%, -50%, +100%)",
+            },
+            "pitch": {
+                "type": "string",
+                "default": "+0Hz",
+                "description": "Pitch adjustment (e.g. +0Hz, -50Hz, +100Hz)",
+            },
+            "output_path": {
+                "type": "string",
+                "description": "Path for the generated MP3 file",
+            },
+            "subtitle_path": {
+                "type": "string",
+                "description": "Optional path for SRT subtitle output",
+            },
+        },
+    }
+
+    output_schema = {
+        "type": "object",
+        "properties": {
+            "output": {"type": "string"},
+            "subtitle_path": {"type": "string"},
+            "voice": {"type": "string"},
+            "rate": {"type": "string"},
+            "text_length": {"type": "integer"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=128, vram_mb=0, disk_mb=50, network_required=True
+    )
+    retry_policy = RetryPolicy(
+        max_retries=2,
+        backoff_seconds=2.0,
+        retryable_errors=["timeout", "connection", "rate_limit"],
+    )
+    idempotency_key_fields = ["text", "voice", "rate", "volume", "pitch"]
+    side_effects = [
+        "writes audio file to output_path",
+        "calls Microsoft Edge TTS service (free, no API key)",
+    ]
+    user_visible_verification = [
+        "Listen to generated audio for Mandarin naturalness and pacing",
+        "Check subtitle timing if subtitle_path was provided",
+    ]
+    quality_score = 0.75
+
+    def get_status(self) -> ToolStatus:
+        try:
+            import edge_tts  # noqa: F401
+            return ToolStatus.AVAILABLE
+        except ImportError:
+            return ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        return 0.0
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        if self.get_status() != ToolStatus.AVAILABLE:
+            return ToolResult(
+                success=False,
+                error="edge-tts not installed. " + self.install_instructions,
+            )
+
+        start = time.time()
+        try:
+            result = asyncio.run(self._generate(inputs))
+        except Exception as exc:
+            return ToolResult(
+                success=False,
+                error=f"Edge TTS failed: {self._safe_error(exc)}",
+            )
+
+        result.duration_seconds = round(time.time() - start, 2)
+        return result
+
+    async def _generate(self, inputs: dict[str, Any]) -> ToolResult:
+        import edge_tts
+
+        text = inputs["text"]
+        voice = inputs.get("voice", "zh-CN-XiaoxiaoNeural")
+        rate = inputs.get("rate", "+0%")
+        volume = inputs.get("volume", "+0%")
+        pitch = inputs.get("pitch", "+0Hz")
+        output_path = Path(inputs.get("output_path", "edge_tts_output.mp3"))
+        subtitle_path = inputs.get("subtitle_path")
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        communicate = edge_tts.Communicate(
+            text=text,
+            voice=voice,
+            rate=rate,
+            volume=volume,
+            pitch=pitch,
+            boundary="WordBoundary",
+        )
+
+        if subtitle_path:
+            sub_path = Path(subtitle_path)
+            sub_path.parent.mkdir(parents=True, exist_ok=True)
+            sub_maker = edge_tts.SubMaker()
+            audio_data = b""
+            async for chunk in communicate.stream():
+                if chunk["type"] == "audio":
+                    audio_data += chunk["data"]
+                elif chunk["type"] == "WordBoundary":
+                    sub_maker.feed(chunk)
+            output_path.write_bytes(audio_data)
+            srt_content = sub_maker.get_srt()
+            if srt_content:
+                sub_path.write_text(srt_content, encoding="utf-8")
+            artifacts = [str(output_path), str(sub_path)]
+        else:
+            await communicate.save(str(output_path))
+            artifacts = [str(output_path)]
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": self.provider,
+                "voice": voice,
+                "rate": rate,
+                "volume": volume,
+                "pitch": pitch,
+                "text_length": len(text),
+                "output": str(output_path),
+                "subtitle_path": str(subtitle_path) if subtitle_path else None,
+            },
+            artifacts=artifacts,
+        )
+
+    @staticmethod
+    def _safe_error(exc: Exception) -> str:
+        msg = str(exc)
+        if "TTS request failed" in msg and "caused by ConnectorError" in msg:
+            return "Network error: cannot reach Edge TTS service. Check internet connection."
+        if "connect" in msg.lower() and "fail" in msg.lower():
+            return "Connection failed: Edge TTS service unreachable. Check internet/proxy."
+        if "timeout" in msg.lower():
+            return "Request timed out. The text may be too long or the service is slow."
+        return msg


### PR DESCRIPTION
## Summary

Adds an `edge-tts` provider to the TTS toolkit, enabling free Chinese voiceover without any API key.

## Changes

### New file: `tools/audio/edge_tts.py`
- Uses Microsoft Edge's free TTS service via the `edge-tts` Python package
- Supports Chinese voices: zh-CN-XiaoxiaoNeural, zh-CN-YunxiNeural, zh-CN-XiaoyiNeural, etc.
- Supports rate/volume/pitch adjustment
- Optional SRT subtitle output via `subtitle_path`
- Automatically discovered by `TTSSelector` (no selector changes needed)
- Marked as `EXPERIMENTAL` with clear warnings

### Modified: `docs/PROVIDERS.md`
- Added edge-tts to the quick-start table (step 2, free tier)
- Added full setup guide with recommended Chinese voices
- Clear warning: experimental/free workflow, not a production SLA-backed API

### Modified: `skills/pipelines/explainer/proposal-director.md`
- Added edge-tts to the TTS Provider tradeoff matrix
- Added Chinese narration policy: prefer doubao_tts for production, edge-tts for MVP/testing, do not silently fallback to piper_tts for Chinese

### Modified: `requirements.txt`
- Added edge-tts>=7.0 as an optional dependency

## Testing

```python
from tools.audio.tts_selector import TTSSelector
result = TTSSelector().execute({
    "preferred_provider": "edge_tts",
    "text": "Shenzhen wetland narration test.",
    "voice": "zh-CN-XiaoxiaoNeural",
    "output_path": "test_narration.mp3",
    "subtitle_path": "test_narration.srt",
})
print(result.success)  # True
```

Closes #1
