### PR TITLE
fix(piper_tts): report availability from the voice model, not just the binary

### DIFF
--- a/tests/tools/test_piper_tts_status.py
+++ b/tests/tools/test_piper_tts_status.py
@@ -1,0 +1,57 @@
+"""Tests for piper_tts status honesty (issue #237).
+
+get_status() must not report AVAILABLE when no voice model is installed, and
+execute() must give an actionable download hint in that state.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.audio.piper_tts import PiperTTS
+from tools.base_tool import ToolStatus
+
+
+def _install_fake_voice(d: Path) -> None:
+    (d / "en_US-lessac-medium.onnx").write_bytes(b"\x00")
+    (d / "en_US-lessac-medium.onnx.json").write_text("{}")
+
+
+def test_unavailable_when_not_installed(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _: None)
+    import builtins
+
+    real_import = builtins.__import__
+
+    def no_piper(name, *a, **k):
+        if name == "piper":
+            raise ImportError("no piper")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", no_piper)
+    assert PiperTTS().get_status() == ToolStatus.UNAVAILABLE
+
+
+def test_degraded_when_installed_without_voice(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/piper")  # "installed"
+    monkeypatch.setattr(PiperTTS, "_voice_search_dirs", staticmethod(lambda: [tmp_path]))
+    assert PiperTTS().get_status() == ToolStatus.DEGRADED
+
+
+def test_available_when_voice_present(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/piper")
+    _install_fake_voice(tmp_path)
+    monkeypatch.setattr(PiperTTS, "_voice_search_dirs", staticmethod(lambda: [tmp_path]))
+    assert PiperTTS().get_status() == ToolStatus.AVAILABLE
+
+
+def test_execute_degraded_gives_actionable_error(monkeypatch, tmp_path):
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/piper")
+    monkeypatch.setattr(PiperTTS, "_voice_search_dirs", staticmethod(lambda: [tmp_path]))
+    r = PiperTTS().execute({"text": "hello", "output_path": str(tmp_path / "o.wav")})
+    assert r.success is False
+    assert "download_voices" in (r.error or "")

--- a/tests/tools/test_piper_tts_status.py
+++ b/tests/tools/test_piper_tts_status.py
@@ -107,3 +107,37 @@ def test_execute_names_the_missing_requested_model(monkeypatch, tmp_path):
     )
     assert r.success is False
     assert "en_US-ryan-high" in (r.error or "")
+
+
+def test_find_voice_requires_companion_json_for_explicit_path(tmp_path):
+    # A bare .onnx with no sibling .onnx.json must not resolve. Piper needs the
+    # pair; returning the lone model passes preflight and then fails at synthesis.
+    lonely = tmp_path / "custom.onnx"
+    lonely.write_bytes(b"\x00")
+    assert PiperTTS()._find_voice(str(lonely)) is None
+
+    # Companion present -> the explicit path resolves.
+    (tmp_path / "custom.onnx.json").write_text("{}")
+    assert PiperTTS()._find_voice(str(lonely)) == lonely
+
+
+def test_execute_rejects_explicit_onnx_without_companion(monkeypatch, tmp_path):
+    # The full execute path must refuse a companion-less explicit model rather
+    # than shelling out to piper with a model it cannot load.
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/piper")
+    _install_fake_voice(tmp_path)  # default voice present, so the tool is AVAILABLE
+    monkeypatch.setattr(PiperTTS, "_voice_search_dirs", staticmethod(lambda: [tmp_path]))
+
+    lonely = tmp_path / "custom.onnx"  # explicit path, no .onnx.json
+    lonely.write_bytes(b"\x00")
+
+    def fail_if_called(*a, **k):  # pragma: no cover - must never run
+        raise AssertionError("piper was invoked with a companion-less model")
+
+    monkeypatch.setattr("subprocess.run", fail_if_called)
+
+    r = PiperTTS().execute(
+        {"text": "hi", "model": str(lonely), "output_path": str(tmp_path / "o.wav")}
+    )
+    assert r.success is False
+    assert str(lonely) in (r.error or "")

--- a/tests/tools/test_piper_tts_status.py
+++ b/tests/tools/test_piper_tts_status.py
@@ -67,6 +67,35 @@ def test_execute_degraded_gives_actionable_error(monkeypatch, tmp_path):
     assert "download_voices" in (r.error or "")
 
 
+def test_execute_passes_resolved_onnx_path_for_voice_outside_cwd(monkeypatch, tmp_path):
+    # A voice installed in a search dir (not cwd) must be passed to piper as its
+    # resolved .onnx path, otherwise piper looks only in cwd and fails to load
+    # despite passing the availability gate.
+    voice_dir = tmp_path / "voices"
+    voice_dir.mkdir()
+    _install_fake_voice(voice_dir)  # default voice, outside cwd
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/piper")
+    monkeypatch.setattr(PiperTTS, "_voice_search_dirs", staticmethod(lambda: [voice_dir]))
+
+    captured = {}
+
+    class FakeProc:
+        returncode = 0
+        stderr = ""
+
+    def fake_run(cmd, *a, **k):
+        captured["cmd"] = cmd
+        Path(cmd[cmd.index("--output_file") + 1]).write_bytes(b"\x00")  # create output
+        return FakeProc()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    r = PiperTTS().execute({"text": "hi", "output_path": str(tmp_path / "o.wav")})
+    assert r.success is True, r.error
+    model_arg = captured["cmd"][captured["cmd"].index("--model") + 1]
+    assert model_arg == str(voice_dir / "en_US-lessac-medium.onnx")
+
+
 def test_execute_names_the_missing_requested_model(monkeypatch, tmp_path):
     # The default voice is present, but the caller requests a different, absent
     # model — the error must name the requested model, not the default.

--- a/tests/tools/test_piper_tts_status.py
+++ b/tests/tools/test_piper_tts_status.py
@@ -16,9 +16,9 @@ from tools.audio.piper_tts import PiperTTS
 from tools.base_tool import ToolStatus
 
 
-def _install_fake_voice(d: Path) -> None:
-    (d / "en_US-lessac-medium.onnx").write_bytes(b"\x00")
-    (d / "en_US-lessac-medium.onnx.json").write_text("{}")
+def _install_fake_voice(d: Path, name: str = "en_US-lessac-medium") -> None:
+    (d / f"{name}.onnx").write_bytes(b"\x00")
+    (d / f"{name}.onnx.json").write_text("{}")
 
 
 def test_unavailable_when_not_installed(monkeypatch):
@@ -49,9 +49,32 @@ def test_available_when_voice_present(monkeypatch, tmp_path):
     assert PiperTTS().get_status() == ToolStatus.AVAILABLE
 
 
+def test_degraded_when_only_nondefault_voice_present(monkeypatch, tmp_path):
+    # A non-default voice is installed, but the default en_US-lessac-medium is
+    # not — preflight must not claim AVAILABLE since the default execute path
+    # would fail.
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/piper")
+    _install_fake_voice(tmp_path, name="en_GB-alba-medium")
+    monkeypatch.setattr(PiperTTS, "_voice_search_dirs", staticmethod(lambda: [tmp_path]))
+    assert PiperTTS().get_status() == ToolStatus.DEGRADED
+
+
 def test_execute_degraded_gives_actionable_error(monkeypatch, tmp_path):
     monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/piper")
     monkeypatch.setattr(PiperTTS, "_voice_search_dirs", staticmethod(lambda: [tmp_path]))
     r = PiperTTS().execute({"text": "hello", "output_path": str(tmp_path / "o.wav")})
     assert r.success is False
     assert "download_voices" in (r.error or "")
+
+
+def test_execute_names_the_missing_requested_model(monkeypatch, tmp_path):
+    # The default voice is present, but the caller requests a different, absent
+    # model — the error must name the requested model, not the default.
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/piper")
+    _install_fake_voice(tmp_path)  # default present
+    monkeypatch.setattr(PiperTTS, "_voice_search_dirs", staticmethod(lambda: [tmp_path]))
+    r = PiperTTS().execute(
+        {"text": "hi", "model": "en_US-ryan-high", "output_path": str(tmp_path / "o.wav")}
+    )
+    assert r.success is False
+    assert "en_US-ryan-high" in (r.error or "")

--- a/tools/audio/piper_tts.py
+++ b/tools/audio/piper_tts.py
@@ -109,13 +109,11 @@ class PiperTTS(BaseTool):
 
     @staticmethod
     def _piper_installed() -> bool:
-        if shutil.which("piper") is not None:
-            return True
-        try:
-            import piper  # noqa: F401
-            return True
-        except ImportError:
-            return False
+        # This tool shells out to the `piper` executable, so execution readiness
+        # is gated on the binary being on PATH. The Python `piper` package
+        # importing is NOT sufficient — a package-only install still cannot run
+        # the subprocess, so preflight must report UNAVAILABLE in that state.
+        return shutil.which("piper") is not None
 
     def _find_voice(self, name: str) -> Path | None:
         """Locate a Piper voice model (.onnx + .onnx.json) by name or path.

--- a/tools/audio/piper_tts.py
+++ b/tools/audio/piper_tts.py
@@ -156,7 +156,8 @@ class PiperTTS(BaseTool):
         # Gate on the specific voice this call will use, not the coarse status —
         # a caller may request an installed voice even when the default is absent.
         model = inputs.get("model", self.default_voice)
-        if self._find_voice(model) is None:
+        voice_path = self._find_voice(model)
+        if voice_path is None:
             searched = ", ".join(str(d) for d in self._voice_search_dirs())
             return ToolResult(
                 success=False,
@@ -169,21 +170,26 @@ class PiperTTS(BaseTool):
 
         start = time.time()
         try:
-            result = self._generate(inputs)
+            result = self._generate(inputs, str(voice_path))
         except Exception as exc:
             return ToolResult(success=False, error=f"Local TTS generation failed: {exc}")
 
         result.duration_seconds = round(time.time() - start, 2)
         return result
 
-    def _generate(self, inputs: dict[str, Any]) -> ToolResult:
+    def _generate(self, inputs: dict[str, Any], model_path: str) -> ToolResult:
+        # model_path is the resolved .onnx file located by _find_voice(). Piper
+        # only searches the current directory for a bare model name, so passing
+        # the resolved path is required when the voice lives in PIPER_VOICE_DIR
+        # or ~/.piper — otherwise a voice that passed the availability gate would
+        # still fail to load at run time from a different cwd.
         output_path = Path(inputs.get("output_path", "tts_output.wav"))
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
         proc = subprocess.run(
             [
                 "piper",
-                "--model", inputs.get("model", self.default_voice),
+                "--model", model_path,
                 "--speaker", str(inputs.get("speaker_id", 0)),
                 "--length-scale", str(inputs.get("length_scale", 1.0)),
                 "--sentence-silence", str(inputs.get("sentence_silence", 0.3)),
@@ -204,12 +210,12 @@ class PiperTTS(BaseTool):
             success=True,
             data={
                 "provider": self.provider,
-                "model": inputs.get("model", self.default_voice),
+                "model": model_path,
                 "speaker_id": inputs.get("speaker_id", 0),
                 "text_length": len(inputs["text"]),
                 "output": str(output_path),
                 "format": "wav",
             },
             artifacts=[str(output_path)],
-            model=inputs.get("model", self.default_voice),
+            model=model_path,
         )

--- a/tools/audio/piper_tts.py
+++ b/tools/audio/piper_tts.py
@@ -107,40 +107,63 @@ class PiperTTS(BaseTool):
         dirs += [Path.home() / ".local/share/piper", Path.home() / ".piper/models"]
         return dirs
 
-    def _has_voice_model(self) -> bool:
-        """True if any Piper voice model (.onnx + .onnx.json) is discoverable."""
+    @staticmethod
+    def _piper_installed() -> bool:
+        if shutil.which("piper") is not None:
+            return True
+        try:
+            import piper  # noqa: F401
+            return True
+        except ImportError:
+            return False
+
+    def _find_voice(self, name: str) -> Path | None:
+        """Locate a Piper voice model (.onnx + .onnx.json) by name or path.
+
+        Accepts a direct path to an .onnx file or a bare model name resolved
+        against the voice search dirs. Returns the .onnx path if found.
+        """
+        direct = Path(name).expanduser()
+        if direct.suffix == ".onnx" and direct.is_file():
+            return direct
         for d in self._voice_search_dirs():
             if d.is_dir():
-                for onnx in d.glob("*.onnx"):
-                    if onnx.with_suffix(".onnx.json").is_file():
-                        return True
-        return False
+                cand = d / f"{name}.onnx"
+                if cand.is_file() and cand.with_suffix(".onnx.json").is_file():
+                    return cand
+        return None
 
     def get_status(self) -> ToolStatus:
-        installed = shutil.which("piper") is not None
-        if not installed:
-            try:
-                import piper  # noqa: F401
-                installed = True
-            except ImportError:
-                return ToolStatus.UNAVAILABLE
-        # Installed but unusable until a voice model is downloaded — report
-        # DEGRADED so preflight doesn't claim TTS is ready when it will fail.
-        return ToolStatus.AVAILABLE if self._has_voice_model() else ToolStatus.DEGRADED
+        if not self._piper_installed():
+            return ToolStatus.UNAVAILABLE
+        # Installed, but preflight is only truthful if the default voice — the
+        # one execute() uses when no model is specified — is actually present.
+        # Report DEGRADED when it is missing so preflight doesn't claim TTS is
+        # ready when the default execute path will fail. Callers may still run
+        # execute() with an explicitly-provided voice that is installed.
+        return (
+            ToolStatus.AVAILABLE
+            if self._find_voice(self.default_voice)
+            else ToolStatus.DEGRADED
+        )
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
         return 0.0
 
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
-        status = self.get_status()
-        if status == ToolStatus.UNAVAILABLE:
+        if not self._piper_installed():
             return ToolResult(success=False, error="Piper TTS not installed. " + self.install_instructions)
-        if status == ToolStatus.DEGRADED:
+        # Gate on the specific voice this call will use, not the coarse status —
+        # a caller may request an installed voice even when the default is absent.
+        model = inputs.get("model", self.default_voice)
+        if self._find_voice(model) is None:
+            searched = ", ".join(str(d) for d in self._voice_search_dirs())
             return ToolResult(
                 success=False,
                 error=(
-                    "Piper is installed but no voice model was found. Download one:\n"
-                    f"  python -m piper.download_voices {self.default_voice}"
+                    f"Piper is installed but voice model '{model}' was not found "
+                    f"(searched: {searched}). Download it:\n"
+                    f"  python -m piper.download_voices {model}"
                 ),
             )
 

--- a/tools/audio/piper_tts.py
+++ b/tools/audio/piper_tts.py
@@ -37,10 +37,11 @@ class PiperTTS(BaseTool):
     install_instructions = (
         "Install Piper TTS:\n"
         "  pip install piper-tts\n"
-        "Or download from https://github.com/rhasspy/piper/releases\n"
-        "Then download a voice model:\n"
-        "  piper --download-dir ~/.piper/models --model en_US-lessac-medium"
+        "Then download at least one voice model (required — Piper ships none):\n"
+        "  python -m piper.download_voices en_US-lessac-medium\n"
+        "The model resolves from the current directory or PIPER_VOICE_DIR."
     )
+    default_voice = "en_US-lessac-medium"
     agent_skills = ["text-to-speech"]
 
     capabilities = [
@@ -95,17 +96,53 @@ class PiperTTS(BaseTool):
     side_effects = ["writes audio file to output_path"]
     user_visible_verification = ["Listen to generated audio for intelligibility"]
 
+    @staticmethod
+    def _voice_search_dirs() -> list[Path]:
+        import os
+
+        dirs = [Path.cwd()]
+        env_dir = os.environ.get("PIPER_VOICE_DIR")
+        if env_dir:
+            dirs.append(Path(env_dir).expanduser())
+        dirs += [Path.home() / ".local/share/piper", Path.home() / ".piper/models"]
+        return dirs
+
+    def _has_voice_model(self) -> bool:
+        """True if any Piper voice model (.onnx + .onnx.json) is discoverable."""
+        for d in self._voice_search_dirs():
+            if d.is_dir():
+                for onnx in d.glob("*.onnx"):
+                    if onnx.with_suffix(".onnx.json").is_file():
+                        return True
+        return False
+
     def get_status(self) -> ToolStatus:
-        if shutil.which("piper"):
-            return ToolStatus.AVAILABLE
-        return ToolStatus.UNAVAILABLE
+        installed = shutil.which("piper") is not None
+        if not installed:
+            try:
+                import piper  # noqa: F401
+                installed = True
+            except ImportError:
+                return ToolStatus.UNAVAILABLE
+        # Installed but unusable until a voice model is downloaded — report
+        # DEGRADED so preflight doesn't claim TTS is ready when it will fail.
+        return ToolStatus.AVAILABLE if self._has_voice_model() else ToolStatus.DEGRADED
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
         return 0.0
 
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
-        if self.get_status() != ToolStatus.AVAILABLE:
-            return ToolResult(success=False, error="Piper TTS not available. " + self.install_instructions)
+        status = self.get_status()
+        if status == ToolStatus.UNAVAILABLE:
+            return ToolResult(success=False, error="Piper TTS not installed. " + self.install_instructions)
+        if status == ToolStatus.DEGRADED:
+            return ToolResult(
+                success=False,
+                error=(
+                    "Piper is installed but no voice model was found. Download one:\n"
+                    f"  python -m piper.download_voices {self.default_voice}"
+                ),
+            )
 
         start = time.time()
         try:
@@ -123,7 +160,7 @@ class PiperTTS(BaseTool):
         proc = subprocess.run(
             [
                 "piper",
-                "--model", inputs.get("model", "en_US-lessac-medium"),
+                "--model", inputs.get("model", self.default_voice),
                 "--speaker", str(inputs.get("speaker_id", 0)),
                 "--length-scale", str(inputs.get("length_scale", 1.0)),
                 "--sentence-silence", str(inputs.get("sentence_silence", 0.3)),
@@ -144,12 +181,12 @@ class PiperTTS(BaseTool):
             success=True,
             data={
                 "provider": self.provider,
-                "model": inputs.get("model", "en_US-lessac-medium"),
+                "model": inputs.get("model", self.default_voice),
                 "speaker_id": inputs.get("speaker_id", 0),
                 "text_length": len(inputs["text"]),
                 "output": str(output_path),
                 "format": "wav",
             },
             artifacts=[str(output_path)],
-            model=inputs.get("model", "en_US-lessac-medium"),
+            model=inputs.get("model", self.default_voice),
         )

--- a/tools/audio/piper_tts.py
+++ b/tools/audio/piper_tts.py
@@ -119,11 +119,16 @@ class PiperTTS(BaseTool):
         """Locate a Piper voice model (.onnx + .onnx.json) by name or path.
 
         Accepts a direct path to an .onnx file or a bare model name resolved
-        against the voice search dirs. Returns the .onnx path if found.
+        against the voice search dirs. Returns the .onnx path only when its
+        sibling .onnx.json config is present — Piper needs the pair, so a lone
+        .onnx would pass preflight and then fail at synthesis. The companion
+        check applies equally to explicit paths and bare names.
         """
         direct = Path(name).expanduser()
-        if direct.suffix == ".onnx" and direct.is_file():
-            return direct
+        if direct.suffix == ".onnx":
+            if direct.is_file() and direct.with_suffix(".onnx.json").is_file():
+                return direct
+            return None
         for d in self._voice_search_dirs():
             if d.is_dir():
                 cand = d / f"{name}.onnx"


### PR DESCRIPTION
Fixes the Piper half of #237: `piper_tts` reports itself available when it cannot actually synthesize.

**Scope note:** this PR originally also carried the Remotion asset-staging and `resolveAsset` fixes. #466 landed independent fixes for both of those on `main` (render-scoped `--public-dir` with `_mirror_public_dir`, and `file://` parsing that covers more Windows forms than mine did), so I've dropped them and rebased what's left onto current `main`. What remains is Piper-only — two files, no overlap with anything already merged.

## The defect (still present on `main`)

```python
def get_status(self) -> ToolStatus:
    if shutil.which("piper"):
        return ToolStatus.AVAILABLE
    return ToolStatus.UNAVAILABLE
```

Availability is gated purely on the binary being on PATH. Piper ships **no** voice models, so a fresh `pip install piper-tts` reports `AVAILABLE` and then fails at synthesis. There is no voice resolution at all — `execute()` passes the bare model name through, so a voice installed anywhere other than the current working directory is invisible to Piper even when present.

## What this changes

1. **Status reflects the voice, not just the binary.** `AVAILABLE` only when the default voice resolves; `DEGRADED` when Piper is installed but that voice is missing; `UNAVAILABLE` when the executable is absent (the Python package importing is not sufficient — this tool shells out).
2. **Voice resolution.** `_find_voice()` searches cwd, `PIPER_VOICE_DIR`, `~/.local/share/piper`, `~/.piper/models`, and passes the resolved `.onnx` path to Piper — a voice outside cwd now loads instead of silently failing.
3. **Per-call gating.** `execute()` gates on the voice that call will use, so an explicitly requested installed voice still runs when the default is absent, and the error names the requested model rather than the default.
4. **Companion file required.** A `.onnx` only resolves when its sibling `.onnx.json` exists. Piper needs the pair; a lone model passes preflight and then fails at load. This now applies to explicit paths as well as bare names.

## Evidence

`tests/tools/test_piper_tts_status.py` — 9 tests, all dependencies mocked, no Piper install needed.

- With `main`'s `piper_tts.py` and these tests: **8 failed, 1 passed**
- With this branch: **9 passed**

Full `tests/tools` + `tests/contracts` on this branch: **1738 passed, 18 failed** — the same 18 Google-provider contract failures present on pristine `upstream/main` (verified in a clean worktree: 1730 passed, 18 failed), unrelated to this change.

Refs #237
