### PR TITLE
fix(documentary-montage): render real footage (Soundtrack guard + cuts→scenes)

### DIFF
--- a/LOCAL_PATCHES_2026-06-30.md
+++ b/LOCAL_PATCHES_2026-06-30.md
@@ -1,0 +1,62 @@
+# Local patches — 2026-06-30
+
+Bug fixes applied on top of upstream `299dd4f` (Merge PR #236).
+Both are independent of, and complementary to, the already-applied **PR #238**
+(local zero-key asset staging → `public/_om_assets`). They make the
+`documentary-montage` (CinematicRenderer) Remotion render path actually produce
+visible footage from a schema-compliant `edit_decisions`.
+
+Verified: full test suite **426 passed / 8 skipped**; end-to-end render of a
+schema `cuts` edit_decisions (no hand-authored `scenes`) with `music:{source:"none"}`
+produces a non-black 1080p MP4 (frame inspected).
+
+---
+
+## Fix 1 — CinematicRenderer crashes on a music/soundtrack object without `src`
+
+**File:** `remotion-composer/src/CinematicRenderer.tsx`
+
+**Symptom:** Whole render aborts with
+`TypeError: Cannot read properties of undefined (reading 'startsWith')`
+at `resolveAsset` ← `Soundtrack`. Triggered by a music opt-out that passes a
+truthy-but-srcless object, e.g. `music: {"source": "none"}`.
+
+**Root cause:** the render sites guarded the *object* (`{music ? …}` /
+`{soundtrack ? …}`) but then passed `music.src` / `soundtrack.src` (which is
+`undefined`) into `<Soundtrack>` → `resolveAsset(undefined).startsWith(...)`.
+
+**Fix:**
+- `resolveAsset()`: `if (!src) return "";` (fail soft instead of throwing).
+- Render sites: guard on `.src` — `{music?.src ? …}` and `{soundtrack?.src ? …}`.
+
+---
+
+## Fix 2 — documentary-montage renders a black video (cuts never mapped to scenes)
+
+**File:** `tools/video/video_compose.py` (`_remotion_render`)
+
+**Symptom:** `operation="render"` with a schema-valid `edit_decisions` (which
+carries `cuts`, per `schemas/artifacts/edit_decisions.schema.json`) and
+`renderer_family="documentary-montage"` "succeeds" but the output is a 30s black
+video. This is the core "local rendering broken" symptom.
+
+**Root cause:** `documentary-montage` / `cinematic-trailer` route to the
+`CinematicRenderer` composition, which consumes a `scenes[]` array
+(`{id, kind, src, startSeconds, durationSeconds}`). `_render` →
+`_remotion_render` passes `edit_decisions` through (staging `cuts[].source` to
+`public/`) but never builds `scenes`. The composition falls back to its empty
+default `scenes` → black render, 30s default duration.
+
+**Fix:** in `_remotion_render`, after asset staging, when the target composition
+is `CinematicRenderer` and no `scenes` are present, build video `scenes` from the
+staged `cuts` (cumulative `startSeconds`, `durationSeconds = out − in`, falling
+back to `duration_seconds`). Gated so non-cinematic compositions (Explainer etc.)
+are untouched.
+
+---
+
+## Not changed / out of scope
+- Music generation still requires a provider key (ElevenLabs `music_gen`
+  unavailable without one); the fixes above make the *no-music* path valid.
+- `corpus_builder` (degraded) / `clip_search` (unavailable) — standard CLIP
+  retrieval path; the fast path (`direct_clip_search`) works zero-key.

--- a/remotion-composer/src/CinematicRenderer.tsx
+++ b/remotion-composer/src/CinematicRenderer.tsx
@@ -14,6 +14,11 @@ import {
 } from "remotion";
 
 function resolveAsset(src: string): string {
+  // Bugfix (2026-06-30): guard against undefined/empty src. A soundtrack/music
+  // entry that is a truthy object without a `.src` (e.g. {source:"none"} from a
+  // music opt-out) previously crashed the entire render here via
+  // `undefined.startsWith`. Fail soft instead.
+  if (!src) return "";
   if (src.startsWith("http://") || src.startsWith("https://") || src.startsWith("data:")) {
     return src;
   }
@@ -475,7 +480,7 @@ export const CinematicRenderer: React.FC<CinematicRendererProps> = ({
   return (
     <AbsoluteFill style={{ backgroundColor: "#000000" }}>
       {/* Layer 1: Narration audio */}
-      {soundtrack ? (
+      {soundtrack?.src ? (
         <Soundtrack
           src={soundtrack.src}
           volume={soundtrack.volume ?? 1}
@@ -486,7 +491,7 @@ export const CinematicRenderer: React.FC<CinematicRendererProps> = ({
         />
       ) : null}
       {/* Layer 2: Music bed (separate track, ducked) */}
-      {music ? (
+      {music?.src ? (
         <Soundtrack
           src={music.src}
           volume={music.volume ?? 0.15}

--- a/tools/video/video_compose.py
+++ b/tools/video/video_compose.py
@@ -1651,15 +1651,71 @@ class VideoCompose(BaseTool):
         # Deep-copy props so we don't mutate the original
         props = json.loads(json.dumps(composition_data))
 
-        # Convert absolute file paths to file:// URIs for Remotion's
-        # Img and OffthreadVideo components
+        # Stage local asset files into the composer's public/ directory and
+        # reference them via staticFile-relative paths. Remotion's renderer only
+        # downloads http(s) URLs or files served from public/ — file:// URIs are
+        # rejected at render time — so local images, video, narration, and music
+        # must be copied under public/ for both cuts and audio layers to resolve.
+        import hashlib
+
+        composer_dir = Path(__file__).resolve().parent.parent.parent / "remotion-composer"
+        staged_dir = composer_dir / "public" / "_om_assets"
+
+        def _stage_asset(value: str) -> str:
+            if not value or value.startswith(("http://", "https://", "data:")):
+                return value
+            local = Path(value.replace("file://", "", 1)).expanduser()
+            if not local.exists():
+                return value
+            staged_dir.mkdir(parents=True, exist_ok=True)
+            digest = hashlib.md5(str(local.resolve()).encode()).hexdigest()[:12]
+            dest_name = f"{digest}{local.suffix}"
+            dest = staged_dir / dest_name
+            if not dest.exists():
+                shutil.copy2(local, dest)
+            return f"_om_assets/{dest_name}"  # resolved by staticFile() in the composer
+
         for cut in props.get("cuts", []):
-            source = cut.get("source", "")
-            if source and not source.startswith(("http://", "https://", "file://")):
-                resolved = Path(source).resolve()
-                if resolved.exists():
-                    posix = resolved.as_posix()
-                    cut["source"] = f"file:///{posix}" if not posix.startswith("/") else f"file://{posix}"
+            cut["source"] = _stage_asset(cut.get("source", ""))
+
+        audio = props.get("audio")
+        if isinstance(audio, dict):
+            for layer in ("narration", "music"):
+                entry = audio.get(layer)
+                if isinstance(entry, dict) and entry.get("src"):
+                    entry["src"] = _stage_asset(entry["src"])
+
+        # Bugfix (2026-06-30): map cuts -> scenes for the CinematicRenderer.
+        # The CinematicRenderer composition (renderer_family documentary-montage /
+        # cinematic-trailer) consumes a `scenes` array (id/kind/src/startSeconds/
+        # durationSeconds). edit_decisions only carry `cuts`, and nothing here was
+        # translating them, so the composition fell back to its empty default
+        # scenes and rendered a black video (the "local rendering broken" symptom).
+        # Build video scenes from the already-staged cuts when none are present.
+        _rf = (composition_data or {}).get("renderer_family", "explainer-data")
+        if self._get_composition_id(_rf) == "CinematicRenderer" and not props.get("scenes"):
+            _scenes: list[dict[str, Any]] = []
+            _t = 0.0
+            for _c in props.get("cuts", []):
+                try:
+                    _dur = float(_c.get("out_seconds", 0)) - float(_c.get("in_seconds", 0))
+                except (TypeError, ValueError):
+                    _dur = 0.0
+                if _dur <= 0:
+                    _dur = float(_c.get("duration_seconds", 0) or 0)
+                _src = _c.get("source", "")
+                if _dur <= 0 or not _src:
+                    continue
+                _scenes.append({
+                    "id": _c.get("id", f"sc{len(_scenes)}"),
+                    "kind": "video",
+                    "src": _src,  # already staged to _om_assets/ above
+                    "startSeconds": round(_t, 3),
+                    "durationSeconds": round(_dur, 3),
+                })
+                _t += _dur
+            if _scenes:
+                props["scenes"] = _scenes
 
         # Build a custom themeConfig from the playbook's actual colors.
         # This ensures every video gets a unique visual identity derived


### PR DESCRIPTION
## What

Two fixes that make the **documentary-montage** (`CinematicRenderer`) Remotion
render path produce **visible footage** from a schema-compliant `edit_decisions`.
Today such a render either crashes (on a music opt-out) or produces a 30s black
video.

### Fix 1 — CinematicRenderer crashes when music/soundtrack has no `src`
The render sites guard the *object* (`{music ? <Soundtrack src={music.src}/> : null}`),
but a music opt-out passes a truthy-but-srcless object (e.g. `{"source":"none"}`),
so `music.src` is `undefined` → `resolveAsset(undefined).startsWith(...)` aborts
the entire render.
- Guard on `.src`: `{music?.src ? … }` / `{soundtrack?.src ? … }`
- Fail-soft `resolveAsset`: `if (!src) return ""`

### Fix 2 — documentary-montage renders a black video (cuts never mapped to scenes)
`renderer_family: documentary-montage` routes to the `CinematicRenderer`
composition, which consumes a `scenes[]` array. But `edit_decisions` carry
`cuts` (per `schemas/artifacts/edit_decisions.schema.json`), and
`_remotion_render` never builds `scenes` from them → the composition falls back
to its empty default `scenes` → 30s black output.
- Build video `scenes` from the staged `cuts` (`startSeconds` cumulative,
  `durationSeconds = out − in`), gated to `CinematicRenderer` compositions so
  Explainer/others are untouched.

## Relationship to #238 (please read)
The cuts→scenes mapping depends on the **local asset staging from #238** (the
`public/_om_assets` staging). That staging is included in this branch's
`video_compose.py` diff because it isn't merged yet. **This PR should be based
on / rebased onto #238** (or merged after it). `CinematicRenderer.tsx` is fully
independent of #238.

## Verification
- Full test suite: **426 passed / 8 skipped**, no regressions.
- End-to-end: a schema-valid `cuts` `edit_decisions` with `music:{source:"none"}`
  now renders non-black 1080p footage (frame inspected) — previously black.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
