### PR TITLE
fix: correct file URI for Unix absolute paths in resolveAsset

### DIFF
--- a/remotion-composer/src/Explainer.tsx
+++ b/remotion-composer/src/Explainer.tsx
@@ -22,7 +22,11 @@ function resolveAsset(src: string): string {
   // Absolute paths (Unix: /foo, Windows: C:\foo or C:/foo) — convert to file:// URI
   // staticFile() only accepts relative paths within public/, so absolute paths must bypass it
   if (clean.startsWith("/") || /^[A-Za-z]:[\\/]/.test(clean)) {
-    return `file:///${clean.replace(/\\/g, "/")}`;
+    // ponytail: Unix paths already start with /, so file:// + /path = file:///path (3 slashes, correct)
+    // Windows paths (C:\...) need the extra slash: file:/// + C:/... = file:///C:/...
+    return clean.startsWith("/")
+      ? `file://${clean}`
+      : `file:///${clean.replace(/\\/g, "/")}`;
   }
   return staticFile(clean);
 }


### PR DESCRIPTION
<!--
Thanks for contributing to OpenMontage! Please fill in the sections below.
Keep PRs focused — one logical change per PR is easier to review and merge.
-->

## Summary

<!-- What does this PR do, and why? -->

## Related issue

<!-- Link the issue this closes, e.g. "Closes #123". Use "Refs #123" if it only relates. -->
Closes #

## Changes

<!-- Bullet the notable changes. -->
-

## Testing

<!-- How did you verify this? Commands run, manual steps, platforms checked. -->
-

## Checklist

- [ ] The change is focused on a single logical concern.
- [ ] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [ ] I updated docs/README if behavior or usage changed.
- [ ] No unrelated files (build artifacts, local config) are included in the diff.
