### PR TITLE
add bootstrap.sh for headless server setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ cd OpenMontage
 make setup
 ```
 
+> **Headless server / fresh VPS?** Run `./bootstrap.sh` instead of `make setup` — it installs the system dependencies a bare server is missing (FFmpeg, Node, Chromium libs for Remotion), downloads a Piper voice, runs `make setup`, and proves the stack with a zero-key demo render.
+
 Open the project in your AI coding assistant and tell it what you want:
 
 ```

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -14,6 +14,10 @@
 #                         (`libnspr4.so: cannot open shared object file`).
 #   4. Piper voice      — `make setup` installs the piper-tts engine but downloads no voice,
 #                         so the offline $0 TTS path has nothing to speak with.
+#   5. Node.js + make   — Node 18+ is a listed prereq (`make setup` npm-installs
+#                         remotion-composer, and HyperFrames wants 22+ per the engines
+#                         table), but like FFmpeg nothing installs it; and a truly bare
+#                         server has no `make` either.
 #
 # Idempotent / re-runnable. Exits 0 = ready, non-zero = names exactly what failed.
 #
@@ -35,17 +39,19 @@ cd "$OM_DIR"
 # ---- 0. detect package manager ----
 if   command -v apt-get >/dev/null 2>&1; then PKG=apt
 elif command -v brew    >/dev/null 2>&1; then PKG=brew
-else die "no apt-get or brew found — install FFmpeg, python3-venv, and (Linux) Chromium libs manually, then re-run."; fi
+else die "no apt-get or brew found — install FFmpeg, Node 18+, python3-venv, and (Linux) Chromium libs manually, then re-run."; fi
 SUDO=""; [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1 && SUDO=sudo
 
 apt_install() { DEBIAN_FRONTEND=noninteractive $SUDO apt-get install -y --no-install-recommends "$@"; }
 
-# ---- 1. FFmpeg + python3-venv (gaps #1, #2) ----
+# ---- 1. FFmpeg + python3-venv + node + make (gaps #1, #2, #5) ----
 say "System prerequisites"
 if [ "$PKG" = apt ]; then
   $SUDO apt-get update -qq
-  apt_install ffmpeg python3 python3-venv python3-pip
-  ok "ffmpeg + python3-venv installed"
+  apt_install ffmpeg python3 python3-venv python3-pip make
+  command -v node >/dev/null 2>&1 || apt_install nodejs
+  command -v npm  >/dev/null 2>&1 || apt_install npm   # separate package on Debian (only "suggested" by nodejs); provides npx
+  ok "ffmpeg + python3-venv + make present; node $(node -v 2>/dev/null || echo missing), npm $(npm -v 2>/dev/null || echo missing)"
 
   # ---- 2. Chromium headless libraries (gap #3) ----
   say "Chromium headless libraries (undocumented Remotion dependency)"
@@ -57,7 +63,22 @@ if [ "$PKG" = apt ]; then
   ok "chromium libs installed"
 else
   brew list ffmpeg >/dev/null 2>&1 || brew install ffmpeg
-  ok "ffmpeg installed (macOS ships the Chromium libs Remotion needs, no extra step)"
+  brew list node   >/dev/null 2>&1 || brew install node   # brew's node includes npm/npx
+  ok "ffmpeg + node installed (macOS ships the Chromium libs Remotion needs, no extra step)"
+fi
+
+# sanity gate before make setup — die with the exact gap, don't let make setup fail confusingly
+command -v make >/dev/null 2>&1 || die "make not found — Debian/Ubuntu: apt-get install make; macOS: xcode-select --install"
+command -v npx  >/dev/null 2>&1 || die "npx not found — Debian/Ubuntu: apt-get install npm; then re-run."
+NODE_VER="$(node -v 2>/dev/null || echo none)"
+NODE_MAJOR="${NODE_VER#v}"; NODE_MAJOR="${NODE_MAJOR%%.*}"
+case "$NODE_MAJOR" in *[!0-9]*|"") NODE_MAJOR=0;; esac
+if   [ "$NODE_MAJOR" -lt 18 ]; then
+  die "node 18+ required (README prereq) but found $NODE_VER — old distro repos ship ancient node (Ubuntu 22.04 apt = v12); install from nodejs.org or NodeSource, then re-run."
+elif [ "$NODE_MAJOR" -lt 22 ]; then
+  warn "node $NODE_VER is fine for Remotion; the HyperFrames runtime wants 22+ (README engines table) — upgrade if you use it"
+else
+  ok "node $NODE_VER"
 fi
 
 # ---- 3. the standard install path ----

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Bootstrap a bare Linux server (or macOS box) to verified-render-ready, then prove it
+# with a zero-key demo render. `make setup` + the README cover the desktop happy path;
+# on a headless server a few things are missing and each one surfaces as its own
+# mid-render failure. This closes those gaps and runs the standard `make setup` for
+# everything else.
+#
+# Gaps this closes:
+#   1. FFmpeg          — listed as a prereq, but `make setup` does not install it.
+#   2. python3-venv     — base python3 lacks ensurepip on Debian/Ubuntu; `python -m venv`
+#                         fails until the distro package is installed.
+#   3. Chromium libs    — Remotion's headless renderer needs them (libnss3, libnspr4, ...);
+#                         not documented anywhere; absence shows up as a first-render crash
+#                         (`libnspr4.so: cannot open shared object file`).
+#   4. Piper voice      — `make setup` installs the piper-tts engine but downloads no voice,
+#                         so the offline $0 TTS path has nothing to speak with.
+#
+# Idempotent / re-runnable. Exits 0 = ready, non-zero = names exactly what failed.
+#
+# Usage:  ./bootstrap.sh [/path/to/OpenMontage]   (default: current directory)
+set -euo pipefail
+
+OM_DIR="${1:-$(pwd)}"
+VOICE="${VOICE:-en_US-lessac-medium}"
+VOICE_DIR="${VOICE_DIR:-$OM_DIR/.voices}"
+
+say()  { printf '\n\033[1;36m==> %s\033[0m\n' "$*"; }
+ok()   { printf '\033[1;32m  [ok] %s\033[0m\n' "$*"; }
+warn() { printf '\033[1;33m  [warn] %s\033[0m\n' "$*"; }
+die()  { printf '\033[1;31m  [FAIL] %s\033[0m\n' "$*" >&2; exit 1; }
+
+cd "$OM_DIR"
+[ -f Makefile ] && [ -f render_demo.py ] || die "run this from an OpenMontage checkout (no Makefile/render_demo.py found in $OM_DIR)."
+
+# ---- 0. detect package manager ----
+if   command -v apt-get >/dev/null 2>&1; then PKG=apt
+elif command -v brew    >/dev/null 2>&1; then PKG=brew
+else die "no apt-get or brew found — install FFmpeg, python3-venv, and (Linux) Chromium libs manually, then re-run."; fi
+SUDO=""; [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1 && SUDO=sudo
+
+apt_install() { DEBIAN_FRONTEND=noninteractive $SUDO apt-get install -y --no-install-recommends "$@"; }
+
+# ---- 1. FFmpeg + python3-venv (gaps #1, #2) ----
+say "System prerequisites"
+if [ "$PKG" = apt ]; then
+  $SUDO apt-get update -qq
+  apt_install ffmpeg python3 python3-venv python3-pip
+  ok "ffmpeg + python3-venv installed"
+
+  # ---- 2. Chromium headless libraries (gap #3) ----
+  say "Chromium headless libraries (undocumented Remotion dependency)"
+  apt_install \
+    libnss3 libnspr4 libdbus-1-3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
+    libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 \
+    libpango-1.0-0 libcairo2 libasound2 libatspi2.0-0 libxshmfence1 || \
+    warn "some chromium libs failed to install — Remotion renders may crash"
+  ok "chromium libs installed"
+else
+  brew list ffmpeg >/dev/null 2>&1 || brew install ffmpeg
+  ok "ffmpeg installed (macOS ships the Chromium libs Remotion needs, no extra step)"
+fi
+
+# ---- 3. the standard install path ----
+say "make setup"
+make setup
+ok "make setup complete"
+
+# ---- 4. Piper voice (gap #4) ----
+say "Piper offline voice: $VOICE"
+mkdir -p "$VOICE_DIR"
+if ls "$VOICE_DIR/$VOICE"* >/dev/null 2>&1; then
+  ok "voice already present"
+else
+  PYTHON_BIN="$OM_DIR/.venv/bin/python"
+  [ -x "$PYTHON_BIN" ] || PYTHON_BIN="python3"
+  "$PYTHON_BIN" -m piper.download_voices "$VOICE" --data-dir "$VOICE_DIR" \
+    && ok "voice downloaded to $VOICE_DIR" \
+    || warn "voice download failed — offline \$0 TTS unavailable; cloud TTS still works with keys in .env"
+fi
+
+# ---- 5. prove it: zero-key demo render ----
+say "Proof render (zero keys, zero tokens)"
+PYTHON_BIN="$OM_DIR/.venv/bin/python"
+[ -x "$PYTHON_BIN" ] || PYTHON_BIN="python3"
+if "$PYTHON_BIN" render_demo.py --list >/dev/null 2>&1; then
+  FIRST_DEMO="$("$PYTHON_BIN" render_demo.py --list 2>/dev/null | awk '/^[[:space:]]+[a-z0-9]/{print $1; exit}' || true)"
+  if [ -n "$FIRST_DEMO" ] && "$PYTHON_BIN" render_demo.py "$FIRST_DEMO" >/dev/null 2>&1; then
+    ok "demo '$FIRST_DEMO' rendered — render stack is live"
+  else
+    warn "demo list works but a render failed — inspect: $PYTHON_BIN render_demo.py $FIRST_DEMO"
+  fi
+else
+  warn "render_demo.py --list failed — check 'make setup' output above"
+fi
+
+say "Bootstrap complete"
+ok "READY — add API keys to .env for cloud providers, then open this project in your AI coding assistant."

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -74,15 +74,15 @@ if [ "$PKG" = apt ]; then
     degrade "Chromium libraries failed to install; Remotion renders may crash"
   fi
 else
+  command -v make >/dev/null 2>&1 || die "make not found. Run: xcode-select --install"
   brew list ffmpeg >/dev/null 2>&1 || brew install ffmpeg
   brew list node   >/dev/null 2>&1 || brew install node   # brew's node includes npm/npx
-  command -v make >/dev/null 2>&1 || die "make not found. Run: xcode-select --install"
   ok "ffmpeg + node installed (macOS ships the Chromium libs Remotion needs, no extra step)"
 fi
 
 # sanity gate before make setup — die with the exact gap, don't let make setup fail confusingly
 command -v make >/dev/null 2>&1 || die "make not found — Debian/Ubuntu: apt-get install make; macOS: xcode-select --install"
-command -v npx  >/dev/null 2>&1 || die "npx not found — Debian/Ubuntu: apt-get install npm; then re-run."
+command -v npx  >/dev/null 2>&1 || die "npx not found — reinstall Node.js from NodeSource (Debian/Ubuntu) or Homebrew (macOS), then re-run."
 NODE_VER="$(node -v 2>/dev/null || echo none)"
 NODE_MAJOR="${NODE_VER#v}"; NODE_MAJOR="${NODE_MAJOR%%.*}"
 case "$NODE_MAJOR" in *[!0-9]*|"") NODE_MAJOR=0;; esac

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -30,11 +30,13 @@ set -euo pipefail
 OM_DIR="${1:-$(pwd)}"
 VOICE="${VOICE:-en_US-lessac-medium}"
 VOICE_DIR="$HOME/.piper/models"
+FAILURES=()
 
 say()  { printf '\n\033[1;36m==> %s\033[0m\n' "$*"; }
 ok()   { printf '\033[1;32m  [ok] %s\033[0m\n' "$*"; }
 warn() { printf '\033[1;33m  [warn] %s\033[0m\n' "$*"; }
 die()  { printf '\033[1;31m  [FAIL] %s\033[0m\n' "$*" >&2; exit 1; }
+degrade() { FAILURES+=("$*"); warn "$*"; }
 
 cd "$OM_DIR"
 [ -f Makefile ] && [ -f render_demo.py ] || die "run this from an OpenMontage checkout (no Makefile/render_demo.py found in $OM_DIR)."
@@ -63,12 +65,14 @@ if [ "$PKG" = apt ]; then
 
   # ---- 2. Chromium headless libraries (gap #3) ----
   say "Chromium headless libraries (undocumented Remotion dependency)"
-  apt_install \
+  if apt_install \
     libnss3 libnspr4 libdbus-1-3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
     libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 \
-    libpango-1.0-0 libcairo2 libasound2 libatspi2.0-0 libxshmfence1 || \
-    warn "some chromium libs failed to install — Remotion renders may crash"
-  ok "chromium libs installed"
+    libpango-1.0-0 libcairo2 libasound2 libatspi2.0-0 libxshmfence1; then
+    ok "chromium libs installed"
+  else
+    degrade "Chromium libraries failed to install; Remotion renders may crash"
+  fi
 else
   brew list ffmpeg >/dev/null 2>&1 || brew install ffmpeg
   brew list node   >/dev/null 2>&1 || brew install node   # brew's node includes npm/npx
@@ -103,9 +107,11 @@ if ls "$VOICE_DIR/$VOICE"* >/dev/null 2>&1; then
 else
   PYTHON_BIN="$OM_DIR/.venv/bin/python"
   [ -x "$PYTHON_BIN" ] || PYTHON_BIN="python3"
-  "$PYTHON_BIN" -m piper.download_voices "$VOICE" --data-dir "$VOICE_DIR" \
-    && ok "voice downloaded to $VOICE_DIR" \
-    || warn "voice download failed — offline \$0 TTS unavailable; cloud TTS still works with keys in .env"
+  if "$PYTHON_BIN" -m piper.download_voices "$VOICE" --data-dir "$VOICE_DIR"; then
+    ok "voice downloaded to $VOICE_DIR"
+  else
+    degrade "Piper voice download failed; offline \$0 TTS is unavailable"
+  fi
 fi
 
 # ---- 5. prove it: zero-key demo render ----
@@ -114,14 +120,23 @@ PYTHON_BIN="$OM_DIR/.venv/bin/python"
 [ -x "$PYTHON_BIN" ] || PYTHON_BIN="python3"
 if "$PYTHON_BIN" render_demo.py --list >/dev/null 2>&1; then
   FIRST_DEMO="$("$PYTHON_BIN" render_demo.py --list 2>/dev/null | awk '/^[[:space:]]+[a-z0-9]/{print $1; exit}' || true)"
-  if [ -n "$FIRST_DEMO" ] && "$PYTHON_BIN" render_demo.py "$FIRST_DEMO" >/dev/null 2>&1; then
+  if [ -z "$FIRST_DEMO" ]; then
+    degrade "Demo list returned no runnable demos"
+  elif "$PYTHON_BIN" render_demo.py "$FIRST_DEMO" >/dev/null 2>&1; then
     ok "demo '$FIRST_DEMO' rendered — render stack is live"
   else
-    warn "demo list works but a render failed — inspect: $PYTHON_BIN render_demo.py $FIRST_DEMO"
+    degrade "Demo '$FIRST_DEMO' failed to render; inspect: $PYTHON_BIN render_demo.py $FIRST_DEMO"
   fi
 else
-  warn "render_demo.py --list failed — check 'make setup' output above"
+  degrade "render_demo.py --list failed; check 'make setup' output above"
 fi
 
 say "Bootstrap complete"
+if [ "${#FAILURES[@]}" -gt 0 ]; then
+  warn "DEGRADED — the following checks failed:"
+  for failure in "${FAILURES[@]}"; do
+    printf '    - %s\n' "$failure"
+  done
+  exit 1
+fi
 ok "READY — add API keys to .env for cloud providers, then open this project in your AI coding assistant."

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -29,7 +29,7 @@ set -euo pipefail
 
 OM_DIR="${1:-$(pwd)}"
 VOICE="${VOICE:-en_US-lessac-medium}"
-VOICE_DIR="${VOICE_DIR:-$OM_DIR/.voices}"
+VOICE_DIR="$HOME/.piper/models"
 
 say()  { printf '\n\033[1;36m==> %s\033[0m\n' "$*"; }
 ok()   { printf '\033[1;32m  [ok] %s\033[0m\n' "$*"; }

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-# Bootstrap a bare Linux server (or macOS box) to verified-render-ready, then prove it
-# with a zero-key demo render. `make setup` + the README cover the desktop happy path;
+# Supported hosts: Debian/Ubuntu with apt-get, and macOS with Homebrew.
+# Other operating systems and package managers are not supported by this script.
+#
+# Bootstrap a supported bare server (or macOS box) to verified-render-ready, then
+# prove it with a zero-key demo render. `make setup` + the README cover the desktop happy path;
 # on a headless server a few things are missing and each one surfaces as its own
 # mid-render failure. This closes those gaps and runs the standard `make setup` for
 # everything else.
@@ -39,7 +42,7 @@ cd "$OM_DIR"
 # ---- 0. detect package manager ----
 if   command -v apt-get >/dev/null 2>&1; then PKG=apt
 elif command -v brew    >/dev/null 2>&1; then PKG=brew
-else die "no apt-get or brew found — install FFmpeg, Node 18+, python3-venv, and (Linux) Chromium libs manually, then re-run."; fi
+else die "unsupported host — this script supports Debian/Ubuntu with apt-get and macOS with Homebrew only."; fi
 SUDO=""; [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1 && SUDO=sudo
 
 apt_install() { DEBIAN_FRONTEND=noninteractive $SUDO apt-get install -y --no-install-recommends "$@"; }
@@ -49,8 +52,13 @@ say "System prerequisites"
 if [ "$PKG" = apt ]; then
   $SUDO apt-get update -qq
   apt_install ffmpeg python3 python3-venv python3-pip make
-  command -v node >/dev/null 2>&1 || apt_install nodejs
-  command -v npm  >/dev/null 2>&1 || apt_install npm   # separate package on Debian (only "suggested" by nodejs); provides npx
+
+  NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null || printf '0')"
+  if [ "$NODE_MAJOR" -lt 18 ]; then
+    apt_install ca-certificates curl
+    curl -fsSL https://deb.nodesource.com/setup_22.x | $SUDO bash -
+    apt_install nodejs
+  fi
   ok "ffmpeg + python3-venv + make present; node $(node -v 2>/dev/null || echo missing), npm $(npm -v 2>/dev/null || echo missing)"
 
   # ---- 2. Chromium headless libraries (gap #3) ----
@@ -64,6 +72,7 @@ if [ "$PKG" = apt ]; then
 else
   brew list ffmpeg >/dev/null 2>&1 || brew install ffmpeg
   brew list node   >/dev/null 2>&1 || brew install node   # brew's node includes npm/npx
+  command -v make >/dev/null 2>&1 || die "make not found. Run: xcode-select --install"
   ok "ffmpeg + node installed (macOS ships the Chromium libs Remotion needs, no extra step)"
 fi
 


### PR DESCRIPTION
## Summary

ran into a few things `make setup` doesn't cover on a bare linux server:
- ffmpeg not installed
- python3-venv missing (venv creation fails)
- chromium libs missing (remotion headless render crashes, libnspr4.so error)
- piper installs the engine but no voice gets downloaded
- node + make missing (node 18+ is in the README prereqs and `make setup` npm-installs remotion-composer, but nothing installs it — and a truly bare box has no `make` either) *(added in the second commit)*

wrote a bootstrap.sh that installs those, runs the normal `make setup`, then does a demo render to prove it actually works. idempotent, tells you what failed if it does. figured it might help anyone running this on a vps instead of a laptop. macOS gets the ffmpeg + node checks since the linux-only stuff isn't needed there.

## Related issue

Closes #

## Changes

- new `bootstrap.sh` at repo root
- one blockquote line in the README Quick Start pointing headless-server users at it (mirrors the existing "No `make`?" note style)

## Testing

- ran it end to end on a fresh debian box, got a real demo render out at the end
- after adding node/make: ran the updated script end to end in a fresh `debian:bookworm` container against current `main` (clone → bootstrap → demo render)
- `bash -n bootstrap.sh` for syntax

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable. (`pytest tests/ --ignore=tests/qa` on this branch: 435 passed, 6 skipped, 0 failed — qa excluded because it makes paid API calls)
- [x] I updated docs/README if behavior or usage changed. (one README line pointing headless setups at bootstrap.sh)
- [x] No unrelated files (build artifacts, local config) are included in the diff.
