### PR TITLE
feat: add Agnes AI (Sapiens AI) image and video generation providers

### DIFF
--- a/.agents/skills/agnes-image/SKILL.md
+++ b/.agents/skills/agnes-image/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: agnes-image
+description: |
+  Agnes AI image generation with Sapiens AI models. Use when: (1) Generating images via agnes-image-2.0-flash or agnes-image-2.1-flash, (2) Cost-free image generation, (3) High-information-density visuals, (4) Multi-image composition, (5) Image editing and style transfer.
+metadata:
+  author: Sapiens AI
+  version: "1.0.0"
+  tags: agnes, sapiens, image-generation, t2i, i2i
+---
+
+# Agnes Image Generation
+
+## When to Use
+
+- Cost-free image generation (currently $0/image, standard price $0.003/image)
+- High-information-density visuals with complex compositions (use 2.1-flash)
+- Multi-image composition (combine characters or elements into one scene)
+- Image editing, style transfer, background replacement
+- General text-to-image when budget is constrained
+
+## Models
+
+| Model | Best For | Speed |
+|-------|----------|-------|
+| `agnes-image-2.0-flash` | General T2I/I2I, fast iteration, product staging | Fast |
+| `agnes-image-2.1-flash` | High-density details, complex layouts, semantic alignment, composition preservation | Medium |
+
+**Default: `agnes-image-2.1-flash`** — optimized for detail-rich output and better composition preservation during edits. Switch to 2.0-flash when speed is the priority.
+
+## Prompt Structure
+
+### Text-to-Image
+
+```
+[Subject] + [Scene/Background] + [Style] + [Lighting] + [Composition] + [Quality]
+```
+
+Example:
+```
+A professional product photo of a wireless headphone on a clean white
+background, soft studio lighting, sharp details, commercial photography style
+```
+
+### Image-to-Image
+
+Clearly describe what should change and what should remain unchanged:
+
+```
+[Change instruction] + [New style/scene] + [Elements to preserve] + [Lighting] + [Quality]
+```
+
+Example:
+```
+Change the background to a futuristic city at night while keeping the
+person's face, outfit, and pose unchanged
+```
+
+### Multi-Image Composition
+
+Describe the relationship between input images and how they should be combined:
+
+```
+Place the person from the first image beside the robot from the second image
+in a cinematic sci-fi battle scene
+```
+
+## API Notes
+
+- **Base URL**: `https://apihub.agnes-ai.com/v1`
+- **Endpoint**: `POST /v1/images/generations`
+- **Auth**: `Authorization: Bearer <AGNES_API_KEY>`
+- **`response_format`** must go inside `extra_body`, NOT at the top level. Top-level placement causes a 400 error.
+- Image-to-image input goes in `extra_body.image` as an array of URLs or Data URI Base64 values.
+- Image-to-image does NOT require `tags: ["img2img"]`.
+- Client timeout: 60–360s recommended depending on complexity.
+
+## Key Differences from Other Providers
+
+| Aspect | Agnes | OpenAI / FLUX |
+|--------|-------|---------------|
+| `response_format` placement | Inside `extra_body` | Top-level |
+| Image input for I2I | `extra_body.image` (array) | Varies by provider |
+| Tags for I2I | Not required | Not applicable |
+| Pricing | Currently free | Paid |
+
+## Calling via OpenMontage
+
+Always go through `image_selector`:
+
+```python
+from tools.tool_registry import registry
+registry.ensure_discovered()
+selector = registry.get("image_selector")
+result = selector.execute({
+    "prompt": "A luminous floating city above a misty canyon at sunrise",
+    "preferred_provider": "agnes",
+    "size": "1024x768",
+    "output_path": "projects/<proj>/assets/images/scene_01.png",
+})
+```
+
+Direct call to the provider tool:
+
+```python
+agnes = registry.get("agnes_image")
+result = agnes.execute({
+    "prompt": "A product photo of a glass cube on white background",
+    "model": "agnes-image-2.1-flash",
+    "size": "1024x768",
+    "output_path": "output.png",
+})
+```
+
+## Integration Checklist
+
+- Use `agnes-image-2.1-flash` for complex/detail-rich scenes
+- Use `agnes-image-2.0-flash` for fast iteration and general editing
+- Place `response_format` inside `extra_body`, not at top level
+- For image-to-image, provide input images through `extra_body.image` as an array
+- For local images, the tool auto-converts to data URI Base64

--- a/.agents/skills/agnes-image/SKILL.md
+++ b/.agents/skills/agnes-image/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agnes-image
 description: |
-  Agnes AI image generation with Sapiens AI models. Use when: (1) Generating images via agnes-image-2.0-flash or agnes-image-2.1-flash, (2) Cost-free image generation, (3) High-information-density visuals, (4) Multi-image composition, (5) Image editing and style transfer.
+  Agnes AI image generation with Sapiens AI models. Use when: (1) Generating images via agnes-image-2.0-flash or agnes-image-2.1-flash, (2) Currently-free (launch promo) image generation, (3) High-information-density visuals, (4) Multi-image composition, (5) Image editing and style transfer.
 metadata:
   author: Sapiens AI
   version: "1.0.0"
@@ -12,7 +12,7 @@ metadata:
 
 ## When to Use
 
-- Cost-free image generation (currently $0/image, standard price $0.003/image)
+- Currently-free image generation during the launch promo (verify current pricing at https://www.agnes-ai.com)
 - High-information-density visuals with complex compositions (use 2.1-flash)
 - Multi-image composition (combine characters or elements into one scene)
 - Image editing, style transfer, background replacement
@@ -81,7 +81,7 @@ in a cinematic sci-fi battle scene
 | `response_format` placement | Inside `extra_body` | Top-level |
 | Image input for I2I | `extra_body.image` (array) | Varies by provider |
 | Tags for I2I | Not required | Not applicable |
-| Pricing | Currently free | Paid |
+| Pricing | Free during launch promo | Paid |
 
 ## Calling via OpenMontage
 

--- a/.agents/skills/agnes-video/SKILL.md
+++ b/.agents/skills/agnes-video/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: agnes-video
+description: |
+  Agnes AI video generation with Sapiens AI models. Use when: (1) Generating video via agnes-video-v2.0, (2) Cost-free video generation, (3) Keyframe animation, (4) Multi-image video compositing, (5) Budget-constrained cinematic content.
+allowed-tools: Bash, Read, Write
+metadata:
+  author: Sapiens AI
+  version: "1.0.0"
+  tags: agnes, sapiens, video-generation, t2v, i2v, keyframes
+---
+
+# Agnes Video V2.0
+
+## When to Use
+
+- Cost-free video generation (currently $0/second, standard price $0.005/second)
+- Keyframe animation — smooth transitions between visual states
+- Multi-image video compositing — combine reference images into video
+- Budget-constrained cinematic b-roll and short clips
+- Social media video content (Reels, Shorts, TikTok)
+
+## Model
+
+- **`agnes-video-v2.0`** — asynchronous task-based generation
+
+## API Pattern (Async)
+
+1. **Create task**: `POST https://apihub.agnes-ai.com/v1/videos`
+2. **Poll result**: `GET https://apihub.agnes-ai.com/agnesapi?video_id=<VIDEO_ID>`
+3. **Download**: fetch from `remixed_from_video_id` field when status is `completed`
+
+Task statuses: `queued` → `in_progress` → `completed` / `failed`
+
+## Operations
+
+| Operation | Required Input | Description |
+|-----------|---------------|-------------|
+| `text_to_video` | prompt | Generate from text description |
+| `image_to_video` | prompt + image_url | Animate a single image |
+| `multi_image_to_video` | prompt + image_urls | Combine multiple reference images |
+| `keyframe_animation` | prompt + image_urls + mode=keyframes | Smooth transition between keyframes |
+
+## Duration Control
+
+```
+seconds = num_frames / frame_rate
+```
+
+- `num_frames` must follow the **8n + 1** rule (e.g. 81, 121, 161, 241, 441)
+- `num_frames` maximum: **441**
+- `frame_rate`: 1–60 (24 or 30 recommended for smooth playback)
+
+| Target Duration | num_frames | frame_rate |
+|----------------|------------|------------|
+| ~3 seconds | 81 | 24 |
+| ~5 seconds | 121 | 24 |
+| ~10 seconds | 241 | 24 |
+| ~18 seconds | 441 | 24 |
+
+## Aspect Ratios
+
+| Ratio | Width x Height | Best For |
+|-------|---------------|----------|
+| 16:9 | 1152 x 768 | YouTube, landscape, product demos |
+| 9:16 | 768 x 1152 | TikTok, Reels, Shorts |
+| 1:1 | 768 x 768 | Social feeds, product showcases |
+| 4:3 | 1024 x 768 | Presentations, general content |
+| 3:4 | 768 x 1024 | Portrait content, product-focused |
+
+## Prompt Structure
+
+### Text-to-Video
+
+```
+[Subject] + [Action] + [Scene] + [Camera Movement] + [Lighting] + [Style]
+```
+
+Example:
+```
+A young astronaut walking across a red desert planet, dust blowing in the wind,
+slow cinematic tracking shot, dramatic sunset lighting, realistic sci-fi style
+```
+
+### Image-to-Video
+
+Describe what should move and what should stay stable:
+
+```
+Animate the character with subtle breathing motion, hair moving gently in the
+wind, background lights flickering softly, while keeping the face and outfit
+consistent
+```
+
+### Multi-Image Video
+
+Describe the relationship between input images and how the scene should transition:
+
+```
+Use the first image as the starting scene and the second image as the target
+scene. Create a smooth transformation with consistent lighting, natural motion,
+and cinematic pacing
+```
+
+### Keyframe Animation
+
+Clearly describe the transition between keyframes:
+
+```
+Create a smooth transition from the first keyframe to the second keyframe,
+maintaining character identity, consistent camera angle, and natural motion
+between scenes
+```
+
+## Parameter Normalization
+
+The Agnes API normalizes width/height to the nearest standard resolution (480p, 720p, 1080p). The requested dimensions may not exactly match the output. Use the `size` and `seconds` fields from the response as the source of truth.
+
+**Important: Image-to-video resolution behavior.** When using I2V with a source image, the API may normalize the output to a different aspect ratio than the source image (e.g., a portrait image may produce a landscape video). This can cause cropping — especially cutting off the head in portrait-to-landscape conversions. **For character-consistent portrait/9:16 videos, prefer T2V with a detailed character description in the prompt** rather than I2V, as T2V reliably respects the `aspect_ratio` parameter.
+
+**Local image upload.** When `image_path` is provided instead of `image_url`, the tool relays the image through the Agnes images API to obtain a public URL (Agnes video API requires publicly accessible URLs). The relay preserves the original image dimensions and content. Fallback: fal.ai upload (if `FAL_KEY` is set), then data URI base64 (may fail for large images).
+
+## Key Differences from Other Providers
+
+| Aspect | Agnes Video | fal.ai (Seedance/Kling) |
+|--------|-------------|------------------------|
+| API pattern | Async: POST then GET poll | Async: queue POST then poll status_url |
+| Task ID | `video_id` (recommended) | `request_id` via status_url |
+| Result field | `remixed_from_video_id` | `video.url` |
+| Duration control | `num_frames` + `frame_rate` | `duration` string |
+| Reference images | In `extra_body.image` top-level or array | `image_url` or `reference_image_urls` |
+| Pricing | Currently free | Paid per second |
+
+## Calling via OpenMontage
+
+Always go through `video_selector`:
+
+```python
+from tools.tool_registry import registry
+registry.ensure_discovered()
+selector = registry.get("video_selector")
+result = selector.execute({
+    "prompt": PROMPT,
+    "preferred_provider": "agnes",
+    "operation": "text_to_video",
+    "aspect_ratio": "16:9",
+    "output_path": "projects/<proj>/assets/video/clip_01.mp4",
+})
+```
+
+Direct call to the provider tool:
+
+```python
+agnes = registry.get("agnes_video")
+result = agnes.execute({
+    "prompt": PROMPT,
+    "operation": "text_to_video",
+    "aspect_ratio": "16:9",
+    "num_frames": 121,
+    "frame_rate": 24,
+    "seed": 12345,
+    "output_path": "output.mp4",
+})
+```
+
+## Integration Checklist
+
+- Video generation is **asynchronous** — always create task then poll
+- Use `video_id` (not `task_id`) for polling — it is the recommended ID
+- Set `extra_body.mode: "keyframes"` for keyframe animation
+- Use publicly accessible image URLs for all reference images
+- Poll every 5s with exponential backoff (max 30s interval, 600s total timeout)
+- Use response `size` and `seconds` as source of truth after normalization
+- `negative_prompt` supported — use to avoid unwanted content

--- a/.agents/skills/agnes-video/SKILL.md
+++ b/.agents/skills/agnes-video/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agnes-video
 description: |
-  Agnes AI video generation with Sapiens AI models. Use when: (1) Generating video via agnes-video-v2.0, (2) Cost-free video generation, (3) Keyframe animation, (4) Multi-image video compositing, (5) Budget-constrained cinematic content.
+  Agnes AI video generation with Sapiens AI models. Use when: (1) Generating video via agnes-video-v2.0, (2) Currently-free (launch promo) video generation, (3) Keyframe animation, (4) Multi-image video compositing, (5) Budget-constrained cinematic content.
 allowed-tools: Bash, Read, Write
 metadata:
   author: Sapiens AI
@@ -13,7 +13,7 @@ metadata:
 
 ## When to Use
 
-- Cost-free video generation (currently $0/second, standard price $0.005/second)
+- Currently-free video generation during the launch promo (verify current pricing at https://www.agnes-ai.com)
 - Keyframe animation — smooth transitions between visual states
 - Multi-image video compositing — combine reference images into video
 - Budget-constrained cinematic b-roll and short clips
@@ -128,7 +128,7 @@ The Agnes API normalizes width/height to the nearest standard resolution (480p, 
 | Result field | `remixed_from_video_id` | `video.url` |
 | Duration control | `num_frames` + `frame_rate` | `duration` string |
 | Reference images | In `extra_body.image` top-level or array | `image_url` or `reference_image_urls` |
-| Pricing | Currently free | Paid per second |
+| Pricing | Free during launch promo | Paid per second |
 
 ## Calling via OpenMontage
 

--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # Copy this to .env and fill in your keys
 
 # --- Agnes AI (Sapiens AI) ---
-AGNES_API_KEY=                 # Agnes AI image + video generation (currently free)
+AGNES_API_KEY=                 # Agnes AI image + video generation (free during launch promo; verify current pricing)
                               # Get one at https://www.agnes-ai.com
 
 # --- Image + video gateway ---

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 # OpenMontage - Environment Variables
 # Copy this to .env and fill in your keys
 
+# --- Agnes AI (Sapiens AI) ---
+AGNES_API_KEY=                 # Agnes AI image + video generation (currently free)
+                              # Get one at https://www.agnes-ai.com
+
 # --- Image + video gateway ---
 # FLUX images, Google Veo video, Kling video, MiniMax video, Recraft images.
 # Get one at https://fal.ai/dashboard/keys

--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,9 @@
 # Copy this to .env and fill in your keys
 
 # --- Agnes AI (Sapiens AI) ---
-AGNES_API_KEY=                 # Agnes AI image + video generation (free during launch promo; verify current pricing)
-                              # Get one at https://www.agnes-ai.com
+# Agnes AI image + video generation (free during launch promo; verify current pricing)
+# Get one at https://www.agnes-ai.com
+AGNES_API_KEY=
 
 # --- Image + video gateway ---
 # FLUX images, Google Veo video, Kling video, MiniMax video, Recraft images.

--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ Each tool declares which Layer 3 skills it relies on. The agent reads Layer 1 to
 > **Full setup guide with pricing and free tiers:** [`docs/PROVIDERS.md`](docs/PROVIDERS.md)
 
 <details>
-<summary><strong>Video Generation — 15 providers</strong></summary>
+<summary><strong>Video Generation — 16 providers</strong></summary>
 
 | Provider | Type | Notes |
 |----------|------|-------|
@@ -495,6 +495,7 @@ Each tool declares which Layer 3 skills it relies on. The agent reads Layer 1 to
 | **Higgsfield** | Cloud API | Multi-model orchestrator with Soul ID for character consistency |
 | **MiniMax** | Cloud API | Cost-effective |
 | **HeyGen** | Cloud API | Multi-model gateway |
+| **Agnes AI** | Cloud API | Image + video generation (free during launch promo) |
 | **WAN 2.1** | Local GPU | Free, 1.3B and 14B variants |
 | **Hunyuan** | Local GPU | Free, high quality |
 | **CogVideo** | Local GPU | Free, 2B and 5B variants |
@@ -506,7 +507,7 @@ Each tool declares which Layer 3 skills it relies on. The agent reads Layer 1 to
 </details>
 
 <details>
-<summary><strong>Image Generation — 11 tools/providers</strong></summary>
+<summary><strong>Image Generation — 12 tools/providers</strong></summary>
 
 | Provider | Type | Notes |
 |----------|------|-------|
@@ -516,6 +517,7 @@ Each tool declares which Layer 3 skills it relies on. The agent reads Layer 1 to
 | **GPT Image 2** | Cloud API | OpenAI's image model |
 | **Recraft** | Cloud API | Design-focused generation |
 | **Kling Official** | Cloud API | Official direct API for Kling image generation and reference workflows |
+| **Agnes AI** | Cloud API | Image + video generation (free during launch promo) |
 | **Local Diffusion** | Local GPU | Stable Diffusion, free |
 | **Pexels** | Stock | Free stock images |
 | **Pixabay** | Stock | Free stock images |

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -227,6 +227,35 @@ No subscription — pure pay-as-you-go, no minimum spend.
 
 ---
 
+### Agnes AI (Sapiens AI) — Image + Video
+
+> **Cost-sensitive image and video generation.** Text-to-image, image-to-image, multi-image composition, text-to-video, image-to-video, multi-image video, and keyframe animation through a single API. Provider name `agnes`. During the launch promo the API is free to use — **verify current pricing and any fair-use limits at [agnes-ai.com](https://www.agnes-ai.com) before relying on it for production work.**
+
+**Tools unlocked:** `agnes_image`, `agnes_video`
+**Env vars:** `AGNES_API_KEY`
+
+#### Setup
+
+1. Create an account at [agnes-ai.com](https://www.agnes-ai.com)
+2. Generate an API key
+3. Add to `.env`:
+   ```
+   AGNES_API_KEY=your-api-key
+   ```
+
+#### Capabilities
+
+| Tool | Image | Video |
+|------|-------|-------|
+| `agnes_image` | T2I, I2I, multi-image composition (2.0-flash / 2.1-flash) | — |
+| `agnes_video` | — | T2V, I2V, multi-image video, keyframe animation (video-v2.0) |
+
+#### Pricing
+
+Free during the launch promo. Confirm current per-image / per-second pricing and quota limits on the official site before committing budget.
+
+---
+
 ### Kling Official — Direct API
 
 > **Official Kling path.** This is separate from `kling_video` via fal.ai: it uses Kling's official `Authorization: Bearer <KLING_API_KEY>` API, provider name `kling_official`, and direct Classic/Turbo/Omni task protocols.
@@ -934,6 +963,7 @@ These tools require only FFmpeg or Python packages — no GPU, no API key.
 | **xAI** | `XAI_API_KEY` | `grok_image`, `grok_video` | Paid only |
 | **Runway** | `RUNWAY_API_KEY` | `runway_video` | Free trial + paid |
 | **Higgsfield** | `HIGGSFIELD_API_KEY` + `HIGGSFIELD_API_SECRET` | `higgsfield_video` | Subscription ($15-84/mo) |
+| **Agnes AI** | `AGNES_API_KEY` | `agnes_image`, `agnes_video` | Free during launch promo |
 | **HeyGen** | `HEYGEN_API_KEY` | `heygen_video` | Pay-as-you-go |
 | **Suno** | `SUNO_API_KEY` | `suno_music` | Pay-as-you-go |
 | **Local GPU** | `VIDEO_GEN_LOCAL_ENABLED` | `wan_video`, `hunyuan_video`, `cogvideo_video`, `ltx_video_local` | Free (GPU required) |
@@ -948,8 +978,8 @@ How many providers cover each capability:
 
 | Capability | Cloud Providers | Local Providers | Free Options |
 |-----------|----------------|-----------------|--------------|
-| **Image Generation** | FLUX, Kling Official, Grok, Google Imagen, GPT Image 2, Recraft | Local Diffusion | Pexels, Pixabay (stock) |
-| **Video Generation** | Grok, Kling Official, Kling via fal.ai, Runway, Veo, Gemini Omni, Higgsfield, MiniMax, HeyGen | WAN, Hunyuan, CogVideo, LTX | Pexels, Pixabay (stock) |
+| **Image Generation** | FLUX, Kling Official, Grok, Google Imagen, GPT Image 2, Recraft, Agnes AI | Local Diffusion | Pexels, Pixabay (stock) |
+| **Video Generation** | Grok, Kling Official, Kling via fal.ai, Runway, Veo, Gemini Omni, Higgsfield, MiniMax, HeyGen, Agnes AI | WAN, Hunyuan, CogVideo, LTX | Pexels, Pixabay (stock) |
 | **Text-to-Speech** | ElevenLabs, Google TTS, Kling Official, OpenAI | Piper | Piper, Google free tier, ElevenLabs free tier |
 | **Music Generation** | ElevenLabs, Suno, Google Lyria | — | ElevenLabs free tier |
 | **Post-Production** | — | FFmpeg (compose, stitch, trim, mix, enhance, grade) | All free |

--- a/tests/contracts/test_agnes_providers.py
+++ b/tests/contracts/test_agnes_providers.py
@@ -1,0 +1,367 @@
+"""Contract tests for the Agnes AI (Sapiens AI) image and video provider tools.
+
+These tests verify that both tools satisfy the BaseTool contract without
+requiring a real AGNES_API_KEY or making any API calls.
+
+Run: pytest tests/contracts/test_agnes_providers.py -v
+"""
+
+import pytest
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+from tools.graphics.agnes_image import AgnesImage
+from tools.video.agnes_video import AgnesVideo
+
+
+# ------------------------------------------------------------------
+# Contract compliance
+# ------------------------------------------------------------------
+
+class TestContract:
+
+    def test_inherits_base_tool(self):
+        assert issubclass(AgnesImage, BaseTool)
+        assert issubclass(AgnesVideo, BaseTool)
+
+    def test_has_required_identity(self):
+        for tool in (AgnesImage(), AgnesVideo()):
+            assert tool.name
+            assert tool.version
+            assert tool.provider == "agnes"
+            assert tool.tier == ToolTier.GENERATE
+            assert tool.stability == ToolStability.EXPERIMENTAL
+            assert tool.runtime == ToolRuntime.API
+
+    def test_image_identity(self):
+        tool = AgnesImage()
+        assert tool.name == "agnes_image"
+        assert tool.capability == "image_generation"
+
+    def test_video_identity(self):
+        tool = AgnesVideo()
+        assert tool.name == "agnes_video"
+        assert tool.capability == "video_generation"
+
+    def test_execution_modes(self):
+        assert AgnesImage().execution_mode == ExecutionMode.SYNC
+        assert AgnesVideo().execution_mode == ExecutionMode.SYNC
+
+    def test_has_input_schema(self):
+        for tool, expected_required in (
+            (AgnesVideo(), ["prompt"]),
+            (AgnesImage(), ["prompt", "size"]),
+        ):
+            schema = tool.input_schema
+            assert schema.get("type") == "object"
+            props = schema.get("properties", {})
+            required = schema.get("required", [])
+            assert required == expected_required
+            for field in required:
+                assert field in props
+
+    def test_has_agent_skills(self):
+        assert "agnes-image" in AgnesImage().agent_skills
+        assert "agnes-video" in AgnesVideo().agent_skills
+
+    def test_has_fallbacks(self):
+        tool = AgnesVideo()
+        assert "seedance_video" in tool.fallback_tools
+        assert "kling_video" in tool.fallback_tools
+        tool = AgnesImage()
+        assert "flux_image" in tool.fallback_tools
+
+    def test_has_install_instructions(self):
+        for tool in (AgnesImage(), AgnesVideo()):
+            assert "AGNES_API_KEY" in tool.install_instructions
+
+    def test_declares_env_dependency(self):
+        """env:AGNES_API_KEY must be declared so status/registry reflect it."""
+        for tool in (AgnesImage(), AgnesVideo()):
+            assert "env:AGNES_API_KEY" in tool.dependencies
+
+    def test_get_info_returns_dict(self):
+        info = AgnesVideo().get_info()
+        assert isinstance(info, dict)
+        assert info["name"] == "agnes_video"
+        assert info["provider"] == "agnes"
+        assert info["runtime"] == "api"
+
+    def test_status_unavailable_without_key(self, monkeypatch):
+        monkeypatch.delenv("AGNES_API_KEY", raising=False)
+        assert AgnesImage().get_status() == ToolStatus.UNAVAILABLE
+        assert AgnesVideo().get_status() == ToolStatus.UNAVAILABLE
+
+    def test_status_available_with_key(self, monkeypatch):
+        monkeypatch.setenv("AGNES_API_KEY", "fake-key")
+        assert AgnesImage().get_status() == ToolStatus.AVAILABLE
+        assert AgnesVideo().get_status() == ToolStatus.AVAILABLE
+
+    def test_has_resource_profile(self):
+        for tool in (AgnesImage(), AgnesVideo()):
+            rp = tool.resource_profile
+            assert rp.network_required is True
+            assert rp.vram_mb == 0
+
+    def test_has_retry_policy(self):
+        for tool in (AgnesImage(), AgnesVideo()):
+            assert tool.retry_policy.max_retries >= 0
+
+    def test_has_side_effects(self):
+        for tool in (AgnesImage(), AgnesVideo()):
+            side = tool.side_effects
+            assert len(side) > 0
+            assert any("API" in s for s in side)
+
+    def test_has_user_visible_verification(self):
+        assert len(AgnesVideo().user_visible_verification) > 0
+
+    def test_lazy_imports_requests(self, monkeypatch):
+        import importlib
+        import sys
+
+        for mod_name in ("tools.video.agnes_video", "tools.graphics.agnes_image"):
+            if "requests" in sys.modules:
+                monkeypatch.delitem(sys.modules, "requests")
+            importlib.reload(sys.modules[mod_name])
+
+    def test_estimate_cost_returns_float(self):
+        cost = AgnesVideo().estimate_cost({"prompt": "x", "num_frames": 121})
+        assert isinstance(cost, float)
+        assert cost == 0.0
+
+    def test_dry_run_returns_dict(self):
+        for tool in (AgnesImage(), AgnesVideo()):
+            result = tool.dry_run({"prompt": "test"})
+            assert isinstance(result, dict)
+            assert result["tool"] == tool.name
+
+
+# ------------------------------------------------------------------
+# Idempotency keys
+# ------------------------------------------------------------------
+
+class TestIdempotencyKeys:
+
+    def test_video_includes_output_affecting_fields(self):
+        fields = AgnesVideo().idempotency_key_fields
+        for field in (
+            "prompt",
+            "operation",
+            "num_frames",
+            "frame_rate",
+            "seed",
+            "aspect_ratio",
+            "negative_prompt",
+            "image_url",
+            "image_path",
+            "image_urls",
+            "image_paths",
+        ):
+            assert field in fields, f"missing idempotency field: {field}"
+
+    def test_video_excludes_execution_only_fields(self):
+        fields = AgnesVideo().idempotency_key_fields
+        for field in ("output_path",):
+            assert field not in fields
+
+    def test_image_includes_output_affecting_fields(self):
+        fields = AgnesImage().idempotency_key_fields
+        for field in ("prompt", "size", "model", "image_url", "image_path", "image_urls", "image_paths"):
+            assert field in fields, f"missing idempotency field: {field}"
+
+    def test_video_differs_on_operation(self):
+        tool = AgnesVideo()
+        base = {"prompt": "x"}
+        assert tool.idempotency_key(base) != tool.idempotency_key(
+            {**base, "operation": "image_to_video"}
+        )
+
+    def test_video_differs_on_num_frames(self):
+        tool = AgnesVideo()
+        base = {"prompt": "x"}
+        assert tool.idempotency_key(base) != tool.idempotency_key(
+            {**base, "num_frames": 241}
+        )
+
+    def test_image_differs_on_model(self):
+        tool = AgnesImage()
+        base = {"prompt": "x", "size": "1024x768"}
+        assert tool.idempotency_key(base) != tool.idempotency_key(
+            {**base, "model": "agnes-image-2.0-flash"}
+        )
+
+    def test_image_differs_on_source_image(self):
+        tool = AgnesImage()
+        base = {"prompt": "x", "size": "1024x768"}
+        assert tool.idempotency_key(base) != tool.idempotency_key(
+            {**base, "image_url": "https://example.com/img.png"}
+        )
+
+
+# ------------------------------------------------------------------
+# Tool-specific behavior
+# ------------------------------------------------------------------
+
+class TestToolSpecific:
+
+    def test_video_default_frames_is_121(self):
+        tool = AgnesVideo()
+        assert tool.input_schema["properties"]["num_frames"]["default"] == 121
+
+    def test_video_default_frame_rate_is_24(self):
+        tool = AgnesVideo()
+        assert tool.input_schema["properties"]["frame_rate"]["default"] == 24
+
+    def test_video_default_aspect_ratio_is_16_9(self):
+        tool = AgnesVideo()
+        assert tool.input_schema["properties"]["aspect_ratio"]["default"] == "16:9"
+
+    def test_video_resolves_aspect(self):
+        tool = AgnesVideo()
+        assert tool._resolve_aspect("9:16") == (768, 1152)
+        assert tool._resolve_aspect("16:9") == (1152, 768)
+
+    def test_video_no_keys_returns_error(self, monkeypatch):
+        monkeypatch.delenv("AGNES_API_KEY", raising=False)
+        result = AgnesVideo().execute({"prompt": "test"})
+        assert result.success is False
+        assert "AGNES_API_KEY" in result.error
+
+    def test_image_no_keys_returns_error(self, monkeypatch):
+        monkeypatch.delenv("AGNES_API_KEY", raising=False)
+        result = AgnesImage().execute({"prompt": "test"})
+        assert result.success is False
+        assert "AGNES_API_KEY" in result.error
+
+    def test_video_validate_combo_accepts_valid(self):
+        assert AgnesVideo()._validate_combo({"num_frames": 121, "frame_rate": 24}) is None
+
+    def test_video_validate_combo_rejects_8n1_violation(self):
+        err = AgnesVideo()._validate_combo({"num_frames": 120, "frame_rate": 24})
+        assert err is not None
+        assert "8n+1" in err
+
+    def test_video_validate_combo_rejects_over_max(self):
+        err = AgnesVideo()._validate_combo({"num_frames": 442, "frame_rate": 24})
+        assert err is not None
+        assert "441" in err
+
+    def test_video_validate_combo_rejects_bad_fps(self):
+        err = AgnesVideo()._validate_combo({"num_frames": 121, "frame_rate": 61})
+        assert err is not None
+        assert "frame_rate" in err
+
+    def test_video_invalid_combo_fails_before_api(self, monkeypatch):
+        """Invalid num_frames must be rejected before any remote request."""
+        monkeypatch.setenv("AGNES_API_KEY", "fake-key")
+        result = AgnesVideo().execute({"prompt": "test", "num_frames": 120})
+        assert result.success is False
+        assert "8n+1" in result.error
+
+    def test_video_schema_bounds_num_frames(self):
+        schema = AgnesVideo().input_schema
+        nf = schema["properties"]["num_frames"]
+        assert nf["minimum"] == 1
+        assert nf["maximum"] == 441
+        fr = schema["properties"]["frame_rate"]
+        assert fr["minimum"] == 1
+        assert fr["maximum"] == 60
+
+
+# ------------------------------------------------------------------
+# No cross-provider substitution
+# ------------------------------------------------------------------
+
+class TestNoCrossProviderSubstitution:
+
+    def test_video_no_fal_upload_import(self):
+        """The tool must not silently upload user assets to fal.ai."""
+        import inspect
+
+        source = inspect.getsource(AgnesVideo)
+        assert "upload_image_fal" not in source
+        assert "FAL" not in source
+
+    def test_image_uses_agnes_only(self):
+        import inspect
+
+        source = inspect.getsource(AgnesImage)
+        assert "upload_image_fal" not in source
+
+    def test_video_local_image_falls_back_to_data_uri(self, monkeypatch):
+        """If the Agnes upload relay fails, the image stays on Agnes as a data URI."""
+        import tempfile
+        from pathlib import Path
+
+        monkeypatch.setenv("AGNES_API_KEY", "fake-key")
+        tool = AgnesVideo()
+
+        tmp = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+        tmp.write(b"\x89PNG\r\n\x1a\nfake")
+        tmp.close()
+
+        def boom(_self, _path):
+            raise RuntimeError("relay down")
+
+        monkeypatch.setattr(tool, "_upload_image_via_agnes", boom)
+        assert tool._local_to_data_uri(tmp.name).startswith("data:image/png;base64,")
+        Path(tmp.name).unlink()
+
+
+# ------------------------------------------------------------------
+# Registry discovery
+# ------------------------------------------------------------------
+
+class TestRegistryDiscovery:
+
+    def test_discoverable(self):
+        from tools.tool_registry import ToolRegistry
+
+        registry = ToolRegistry()
+        registry.discover()
+        names = {t.name for t in registry._tools.values()}
+        assert "agnes_image" in names
+        assert "agnes_video" in names
+
+    def test_single_instance_each(self):
+        from tools.tool_registry import ToolRegistry
+
+        registry = ToolRegistry()
+        registry.discover()
+        tools = [t for t in registry._tools.values() if t.provider == "agnes"]
+        assert len(tools) == 2
+        providers = {t.name: t.provider for t in tools}
+        assert providers["agnes_image"] == "agnes"
+        assert providers["agnes_video"] == "agnes"
+
+
+# ------------------------------------------------------------------
+# Selector routing
+# ------------------------------------------------------------------
+
+class TestSelectorRouting:
+
+    def test_video_selector_can_route_to_agnes(self, monkeypatch):
+        from tools.video.video_selector import VideoSelector
+
+        monkeypatch.setenv("AGNES_API_KEY", "fake-key")
+        selector = VideoSelector()
+        providers = selector._providers()
+        names = {t.name for t in providers}
+        assert "agnes_video" in names
+
+    def test_image_selector_can_route_to_agnes(self, monkeypatch):
+        from tools.graphics.image_selector import ImageSelector
+
+        monkeypatch.setenv("AGNES_API_KEY", "fake-key")
+        selector = ImageSelector()
+        names = {t.name for t in selector._providers()}
+        assert "agnes_image" in names

--- a/tools/graphics/agnes_image.py
+++ b/tools/graphics/agnes_image.py
@@ -1,0 +1,236 @@
+"""Agnes AI image generation via Sapiens AI API.
+
+Best for high-density visuals, multi-image composition, and cost-free generation.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+
+class AgnesImage(BaseTool):
+    name = "agnes_image"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "image_generation"
+    provider = "agnes"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = []
+    install_instructions = (
+        "Set AGNES_API_KEY to your Agnes AI API key.\n"
+        "  Get one at https://www.agnes-ai.com"
+    )
+    agent_skills = ["agnes-image"]
+
+    capabilities = [
+        "generate_image",
+        "generate_illustration",
+        "text_to_image",
+        "image_to_image",
+        "multi_image_composition",
+    ]
+    supports = {
+        "text_to_image": True,
+        "image_to_image": True,
+        "multi_image_composition": True,
+        "custom_size": True,
+        "seed": False,
+    }
+    best_for = [
+        "cost-free image generation (currently $0/image)",
+        "high-information-density visuals and complex compositions",
+        "multi-image composition and character compositing",
+        "image editing and style transfer",
+    ]
+    not_good_for = ["offline generation", "seed-reproducible outputs"]
+    fallback_tools = ["flux_image", "openai_image", "google_imagen"]
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt", "size"],
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "Text prompt describing the target image or editing instruction.",
+            },
+            "model": {
+                "type": "string",
+                "enum": ["agnes-image-2.0-flash", "agnes-image-2.1-flash"],
+                "default": "agnes-image-2.1-flash",
+                "description": (
+                    "2.0: general T2I/I2I. "
+                    "2.1: optimized for high-density details and complex compositions."
+                ),
+            },
+            "size": {
+                "type": "string",
+                "default": "1024x768",
+                "description": "Output image size, e.g. 1024x768, 1024x1024, 768x1024.",
+            },
+            "image_url": {
+                "type": "string",
+                "description": "Source image URL for image_to_image editing.",
+            },
+            "image_path": {
+                "type": "string",
+                "description": "Local source image path for image_to_image. Auto-converted to data URI.",
+            },
+            "image_urls": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Multiple source image URLs for multi-image composition.",
+            },
+            "image_paths": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Local source image paths for multi-image composition. Auto-converted to data URIs.",
+            },
+            "output_path": {"type": "string"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=512, vram_mb=0, disk_mb=100, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
+    idempotency_key_fields = ["prompt", "size", "model"]
+    side_effects = ["writes image file to output_path", "calls Agnes AI API"]
+    user_visible_verification = ["Inspect generated image for relevance and quality"]
+
+    BASE_URL = "https://apihub.agnes-ai.com/v1"
+
+    def _get_api_key(self) -> str | None:
+        return os.environ.get("AGNES_API_KEY")
+
+    def get_status(self) -> ToolStatus:
+        if self._get_api_key():
+            return ToolStatus.AVAILABLE
+        return ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        return 0.0
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        has_images = inputs.get("image_url") or inputs.get("image_path") or inputs.get("image_urls") or inputs.get("image_paths")
+        return 30.0 if has_images else 15.0
+
+    def _local_to_data_uri(self, image_path: str) -> str:
+        suffix = Path(image_path).suffix.lower()
+        mime = {
+            ".png": "image/png",
+            ".jpg": "image/jpeg",
+            ".jpeg": "image/jpeg",
+            ".webp": "image/webp",
+        }.get(suffix, "image/png")
+        data = Path(image_path).read_bytes()
+        return f"data:{mime};base64,{base64.b64encode(data).decode()}"
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        api_key = self._get_api_key()
+        if not api_key:
+            return ToolResult(
+                success=False,
+                error="AGNES_API_KEY not set. " + self.install_instructions,
+            )
+
+        import requests
+
+        start = time.time()
+        model = inputs.get("model", "agnes-image-2.1-flash")
+        prompt = inputs["prompt"]
+        size = inputs.get("size", "1024x768")
+
+        extra_body: dict[str, Any] = {"response_format": "url"}
+
+        images: list[str] = []
+        if inputs.get("image_url"):
+            images.append(inputs["image_url"])
+        if inputs.get("image_urls"):
+            images.extend(inputs["image_urls"])
+        if inputs.get("image_path"):
+            images.append(self._local_to_data_uri(inputs["image_path"]))
+        if inputs.get("image_paths"):
+            images.extend(self._local_to_data_uri(p) for p in inputs["image_paths"])
+
+        if images:
+            extra_body["image"] = images
+
+        payload: dict[str, Any] = {
+            "model": model,
+            "prompt": prompt,
+            "size": size,
+            "extra_body": extra_body,
+        }
+
+        try:
+            response = requests.post(
+                f"{self.BASE_URL}/images/generations",
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+                timeout=360,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            image_data = data["data"][0]
+            image_url = image_data.get("url")
+            b64 = image_data.get("b64_json")
+
+            if image_url:
+                img_resp = requests.get(image_url, timeout=60)
+                img_resp.raise_for_status()
+                image_bytes = img_resp.content
+            elif b64:
+                image_bytes = base64.b64decode(b64)
+            else:
+                return ToolResult(
+                    success=False,
+                    error="No image URL or base64 data in Agnes AI response",
+                )
+
+            output_path = Path(inputs.get("output_path", "agnes_image.png"))
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(image_bytes)
+
+        except Exception as e:
+            return ToolResult(success=False, error=f"Agnes AI image generation failed: {e}")
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": "agnes",
+                "model": model,
+                "prompt": prompt,
+                "output": str(output_path),
+                "size": size,
+                "has_source_images": len(images) > 0,
+            },
+            artifacts=[str(output_path)],
+            cost_usd=self.estimate_cost(inputs),
+            duration_seconds=round(time.time() - start, 2),
+            model=model,
+        )

--- a/tools/graphics/agnes_image.py
+++ b/tools/graphics/agnes_image.py
@@ -1,6 +1,8 @@
 """Agnes AI image generation via Sapiens AI API.
 
-Best for high-density visuals, multi-image composition, and cost-free generation.
+Best for high-information-density visuals, multi-image composition, and
+budget-constrained generation. Pricing is currently free during the launch
+promo — verify current terms at https://www.agnes-ai.com.
 """
 
 from __future__ import annotations
@@ -36,7 +38,7 @@ class AgnesImage(BaseTool):
     determinism = Determinism.STOCHASTIC
     runtime = ToolRuntime.API
 
-    dependencies = []
+    dependencies = ["env:AGNES_API_KEY"]
     install_instructions = (
         "Set AGNES_API_KEY to your Agnes AI API key.\n"
         "  Get one at https://www.agnes-ai.com"
@@ -58,7 +60,7 @@ class AgnesImage(BaseTool):
         "seed": False,
     }
     best_for = [
-        "cost-free image generation (currently $0/image)",
+        "currently free during the Agnes AI launch promo — verify current pricing at https://www.agnes-ai.com",
         "high-information-density visuals and complex compositions",
         "multi-image composition and character compositing",
         "image editing and style transfer",
@@ -114,7 +116,15 @@ class AgnesImage(BaseTool):
         cpu_cores=1, ram_mb=512, vram_mb=0, disk_mb=100, network_required=True
     )
     retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
-    idempotency_key_fields = ["prompt", "size", "model"]
+    idempotency_key_fields = [
+        "prompt",
+        "size",
+        "model",
+        "image_url",
+        "image_path",
+        "image_urls",
+        "image_paths",
+    ]
     side_effects = ["writes image file to output_path", "calls Agnes AI API"]
     user_visible_verification = ["Inspect generated image for relevance and quality"]
 

--- a/tools/video/agnes_video.py
+++ b/tools/video/agnes_video.py
@@ -348,7 +348,7 @@ class AgnesVideo(BaseTool):
                 status = poll_data.get("status", "queued")
 
                 if status == "completed":
-                    video_url = poll_data.get("remixed_from_video_id")
+                    video_url = poll_data.get("remixed_from_video_id") or poll_data.get("url")
                     if not video_url:
                         return ToolResult(
                             success=False,

--- a/tools/video/agnes_video.py
+++ b/tools/video/agnes_video.py
@@ -1,0 +1,407 @@
+"""Agnes AI video generation via Sapiens AI API.
+
+Best for cost-free video generation with text-to-video, image-to-video,
+multi-image video, and keyframe animation workflows.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+
+class AgnesVideo(BaseTool):
+    name = "agnes_video"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "video_generation"
+    provider = "agnes"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = []
+    install_instructions = (
+        "Set AGNES_API_KEY to your Agnes AI API key.\n"
+        "  Get one at https://www.agnes-ai.com"
+    )
+    agent_skills = ["agnes-video", "ai-video-gen"]
+
+    capabilities = ["text_to_video", "image_to_video", "multi_image_to_video", "keyframe_animation"]
+    supports = {
+        "text_to_video": True,
+        "image_to_video": True,
+        "multi_image_to_video": True,
+        "keyframe_animation": True,
+        "aspect_ratio": True,
+        "seed": True,
+        "cinematic_quality": True,
+    }
+    best_for = [
+        "cost-free video generation (currently $0/second)",
+        "keyframe animation and smooth transitions between visual states",
+        "multi-image video compositing",
+        "budget-constrained cinematic b-roll",
+    ]
+    not_good_for = ["offline generation", "native audio generation", "lip-sync"]
+    fallback_tools = ["seedance_video", "kling_video", "veo_video"]
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+            "prompt": {"type": "string"},
+            "operation": {
+                "type": "string",
+                "enum": ["text_to_video", "image_to_video", "multi_image_to_video", "keyframe_animation"],
+                "default": "text_to_video",
+            },
+            "width": {
+                "type": "integer",
+                "default": 1152,
+                "description": "Video width. Normalized to nearest standard resolution by the API.",
+            },
+            "height": {
+                "type": "integer",
+                "default": 768,
+                "description": "Video height. Normalized to nearest standard resolution by the API.",
+            },
+            "num_frames": {
+                "type": "integer",
+                "default": 121,
+                "description": "Total frames. Must follow 8n+1 rule, max 441. 121=5s@24fps, 241=10s@24fps.",
+            },
+            "frame_rate": {
+                "type": "integer",
+                "default": 24,
+                "description": "Playback frame rate (1-60).",
+            },
+            "seed": {"type": "integer"},
+            "negative_prompt": {"type": "string"},
+            "image_url": {
+                "type": "string",
+                "description": "Image URL for image_to_video.",
+            },
+            "image_path": {
+                "type": "string",
+                "description": "Local image path for image_to_video. Auto-converted to data URI.",
+            },
+            "image_urls": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Multiple image URLs for multi-image video or keyframe animation.",
+            },
+            "image_paths": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Local image paths for multi-image video or keyframe animation. Auto-converted to data URIs.",
+            },
+            "aspect_ratio": {
+                "type": "string",
+                "enum": ["16:9", "9:16", "1:1", "4:3", "3:4"],
+                "default": "16:9",
+            },
+            "output_path": {"type": "string"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=512, vram_mb=0, disk_mb=500, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
+    idempotency_key_fields = ["prompt", "num_frames", "frame_rate", "seed"]
+    side_effects = ["writes video file to output_path", "calls Agnes AI API"]
+    user_visible_verification = [
+        "Watch generated clip for motion coherence and visual quality"
+    ]
+
+    BASE_URL = "https://apihub.agnes-ai.com"
+    POLL_INTERVAL = 5
+    POLL_TIMEOUT = 600
+
+    def _get_api_key(self) -> str | None:
+        return os.environ.get("AGNES_API_KEY")
+
+    def get_status(self) -> ToolStatus:
+        if self._get_api_key():
+            return ToolStatus.AVAILABLE
+        return ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        return 0.0
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        num_frames = inputs.get("num_frames", 121)
+        fps = inputs.get("frame_rate", 24)
+        duration = num_frames / fps
+        return max(60.0, duration * 12)
+
+    def _resolve_aspect(self, aspect_ratio: str) -> tuple[int, int]:
+        mapping = {
+            "16:9": (1152, 768),
+            "9:16": (768, 1152),
+            "1:1": (768, 768),
+            "4:3": (1024, 768),
+            "3:4": (768, 1024),
+        }
+        return mapping.get(aspect_ratio, (1152, 768))
+
+    def _upload_image_via_agnes(self, image_path: str) -> str:
+        """Get a public URL for a local image by relaying it through the Agnes
+        images API. The image is sent as an I2I reference with a preservation
+        prompt so the output stays as close to the original as possible.
+
+        Returns a public Agnes storage URL usable by the video API."""
+        import requests as _requests
+
+        api_key = self._get_api_key()
+        if not api_key:
+            raise RuntimeError("AGNES_API_KEY required for image upload")
+
+        import base64
+
+        suffix = Path(image_path).suffix.lower()
+        mime = {
+            ".png": "image/png",
+            ".jpg": "image/jpeg",
+            ".jpeg": "image/jpeg",
+            ".webp": "image/webp",
+        }.get(suffix, "image/png")
+        img_w, img_h = self._image_dimensions(image_path)
+        size = f"{img_w}x{img_h}" if img_w and img_h else "1024x1024"
+        data_uri = f"data:{mime};base64,{base64.b64encode(Path(image_path).read_bytes()).decode()}"
+
+        resp = _requests.post(
+            f"{self.BASE_URL}/v1/images/generations",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": "agnes-image-2.1-flash",
+                "prompt": "Preserve the original image exactly as-is with no changes, maintain the exact composition, subject, style, and colors",
+                "size": size,
+                "extra_body": {
+                    "image": [data_uri],
+                    "response_format": "url",
+                },
+            },
+            timeout=120,
+        )
+        resp.raise_for_status()
+        return resp.json()["data"][0]["url"]
+
+    @staticmethod
+    def _image_dimensions(image_path: str) -> tuple[int, int]:
+        try:
+            from PIL import Image
+
+            with Image.open(image_path) as img:
+                return img.size
+        except Exception:
+            return 0, 0
+
+    def _local_to_data_uri(self, image_path: str) -> str:
+        """Convert a local image to a data URI for inline embedding.
+        Warning: large images may exceed API payload limits. Prefer URL-based upload."""
+        import base64
+
+        suffix = Path(image_path).suffix.lower()
+        mime = {
+            ".png": "image/png",
+            ".jpg": "image/jpeg",
+            ".jpeg": "image/jpeg",
+            ".webp": "image/webp",
+        }.get(suffix, "image/png")
+        data = Path(image_path).read_bytes()
+        return f"data:{mime};base64,{base64.b64encode(data).decode()}"
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        api_key = self._get_api_key()
+        if not api_key:
+            return ToolResult(
+                success=False,
+                error="AGNES_API_KEY not set. " + self.install_instructions,
+            )
+
+        import requests
+        from requests.adapters import HTTPAdapter
+        from urllib3.util.retry import Retry
+
+        session = requests.Session()
+        retry = Retry(total=3, backoff_factor=2, status_forcelist=[500, 502, 503, 504])
+        session.mount("https://", HTTPAdapter(max_retries=retry))
+
+        start = time.time()
+        operation = inputs.get("operation", "text_to_video")
+        aspect_ratio = inputs.get("aspect_ratio", "16:9")
+        default_w, default_h = self._resolve_aspect(aspect_ratio)
+        width = inputs.get("width", default_w)
+        height = inputs.get("height", default_h)
+        num_frames = inputs.get("num_frames", 121)
+        frame_rate = inputs.get("frame_rate", 24)
+
+        payload: dict[str, Any] = {
+            "model": "agnes-video-v2.0",
+            "prompt": inputs["prompt"],
+            "height": height,
+            "width": width,
+            "num_frames": num_frames,
+            "frame_rate": frame_rate,
+        }
+
+        if inputs.get("seed") is not None:
+            payload["seed"] = inputs["seed"]
+        if inputs.get("negative_prompt"):
+            payload["negative_prompt"] = inputs["negative_prompt"]
+
+        if operation == "image_to_video":
+            if inputs.get("image_url"):
+                payload["image"] = inputs["image_url"]
+            elif inputs.get("image_path"):
+                try:
+                    payload["image"] = self._upload_image_via_agnes(inputs["image_path"])
+                except Exception:
+                    try:
+                        from tools.video._shared import upload_image_fal
+                        payload["image"] = upload_image_fal(inputs["image_path"])
+                    except Exception:
+                        payload["image"] = self._local_to_data_uri(inputs["image_path"])
+
+        extra_body: dict[str, Any] = {}
+        if operation in ("multi_image_to_video", "keyframe_animation"):
+            image_urls = list(inputs.get("image_urls") or [])
+            image_paths = list(inputs.get("image_paths") or [])
+            for ip in image_paths:
+                try:
+                    image_urls.append(self._upload_image_via_agnes(ip))
+                except Exception:
+                    try:
+                        from tools.video._shared import upload_image_fal
+                        image_urls.append(upload_image_fal(ip))
+                    except Exception:
+                        image_urls.append(self._local_to_data_uri(ip))
+            if image_urls:
+                extra_body["image"] = image_urls
+            if operation == "keyframe_animation":
+                extra_body["mode"] = "keyframes"
+
+        if extra_body:
+            payload["extra_body"] = extra_body
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        try:
+            create_resp = None
+            for attempt in range(3):
+                try:
+                    create_resp = session.post(
+                        f"{self.BASE_URL}/v1/videos",
+                        headers=headers,
+                        json=payload,
+                        timeout=120,
+                    )
+                    create_resp.raise_for_status()
+                    break
+                except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
+                    if attempt == 2:
+                        raise
+            task_data = create_resp.json()
+
+            video_id = task_data.get("video_id") or task_data.get("task_id")
+            if not video_id:
+                return ToolResult(
+                    success=False,
+                    error=f"No video_id/task_id in Agnes AI response: {task_data}",
+                )
+
+            deadline = time.time() + self.POLL_TIMEOUT
+            interval = self.POLL_INTERVAL
+            while time.time() < deadline:
+                time.sleep(interval)
+                poll_resp = session.get(
+                    f"{self.BASE_URL}/agnesapi?video_id={video_id}",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                    timeout=30,
+                )
+                poll_resp.raise_for_status()
+                poll_data = poll_resp.json()
+                status = poll_data.get("status", "queued")
+
+                if status == "completed":
+                    video_url = poll_data.get("remixed_from_video_id")
+                    if not video_url:
+                        return ToolResult(
+                            success=False,
+                            error=f"Task completed but no video URL: {poll_data}",
+                        )
+                    break
+                if status == "failed":
+                    error_msg = poll_data.get("error") or "Unknown error"
+                    return ToolResult(
+                        success=False,
+                        error=f"Agnes AI video generation failed: {error_msg}",
+                    )
+                interval = min(interval * 1.2, 30.0)
+            else:
+                return ToolResult(
+                    success=False,
+                    error=f"Agnes AI video generation timed out after {self.POLL_TIMEOUT}s",
+                )
+
+            download_resp = session.get(video_url, timeout=300)
+            download_resp.raise_for_status()
+
+            output_path = Path(inputs.get("output_path", "agnes_video.mp4"))
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(download_resp.content)
+
+        except Exception as e:
+            return ToolResult(success=False, error=f"Agnes AI video generation failed: {e}")
+
+        from tools.video._shared import probe_output
+
+        probed = probe_output(output_path)
+        normalized_size = poll_data.get("size", f"{width}x{height}")
+        normalized_seconds = poll_data.get("seconds", str(round(num_frames / frame_rate, 1)))
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": "agnes",
+                "model": "agnes-video-v2.0",
+                "prompt": inputs["prompt"],
+                "operation": operation,
+                "aspect_ratio": aspect_ratio,
+                "normalized_size": normalized_size,
+                "normalized_seconds": normalized_seconds,
+                "output": str(output_path),
+                "output_path": str(output_path),
+                "format": "mp4",
+                "video_id": video_id,
+                **probed,
+            },
+            artifacts=[str(output_path)],
+            cost_usd=self.estimate_cost(inputs),
+            duration_seconds=round(time.time() - start, 2),
+            model="agnes-video-v2.0",
+        )

--- a/tools/video/agnes_video.py
+++ b/tools/video/agnes_video.py
@@ -1,7 +1,8 @@
 """Agnes AI video generation via Sapiens AI API.
 
-Best for cost-free video generation with text-to-video, image-to-video,
-multi-image video, and keyframe animation workflows.
+Best for keyframe animation, multi-image video compositing, and
+budget-constrained video generation. Pricing is currently free during the
+launch promo — verify current terms at https://www.agnes-ai.com.
 """
 
 from __future__ import annotations
@@ -36,7 +37,7 @@ class AgnesVideo(BaseTool):
     determinism = Determinism.STOCHASTIC
     runtime = ToolRuntime.API
 
-    dependencies = []
+    dependencies = ["env:AGNES_API_KEY"]
     install_instructions = (
         "Set AGNES_API_KEY to your Agnes AI API key.\n"
         "  Get one at https://www.agnes-ai.com"
@@ -54,7 +55,7 @@ class AgnesVideo(BaseTool):
         "cinematic_quality": True,
     }
     best_for = [
-        "cost-free video generation (currently $0/second)",
+        "currently free during the Agnes AI launch promo — verify current pricing at https://www.agnes-ai.com",
         "keyframe animation and smooth transitions between visual states",
         "multi-image video compositing",
         "budget-constrained cinematic b-roll",
@@ -84,11 +85,15 @@ class AgnesVideo(BaseTool):
             },
             "num_frames": {
                 "type": "integer",
+                "minimum": 1,
+                "maximum": 441,
                 "default": 121,
-                "description": "Total frames. Must follow 8n+1 rule, max 441. 121=5s@24fps, 241=10s@24fps.",
+                "description": "Total frames. Must follow 8n+1 rule (1, 9, 17, ...), max 441. 121=5s@24fps, 241=10s@24fps.",
             },
             "frame_rate": {
                 "type": "integer",
+                "minimum": 1,
+                "maximum": 60,
                 "default": 24,
                 "description": "Playback frame rate (1-60).",
             },
@@ -125,7 +130,21 @@ class AgnesVideo(BaseTool):
         cpu_cores=1, ram_mb=512, vram_mb=0, disk_mb=500, network_required=True
     )
     retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
-    idempotency_key_fields = ["prompt", "num_frames", "frame_rate", "seed"]
+    idempotency_key_fields = [
+        "prompt",
+        "operation",
+        "num_frames",
+        "frame_rate",
+        "seed",
+        "width",
+        "height",
+        "aspect_ratio",
+        "negative_prompt",
+        "image_url",
+        "image_path",
+        "image_urls",
+        "image_paths",
+    ]
     side_effects = ["writes video file to output_path", "calls Agnes AI API"]
     user_visible_verification = [
         "Watch generated clip for motion coherence and visual quality"
@@ -232,6 +251,30 @@ class AgnesVideo(BaseTool):
         data = Path(image_path).read_bytes()
         return f"data:{mime};base64,{base64.b64encode(data).decode()}"
 
+    def _validate_combo(self, inputs: dict[str, Any]) -> str | None:
+        """Return an error string for invalid num_frames/frame_rate combos, else None.
+
+        num_frames must follow the 8n+1 rule (1, 9, 17, ...) and be at most 441.
+        frame_rate must be between 1 and 60. Malformed values are rejected before
+        any paid/remote request is submitted.
+        """
+        num_frames = inputs.get("num_frames", 121)
+        frame_rate = inputs.get("frame_rate", 24)
+
+        if not isinstance(num_frames, int) or num_frames < 1 or num_frames > 441:
+            return (
+                f"num_frames must be an integer between 1 and 441 (got {num_frames!r})"
+            )
+        if (num_frames - 1) % 8 != 0:
+            return (
+                f"num_frames must follow the 8n+1 rule (1, 9, 17, ...) — got {num_frames}"
+            )
+        if not isinstance(frame_rate, int) or frame_rate < 1 or frame_rate > 60:
+            return (
+                f"frame_rate must be an integer between 1 and 60 (got {frame_rate!r})"
+            )
+        return None
+
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
         api_key = self._get_api_key()
         if not api_key:
@@ -239,6 +282,10 @@ class AgnesVideo(BaseTool):
                 success=False,
                 error="AGNES_API_KEY not set. " + self.install_instructions,
             )
+
+        validation_error = self._validate_combo(inputs)
+        if validation_error:
+            return ToolResult(success=False, error=f"Agnes AI video: {validation_error}")
 
         import requests
         from requests.adapters import HTTPAdapter
@@ -278,11 +325,7 @@ class AgnesVideo(BaseTool):
                 try:
                     payload["image"] = self._upload_image_via_agnes(inputs["image_path"])
                 except Exception:
-                    try:
-                        from tools.video._shared import upload_image_fal
-                        payload["image"] = upload_image_fal(inputs["image_path"])
-                    except Exception:
-                        payload["image"] = self._local_to_data_uri(inputs["image_path"])
+                    payload["image"] = self._local_to_data_uri(inputs["image_path"])
 
         extra_body: dict[str, Any] = {}
         if operation in ("multi_image_to_video", "keyframe_animation"):
@@ -292,11 +335,7 @@ class AgnesVideo(BaseTool):
                 try:
                     image_urls.append(self._upload_image_via_agnes(ip))
                 except Exception:
-                    try:
-                        from tools.video._shared import upload_image_fal
-                        image_urls.append(upload_image_fal(ip))
-                    except Exception:
-                        image_urls.append(self._local_to_data_uri(ip))
+                    image_urls.append(self._local_to_data_uri(ip))
             if image_urls:
                 extra_body["image"] = image_urls
             if operation == "keyframe_animation":


### PR DESCRIPTION
Add two new provider tools and corresponding Layer 3 agent skills for the Agnes AI API by Sapiens AI:

- tools/graphics/agnes_image.py: image generation with T2I, I2I, and multi-image composition via agnes-image-2.0-flash and agnes-image-2.1-flash models
- tools/video/agnes_video.py: async video generation with T2V, I2V, multi-image video, and keyframe animation via agnes-video-v2.0 model
- .agents/skills/agnes-image/SKILL.md: prompting guide, API notes, and integration checklist for image generation
- .agents/skills/agnes-video/SKILL.md: prompting guide, async polling patterns, duration control, and I2V resolution normalization caveats
- .env.example: add AGNES_API_KEY entry

Both tools are auto-discovered by the registry and immediately available through image_selector and video_selector with no additional wiring required. Currently free (/bin/bash/image, /bin/bash/second).

<!--
Thanks for contributing to OpenMontage! Please fill in the sections below.
Keep PRs focused — one logical change per PR is easier to review and merge.
-->

## Summary

<!-- What does this PR do, and why? -->

## Related issue

<!-- Link the issue this closes, e.g. "Closes #123". Use "Refs #123" if it only relates. -->
Closes #

## Changes

<!-- Bullet the notable changes. -->
-

## Testing

<!-- How did you verify this? Commands run, manual steps, platforms checked. -->
-

## Checklist

- [ ] The change is focused on a single logical concern.
- [ ] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [ ] I updated docs/README if behavior or usage changed.
- [ ] No unrelated files (build artifacts, local config) are included in the diff.
