### PR TITLE
fix(ProgressBar): normalize progress input to accept both 0-1 and 0-100 scales

### DIFF
--- a/remotion-composer/public/demo-props/code-to-screen.json
+++ b/remotion-composer/public/demo-props/code-to-screen.json
@@ -46,7 +46,7 @@
       "in_seconds": 13,
       "out_seconds": 17.5,
       "title": "Automation coverage",
-      "progress": 0.82,
+      "progress": 82,
       "progressLabel": "82% of the release path is scripted",
       "progressColor": "#34D399",
       "backgroundColor": "#0F172A"

--- a/remotion-composer/src/components/ProgressBar.tsx
+++ b/remotion-composer/src/components/ProgressBar.tsx
@@ -50,10 +50,9 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
   const frame = useCurrentFrame();
   const { fps, durationInFrames } = useVideoConfig();
 
-  // Normalize: accept both 0-1 fraction (e.g. 0.82 = 82%) and 0-100 percentage (e.g. 82 = 82%)
-  // This ensures backward compatibility with existing demo props.
-  const normalized = progress <= 1 ? progress * 100 : progress;
-  const clampedProgress = Math.max(0, Math.min(100, normalized));
+  // progress is a 0-100 percentage integer (e.g. 82 = 82%).
+  // Values on a 0-1 fraction scale are NOT supported — use 0-100 directly.
+  const clampedProgress = Math.max(0, Math.min(100, progress));
 
   // Container entrance animation
   const containerOpacity = spring({

--- a/remotion-composer/src/components/ProgressBar.tsx
+++ b/remotion-composer/src/components/ProgressBar.tsx
@@ -50,7 +50,10 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
   const frame = useCurrentFrame();
   const { fps, durationInFrames } = useVideoConfig();
 
-  const clampedProgress = Math.max(0, Math.min(100, progress));
+  // Normalize: accept both 0-1 fraction (e.g. 0.82 = 82%) and 0-100 percentage (e.g. 82 = 82%)
+  // This ensures backward compatibility with existing demo props.
+  const normalized = progress <= 1 ? progress * 100 : progress;
+  const clampedProgress = Math.max(0, Math.min(100, normalized));
 
   // Container entrance animation
   const containerOpacity = spring({


### PR DESCRIPTION
## Description

The `ProgressBar` component expects the `progress` prop as a **0-100 percentage integer** (e.g. `82` for 82%), but the existing demo props (`code-to-screen.json`) pass it as a **0-1 decimal fraction** (e.g. `0.82` for 82%).

Since `0.82` lies inside `Math.min(100, 0.82)`, it passes through unmodified and then gets divided by 100 in the fill animation:
- `0.82 / 100 = 0.0082` → bar fills to **0.82%** instead of the intended **82%**

## Fix

1. **Normalize the input in ProgressBar.tsx**: if the value is ≤ 1, multiply by 100 to treat it as a 0-1 fraction. This makes the component accept both scales transparently.
2. **Update `code-to-screen.json`**: change `progress: 0.82` to `progress: 82` for consistency.

## Testing

- Verified the fix locally: `progress: 0.82` → normalized to 82 → renders correctly
- Verified backward compatibility: `progress: 82` → stays 82 → renders correctly
- Other demo props checked for same issue — no other occurrences found