### PR TITLE
fix(review): distinguish music-only audio from narration

### DIFF
--- a/tests/tools/test_hyperframes_compose.py
+++ b/tests/tools/test_hyperframes_compose.py
@@ -539,6 +539,40 @@ def test_runtime_swap_detected_stays_false_when_proposal_matches(tmp_path):
     assert "ok" in pp["runtime_swap_check"]
 
 
+def test_final_review_does_not_mark_music_only_audio_as_narration(tmp_path):
+    import subprocess
+
+    mp4 = tmp_path / "music_only.mp4"
+    subprocess.run(
+        [
+            "ffmpeg", "-y",
+            "-f", "lavfi", "-i", "color=c=blue:s=320x240:d=2",
+            "-f", "lavfi", "-i", "sine=frequency=440:duration=2",
+            "-c:v", "libx264", "-pix_fmt", "yuv420p",
+            "-c:a", "aac",
+            "-shortest", str(mp4),
+        ],
+        capture_output=True, check=True, timeout=30,
+    )
+
+    review = VideoCompose()._run_final_review(
+        mp4,
+        edit_decisions={
+            "version": "1.0",
+            "render_runtime": "remotion",
+            "renderer_family": "animation-first",
+            "cuts": [{"id": "c1", "source": "x", "in_seconds": 0, "out_seconds": 2}],
+            "audio": {
+                "music": {"asset_id": "music_1", "volume": 1.0},
+            },
+        },
+    )
+
+    audio = review["checks"]["audio_spotcheck"]
+    assert audio["music_present"] is True
+    assert audio["narration_present"] is False
+
+
 def test_both_runtimes_visible_in_render_engines_when_available():
     """Regression for the 'silently picks Remotion' failure mode.
 

--- a/tools/video/video_compose.py
+++ b/tools/video/video_compose.py
@@ -2078,6 +2078,14 @@ class VideoCompose(BaseTool):
             "mix_intelligible": True,
             "issues": [],
         }
+        audio_config = (edit_decisions.get("audio") or {}) if edit_decisions else {}
+        legacy_music = edit_decisions.get("music") if edit_decisions else None
+        declared_narration = self._declares_audio_layer(audio_config.get("narration"))
+        declared_music = (
+            self._declares_audio_layer(audio_config.get("music"))
+            or self._declares_audio_layer(legacy_music)
+        )
+        declared_audio_layers = declared_narration or declared_music
         if technical_probe.get("has_audio") and duration > 0:
             try:
                 # Use ffmpeg volumedetect to check audio levels
@@ -2110,11 +2118,14 @@ class VideoCompose(BaseTool):
                         audio_spotcheck["issues"].append(
                             f"Mean volume {mean_vol:.1f} dB — effectively silent"
                         )
-                    # Assume narration present if mean volume is reasonable
-                    if mean_vol > -40:
+                    audible_audio = mean_vol > -60
+                    if declared_narration:
+                        audio_spotcheck["narration_present"] = audible_audio
+                    elif not declared_audio_layers and mean_vol > -40:
                         audio_spotcheck["narration_present"] = True
-                    # Assume music present if audio exists (conservative)
-                    if mean_vol > -50:
+                    if declared_music:
+                        audio_spotcheck["music_present"] = audible_audio
+                    elif not declared_audio_layers and mean_vol > -50:
                         audio_spotcheck["music_present"] = True
 
                 if max_vol is not None and max_vol > -0.5:
@@ -2325,6 +2336,12 @@ class VideoCompose(BaseTool):
         )
 
         return final_review
+
+    @staticmethod
+    def _declares_audio_layer(layer: Any) -> bool:
+        if not isinstance(layer, dict):
+            return bool(layer)
+        return any(value not in (None, "", [], {}) for value in layer.values())
 
     @staticmethod
     def _parse_probe_fps(fps_str: str) -> float:


### PR DESCRIPTION
## Summary

Final review previously inferred `narration_present` from audio loudness alone. That made music-only renders show up as if narration/dialogue was present whenever the audio stream was loud enough.

This PR makes the audio spotcheck use the structured edit-decision audio intent when it is available: `audio.narration` marks narration, `audio.music` or legacy `music` marks music. If no audio layer intent is declared, the existing loudness-based fallback is preserved for compatibility.

## Related issue

Refs #218

## Changes

- Use declared `edit_decisions.audio` layers to distinguish narration from music in final review.
- Preserve the previous volume heuristic when no audio layer intent is declared.
- Add a regression test for a music-only render so it reports `music_present=true` and `narration_present=false`.

## Testing

- `.venv/bin/python -m pytest tests/tools/test_hyperframes_compose.py::test_final_review_does_not_mark_music_only_audio_as_narration -q`
- `.venv/bin/python -m pytest tests/tools/test_hyperframes_compose.py::test_runtime_swap_detected_flips_when_proposal_packet_disagrees tests/tools/test_hyperframes_compose.py::test_runtime_swap_detected_stays_false_when_proposal_matches tests/tools/test_hyperframes_compose.py::test_final_review_does_not_mark_music_only_audio_as_narration tests/tools/test_hyperframes_compose.py::test_run_final_review_includes_transcript_comparison_section -q`
- `PYTHON=.venv/bin/python make lint`
- `git diff --check`

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally.
- [x] No docs/README update needed; this corrects review metadata behavior without changing user setup or commands.
- [x] No unrelated files are included in the diff.
