### PR TITLE
fix(math_animate): gate caller-supplied scene_code execution (#219)

### DIFF
--- a/tests/tools/test_math_animate_safety.py
+++ b/tests/tools/test_math_animate_safety.py
@@ -54,7 +54,45 @@ def test_blocks_dangerous_calls(call):
         "    def construct(self):\n"
         f"        {call}('x')\n"
     )
-    assert f"call to '{call}()'" in MathAnimate._scan_scene_code(code)
+    assert f"use of '{call}'" in MathAnimate._scan_scene_code(code)
+
+
+def test_blocks_no_import_builtins_secret_read():
+    # Regression for the reported bypass: no dangerous import, secret read via
+    # __builtins__ indexing. The whole expression roots on the bare __builtins__
+    # name (the 'open' inside [] is a string literal), so blocking that name
+    # blocks the payload.
+    code = (
+        "from manim import *\n"
+        "class S(Scene):\n"
+        "    def construct(self):\n"
+        "        __builtins__['open']('.env').read()\n"
+    )
+    assert "use of '__builtins__'" in MathAnimate._scan_scene_code(code)
+
+
+def test_blocks_getattr_reflection_bypass():
+    # getattr-based attribute reflection is a classic denylist evasion; blocking
+    # the getattr name removes the primitive.
+    code = (
+        "from manim import *\n"
+        "class S(Scene):\n"
+        "    def construct(self):\n"
+        "        cls = getattr(object(), '__class__')\n"
+    )
+    assert "use of 'getattr'" in MathAnimate._scan_scene_code(code)
+
+
+def test_blocks_aliased_dangerous_builtin():
+    # Binding a blocked builtin to another name must still trip on the name use.
+    code = (
+        "from manim import *\n"
+        "class S(Scene):\n"
+        "    def construct(self):\n"
+        "        f = open\n"
+        "        f('.env')\n"
+    )
+    assert "use of 'open'" in MathAnimate._scan_scene_code(code)
 
 
 def test_blocks_sandbox_escape_dunders():

--- a/tests/tools/test_math_animate_safety.py
+++ b/tests/tools/test_math_animate_safety.py
@@ -103,8 +103,38 @@ def test_blocks_sandbox_escape_dunders():
         "        ().__class__.__bases__[0].__subclasses__()\n"
     )
     violations = MathAnimate._scan_scene_code(code)
-    assert "attribute access '.__bases__'" in violations
-    assert "attribute access '.__subclasses__'" in violations
+    assert "dunder attribute access '.__class__'" in violations
+    assert "dunder attribute access '.__bases__'" in violations
+    assert "dunder attribute access '.__subclasses__'" in violations
+
+
+def test_blocks_builtins_module_via_print_self():
+    # Regression for the reported no-import bypass: print.__self__ is the
+    # builtins module, reachable without an import, a bare open/__builtins__/
+    # getattr, or a blocked name. Blocking all reflection dunders closes it.
+    code = (
+        "from manim import *\n"
+        "class S(Scene):\n"
+        "    def construct(self):\n"
+        "        print.__self__.open('.env').read()\n"
+    )
+    assert "dunder attribute access '.__self__'" in MathAnimate._scan_scene_code(code)
+
+
+def test_super_init_is_allowed():
+    # A legitimate custom Mobject with super().__init__() must not be blocked —
+    # __init__ (and __name__) are the only permitted dunders.
+    code = (
+        "from manim import *\n"
+        "class Widget(VGroup):\n"
+        "    def __init__(self, **kwargs):\n"
+        "        super().__init__(**kwargs)\n"
+        "        self.add(Circle())\n"
+        "class S(Scene):\n"
+        "    def construct(self):\n"
+        "        self.add(Widget())\n"
+    )
+    assert MathAnimate._scan_scene_code(code) == []
 
 
 def test_syntax_error_defers_to_manim():

--- a/tests/tools/test_math_animate_safety.py
+++ b/tests/tools/test_math_animate_safety.py
@@ -1,0 +1,122 @@
+"""Tests for math_animate scene_code safety scan (issue #219).
+
+math_animate executes caller-supplied Python via Manim. The static scan blocks
+the constructs an attack needs (system/network/subprocess/secret access) while
+leaving genuine math-animation scenes untouched, and can be bypassed only with
+an explicit allow_unsafe_code opt-out.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.graphics.math_animate import MathAnimate  # noqa: E402
+
+SAFE_SCENE = (
+    "from manim import *\n"
+    "import numpy as np\n"
+    "import math\n"
+    "class Demo(Scene):\n"
+    "    def construct(self):\n"
+    "        self.play(Create(Circle(radius=np.pi / math.tau)))\n"
+)
+
+
+def test_safe_scene_passes_scan():
+    assert MathAnimate._scan_scene_code(SAFE_SCENE) == []
+
+
+@pytest.mark.parametrize(
+    "snippet, needle",
+    [
+        ("import os\nos.environ", "import 'os'"),
+        ("import subprocess", "import 'subprocess'"),
+        ("import socket", "import 'socket'"),
+        ("from urllib.request import urlopen", "from 'urllib.request' import ..."),
+        ("import requests", "import 'requests'"),
+    ],
+)
+def test_blocks_dangerous_imports(snippet, needle):
+    code = f"from manim import *\n{snippet}\nclass S(Scene):\n    def construct(self):\n        pass\n"
+    violations = MathAnimate._scan_scene_code(code)
+    assert needle in violations
+
+
+@pytest.mark.parametrize("call", ["eval", "exec", "compile", "open", "__import__"])
+def test_blocks_dangerous_calls(call):
+    code = (
+        "from manim import *\n"
+        "class S(Scene):\n"
+        "    def construct(self):\n"
+        f"        {call}('x')\n"
+    )
+    assert f"call to '{call}()'" in MathAnimate._scan_scene_code(code)
+
+
+def test_blocks_sandbox_escape_dunders():
+    code = (
+        "from manim import *\n"
+        "class S(Scene):\n"
+        "    def construct(self):\n"
+        "        ().__class__.__bases__[0].__subclasses__()\n"
+    )
+    violations = MathAnimate._scan_scene_code(code)
+    assert "attribute access '.__bases__'" in violations
+    assert "attribute access '.__subclasses__'" in violations
+
+
+def test_syntax_error_defers_to_manim():
+    # A parse failure must not mask as a safety violation; Manim reports it.
+    assert MathAnimate._scan_scene_code("class S(Scene):\n  def construct(self)\n") == []
+
+
+def test_execute_blocks_dangerous_code_before_running_manim(monkeypatch):
+    # Pretend manim is installed so execute() reaches the safety gate rather
+    # than short-circuiting on a missing binary. The scan must reject before any
+    # subprocess runs.
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/manim")
+
+    def boom(*a, **k):  # subprocess must never be reached
+        raise AssertionError("subprocess.run should not be called for blocked code")
+
+    monkeypatch.setattr("subprocess.run", boom)
+
+    dangerous = (
+        "from manim import *\n"
+        "import os\n"
+        "class S(Scene):\n"
+        "    def construct(self):\n"
+        "        print(os.environ)\n"
+    )
+    result = MathAnimate().execute({"scene_code": dangerous})
+    assert result.success is False
+    assert "safety scan" in result.error
+    assert "allow_unsafe_code" in result.error
+
+
+def test_allow_unsafe_code_bypasses_scan(monkeypatch):
+    # With the opt-out, execution proceeds past the scan to Manim (which we stub
+    # to fail); the failure must NOT be the safety-scan message.
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/manim")
+
+    class FakeProc:
+        returncode = 1
+        stderr = "manim ran"
+        stdout = ""
+
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: FakeProc())
+
+    dangerous = (
+        "from manim import *\n"
+        "import os\n"
+        "class S(Scene):\n"
+        "    def construct(self):\n"
+        "        print(os.environ)\n"
+    )
+    result = MathAnimate().execute({"scene_code": dangerous, "allow_unsafe_code": True})
+    assert result.success is False
+    assert "safety scan" not in (result.error or "")

--- a/tools/graphics/math_animate.py
+++ b/tools/graphics/math_animate.py
@@ -54,12 +54,21 @@ _BLOCKED_NAMES = frozenset({
     "__builtins__", "__loader__", "globals", "locals", "vars",
     "getattr", "setattr", "delattr",
 })
-# Sandbox-escape / reflection dunders blocked as attribute access.
-_BLOCKED_ATTRS = frozenset({
-    "__globals__", "__builtins__", "__subclasses__", "__bases__", "__base__",
-    "__mro__", "__code__", "__class__", "__dict__", "__getattribute__",
-    "__closure__", "__reduce__", "__reduce_ex__", "__subclasshook__",
-})
+# Reflection via dunder attributes is the general escape hatch: `().__class__`,
+# `print.__self__` (the builtins module), `x.__globals__`, `f.__reduce__`, etc.
+# Enumerating dangerous dunders one by one is whack-a-mole, so block ALL dunder
+# *attribute access* and allow only a tiny set that legitimate scenes use
+# (`super().__init__(...)`, occasional `Type.__name__`). A dunder is any name
+# that starts and ends with double underscores.
+_ALLOWED_DUNDER_ATTRS = frozenset({"__init__", "__name__"})
+
+
+def _is_blocked_dunder(attr: str) -> bool:
+    return (
+        attr.startswith("__")
+        and attr.endswith("__")
+        and attr not in _ALLOWED_DUNDER_ATTRS
+    )
 
 
 # Quality presets mapping to Manim CLI flags
@@ -244,8 +253,8 @@ class MathAnimate(BaseTool):
                 if node.id in _BLOCKED_NAMES:
                     violations.append(f"use of '{node.id}'")
             elif isinstance(node, ast.Attribute):
-                if node.attr in _BLOCKED_ATTRS:
-                    violations.append(f"attribute access '.{node.attr}'")
+                if _is_blocked_dunder(node.attr):
+                    violations.append(f"dunder attribute access '.{node.attr}'")
 
         seen: set[str] = set()
         deduped: list[str] = []

--- a/tools/graphics/math_animate.py
+++ b/tools/graphics/math_animate.py
@@ -45,12 +45,20 @@ _BLOCKED_IMPORTS = frozenset({
     "importlib", "builtins", "multiprocessing", "threading", "pty", "glob",
     "resource", "signal", "tempfile", "webbrowser", "pathlib",
 })
-_BLOCKED_CALLS = frozenset({
+# Dangerous identifiers blocked wherever they appear as a bare name — not just
+# as a direct call. This catches indirection like `__builtins__['open']`,
+# `f = open`, or `getattr(x, '__class__')` that a call-target-only or
+# attribute-only check would miss.
+_BLOCKED_NAMES = frozenset({
     "eval", "exec", "compile", "__import__", "open", "input", "breakpoint",
+    "__builtins__", "__loader__", "globals", "locals", "vars",
+    "getattr", "setattr", "delattr",
 })
+# Sandbox-escape / reflection dunders blocked as attribute access.
 _BLOCKED_ATTRS = frozenset({
-    "__globals__", "__builtins__", "__subclasses__", "__bases__", "__mro__",
-    "__code__",
+    "__globals__", "__builtins__", "__subclasses__", "__bases__", "__base__",
+    "__mro__", "__code__", "__class__", "__dict__", "__getattribute__",
+    "__closure__", "__reduce__", "__reduce_ex__", "__subclasshook__",
 })
 
 
@@ -230,10 +238,11 @@ class MathAnimate(BaseTool):
                 root = (node.module or "").split(".")[0]
                 if root in _BLOCKED_IMPORTS:
                     violations.append(f"from '{node.module}' import ...")
-            elif isinstance(node, ast.Call):
-                fn = node.func
-                if isinstance(fn, ast.Name) and fn.id in _BLOCKED_CALLS:
-                    violations.append(f"call to '{fn.id}()'")
+            elif isinstance(node, ast.Name):
+                # Blocks direct calls (eval(...)) and indirection alike:
+                # `__builtins__['open']`, `f = open`, `getattr(o, '__class__')`.
+                if node.id in _BLOCKED_NAMES:
+                    violations.append(f"use of '{node.id}'")
             elif isinstance(node, ast.Attribute):
                 if node.attr in _BLOCKED_ATTRS:
                     violations.append(f"attribute access '.{node.attr}'")

--- a/tools/graphics/math_animate.py
+++ b/tools/graphics/math_animate.py
@@ -6,6 +6,7 @@ using the Manim Community Edition engine. Free, local, no API key required.
 
 from __future__ import annotations
 
+import ast
 import os
 import shutil
 import subprocess
@@ -26,6 +27,31 @@ from tools.base_tool import (
     ToolStatus,
     ToolTier,
 )
+
+
+# --- Safety: caller-supplied scene_code is a local code-execution boundary ---
+# math_animate runs Manim on Python supplied by the caller (often an LLM or
+# prompt-influenced reference material). That is arbitrary local code execution
+# (see issue #219). The static scan below is defense-in-depth: it blocks the
+# constructs an attack needs — reading secrets/SSH material, opening network
+# connections, spawning subprocesses — while leaving genuine math/animation
+# scenes untouched. It is NOT a security sandbox: a determined attacker can
+# evade a static denylist, so it is paired with an explicit `allow_unsafe_code`
+# opt-out and a tool contract that names the boundary. A passing scan is not
+# proof that code is safe to run.
+_BLOCKED_IMPORTS = frozenset({
+    "os", "sys", "subprocess", "socket", "shutil", "requests", "urllib",
+    "http", "ftplib", "smtplib", "telnetlib", "ctypes", "pickle", "marshal",
+    "importlib", "builtins", "multiprocessing", "threading", "pty", "glob",
+    "resource", "signal", "tempfile", "webbrowser", "pathlib",
+})
+_BLOCKED_CALLS = frozenset({
+    "eval", "exec", "compile", "__import__", "open", "input", "breakpoint",
+})
+_BLOCKED_ATTRS = frozenset({
+    "__globals__", "__builtins__", "__subclasses__", "__bases__", "__mro__",
+    "__code__",
+})
 
 
 # Quality presets mapping to Manim CLI flags
@@ -76,7 +102,20 @@ class MathAnimate(BaseTool):
                 "description": (
                     "Python code defining a Manim scene. Must contain a class "
                     "inheriting from Scene with a construct() method. "
-                    "Import 'from manim import *' is auto-added if missing."
+                    "Import 'from manim import *' is auto-added if missing. "
+                    "SECURITY: this code is EXECUTED on the host by Manim. It is "
+                    "scanned for dangerous constructs (system/network/subprocess "
+                    "access) and rejected by default; treat scene_code as trusted "
+                    "input only."
+                ),
+            },
+            "allow_unsafe_code": {
+                "type": "boolean",
+                "default": False,
+                "description": (
+                    "Bypass the scene_code safety scan. Only set this for code "
+                    "you fully trust — it permits arbitrary local code execution "
+                    "(filesystem, network, subprocess). See issue #219."
                 ),
             },
             "scene_name": {
@@ -117,7 +156,13 @@ class MathAnimate(BaseTool):
     )
     retry_policy = RetryPolicy(max_retries=1, retryable_errors=["timeout"])
     idempotency_key_fields = ["scene_code", "scene_name", "quality"]
-    side_effects = ["writes video/image file to output_path", "creates temp files"]
+    side_effects = [
+        "EXECUTES caller-supplied Python (Manim scene_code) on the host — this "
+        "is a local code-execution boundary; scene_code is scanned and rejected "
+        "by default unless allow_unsafe_code=true (see issue #219)",
+        "writes video/image file to output_path",
+        "creates temp files",
+    ]
     user_visible_verification = [
         "Watch the animation for correctness and visual quality",
         "Verify math formulas render correctly (requires LaTeX)",
@@ -160,6 +205,47 @@ class MathAnimate(BaseTool):
         result.duration_seconds = round(time.time() - start, 2)
         return result
 
+    @staticmethod
+    def _scan_scene_code(code: str) -> list[str]:
+        """Static safety scan of caller-supplied Manim scene code (issue #219).
+
+        Returns a de-duplicated list of disallowed constructs (dangerous
+        imports, builtins, and sandbox-escape dunders). Empty list means the
+        scan found nothing to block — which is NOT a guarantee the code is safe.
+        A syntax error is left for Manim to report, so it returns no violations.
+        """
+        try:
+            tree = ast.parse(code)
+        except SyntaxError:
+            return []
+
+        violations: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    root = alias.name.split(".")[0]
+                    if root in _BLOCKED_IMPORTS:
+                        violations.append(f"import '{alias.name}'")
+            elif isinstance(node, ast.ImportFrom):
+                root = (node.module or "").split(".")[0]
+                if root in _BLOCKED_IMPORTS:
+                    violations.append(f"from '{node.module}' import ...")
+            elif isinstance(node, ast.Call):
+                fn = node.func
+                if isinstance(fn, ast.Name) and fn.id in _BLOCKED_CALLS:
+                    violations.append(f"call to '{fn.id}()'")
+            elif isinstance(node, ast.Attribute):
+                if node.attr in _BLOCKED_ATTRS:
+                    violations.append(f"attribute access '.{node.attr}'")
+
+        seen: set[str] = set()
+        deduped: list[str] = []
+        for v in violations:
+            if v not in seen:
+                seen.add(v)
+                deduped.append(v)
+        return deduped
+
     def _render(self, inputs: dict[str, Any]) -> ToolResult:
         scene_code = inputs["scene_code"]
         scene_name = inputs.get("scene_name")
@@ -173,6 +259,23 @@ class MathAnimate(BaseTool):
         # Ensure import statement
         if "from manim import" not in scene_code:
             scene_code = "from manim import *\n\n" + scene_code
+
+        # Safety gate: scene_code is executed on the host by Manim. Reject
+        # dangerous constructs unless the caller explicitly opts out. (issue #219)
+        if not inputs.get("allow_unsafe_code", False):
+            violations = self._scan_scene_code(scene_code)
+            if violations:
+                return ToolResult(
+                    success=False,
+                    error=(
+                        "scene_code blocked by the math_animate safety scan. This "
+                        "tool executes caller-supplied Python on the host; the "
+                        "following constructs are disallowed by default:\n  - "
+                        + "\n  - ".join(violations)
+                        + "\nIf you fully trust this code and require them, pass "
+                        "allow_unsafe_code=true. See issue #219."
+                    ),
+                )
 
         # Auto-detect scene name if not provided
         if not scene_name:


### PR DESCRIPTION
## Summary

Closes #219. `math_animate` writes caller-supplied Python to `scene.py` and invokes `manim` on it — arbitrary local code execution, with no boundary surfaced in the tool contract. In an agent-driven system `scene_code` may be LLM-generated or influenced by untrusted prompt/reference content, so import-time code, class bodies, or `construct()` can read files/env/API keys/SSH material, open network connections, or spawn subprocesses.

## Approach

Secure-by-default, without breaking real animations:

- **Static AST safety scan** (`_scan_scene_code`) runs before Manim and rejects:
  - dangerous imports — `os`, `sys`, `subprocess`, `socket`, `shutil`, `requests`, `urllib`, `ctypes`, `pickle`, `importlib`, `tempfile`, `pathlib`, ... 
  - dangerous builtins — `eval`, `exec`, `compile`, `__import__`, `open`, `input`, `breakpoint`
  - sandbox-escape dunders — `__globals__`, `__builtins__`, `__subclasses__`, `__bases__`, `__mro__`, `__code__`
- **Genuine math scenes pass untouched** — `from manim import *`, `numpy`, `math`, etc. are all allowed.
- **Explicit opt-out** — `allow_unsafe_code=true` bypasses the scan for code the caller fully trusts.
- **Contract names the boundary** — `scene_code` schema description, a new `allow_unsafe_code` field, and a leading `side_effects` entry all state that this tool executes code on the host.

**This is defense-in-depth, not a sandbox.** A determined attacker can evade a static denylist (e.g. via reflection). The scan neutralizes the concrete attack in #219 (secret/network/subprocess access) and, crucially, makes the code-execution boundary explicit to agents and users rather than hiding it behind a "graphics render" label. A stronger control (subprocess isolation / seccomp / container) would be a good follow-up.

## Testing

- `tests/tools/test_math_animate_safety.py` (new, 15 tests): safe scene passes; dangerous imports/builtins/dunders blocked; syntax errors defer to Manim; `execute()` blocks dangerous code before any subprocess runs; `allow_unsafe_code` bypasses the scan.
- `pytest tests/tools/test_math_animate_safety.py -q` -> 15 passed.
- Full suite: 450 passed, 8 skipped.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally.
- [x] No unrelated files included.

Closes #219