### PR TITLE
replace retired openai image models with gpt-image-2 (dall-e 3 is shut down too)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ GOOGLE_CLOUD_LOCATION=            # Vertex AI region, default us-central1
 
 # --- Voice ---
 ELEVENLABS_API_KEY=          # TTS narration, music generation, sound effects
-OPENAI_API_KEY=              # OpenAI TTS fallback and DALL-E image generation
+OPENAI_API_KEY=              # OpenAI TTS fallback and GPT Image 2 image generation
 XAI_API_KEY=                 # Grok image generation/editing and Grok video generation
 DOUBAO_SPEECH_API_KEY=       # Volcengine Doubao Speech TTS (new console API Key)
 DOUBAO_SPEECH_VOICE_TYPE=    # Default Doubao speaker/voice type, e.g. zh_female_vv_uranus_bigtts

--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -489,7 +489,7 @@ Three selector tools abstract multi-provider capabilities. **Selectors auto-disc
 | Selector | Routes to | How it discovers |
 |----------|-----------|-----------------|
 | `tts_selector` | All tools with `capability="tts"` (ElevenLabs, Google TTS, OpenAI, Piper) | `registry.get_by_capability("tts")` |
-| `image_selector` | All tools with `capability="image_generation"` (FLUX, Google Imagen, DALL-E, Recraft, etc.) | `registry.get_by_capability("image_generation")` |
+| `image_selector` | All tools with `capability="image_generation"` (FLUX, Google Imagen, GPT Image, Recraft, etc.) | `registry.get_by_capability("image_generation")` |
 | `video_selector` | All tools with `capability="video_generation"` | `registry.get_by_capability("video_generation")` |
 
 Selectors route based on: user preference > availability > discovery order. They adapt input schemas between providers transparently.

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ SUNO_API_KEY=your-key          # Full songs, instrumentals, any genre
 
 # Voice & images:
 ELEVENLABS_API_KEY=your-key    # Premium TTS, AI music, sound effects
-OPENAI_API_KEY=your-key        # OpenAI TTS, DALL-E 3 images
+OPENAI_API_KEY=your-key        # OpenAI TTS, GPT Image 2 images
 XAI_API_KEY=your-key           # xAI Grok image edits/generation + Grok video generation
 GOOGLE_API_KEY=your-key        # Google Imagen images, Google TTS (700+ voices)
 
@@ -447,7 +447,7 @@ Each tool declares which Layer 3 skills it relies on. The agent reads Layer 1 to
 | **FLUX** | Cloud API | State-of-the-art quality |
 | **Google Imagen** | Cloud API | Imagen 4 — high-quality, multiple aspect ratios |
 | **Grok Imagine Image** | Cloud API | Strong image edits, style transfer, and multi-image compositing |
-| **DALL-E 3** | Cloud API | OpenAI's image model |
+| **GPT Image 2** | Cloud API | OpenAI's image model |
 | **Recraft** | Cloud API | Design-focused generation |
 | **Local Diffusion** | Local GPU | Stable Diffusion, free |
 | **Pexels** | Stock | Free stock images |

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -177,7 +177,7 @@ SUNO_API_KEY=your-key          # 完整的歌曲、伴奏，涵盖任何流派
 
 # 语音与图像:
 ELEVENLABS_API_KEY=your-key    # 顶级 TTS、AI 音乐、音效
-OPENAI_API_KEY=your-key        # OpenAI TTS、DALL-E 3 图像
+OPENAI_API_KEY=your-key        # OpenAI TTS、GPT Image 2 图像
 XAI_API_KEY=your-key           # xAI Grok 图像编辑/生成 + Grok 视频生成
 GOOGLE_API_KEY=your-key        # Google Imagen 图像、Google TTS（700+ 种声音）
 
@@ -441,7 +441,7 @@ OpenMontage/
 | **FLUX** | 云端 API | 业界顶尖质量 |
 | **Google Imagen** | 云端 API | Imagen 4 — 高质量、多种长宽比 |
 | **Grok Imagine Image** | 云端 API | 强大的图像编辑、风格转换和多图合成 |
-| **DALL-E 3** | 云端 API | OpenAI 的图像模型 |
+| **GPT Image 2** | 云端 API | OpenAI 的图像模型 |
 | **Recraft** | 云端 API | 专注于设计的生成 |
 | **Local Diffusion** | 本地 GPU | Stable Diffusion，免费 |
 | **Pexels** | 素材库 | 免费的库存图片 |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -48,7 +48,7 @@ OpenMontage/
 │   ├── audio/              # TTS (ElevenLabs, OpenAI, Piper), music gen, mixing, enhancement
 │   ├── avatar/             # Talking head animation, lip sync
 │   ├── enhancement/        # Upscale, bg removal, face enhance/restore, color grading
-│   ├── graphics/           # Image gen (FLUX, DALL-E, Recraft, local diffusion), stock, diagrams, code snippets, math animation
+│   ├── graphics/           # Image gen (FLUX, GPT Image, Recraft, local diffusion), stock, diagrams, code snippets, math animation
 │   ├── publishers/         # (Reserved)
 │   ├── subtitle/           # SRT/VTT generation from timestamps
 │   └── video/              # 13 video gen providers, composition, stitching, trimming
@@ -383,7 +383,7 @@ All config is validated via Pydantic models in `lib/config_model.py`.
 | Variable | Used By | Purpose |
 |----------|---------|---------|
 | `ELEVENLABS_API_KEY` | elevenlabs_tts, music_gen | TTS, music, sound effects |
-| `OPENAI_API_KEY` | openai_tts, openai_image | TTS fallback, DALL-E 3 |
+| `OPENAI_API_KEY` | openai_tts, openai_image | TTS fallback, GPT Image 2 |
 | `XAI_API_KEY` | grok_image, grok_video | Grok image editing/generation, Grok video generation |
 | `FAL_KEY` | flux_image, kling_video, veo_video, minimax_video, recraft_image | fal.ai hosted models (FLUX, Veo, Kling, MiniMax, Recraft) |
 | `HEYGEN_API_KEY` | heygen_video | Multi-provider video generation |

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -15,7 +15,7 @@ Everything you need to know about every provider in OpenMontage — setup instru
 | 3 | **$0** | ElevenLabs | Premium TTS + music + SFX (10K chars/month free) |
 | 4 | **$0** | Piper (local install) | Fully offline TTS — no API key, no cost, no network |
 | 5 | **~$0.03/image** | fal.ai | FLUX images + Kling/Veo/MiniMax video + Recraft — broad single-key image + video coverage |
-| 6 | **~$0.04/image** | OpenAI | DALL-E 3 images + OpenAI TTS |
+| 6 | **~$0.05/image** | OpenAI | GPT Image 2 images + OpenAI TTS |
 | 7 | **~$0.04/image** | Google Imagen | Imagen 4 images (shares the Google API key) |
 | 8 | **$12/month** | Runway | Gen-4 video — highest quality AI video |
 | 9 | **pay-as-you-go** | HeyGen | Avatar videos, multi-model video gateway |
@@ -37,7 +37,7 @@ GOOGLE_API_KEY=              # Google TTS + Google Imagen
 
 # VOICE + MUSIC
 ELEVENLABS_API_KEY=          # TTS, music, sound effects (10K chars/month free)
-OPENAI_API_KEY=              # OpenAI TTS + DALL-E 3 images
+OPENAI_API_KEY=              # OpenAI TTS + GPT Image 2 images
 XAI_API_KEY=                 # xAI Grok image generation/editing + Grok video generation
 DOUBAO_SPEECH_API_KEY=       # Volcengine Doubao Speech TTS (strong Mandarin narration)
 DOUBAO_SPEECH_VOICE_TYPE=    # Default Doubao speaker/voice type
@@ -276,7 +276,7 @@ Google TTS offers 700+ voices across 50+ languages. Voice names follow the patte
 
 ### OpenAI — TTS + Image Generation
 
-> **Solid all-rounder.** DALL-E 3 handles complex multi-element compositions well. TTS is fast and affordable.
+> **Solid all-rounder.** GPT Image 2 handles complex multi-element compositions and in-image text well. TTS is fast and affordable.
 
 **Tools unlocked:** `openai_tts`, `openai_image`
 **Env var:** `OPENAI_API_KEY`
@@ -301,10 +301,14 @@ Google TTS offers 700+ voices across 50+ languages. Voice names follow the patte
 
 | Model | Size | Quality | Price per image |
 |-------|------|---------|----------------|
-| DALL-E 3 | 1024x1024 | standard | $0.040 |
-| DALL-E 3 | 1024x1024 | hd | $0.080 |
-| DALL-E 3 | 1024x1792 | standard | $0.080 |
-| DALL-E 3 | 1024x1792 | hd | $0.120 |
+| GPT Image 2 | 1024x1024 | low | $0.006 |
+| GPT Image 2 | 1024x1024 | medium | $0.053 |
+| GPT Image 2 | 1024x1024 | high | $0.211 |
+| GPT Image 2 | 1024x1536 / 1536x1024 | low | $0.005 |
+| GPT Image 2 | 1024x1536 / 1536x1024 | medium | $0.041 |
+| GPT Image 2 | 1024x1536 / 1536x1024 | high | $0.165 |
+
+> **Note:** DALL-E 2/3 were shut down by OpenAI on 2026-05-12, and the `gpt-image-1` family (`gpt-image-1-mini`, `gpt-image-1.5`) retires 2026-12-01 — `gpt-image-2` is OpenAI's recommended replacement ([deprecations](https://developers.openai.com/api/docs/deprecations)).
 
 **Free tier:** None. Requires prepaid billing. Previously offered $5 in free credits for new accounts (discontinued for most signups).
 
@@ -672,7 +676,7 @@ First run downloads the model (~4GB). Subsequent runs use the cached model.
 
 **VRAM requirement:** 4GB+ (8GB recommended for 1024x1024 images)
 
-**Supports:** Negative prompts, seeds, custom sizes. Quality is lower than FLUX or DALL-E 3 but completely free and offline.
+**Supports:** Negative prompts, seeds, custom sizes. Quality is lower than FLUX or GPT Image 2 but completely free and offline.
 
 ---
 
@@ -743,7 +747,7 @@ How many providers cover each capability:
 
 | Capability | Cloud Providers | Local Providers | Free Options |
 |-----------|----------------|-----------------|--------------|
-| **Image Generation** | FLUX, Grok, Google Imagen, DALL-E 3, Recraft | Local Diffusion | Pexels, Pixabay (stock) |
+| **Image Generation** | FLUX, Grok, Google Imagen, GPT Image 2, Recraft | Local Diffusion | Pexels, Pixabay (stock) |
 | **Video Generation** | Grok, Kling, Runway, Veo, Higgsfield, MiniMax, HeyGen | WAN, Hunyuan, CogVideo, LTX | Pexels, Pixabay (stock) |
 | **Text-to-Speech** | ElevenLabs, Google TTS, OpenAI | Piper | Piper, Google free tier, ElevenLabs free tier |
 | **Music Generation** | ElevenLabs, Suno | — | ElevenLabs free tier |

--- a/skills/creative/data-visualization.md
+++ b/skills/creative/data-visualization.md
@@ -12,7 +12,7 @@ clear, accurate, and effective in video.
 | Tool | Role |
 |------|------|
 | `diagram_gen` | Generate charts via Mermaid or D3 |
-| `image_selector` | Generate stylized chart illustrations (FLUX/DALL-E) |
+| `image_selector` | Generate stylized chart illustrations (FLUX/GPT Image) |
 | Remotion | Animated chart components (bar grow, line draw, pie fill) |
 | Manim | Mathematical plots, coordinate systems, function graphs |
 

--- a/skills/creative/image-gen-usage.md
+++ b/skills/creative/image-gen-usage.md
@@ -1,6 +1,6 @@
 # Image Generation Usage for OpenMontage
 
-> Sources: OpenAI DALL-E 3 documentation, FLUX/BFL API documentation, existing Layer 3 skills
+> Sources: OpenAI GPT Image documentation, FLUX/BFL API documentation, existing Layer 3 skills
 > at `.agents/skills/flux-best-practices/` and `.agents/skills/bfl-api/`
 
 ## Quick Reference Card
@@ -150,7 +150,7 @@ optimized for image/video generation providers.
 ## Common Pitfalls
 
 1. **Text in images** — AI image generators are unreliable with text. Never include text in prompts; add text as overlays in the compose stage
-2. **Hands and fingers** — DALL-E 3 and FLUX still struggle. Avoid prompts requiring detailed hand poses
+2. **Hands and fingers** — AI image models still struggle. Avoid prompts requiring detailed hand poses
 3. **Inconsistent characters** — Without reference images, the same character will look different each time. Always use the hero reference strategy
 4. **Over-prompting** — Long, complex prompts produce unpredictable results. Keep to 2-3 sentences
 5. **Over-unifying prompts** — Forcing the exact same style phrase into every prompt makes scenes look samey. Keep the visual system consistent, but let each scene express its own subject, shot, and emotional beat.

--- a/skills/creative/image-provider-usage.md
+++ b/skills/creative/image-provider-usage.md
@@ -11,7 +11,7 @@
 |------|----------|------|-------|----------|
 | `flux_image` | FLUX 2 Pro via fal.ai | ~$0.03-0.05 | ~5-10s | Photorealism, general purpose, workhorse |
 | `grok_image` | Grok Imagine Image (xAI) | $0.02/output + $0.002/input edit image | ~5-15s | Image edits, style transfer, multi-image compositing |
-| `openai_image` | GPT Image 1 (OpenAI) | ~$0.01-0.17 | ~5-15s | Complex instructions, text in images, multi-element |
+| `openai_image` | GPT Image 2 (OpenAI) | ~$0.01-0.21 | ~5-15s | Complex instructions, text in images, multi-element |
 | `recraft_image` | Recraft V4 via fal.ai | ~$0.04-0.25 | ~5-10s | Logos, SVG vectors, brand assets, text rendering (see caveat below) |
 | `local_diffusion` | Stable Diffusion (local) | Free | ~30s+ | Offline, privacy, free |
 | `image_gen` | Multi (legacy, deprecated) | Varies | Varies | **Deprecated** — use `image_selector` or per-provider tools |
@@ -39,7 +39,7 @@
 | **Style transfer / repaint of an existing image** | `grok_image` | Native edit flow, strong promptable transforms | `openai_image` |
 | **Multi-image merge / composite** | `grok_image` | Can combine multiple source images into one scene | `openai_image` |
 | **Logo or brand asset** | `recraft_image` | SVG support, text accuracy | `openai_image` |
-| **Image with text/labels** | `openai_image` | Best text rendering (GPT Image 1) | `recraft_image` |
+| **Image with text/labels** | `openai_image` | Best text rendering (GPT Image 2) | `recraft_image` |
 | **Complex multi-element composition** | `openai_image` | Best instruction following | `flux_image` |
 | **Hero image (key visual)** | `flux_image` | Highest visual quality | `openai_image` |
 | **Thumbnail** | `flux_image` or `recraft_image` | Needs to be eye-catching | — |
@@ -59,7 +59,7 @@
 PRODUCTION PATH: Premium
 ├── Hero images: flux_image ($0.05/img)
 ├── Supporting visuals: flux_image ($0.03/img)
-├── Text overlays: openai_image ($0.04/img)
+├── Text overlays: openai_image ($0.05/img medium)
 ├── B-roll stills: pexels_image ($0.00)
 └── Total for 10 images: ~$0.35
 

--- a/skills/pipelines/animation/asset-director.md
+++ b/skills/pipelines/animation/asset-director.md
@@ -159,7 +159,7 @@ If you encounter a generation technique, provider behavior, or prompting pattern
 
 This is especially important for:
 - **Video generation prompting** — models respond to specific vocabularies that change with each version
-- **Image model parameters** — optimal settings for FLUX, DALL-E, Imagen differ and evolve
+- **Image model parameters** — optimal settings for FLUX, GPT Image, Imagen differ and evolve
 - **Audio provider quirks** — voice cloning, music generation, and TTS each have model-specific best practices
 - **Remotion component patterns** — new composition techniques emerge as the framework evolves
 

--- a/skills/pipelines/animation/proposal-director.md
+++ b/skills/pipelines/animation/proposal-director.md
@@ -278,7 +278,7 @@ For each concept, specify:
 For each concept, specify:
 - **Animation approach**: `image_animation` / `clip_video` / `manim` / `remotion_dataviz` / `diagram_stills` / `mixed`
 - **Why this approach**: grounded in technique research AND tool availability from Step 3
-- **Image/video generation provider**: which specific provider from the preflight scan (e.g., "FLUX via fal.ai", "gpt-image-1 via OpenAI", "Stable Diffusion local")
+- **Image/video generation provider**: which specific provider from the preflight scan (e.g., "FLUX via fal.ai", "gpt-image-2 via OpenAI", "Stable Diffusion local")
 - **Reuse strategy**: What's the visual system? (recurring motifs, layout grid, color scheme, transition family)
 - **Complexity estimate**: How many unique scene types vs. reusable templates?
 - **Visual identity**: palette, typography, texture, motion energy, and why they fit this subject, audience, and platform
@@ -461,7 +461,7 @@ If you encounter a generation technique, provider behavior, or prompting pattern
 
 This is especially important for:
 - **Video generation prompting** — models respond to specific vocabularies that change with each version
-- **Image model parameters** — optimal settings for FLUX, DALL-E, Imagen differ and evolve
+- **Image model parameters** — optimal settings for FLUX, GPT Image, Imagen differ and evolve
 - **Audio provider quirks** — voice cloning, music generation, and TTS each have model-specific best practices
 - **Remotion component patterns** — new composition techniques emerge as the framework evolves
 

--- a/skills/pipelines/avatar-spokesperson/asset-director.md
+++ b/skills/pipelines/avatar-spokesperson/asset-director.md
@@ -124,7 +124,7 @@ If you encounter a generation technique, provider behavior, or prompting pattern
 
 This is especially important for:
 - **Video generation prompting** — models respond to specific vocabularies that change with each version
-- **Image model parameters** — optimal settings for FLUX, DALL-E, Imagen differ and evolve
+- **Image model parameters** — optimal settings for FLUX, GPT Image, Imagen differ and evolve
 - **Audio provider quirks** — voice cloning, music generation, and TTS each have model-specific best practices
 - **Remotion component patterns** — new composition techniques emerge as the framework evolves
 

--- a/skills/pipelines/cinematic/asset-director.md
+++ b/skills/pipelines/cinematic/asset-director.md
@@ -157,7 +157,7 @@ If you encounter a generation technique, provider behavior, or prompting pattern
 
 This is especially important for:
 - **Video generation prompting** — models respond to specific vocabularies that change with each version
-- **Image model parameters** — optimal settings for FLUX, DALL-E, Imagen differ and evolve
+- **Image model parameters** — optimal settings for FLUX, GPT Image, Imagen differ and evolve
 - **Audio provider quirks** — voice cloning, music generation, and TTS each have model-specific best practices
 - **Remotion component patterns** — new composition techniques emerge as the framework evolves
 

--- a/skills/pipelines/cinematic/proposal-director.md
+++ b/skills/pipelines/cinematic/proposal-director.md
@@ -285,7 +285,7 @@ If you encounter a generation technique, provider behavior, or prompting pattern
 
 This is especially important for:
 - **Video generation prompting** — models respond to specific vocabularies that change with each version
-- **Image model parameters** — optimal settings for FLUX, DALL-E, Imagen differ and evolve
+- **Image model parameters** — optimal settings for FLUX, GPT Image, Imagen differ and evolve
 - **Audio provider quirks** — voice cloning, music generation, and TTS each have model-specific best practices
 - **Remotion component patterns** — new composition techniques emerge as the framework evolves
 

--- a/skills/pipelines/clip-factory/asset-director.md
+++ b/skills/pipelines/clip-factory/asset-director.md
@@ -101,7 +101,7 @@ If you encounter a generation technique, provider behavior, or prompting pattern
 
 This is especially important for:
 - **Video generation prompting** — models respond to specific vocabularies that change with each version
-- **Image model parameters** — optimal settings for FLUX, DALL-E, Imagen differ and evolve
+- **Image model parameters** — optimal settings for FLUX, GPT Image, Imagen differ and evolve
 - **Audio provider quirks** — voice cloning, music generation, and TTS each have model-specific best practices
 - **Remotion component patterns** — new composition techniques emerge as the framework evolves
 

--- a/skills/pipelines/explainer/asset-director.md
+++ b/skills/pipelines/explainer/asset-director.md
@@ -273,7 +273,7 @@ If you encounter a generation technique, provider behavior, or prompting pattern
 
 This is especially important for:
 - **Video generation prompting** — models respond to specific vocabularies that change with each version
-- **Image model parameters** — optimal settings for FLUX, DALL-E, Imagen differ and evolve
+- **Image model parameters** — optimal settings for FLUX, GPT Image, Imagen differ and evolve
 - **Audio provider quirks** — voice cloning, music generation, and TTS each have model-specific best practices
 - **Remotion component patterns** — new composition techniques emerge as the framework evolves
 

--- a/skills/pipelines/explainer/proposal-director.md
+++ b/skills/pipelines/explainer/proposal-director.md
@@ -535,7 +535,7 @@ If you encounter a generation technique, provider behavior, or prompting pattern
 
 This is especially important for:
 - **Video generation prompting** — models respond to specific vocabularies that change with each version
-- **Image model parameters** — optimal settings for FLUX, DALL-E, Imagen differ and evolve
+- **Image model parameters** — optimal settings for FLUX, GPT Image, Imagen differ and evolve
 - **Audio provider quirks** — voice cloning, music generation, and TTS each have model-specific best practices
 - **Remotion component patterns** — new composition techniques emerge as the framework evolves
 

--- a/skills/pipelines/explainer/scene-director.md
+++ b/skills/pipelines/explainer/scene-director.md
@@ -79,7 +79,7 @@ Transform each script section into 1-3 visual scenes. Each scene is a distinct v
 | `text_card` | Statements, closing messages, key terms | Remotion TextCard (centered, spring animation) | 3-5s |
 | `animation` | Concepts needing motion (data flow, math) | Remotion, Manim | 4-10s |
 | `diagram` | Processes, architecture, relationships | `diagram_gen` (Mermaid), `image_selector` | 4-8s |
-| `generated` | Illustrations, metaphors, real-world imagery | `image_selector` (FLUX/DALL-E) | 3-6s |
+| `generated` | Illustrations, metaphors, real-world imagery | `image_selector` (FLUX/GPT Image) | 3-6s |
 | `talking_head` | AI avatar speaking (if HeyGen available) | HeyGen tools | 5-15s |
 | `broll` | Context, real-world examples | Stock or generated footage | 3-6s |
 | `screen_recording` | Code demos, UI walkthroughs | Recorded or simulated | 5-15s |
@@ -206,7 +206,7 @@ The style playbook constrains your visual choices:
 **Feasibility check:**
 - [ ] Every `required_asset` with `source: "generate"` is achievable with available tools
 - [ ] Diagram descriptions are specific enough for Mermaid syntax generation
-- [ ] Image descriptions are specific enough for FLUX/DALL-E prompt engineering
+- [ ] Image descriptions are specific enough for FLUX/GPT Image prompt engineering
 - [ ] No scene requires tools that aren't in the tool registry
 
 ### Step 7: Self-Evaluate

--- a/skills/pipelines/hybrid/asset-director.md
+++ b/skills/pipelines/hybrid/asset-director.md
@@ -93,7 +93,7 @@ If you encounter a generation technique, provider behavior, or prompting pattern
 
 This is especially important for:
 - **Video generation prompting** — models respond to specific vocabularies that change with each version
-- **Image model parameters** — optimal settings for FLUX, DALL-E, Imagen differ and evolve
+- **Image model parameters** — optimal settings for FLUX, GPT Image, Imagen differ and evolve
 - **Audio provider quirks** — voice cloning, music generation, and TTS each have model-specific best practices
 - **Remotion component patterns** — new composition techniques emerge as the framework evolves
 

--- a/skills/pipelines/localization-dub/asset-director.md
+++ b/skills/pipelines/localization-dub/asset-director.md
@@ -85,7 +85,7 @@ If you encounter a generation technique, provider behavior, or prompting pattern
 
 This is especially important for:
 - **Video generation prompting** — models respond to specific vocabularies that change with each version
-- **Image model parameters** — optimal settings for FLUX, DALL-E, Imagen differ and evolve
+- **Image model parameters** — optimal settings for FLUX, GPT Image, Imagen differ and evolve
 - **Audio provider quirks** — voice cloning, music generation, and TTS each have model-specific best practices
 - **Remotion component patterns** — new composition techniques emerge as the framework evolves
 

--- a/skills/pipelines/podcast-repurpose/asset-director.md
+++ b/skills/pipelines/podcast-repurpose/asset-director.md
@@ -98,7 +98,7 @@ If you encounter a generation technique, provider behavior, or prompting pattern
 
 This is especially important for:
 - **Video generation prompting** — models respond to specific vocabularies that change with each version
-- **Image model parameters** — optimal settings for FLUX, DALL-E, Imagen differ and evolve
+- **Image model parameters** — optimal settings for FLUX, GPT Image, Imagen differ and evolve
 - **Audio provider quirks** — voice cloning, music generation, and TTS each have model-specific best practices
 - **Remotion component patterns** — new composition techniques emerge as the framework evolves
 

--- a/skills/pipelines/screen-demo/asset-director.md
+++ b/skills/pipelines/screen-demo/asset-director.md
@@ -159,7 +159,7 @@ If you encounter a generation technique, provider behavior, or prompting pattern
 
 This is especially important for:
 - **Video generation prompting** — models respond to specific vocabularies that change with each version
-- **Image model parameters** — optimal settings for FLUX, DALL-E, Imagen differ and evolve
+- **Image model parameters** — optimal settings for FLUX, GPT Image, Imagen differ and evolve
 - **Audio provider quirks** — voice cloning, music generation, and TTS each have model-specific best practices
 - **Remotion component patterns** — new composition techniques emerge as the framework evolves
 

--- a/skills/pipelines/talking-head/asset-director.md
+++ b/skills/pipelines/talking-head/asset-director.md
@@ -201,7 +201,7 @@ If you encounter a generation technique, provider behavior, or prompting pattern
 
 This is especially important for:
 - **Video generation prompting** — models respond to specific vocabularies that change with each version
-- **Image model parameters** — optimal settings for FLUX, DALL-E, Imagen differ and evolve
+- **Image model parameters** — optimal settings for FLUX, GPT Image, Imagen differ and evolve
 - **Audio provider quirks** — voice cloning, music generation, and TTS each have model-specific best practices
 - **Remotion component patterns** — new composition techniques emerge as the framework evolves
 

--- a/tests/qa/QA_PLAN.md
+++ b/tests/qa/QA_PLAN.md
@@ -9,7 +9,7 @@ Run every tool with real API keys, inspect outputs (see images, listen to audio,
 | Script | Tools Tested | API Keys Used | Est. Cost |
 |--------|-------------|---------------|-----------|
 | `test_01_tts.py` | `elevenlabs_tts` (ElevenLabs) | ELEVENLABS_API_KEY | ~$0.02 |
-| `test_02_image_gen.py` | `image_gen` (DALL-E 3 + FLUX) | OPENAI_API_KEY, FAL_AI_API_KEY | ~$0.15 |
+| `test_02_image_gen.py` | `image_gen` (GPT Image 2 + FLUX) | OPENAI_API_KEY, FAL_AI_API_KEY | ~$0.15 |
 | `test_03_music.py` | `music_gen` (ElevenLabs) | ELEVENLABS_API_KEY | ~$0.10 |
 | `test_04_audio_mix.py` | `audio_mixer` | None (ffmpeg only) | $0 |
 | `test_05_video_compose.py` | `video_compose` | None (ffmpeg only) | $0 |
@@ -30,7 +30,7 @@ For each output:
 | Area | Risk | How to Validate |
 |------|------|-----------------|
 | TTS voice selection | Default voice may not match playbook mood | Test with multiple voice IDs, compare against playbook `voice_style` |
-| Image gen consistency | DALL-E/FLUX outputs vary wildly per prompt | Test with playbook `image_prompt_prefix` prepended |
+| Image gen consistency | GPT Image/FLUX outputs vary wildly per prompt | Test with playbook `image_prompt_prefix` prepended |
 | Music duration alignment | Music may not match narration duration | Compare `music.duration` vs `tts.duration`, check padding/looping |
 | Audio ducking timing | Ducking may cut music too aggressively | Inspect waveform: music should duck ~6dB under speech, recover smoothly |
 | Video stitch transitions | Crossfade may flicker with mismatched codecs | Test with both matching and mismatched clips, check `auto_normalize` |

--- a/tools/graphics/image_gen.py
+++ b/tools/graphics/image_gen.py
@@ -7,7 +7,7 @@
     pexels_image, pixabay_image). This file is kept for backwards
     compatibility and will be removed in a future release.
 
-Supports cloud API providers (FLUX via fal.ai/Replicate, OpenAI DALL-E)
+Supports cloud API providers (FLUX via fal.ai/Replicate, OpenAI GPT Image)
 and local Stable Diffusion via diffusers. Reports unavailable with
 install instructions when no provider is configured.
 """
@@ -43,12 +43,12 @@ class ImageGen(BaseTool):
     stability = ToolStability.EXPERIMENTAL
     execution_mode = ExecutionMode.SYNC
     determinism = Determinism.SEEDED
-    runtime = ToolRuntime.HYBRID  # API (DALL-E/FLUX) or local (diffusers)
+    runtime = ToolRuntime.HYBRID  # API (GPT Image/FLUX) or local (diffusers)
 
     dependencies = []  # checked dynamically based on provider
     install_instructions = (
         "Set one of these environment variables:\n"
-        "  OPENAI_API_KEY — for DALL-E 3\n"
+        "  OPENAI_API_KEY — for GPT Image 2\n"
         "  FAL_KEY — for FLUX via fal.ai\n"
         "Or install diffusers for local generation:\n"
         "  pip install diffusers transformers accelerate torch"
@@ -121,7 +121,7 @@ class ImageGen(BaseTool):
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
         provider = inputs.get("provider") or self._detect_provider()
         if provider == "openai":
-            return 0.04  # DALL-E 3 standard
+            return 0.053  # gpt-image-2 medium at 1024x1024 (call uses auto quality)
         if provider == "flux":
             return 0.03
         return 0.0  # local
@@ -159,14 +159,14 @@ class ImageGen(BaseTool):
         client = OpenAI()
         prompt = inputs["prompt"]
         size = f"{inputs.get('width', 1024)}x{inputs.get('height', 1024)}"
-        model = inputs.get("model", "dall-e-3")
+        model = inputs.get("model", "gpt-image-2")
 
+        # GPT image models don't accept response_format; they always return b64
         response = client.images.generate(
             model=model,
             prompt=prompt,
             size=size,
             n=1,
-            response_format="b64_json",
         )
 
         image_data = base64.b64decode(response.data[0].b64_json)

--- a/tools/graphics/openai_image.py
+++ b/tools/graphics/openai_image.py
@@ -1,4 +1,4 @@
-"""OpenAI GPT Image generation (gpt-image-2 / DALL-E 3)."""
+"""OpenAI GPT Image generation (gpt-image-2)."""
 
 from __future__ import annotations
 
@@ -60,20 +60,17 @@ class OpenAIImage(BaseTool):
             "prompt": {"type": "string"},
             "model": {
                 "type": "string",
-                "enum": ["gpt-image-2", "dall-e-3"],
+                "enum": ["gpt-image-2"],
                 "default": "gpt-image-2",
             },
             "size": {
                 "type": "string",
-                "enum": [
-                    "1024x1024", "1536x1024", "1024x1536", "auto",
-                    "1024x1792", "1792x1024",  # dall-e-3 only
-                ],
+                "enum": ["1024x1024", "1536x1024", "1024x1536", "auto"],
                 "default": "1024x1024",
             },
             "quality": {
                 "type": "string",
-                "enum": ["low", "medium", "high", "auto", "standard", "hd"],
+                "enum": ["low", "medium", "high", "auto"],
                 "default": "high",
             },
             "output_format": {
@@ -100,15 +97,12 @@ class OpenAIImage(BaseTool):
         return ToolStatus.UNAVAILABLE
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
-        model = inputs.get("model", "gpt-image-2")
+        # gpt-image-2 per-image pricing at 1024x1024 (non-square sizes run
+        # slightly cheaper): https://developers.openai.com/api/docs/guides/image-generation
         quality = inputs.get("quality", "high")
         n = inputs.get("n", 1)
-        if "gpt-image" in model:
-            cost_map = {"low": 0.011, "medium": 0.042, "high": 0.167, "auto": 0.042}
-            return cost_map.get(quality, 0.042) * n
-        # dall-e-3 fallback pricing
-        quality_map = {"standard": 0.04, "hd": 0.08}
-        return quality_map.get(quality, 0.04) * n
+        cost_map = {"low": 0.006, "medium": 0.053, "high": 0.211, "auto": 0.053}
+        return cost_map.get(quality, 0.053) * n
 
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
         if not os.environ.get("OPENAI_API_KEY"):
@@ -127,30 +121,16 @@ class OpenAIImage(BaseTool):
         n = inputs.get("n", 1)
 
         try:
-            if "gpt-image" in model:
-                quality = inputs.get("quality", "high")
-                output_format = inputs.get("output_format", "png")
-                response = client.images.generate(
-                    model=model,
-                    prompt=prompt,
-                    size=size,
-                    quality=quality,
-                    output_format=output_format,
-                    n=n,
-                )
-            else:
-                # dall-e-3 path
-                quality = inputs.get("quality", "standard")
-                if quality in ("low", "medium", "high", "auto"):
-                    quality = "standard"  # map to dall-e-3 quality options
-                response = client.images.generate(
-                    model=model,
-                    prompt=prompt,
-                    size=size,
-                    quality=quality,
-                    n=1,  # dall-e-3 only supports n=1
-                    response_format="b64_json",
-                )
+            quality = inputs.get("quality", "high")
+            output_format = inputs.get("output_format", "png")
+            response = client.images.generate(
+                model=model,
+                prompt=prompt,
+                size=size,
+                quality=quality,
+                output_format=output_format,
+                n=n,
+            )
 
             image_data = base64.b64decode(response.data[0].b64_json)
             ext = inputs.get("output_format", "png")

--- a/tools/graphics/openai_image.py
+++ b/tools/graphics/openai_image.py
@@ -1,4 +1,4 @@
-"""OpenAI GPT Image generation (gpt-image-1 / DALL-E 3)."""
+"""OpenAI GPT Image generation (gpt-image-2 / DALL-E 3)."""
 
 from __future__ import annotations
 
@@ -60,8 +60,8 @@ class OpenAIImage(BaseTool):
             "prompt": {"type": "string"},
             "model": {
                 "type": "string",
-                "enum": ["gpt-image-1", "dall-e-3"],
-                "default": "gpt-image-1",
+                "enum": ["gpt-image-2", "dall-e-3"],
+                "default": "gpt-image-2",
             },
             "size": {
                 "type": "string",
@@ -100,10 +100,10 @@ class OpenAIImage(BaseTool):
         return ToolStatus.UNAVAILABLE
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
-        model = inputs.get("model", "gpt-image-1")
+        model = inputs.get("model", "gpt-image-2")
         quality = inputs.get("quality", "high")
         n = inputs.get("n", 1)
-        if model == "gpt-image-1":
+        if "gpt-image" in model:
             cost_map = {"low": 0.011, "medium": 0.042, "high": 0.167, "auto": 0.042}
             return cost_map.get(quality, 0.042) * n
         # dall-e-3 fallback pricing
@@ -121,13 +121,13 @@ class OpenAIImage(BaseTool):
 
         start = time.time()
         client = OpenAI()
-        model = inputs.get("model", "gpt-image-1")
+        model = inputs.get("model", "gpt-image-2")
         prompt = inputs["prompt"]
         size = inputs.get("size", "1024x1024")
         n = inputs.get("n", 1)
 
         try:
-            if model == "gpt-image-1":
+            if "gpt-image" in model:
                 quality = inputs.get("quality", "high")
                 output_format = inputs.get("output_format", "png")
                 response = client.images.generate(


### PR DESCRIPTION
## Summary

turns out it's not just gpt-image-1 — dall-e-2/3 got shut down on 2026-05-12 ([deprecations page](https://developers.openai.com/api/docs/deprecations)), so the dall-e-3 fallback in this tool has been 400ing for weeks too. this revision drops the dead models instead of keeping them in the enum, updates the pricing per the review, and scrubs the stale model references from the docs/skills that feed provider planning.

went with narrowing the enum to just `gpt-image-2` rather than widening to the family — `gpt-image-1.5` and `gpt-image-1-mini` are also on the deprecations page (shutdown 2026-12-01, recommended replacement `gpt-image-2`), so adding them just sets up the same breakage in five months.

## Related issue

Closes #

## Changes

- `openai_image`: enum -> `["gpt-image-2"]`, dall-e code path / sizes (1024x1792, 1792x1024) / qualities (standard, hd) removed, `estimate_cost` = real gpt-image-2 pricing ($0.006 / $0.053 / $0.211 low/med/high at 1024x1024, per the [image gen guide](https://developers.openai.com/api/docs/guides/image-generation))
- `image_gen` (the deprecated one): default dall-e-3 -> gpt-image-2, and dropped `response_format="b64_json"` — the api reference says gpt-image models don't take that param, so swapping the model name alone would still error
- docs/skills sweep: README (en + zh), `.env.example`, `docs/PROVIDERS.md` (pricing table + a short note on the shutdowns), `docs/ARCHITECTURE.md`, `AGENT_GUIDE.md`, 3 `skills/creative/*` files, the "image model parameters" line across 14 `skills/pipelines/*` director files, `tests/qa/QA_PLAN.md`
- left the two README showcase blurbs that mention gpt-image-1 — that's just how that demo was made at the time

## Testing

- `python3 -m py_compile` on both tools
- registry discovery against the changed files: both tools found, `openai_image` enum reads `['gpt-image-2']`, costs return 0.211/0.053/0.006
- checked for callers passing the removed values (standard/hd, the dall-e sizes, dall-e-3): nothing calls `openai_image` directly except these two files, and `image_selector` strips params the target schema doesn't declare
- `grep -riE "dall-?e|gpt-image-1"` across the repo comes back with just the two showcase blurbs + the note this PR adds to PROVIDERS.md

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable. (`pytest tests/ --ignore=tests/qa`: 336 passed, 6 skipped, 4 failed — the qa dir makes paid API calls so it was excluded, and the 4 failures reproduce identically on a copy *without* this change, so they're local-environment drift, not this diff)
- [x] I updated docs/README if behavior or usage changed.
- [x] No unrelated files (build artifacts, local config) are included in the diff.
