### PR TITLE
fix: reconcile hardlinked .claude/skills ↔ .agents/skills blobs (clean dirty tree)

### DIFF
--- a/.claude/skills/flux-best-practices/SKILL.md
+++ b/.claude/skills/flux-best-practices/SKILL.md
@@ -11,6 +11,8 @@ metadata:
 
 Use this skill when generating prompts for any BFL FLUX model to ensure optimal image quality and accurate prompt interpretation.
 
+> **Extended reference:** [`AGENTS.md`](AGENTS.md) in this directory is the long-form upstream FLUX guide (vendored from Black Forest Labs). It is supplementary reference material scoped to this skill only — `SKILL.md` is the loadable entry point and the authority. It does not override or extend the repository-root `AGENTS.md` / `AGENT_GUIDE.md`.
+
 ## When to Use
 
 - Creating prompts for FLUX.2 or FLUX.1 models

--- a/.claude/skills/vercel-composition-patterns/SKILL.md
+++ b/.claude/skills/vercel-composition-patterns/SKILL.md
@@ -19,6 +19,8 @@ boolean prop proliferation by using compound components, lifting state, and
 composing internals. These patterns make codebases easier for both humans and AI
 agents to work with as they scale.
 
+> **Extended reference:** [`AGENTS.md`](AGENTS.md) in this directory is the long-form upstream guide (vendored from Vercel). It is supplementary reference material scoped to this skill only — `SKILL.md` is the loadable entry point and the authority. It does not override or extend the repository-root `AGENTS.md` / `AGENT_GUIDE.md`.
+
 ## When to Apply
 
 Reference these guidelines when:

--- a/.claude/skills/vercel-react-best-practices/SKILL.md
+++ b/.claude/skills/vercel-react-best-practices/SKILL.md
@@ -11,6 +11,8 @@ metadata:
 
 Comprehensive performance optimization guide for React and Next.js applications, maintained by Vercel. Contains 65 rules across 8 categories, prioritized by impact to guide automated refactoring and code generation.
 
+> **Extended reference:** [`AGENTS.md`](AGENTS.md) in this directory is the long-form upstream guide (vendored from Vercel). It is supplementary reference material scoped to this skill only — `SKILL.md` is the loadable entry point and the authority. It does not override or extend the repository-root `AGENTS.md` / `AGENT_GUIDE.md`.
+
 ## When to Apply
 
 Reference these guidelines when:


### PR DESCRIPTION
## Problem

Three skill files showed as permanently **modified** on `main`, producing an unfixable dirty working tree:

- `.claude/skills/flux-best-practices/SKILL.md`
- `.claude/skills/vercel-composition-patterns/SKILL.md`
- `.claude/skills/vercel-react-best-practices/SKILL.md`

### Root cause

Each of these files is **hardlinked** across `.agents/skills/` and `.claude/skills/` — one physical inode, two paths. But git had committed **divergent blobs** for the two paths: the `.agents/` copies carried an *"Extended reference: AGENTS.md"* note that the `.claude/` copies were missing (2 lines each).

A single physical file cannot simultaneously match two different committed blobs, so `git status` always reported one of the paths as modified. `git checkout` could never resolve it — restoring one path just dirtied the other (ping-pong). This was a vendoring-sync bug, not a local edit.

## Fix

Stage the `.claude/skills` copies so both paths commit **identical** content — keeping the `.agents/` version *with* the AGENTS.md reference note (the fuller, intended form). After this, the two blobs are byte-identical and `git status` stays clean across checkouts.

Verified: `git diff HEAD:.agents/... HEAD:.claude/...` now reports no difference for all three files.

## Scope

Docs/skill-metadata only — adds the missing 2-line reference note to three `.claude/skills` SKILL.md blobs. No behavioral change.