### PR TITLE
docs: security advisory for malicious lookalike repo (#200)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,13 @@ cd OpenMontage
 make setup
 ```
 
+> [!WARNING]
+> **Only install OpenMontage from this official repository — `github.com/calesthio/OpenMontage`.**
+> A malicious lookalike (`Open-Montage/OpenMontage`, note the hyphen) distributes a
+> trojanized Windows build that drops malware and establishes persistence.
+> OpenMontage ships **as source only** — it has no prebuilt `.exe`. See
+> [SECURITY.md](SECURITY.md) for details and indicators of compromise.
+
 Open the project in your AI coding assistant and tell it what you want:
 
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,74 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you believe you have found a security vulnerability in OpenMontage, please report
+it **privately** so it can be triaged before public disclosure:
+
+- Use GitHub's private vulnerability reporting: open the repository's
+  **Security** tab → **Report a vulnerability**, or
+- Open a minimal issue that describes the impact **without** including a working
+  exploit, and ask a maintainer for a private channel.
+
+Please do not disclose the details publicly until a fix or mitigation is available.
+
+## Official distribution
+
+The **only** official source of OpenMontage is this repository:
+
+> **https://github.com/calesthio/OpenMontage**
+
+OpenMontage is distributed **as source code** and installed from source (see the
+README "Install & Run" steps). The project does **not** publish prebuilt Windows
+`.exe` release binaries. Treat any standalone OpenMontage executable — especially
+one offered as a GitHub *release asset* — as untrusted.
+
+## ⚠️ Known malicious impersonation
+
+A lookalike repository impersonates this project and distributes malware. It is
+**not affiliated with OpenMontage** in any way.
+
+- **Impersonating repository:** `Open-Montage/OpenMontage` (hyphenated — note that
+  the official org is `calesthio`, not `Open-Montage`).
+- It has published a Windows release archive (`OpenMontage-x64.7z` containing
+  `OpenMontage-x64.exe`) that behaves like a trojan/loader when executed.
+- Microsoft Defender detects the payload as **`Trojan:MSIL/PureRat.ABA!MTB`**.
+
+### Observed behaviour when run
+
+- Fetches a configuration manifest and a token/string from Pastebin.
+- Downloads additional `.7z` payloads from an Azure DevOps-hosted endpoint.
+- Writes payloads under `C:\Users\Public\...` using system-like folder names.
+- Drops/spawns executables such as `serveless.exe`, `cloude_edge.exe`,
+  `vsghssl.exe`, `vi_labs.exe`, `ngrok-daemon.exe`, `sqlite-host.exe`,
+  `DeltaNet.exe`, `SkyBridge.exe`, `node_ipsec.exe`, `audioconfig.exe`.
+- Establishes persistence via `Run` keys and scheduled tasks, and attempts to
+  tamper with Microsoft Defender.
+
+### Indicators of compromise (IOCs)
+
+Network indicators are **defanged** below — do not visit them.
+
+| Type | Indicator |
+| --- | --- |
+| Archive SHA-256 | `5a9844c2cb469e913e2653f644965ba047c0c6a43b0204f568c29b89400ef574` |
+| EXE SHA-256 | `d1a7e531176d4345f49ee1cdcb3ad43877623fa26de6a62c3cd05e4624ee8502` |
+| Defender signature | `Trojan:MSIL/PureRat.ABA!MTB` |
+| C2 / config | `hxxps://pastebin[.]com/raw/kh7qrEqA`, `hxxps://pastebin[.]com/raw/1zM5Xtif` |
+| Payload host | `hxxps://dev[.]azure[.]com/sagonbretzpr/...` |
+| Persistence (HKCU\...\Run) | `USBController`, `USBHost`, `SyncCoordinator` |
+| Persistence (HKLM\...\Run) | `WindowsSystemUpdate` |
+| Scheduled tasks | `NgrokUpdateTask*`, `SQLiteUpdateTask*` |
+
+### What to do
+
+- **Only** obtain OpenMontage by cloning the official repository above; never run a
+  prebuilt OpenMontage `.exe`.
+- If you downloaded or ran the impersonating build: disconnect from the network,
+  run a full anti-malware scan, remove the persistence entries and scheduled tasks
+  listed above, and **rotate any credentials or API keys** that were present on the
+  machine.
+- Report the impersonating repository to GitHub via
+  <https://github.com/contact/report-abuse>.
+
+_Reference: reported in issue #200._


### PR DESCRIPTION
## Summary

Warn users about a malicious repository impersonating OpenMontage (reported in #200), document the official distribution source, and record indicators of compromise.

## Related issue

Closes #200

## Changes

- Add `SECURITY.md`: a vulnerability-reporting policy; a note that OpenMontage ships **as source** (no prebuilt `.exe`); and a "Known malicious impersonation" section documenting the `Open-Montage/OpenMontage` lookalike with **defanged** indicators of compromise (archive/EXE SHA-256, C2/payload hosts, dropped binaries, persistence entries, and the Defender signature `Trojan:MSIL/PureRat.ABA!MTB`) plus remediation steps.
- Add a `> [!WARNING]` callout to the README "Install & Run" section pointing users to the official repo and linking to `SECURITY.md`.

## Testing

Docs-only change; no code paths touched. Verified the official clone URL (`github.com/calesthio/OpenMontage`) is correct, the GitHub alert + IOC table render, and all network indicators are intentionally defanged (`hxxps`, `[.]`).

## Checklist

- [x] The change is focused on a single logical concern.
- [ ] Tests — N/A (docs-only change).
- [x] I updated docs/README.
- [x] No unrelated files are included in the diff.
