### PR TITLE
feat(providers): add Clipia aggregator (clipia_video + clipia_image) — one key, 50+ models, sandbox test mode

### DIFF
--- a/.agents/skills/clipia/SKILL.md
+++ b/.agents/skills/clipia/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: clipia
+description: |
+  Generate images and video through Clipia (api.clipia.ai) — a multi-model aggregator where one API key unlocks 50+ hosted models (Kling, Veo, Seedance, Wan, Sora, Nano Banana, FLUX, GPT-Image, ...). Use when: (1) CLIPIA_API_KEY is configured, (2) you need several different video/image models without opening new provider accounts, (3) you need a RU/CIS-payable route to premium models (billing in rubles, Russian bank cards), (4) you want spend-safe integration testing — clipia_test_ sandbox keys return instant mock COMPLETED results with zero credit spend. Wrapped by the `clipia_video` and `clipia_image` tools; also exposed as a remote MCP server at https://mcp.clipia.ai/mcp.
+allowed-tools: Bash, Read, Write
+metadata:
+  openclaw:
+    requires:
+      env_any:
+        - CLIPIA_API_KEY
+---
+
+# Clipia (api.clipia.ai)
+
+Clipia is a generation **aggregator**: `POST /v1/models/{slug}` submits to any of 50+ hosted image/video models through one account, one key, one queue API. The API is deliberately fal.ai-shaped (`submit → status → result`, same field names like `request_id` / `status_url` / `response_url`), so fal.ai integration habits transfer directly. Billing is in **credits** with a fixed, deterministic price per call known at submit time.
+
+**Base URL:** `https://api.clipia.ai` · **Docs:** https://clipia.ai/docs · **Key management:** https://clipia.ai/ru/developer
+
+## Auth
+
+```
+Authorization: Key clipia_live_xxxxxxxxxxxxxxxxxxxxxx
+```
+
+`Authorization: Bearer <key>` and `X-Api-Key: <key>` are accepted too. Keys are created in the Developer console and shown **once**. The key is a server-side secret — never put it in client code or repos. Key prefixes: `clipia_live_` (production) and `clipia_test_` (sandbox, see below).
+
+## Queue lifecycle (the only mode — async)
+
+```bash
+# 1. Submit
+curl -X POST https://api.clipia.ai/v1/models/seedance-2-fast-t2v \
+  -H "Authorization: Key $CLIPIA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -d '{"input": {"prompt": "aerial dolly over a foggy coast, cinematic", "duration": 5, "aspect_ratio": "16:9"}}'
+# -> { "request_id": "...", "status": "IN_QUEUE", "queue_position": 0,
+#      "status_url": ".../v1/requests/{id}/status", "response_url": ".../v1/requests/{id}",
+#      "cost": 47 }            # <- fixed price in credits, reserved now
+
+# 2. Poll
+curl -H "Authorization: Key $CLIPIA_API_KEY" https://api.clipia.ai/v1/requests/{id}/status
+# -> { "status": "IN_PROGRESS", "progress": 45, ... }
+
+# 3. Result (when status == COMPLETED)
+curl -H "Authorization: Key $CLIPIA_API_KEY" https://api.clipia.ai/v1/requests/{id}
+```
+
+| Status | Meaning |
+|--------|---------|
+| `IN_QUEUE` | queued, `queue_position` ≥ 0 |
+| `IN_PROGRESS` | running, `progress` 0–100 |
+| `COMPLETED` | done — fetch `response_url` |
+| `FAILED` | error; **reserved credits are refunded in full**; `error {code, message}` in the result |
+| `CANCELED` | terminal; canceled outside the public API (e.g. from the web account). **Note the single L** — not fal's `CANCELLED`. There is no cancel endpoint in the public API. |
+
+Result endpoint HTTP codes: `200` for terminal statuses (including `FAILED`/`CANCELED`), `202` while still running. Reasonable client timeouts: submit 60 s, poll every ~5 s, overall 15 min for video / 5 min for images.
+
+## Output shapes
+
+Image models:
+
+```json
+"output": { "images": [ { "url": "https://media.clipia.ai/....webp",
+                           "original_url": "https://media.clipia.ai/....png",
+                           "width": 1024, "height": 1024 } ] }
+```
+
+Video models:
+
+```json
+"output": { "video": { "url": "...", "original_url": "...", "width": 1280, "height": 720, "duration": 5 } }
+```
+
+`url` is a display-optimized rendition (usually WebP for images); **`original_url` is the full-quality file — prefer it for downloads** (fall back to `url` when absent).
+
+## Model discovery is dynamic — never hardcode the catalog
+
+- `GET /v1/models` → `{ "data": [ { "slug", "type": "image"|"video", "name", "modalities", "pricing": { "credits" } } ] }`
+- `GET /v1/models/{slug}` → per-model `input_schema` (which fields exist, enums, defaults) + pricing multipliers
+- `POST /v1/models/{slug}/estimate` → exact `credits` for a concrete parameter set, without queueing
+
+Common `input` fields (availability varies per model — check the schema): `prompt`, `image_url`, `image_urls` (multi-reference), `aspect_ratio`, `duration` (number, seconds, video), `resolution`, `num_images` (images, 1–4).
+
+Popular slugs as of 2026-07 (approximate list prices in credits; 1 credit ≈ $0.04–0.06):
+
+| Slug | Type | Price |
+|------|------|-------|
+| `seedance-2-fast-t2v` / `seedance-2-fast-i2v` | video | 47 cr / 5 s @ 720p (28 @ 480p) |
+| `kling-3` | video | 36 cr / 5 s @ 720p |
+| `wan-2-7` | video | 24 cr / 5 s @ 720p |
+| `sora-2` / `sora-2-pro` | video | 17 / 28 cr per clip |
+| `nano-banana-2` (default image) | image | 4 cr |
+| `nano-banana-pro` | image | 5 cr |
+| `flux-2-pro` | image | 3 cr |
+| `gpt-image-2` | image | 3–7 cr by resolution |
+
+## Sandbox mode (`clipia_test_` keys)
+
+Create a key with the environment toggle set to **Test** → prefix `clipia_test_`. Same header, same code paths:
+
+- **No credits are spent**, no real generation runs.
+- `submit` returns `status: COMPLETED` **immediately** (no `IN_QUEUE`/`IN_PROGRESS` phases).
+- `output` is a **fixed sample asset** (image or video by model type) — for verifying parsing/polling/download code, not model quality.
+- `cost` shows what the call *would* cost on a live key.
+- Webhooks are still delivered and HMAC-signed; RPM limits and idempotency behave as in production.
+
+Swap `clipia_test_` → `clipia_live_` and nothing else changes. This is the recommended way to test any Clipia integration end-to-end for $0.
+
+## Idempotency
+
+Send `Idempotency-Key: <UUID v4>` on every submit. Stripe-style rules: same key + same params within 24 h → the **same** `request_id` back (no double generation, no double billing); same key + different params → `409 idempotency_key_reuse`; retry while the first attempt is still processing → `409 request_in_progress`. POST only.
+
+## Errors
+
+Envelope: `{ "error": { "type", "code", "message" } }` (messages are sanitized).
+
+| HTTP | code | Note |
+|------|------|------|
+| 400 | `invalid_request` | malformed body/params |
+| 401 | `invalid_api_key` | missing/wrong/revoked key |
+| 402 | `insufficient_credits` | top up credits |
+| 402 | `subscription_required` | credits exist but frozen — an **active subscription** is required for API generation; topping up will not help |
+| 403 | `insufficient_scope` | key lacks the `generate` scope |
+| 404 | `not_found` | unknown `request_id` / model slug |
+| 409 | `idempotency_key_reuse` / `request_in_progress` | idempotency conflict |
+| 422 | `model_input_invalid` | params don't fit this model — check `GET /v1/models/{slug}` |
+| 429 | `rate_limit_exceeded` | default 120 RPM, 10 concurrent; honor `Retry-After` |
+| 5xx | `internal_error` / `service_unavailable` | retry with backoff |
+
+## Webhooks (optional, instead of polling)
+
+Pass `webhook_url` next to `input` at submit. On completion Clipia POSTs `{ "request_id", "status": "OK"|"ERROR", "payload": { model, output, cost } }`. Every delivery is HMAC-SHA256-signed: header `X-Clipia-Signature: t=<ts>,v1=<hex>`, signature = `HMAC_SHA256(secret, "{timestamp}.{raw_body}")` with the signing secret from the account; verify with a timing-safe compare and a ±5 min freshness window. Up to 6 retries with exponential backoff; handle deliveries idempotently by `request_id`.
+
+## Calling Clipia inside OpenMontage
+
+Prefer the selectors — both tools are auto-discovered by capability:
+
+```python
+from tools.tool_registry import registry
+registry.ensure_discovered()
+
+selector = registry.get("video_selector")
+result = selector.execute({
+    "prompt": PROMPT,
+    "preferred_provider": "clipia",
+    "operation": "text_to_video",        # or image_to_video
+    "duration": "5",
+    "aspect_ratio": "16:9",
+    "output_path": "projects/<proj>/assets/video/clip_01.mp4",
+})
+```
+
+Direct calls when you must bypass the selector:
+
+```python
+video = registry.get("clipia_video")
+video.execute({
+    "prompt": PROMPT,
+    "model": "kling-3",                  # any slug from GET /v1/models; default seedance-2-fast-t2v
+    "duration": "5",
+    "resolution": "720p",
+    "output_path": "...",
+})
+
+image = registry.get("clipia_image")
+image.execute({
+    "prompt": PROMPT,
+    "model": "nano-banana-2",            # default
+    "aspect_ratio": "16:9",
+    "num_images": 2,
+    "output_path": "...",
+})
+```
+
+## Prompting notes
+
+- English prompts work best for the video models (Russian is fine for image models).
+- Do **not** bake on-screen text/captions into video prompts — text renders with artifacts; overlay it in the compose stage instead.
+- For a locked-off shot add: `static locked camera, no zoom, no pan`.
+- Model-specific prompting (e.g. Seedance shot-structure openers) lives in the model's own skill — e.g. `seedance-2-0` applies to Clipia's `seedance-2-*` slugs too.
+
+## MCP alternative
+
+Clipia also runs a remote MCP server: `https://mcp.clipia.ai/mcp` (stateless Streamable HTTP, `Authorization: Bearer <same key>`), with tools like `generate_image`, `generate_video`, `wait_generation`, `list_models`, `search_templates`. Useful for MCP-native agents; the OpenMontage tools use the REST API and do not need it.
+
+## Sources
+
+- API docs: https://clipia.ai/docs
+- Developer console (keys, request logs, usage): https://clipia.ai/ru/developer
+- MCP landing: https://clipia.ai/mcp
+- Live model catalog: `GET https://api.clipia.ai/v1/models`

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -44,6 +44,7 @@ DOUBAO_SPEECH_VOICE_TYPE=    # Default Doubao speaker/voice type
 
 # MULTI-MODEL GATEWAY (one key, 6+ tools)
 FAL_KEY=                     # FLUX, Recraft, Kling, Veo, MiniMax video
+CLIPIA_API_KEY=              # Clipia aggregator: 50+ video+image models (Kling, Veo, Seedance, Wan, Sora, Nano Banana, FLUX); RU-friendly billing
 
 # VIDEO
 HEYGEN_API_KEY=              # HeyGen avatar video gateway
@@ -130,6 +131,81 @@ No subscription — pure pay-as-you-go, no minimum spend.
 | WAN 2.5 | $0.05/sec | 20 seconds |
 
 **Free tier:** None — but $0 to start, you only pay for what you use.
+
+---
+
+### Clipia" section below into the "## Cloud Providers"
+   chapter, right after the "### fal.ai — Multi-Model Gateway" section
+   (Clipia is the same kind of multi-model gateway, so they read well
+   side by side).
+2. Apply the three small edits listed at the bottom of this file
+   (env summary block, provider-to-tool mapping table, capability table).
+-->
+
+### Clipia — Multi-Model Aggregator (RU-Friendly)
+
+> **One key, 50+ image and video models, payable in rubles.** Clipia is a generation aggregator: a single API key unlocks Kling, Veo, Seedance, Wan, Sora, Nano Banana, FLUX, GPT-Image and more behind one fal.ai-shaped queue API. Includes a sandbox mode (`clipia_test_` keys) that returns instant mock results with zero spend — you can test the whole integration before paying anything.
+
+**Tools unlocked:** `clipia_video`, `clipia_image`
+**Env var:** `CLIPIA_API_KEY`
+
+#### Setup
+
+1. Go to [clipia.ai](https://clipia.ai) and create an account
+2. Open the Developer console: [clipia.ai/ru/developer](https://clipia.ai/ru/developer) (Settings → API keys redirects there)
+3. On the **API keys** tab, click **Create key** — the full key is shown **once**, copy it immediately
+   - Toggle the environment switch to **Test** to get a `clipia_test_…` sandbox key instead
+4. Add to `.env`: `CLIPIA_API_KEY=clipia_live_...`
+
+The key is a server-side secret; auth header is `Authorization: Key <key>` (`Bearer` and `X-Api-Key` are also accepted).
+
+#### Pricing
+
+Billing is in **credits** attached to a subscription plan. Every API call has a fixed, deterministic price known at submit time (`cost` in the submit response); failed generations are refunded in full.
+
+**Plans (monthly credits):**
+
+| Plan | Price | Credits/month |
+|------|-------|---------------|
+| Basic | 799 ₽ / $15/mo | 240 |
+| Standard | 1 499 ₽ / $29/mo | 480 |
+| Pro | 2 990 ₽ / $49/mo | 960 |
+| Ultima | 8 990 ₽ / $149/mo | 2 900 |
+
+Annual billing is ~10% cheaper. A 7-day trial (199 ₽ / $2.99, 55 credits) is available. 1 credit ≈ **$0.04–0.06** depending on plan; OpenMontage's estimators use $0.04.
+
+**Per-generation reference prices (2026-07, default/720p tiers):**
+
+| Model (slug) | Unit | Credits | ≈ USD |
+|--------------|------|---------|-------|
+| `seedance-2-fast-t2v` / `-i2v` | 5 s @ 720p | 47 | $1.88 |
+| `kling-3` | 5 s @ 720p | 36 | $1.44 |
+| `wan-2-7` | 5 s @ 720p | 24 | $0.96 |
+| `sora-2` | per clip | 17 | $0.68 |
+| `nano-banana-2` | per image (1K/2K) | 4 | $0.16 |
+| `nano-banana-pro` | per image | 5 | $0.20 |
+| `flux-2-pro` | per image | 3 | $0.12 |
+| `gpt-image-2` | per image | 3–7 (by resolution) | $0.12–0.28 |
+
+The exact price for any parameter set: `POST /v1/models/{slug}/estimate` (returns credits without queueing). Live catalog with per-model pricing: `GET /v1/models`.
+
+**Free tier:** None — subscription-based credits. Sandbox keys (`clipia_test_`) cost nothing but return fixed sample assets, not real generations.
+
+**Caveat:** API generation requires an active subscription; with credits but no active plan the API returns `402 subscription_required`.
+
+#### Why add it when fal.ai is already configured?
+
+- **Region coverage:** billing in RUB with Russian bank cards (USD/EUR plans too) — a working route to premium video models for RU/CIS users who cannot pay Western providers directly.
+- **Model breadth on one key:** video (Kling, Veo, Seedance, Wan, Sora, …) *and* image (Nano Banana, FLUX, GPT-Image, …) without juggling per-provider accounts.
+- **Sandbox mode:** `clipia_test_` keys make CI/integration tests spend-safe — submit returns a deterministic mock `COMPLETED` instantly, webhooks are still delivered and signed.
+
+#### Rate limits
+
+120 requests/minute and 10 concurrent generations per key by default (`RateLimit-*` response headers, `429` + `Retry-After` on excess).
+
+#### MCP alternative
+
+Clipia also runs a remote MCP server at `https://mcp.clipia.ai/mcp` (Streamable HTTP, same API key as Bearer token) with generate/wait/list-models tools — useful for agents that speak MCP instead of REST. The OpenMontage tools use the REST API and do not require MCP.
 
 ---
 
@@ -725,6 +801,7 @@ These tools require only FFmpeg or Python packages — no GPU, no API key.
 | **Google** | `GOOGLE_API_KEY` | `google_tts`, `google_imagen` | Free tier + paid |
 | **ElevenLabs** | `ELEVENLABS_API_KEY` | `elevenlabs_tts`, `music_gen` | Free tier + paid |
 | **fal.ai** | `FAL_KEY` | `flux_image`, `recraft_image`, `kling_video`, `veo_video`, `minimax_video` | Pay-as-you-go |
+| **Clipia** | `CLIPIA_API_KEY` | `clipia_video`, `clipia_image` | Subscription (credits) + sandbox test keys |
 | **OpenAI** | `OPENAI_API_KEY` | `openai_tts`, `openai_image` | Paid only |
 | **xAI** | `XAI_API_KEY` | `grok_image`, `grok_video` | Paid only |
 | **Runway** | `RUNWAY_API_KEY` | `runway_video` | Free trial + paid |
@@ -743,8 +820,8 @@ How many providers cover each capability:
 
 | Capability | Cloud Providers | Local Providers | Free Options |
 |-----------|----------------|-----------------|--------------|
-| **Image Generation** | FLUX, Grok, Google Imagen, DALL-E 3, Recraft | Local Diffusion | Pexels, Pixabay (stock) |
-| **Video Generation** | Grok, Kling, Runway, Veo, Higgsfield, MiniMax, HeyGen | WAN, Hunyuan, CogVideo, LTX | Pexels, Pixabay (stock) |
+| **Image Generation** | FLUX, Grok, Google Imagen, DALL-E 3, Recraft, Clipia (Nano Banana, FLUX, GPT-Image) | Local Diffusion | Pexels, Pixabay (stock) |
+| **Video Generation** | Grok, Kling, Runway, Veo, Higgsfield, MiniMax, HeyGen, Clipia (Kling, Veo, Seedance, Wan, Sora) | WAN, Hunyuan, CogVideo, LTX | Pexels, Pixabay (stock) |
 | **Text-to-Speech** | ElevenLabs, Google TTS, OpenAI | Piper | Piper, Google free tier, ElevenLabs free tier |
 | **Music Generation** | ElevenLabs, Suno | — | ElevenLabs free tier |
 | **Post-Production** | — | FFmpeg (compose, stitch, trim, mix, enhance, grade) | All free |

--- a/tests/tools/test_clipia_tools.py
+++ b/tests/tools/test_clipia_tools.py
@@ -1,0 +1,312 @@
+"""Contract, status, and mocked-execution tests for the Clipia provider tools.
+
+No network and no real API key are required: HTTP is faked by injecting a
+stub ``requests`` module into ``sys.modules`` (the tools import requests
+lazily inside ``execute()``, matching the other API tools).
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import pytest
+
+import tools.graphics.clipia_image as clipia_image
+import tools.video.clipia_video as clipia_video
+from tools.base_tool import ToolStatus
+from tools.graphics.clipia_image import ClipiaImage
+from tools.video.clipia_video import ClipiaVideo
+
+API_BASE = "https://api.clipia.ai"
+
+
+# ---------------------------------------------------------------------------
+# Fake `requests` module
+# ---------------------------------------------------------------------------
+
+
+class FakeResponse:
+    def __init__(self, json_data: Any = None, content: bytes = b"", status_code: int = 200):
+        self._json = json_data
+        self.content = content
+        self.status_code = status_code
+
+    @property
+    def ok(self) -> bool:
+        return self.status_code < 400
+
+    def json(self) -> Any:
+        if self._json is None:
+            raise ValueError("no JSON body")
+        return self._json
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise FakeRequests.RequestException(f"HTTP {self.status_code}")
+
+
+class FakeRequests:
+    """Minimal stand-in for the `requests` module, routed by URL."""
+
+    class RequestException(Exception):
+        pass
+
+    def __init__(self, post_response: FakeResponse, get_routes: dict[str, FakeResponse]):
+        self._post_response = post_response
+        self._get_routes = get_routes
+        self.post_calls: list[dict[str, Any]] = []
+        self.get_calls: list[str] = []
+
+    def post(self, url: str, **kwargs: Any) -> FakeResponse:
+        self.post_calls.append({"url": url, **kwargs})
+        return self._post_response
+
+    def get(self, url: str, **kwargs: Any) -> FakeResponse:
+        self.get_calls.append(url)
+        for prefix, response in self._get_routes.items():
+            if url.startswith(prefix):
+                return response
+        raise AssertionError(f"unexpected GET {url}")
+
+
+# ---------------------------------------------------------------------------
+# Contract / metadata
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tool_cls, capability",
+    [(ClipiaVideo, "video_generation"), (ClipiaImage, "image_generation")],
+)
+def test_contract_metadata(tool_cls, capability):
+    tool = tool_cls()
+    assert tool.provider == "clipia"
+    assert tool.capability == capability
+    assert tool.runtime.value == "api"
+    assert "prompt" in tool.input_schema["required"]
+    # get_info() must serialize without touching the network.
+    info = tool.get_info()
+    assert info["name"] == tool.name
+    assert info["fallback_tools"]
+
+
+def test_video_default_model_constants_match_schema():
+    schema_default = ClipiaVideo().input_schema["properties"]["model"]["default"]
+    assert clipia_video._DEFAULT_T2V_MODEL == schema_default
+    assert clipia_video._DEFAULT_I2V_MODEL == "seedance-2-fast-i2v"
+
+
+def test_image_default_model_constant_matches_schema():
+    schema_default = ClipiaImage().input_schema["properties"]["model"]["default"]
+    assert clipia_image._DEFAULT_MODEL == schema_default
+
+
+@pytest.mark.parametrize("tool_cls", [ClipiaVideo, ClipiaImage])
+def test_estimate_default_model_matches_schema(tool_cls):
+    tool = tool_cls()
+    schema_default = tool.input_schema["properties"]["model"]["default"]
+    assert tool.estimate_cost({}) == tool.estimate_cost({"model": schema_default})
+    assert tool.estimate_cost({}) > 0
+
+
+def test_estimate_cost_is_offline_and_scales():
+    video = ClipiaVideo()
+    # Per-second models scale with duration; flat models do not.
+    assert video.estimate_cost({"duration": "10"}) == pytest.approx(
+        2 * video.estimate_cost({"duration": "5"})
+    )
+    assert video.estimate_cost({"model": "sora-2", "duration": "5"}) == video.estimate_cost(
+        {"model": "sora-2", "duration": "10"}
+    )
+    image = ClipiaImage()
+    assert image.estimate_cost({"num_images": 4}) == pytest.approx(
+        4 * image.estimate_cost({"num_images": 1})
+    )
+
+
+# ---------------------------------------------------------------------------
+# Status / dependency behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tool_cls", [ClipiaVideo, ClipiaImage])
+def test_status_reflects_api_key(tool_cls, monkeypatch):
+    monkeypatch.delenv("CLIPIA_API_KEY", raising=False)
+    assert tool_cls().get_status() == ToolStatus.UNAVAILABLE
+    monkeypatch.setenv("CLIPIA_API_KEY", "clipia_test_dummy")
+    assert tool_cls().get_status() == ToolStatus.AVAILABLE
+
+
+@pytest.mark.parametrize("tool_cls", [ClipiaVideo, ClipiaImage])
+def test_execute_without_key_fails_cleanly(tool_cls, monkeypatch):
+    monkeypatch.delenv("CLIPIA_API_KEY", raising=False)
+    result = tool_cls().execute({"prompt": "a test"})
+    assert result.success is False
+    assert "CLIPIA_API_KEY" in result.error
+
+
+def test_image_to_video_requires_image_url(monkeypatch):
+    monkeypatch.setenv("CLIPIA_API_KEY", "clipia_test_dummy")
+    result = ClipiaVideo().execute({"prompt": "x", "operation": "image_to_video"})
+    assert result.success is False
+    assert "image_url" in result.error
+
+
+# ---------------------------------------------------------------------------
+# Registry discovery (runs against the real registry, still offline)
+# ---------------------------------------------------------------------------
+
+
+def test_registry_discovers_clipia_tools():
+    from tools.tool_registry import registry
+
+    registry.ensure_discovered()
+    video_names = {t.name for t in registry.get_by_capability("video_generation")}
+    image_names = {t.name for t in registry.get_by_capability("image_generation")}
+    assert "clipia_video" in video_names
+    assert "clipia_image" in image_names
+
+
+# ---------------------------------------------------------------------------
+# Mocked execution (sandbox-shaped: submit returns COMPLETED immediately)
+# ---------------------------------------------------------------------------
+
+
+def test_video_execute_happy_path(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLIPIA_API_KEY", "clipia_test_dummy")
+    request_url = f"{API_BASE}/v1/requests/req-vid-1"
+    fake = FakeRequests(
+        post_response=FakeResponse(
+            {
+                "request_id": "req-vid-1",
+                "status": "COMPLETED",
+                "queue_position": 0,
+                "status_url": f"{request_url}/status",
+                "response_url": request_url,
+                "cost": 47,
+            }
+        ),
+        get_routes={
+            f"{request_url}/status": FakeResponse({"status": "COMPLETED"}),
+            request_url: FakeResponse(
+                {
+                    "request_id": "req-vid-1",
+                    "status": "COMPLETED",
+                    "model": "seedance-2-fast-t2v",
+                    "output": {
+                        "video": {
+                            "url": "https://media.example/sample.mp4",
+                            "width": 1280,
+                            "height": 720,
+                            "duration": 5,
+                        }
+                    },
+                    "cost": 47,
+                }
+            ),
+            "https://media.example/sample.mp4": FakeResponse(content=b"fake-mp4-bytes"),
+        },
+    )
+    monkeypatch.setitem(sys.modules, "requests", fake)
+
+    out = tmp_path / "clip.mp4"
+    result = ClipiaVideo().execute({"prompt": "a sunset, cinematic", "output_path": str(out)})
+
+    assert result.success is True
+    assert out.read_bytes() == b"fake-mp4-bytes"
+    assert result.artifacts == [str(out)]
+    assert result.data["provider"] == "clipia"
+    assert result.data["request_id"] == "req-vid-1"
+    assert result.data["cost_credits"] == 47
+    assert result.data["sandbox"] is True
+    assert result.cost_usd == pytest.approx(47 * 0.04)
+    # Submit went to the right endpoint with the schema-default model.
+    assert fake.post_calls[0]["url"] == f"{API_BASE}/v1/models/seedance-2-fast-t2v"
+    assert fake.post_calls[0]["json"]["input"]["prompt"] == "a sunset, cinematic"
+    assert "Idempotency-Key" in fake.post_calls[0]["headers"]
+
+
+def test_image_execute_happy_path_multi_image(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLIPIA_API_KEY", "clipia_test_dummy")
+    request_url = f"{API_BASE}/v1/requests/req-img-1"
+    fake = FakeRequests(
+        post_response=FakeResponse(
+            {
+                "request_id": "req-img-1",
+                "status": "COMPLETED",
+                "queue_position": 0,
+                "status_url": f"{request_url}/status",
+                "response_url": request_url,
+                "cost": 8,
+            }
+        ),
+        get_routes={
+            f"{request_url}/status": FakeResponse({"status": "COMPLETED"}),
+            request_url: FakeResponse(
+                {
+                    "request_id": "req-img-1",
+                    "status": "COMPLETED",
+                    "model": "nano-banana-2",
+                    "output": {
+                        "images": [
+                            {
+                                "url": "https://media.example/a.webp",
+                                "original_url": "https://media.example/a.png",
+                                "width": 1024,
+                                "height": 1024,
+                            },
+                            {
+                                "url": "https://media.example/b.webp",
+                                "original_url": "https://media.example/b.png",
+                                "width": 1024,
+                                "height": 1024,
+                            },
+                        ]
+                    },
+                    "cost": 8,
+                }
+            ),
+            "https://media.example/a.png": FakeResponse(content=b"png-a"),
+            "https://media.example/b.png": FakeResponse(content=b"png-b"),
+        },
+    )
+    monkeypatch.setitem(sys.modules, "requests", fake)
+
+    out = tmp_path / "img.png"
+    result = ClipiaImage().execute(
+        {"prompt": "a red apple", "num_images": 2, "output_path": str(out)}
+    )
+
+    assert result.success is True
+    assert result.data["num_images"] == 2
+    assert result.artifacts == [str(out), str(tmp_path / "img_2.png")]
+    assert out.read_bytes() == b"png-a"
+    assert (tmp_path / "img_2.png").read_bytes() == b"png-b"
+    # original_url (full quality) preferred over the display-optimized url.
+    assert "https://media.example/a.png" in fake.get_calls
+    assert result.cost_usd == pytest.approx(8 * 0.04)
+    assert fake.post_calls[0]["json"]["input"]["num_images"] == 2
+
+
+@pytest.mark.parametrize("tool_cls", [ClipiaVideo, ClipiaImage])
+def test_execute_surfaces_api_error_envelope(tool_cls, monkeypatch):
+    monkeypatch.setenv("CLIPIA_API_KEY", "clipia_live_dummy")
+    fake = FakeRequests(
+        post_response=FakeResponse(
+            {
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "insufficient_credits",
+                    "message": "Not enough credits.",
+                }
+            },
+            status_code=402,
+        ),
+        get_routes={},
+    )
+    monkeypatch.setitem(sys.modules, "requests", fake)
+
+    result = tool_cls().execute({"prompt": "x"})
+    assert result.success is False
+    assert "insufficient_credits" in result.error

--- a/tools/graphics/clipia_image.py
+++ b/tools/graphics/clipia_image.py
@@ -1,0 +1,389 @@
+"""Clipia multi-model image generation via the Clipia public API.
+
+Clipia (https://clipia.ai) is a generation aggregator: one API key covers
+50+ hosted image and video models (Nano Banana, FLUX, GPT-Image, plus the
+video catalog served by tools/video/clipia_video.py) behind a single
+fal.ai-shaped queue API (submit -> status -> result). Model slugs are
+discovered dynamically via GET /v1/models.
+
+Notable for RU/CIS users: Clipia bills in rubles and accepts Russian bank
+cards (USD/EUR plans exist too). Keys with the ``clipia_test_`` prefix run
+in sandbox mode: instant mock COMPLETED results, no credits spent. See
+docs/PROVIDERS.md and the ``clipia`` agent skill for the full API contract.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+_API_BASE = "https://api.clipia.ai"
+_DEFAULT_MODEL = "nano-banana-2"
+
+_POLL_INTERVAL_SECONDS = 3.0
+_POLL_TIMEOUT_SECONDS = 300.0  # images usually complete in seconds to ~2 min
+
+# Clipia bills in credits; 1 credit ≈ $0.04 derived from public plan pricing
+# ($0.04–0.06 depending on plan). Used only for ToolResult.cost_usd.
+_CREDIT_USD = 0.04
+
+# Approximate public credit prices per image at default resolution
+# (clipia.ai pricing matrix, 2026-07). Resolution multipliers (e.g. 4K is
+# roughly x1.4-1.5 on Nano Banana) are not modeled here — the exact price
+# for a parameter set is POST /v1/models/{slug}/estimate (returns credits
+# without queueing), not called here because estimate_cost() must stay
+# fast and offline.
+_CREDITS_PER_IMAGE = {
+    "nano-banana-2": 4.0,
+    "nano-banana-pro": 5.0,
+    "flux-2-pro": 3.0,
+    "gpt-image-2": 6.0,  # 3-7 depending on resolution
+}
+_DEFAULT_CREDITS_PER_IMAGE = 5.0
+
+_TERMINAL_STATUSES = ("COMPLETED", "FAILED", "CANCELED")  # note: single L
+
+
+class ClipiaImage(BaseTool):
+    name = "clipia_image"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "image_generation"
+    provider = "clipia"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = []  # checked dynamically via env var
+    install_instructions = (
+        "Set CLIPIA_API_KEY to your Clipia API key.\n"
+        "  Get one at https://clipia.ai/ru/developer (Developer console -> API keys).\n"
+        "  A key with the clipia_test_ prefix runs in sandbox mode: instant mock\n"
+        "  results, no credits spent — handy for testing this integration."
+    )
+    agent_skills = ["clipia"]
+
+    capabilities = ["generate_image", "text_to_image", "image_to_image"]
+    supports = {
+        "text_to_image": True,
+        "image_to_image": True,
+        "multi_reference": True,
+        "num_images": True,
+        "model_selection": True,
+        "sandbox_mode": True,
+        "multi_model_aggregator": True,
+    }
+    best_for = [
+        "one API key across Nano Banana, FLUX, GPT-Image and 20+ image models",
+        "instruction-following edits and multi-reference composites (image_urls)",
+        "RU/CIS users — billing in rubles with Russian bank cards",
+        "integration testing via sandbox keys (clipia_test_) with zero credit spend",
+    ]
+    not_good_for = ["offline generation", "pixel-exact reproducibility (no seed parameter)"]
+    fallback_tools = ["flux_image"]
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+            "prompt": {"type": "string"},
+            "operation": {
+                "type": "string",
+                "enum": ["text_to_image", "image_to_image"],
+                "default": "text_to_image",
+            },
+            "model": {
+                "type": "string",
+                "default": _DEFAULT_MODEL,
+                "description": (
+                    "Clipia model slug, e.g. nano-banana-2, nano-banana-pro, "
+                    "flux-2-pro, gpt-image-2. Full live catalog: "
+                    "GET https://api.clipia.ai/v1/models."
+                ),
+            },
+            "aspect_ratio": {
+                "type": "string",
+                "default": "1:1",
+                "description": "e.g. 1:1, 16:9, 9:16, 4:3, 3:4 (model-dependent).",
+            },
+            "resolution": {
+                "type": "string",
+                "enum": ["1K", "2K", "4K"],
+                "description": (
+                    "Only sent when provided; supported values and price "
+                    "multipliers vary per model (see GET /v1/models/{slug})."
+                ),
+            },
+            "num_images": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 4,
+                "default": 1,
+                "description": "Variants per request (support varies by model).",
+            },
+            "image_url": {
+                "type": "string",
+                "description": "Input image URL, required for image_to_image.",
+            },
+            "image_urls": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Multiple reference images for multi-reference edits.",
+            },
+            "idempotency_key": {
+                "type": "string",
+                "description": (
+                    "Optional UUID v4 sent as the Idempotency-Key header. Resubmitting "
+                    "with the same key and params within 24h returns the same request "
+                    "instead of generating (and billing) again. Auto-generated per call "
+                    "when omitted."
+                ),
+            },
+            "output_path": {"type": "string"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=512, vram_mb=0, disk_mb=100, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
+    idempotency_key_fields = ["prompt", "model", "operation", "aspect_ratio", "num_images"]
+    side_effects = ["writes image file(s) to output_path", "calls the Clipia API (api.clipia.ai)"]
+    user_visible_verification = [
+        "Inspect generated image(s) for relevance and quality",
+        "Sandbox keys return a fixed sample image — do not judge model quality from it",
+    ]
+
+    def _get_api_key(self) -> str | None:
+        return os.environ.get("CLIPIA_API_KEY")
+
+    def get_status(self) -> ToolStatus:
+        if self._get_api_key():
+            return ToolStatus.AVAILABLE
+        return ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        """Approximate cost in USD from a static credit table (offline).
+
+        Exact per-call pricing lives server-side at
+        POST /v1/models/{slug}/estimate.
+        """
+        model = inputs.get("model", _DEFAULT_MODEL)
+        num_images = int(inputs.get("num_images", 1) or 1)
+        credits = _DEFAULT_CREDITS_PER_IMAGE
+        for prefix, per_image in _CREDITS_PER_IMAGE.items():
+            if model.startswith(prefix):
+                credits = per_image
+                break
+        return round(credits * num_images * _CREDIT_USD, 2)
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        return 30.0  # seconds to ~2 min typical; sandbox keys return instantly
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        api_key = self._get_api_key()
+        if not api_key:
+            return ToolResult(
+                success=False,
+                error="CLIPIA_API_KEY not set. " + self.install_instructions,
+            )
+
+        import requests
+
+        start = time.time()
+        operation = inputs.get("operation", "text_to_image")
+        model = inputs.get("model", _DEFAULT_MODEL)
+
+        if operation == "image_to_image" and not (
+            inputs.get("image_url") or inputs.get("image_urls")
+        ):
+            return ToolResult(
+                success=False,
+                error="image_url (or image_urls) is required for operation='image_to_image'",
+            )
+
+        payload: dict[str, Any] = {"prompt": inputs["prompt"]}
+        if inputs.get("aspect_ratio"):
+            payload["aspect_ratio"] = inputs["aspect_ratio"]
+        if inputs.get("resolution"):
+            payload["resolution"] = inputs["resolution"]
+        num_images = int(inputs.get("num_images", 1) or 1)
+        if num_images > 1:
+            payload["num_images"] = num_images
+        if inputs.get("image_url"):
+            payload["image_url"] = inputs["image_url"]
+        if inputs.get("image_urls"):
+            payload["image_urls"] = inputs["image_urls"]
+
+        headers = {
+            # "Bearer <key>" and "X-Api-Key: <key>" are accepted too.
+            "Authorization": f"Key {api_key}",
+            "Content-Type": "application/json",
+            "Idempotency-Key": inputs.get("idempotency_key") or str(uuid.uuid4()),
+        }
+
+        try:
+            # Submit to the queue API; `cost` is the fixed price in credits,
+            # reserved at submit and refunded in full on failure.
+            submit_resp = requests.post(
+                f"{_API_BASE}/v1/models/{model}",
+                headers=headers,
+                json={"input": payload},
+                timeout=60,
+            )
+            if not submit_resp.ok:
+                return ToolResult(
+                    success=False,
+                    error=f"Clipia submit failed ({_api_error(submit_resp)})",
+                )
+            queue_data = submit_resp.json()
+            request_id = queue_data["request_id"]
+            status_url = queue_data["status_url"]
+            response_url = queue_data["response_url"]
+            cost_credits = queue_data.get("cost")
+            status = queue_data.get("status", "IN_QUEUE")
+
+            # Poll until terminal. Sandbox keys (clipia_test_) return
+            # status=COMPLETED directly from submit, skipping this loop.
+            deadline = start + _POLL_TIMEOUT_SECONDS
+            while status not in _TERMINAL_STATUSES:
+                if time.time() >= deadline:
+                    return ToolResult(
+                        success=False,
+                        error=(
+                            f"Clipia image generation timed out after "
+                            f"{int(_POLL_TIMEOUT_SECONDS)}s (request_id={request_id} "
+                            "may still complete server-side)"
+                        ),
+                    )
+                time.sleep(_POLL_INTERVAL_SECONDS)
+                try:
+                    status_resp = requests.get(status_url, headers=headers, timeout=15)
+                    status_resp.raise_for_status()
+                    status = status_resp.json().get("status", status)
+                except requests.RequestException:
+                    continue  # transient poll error — bounded by the deadline above
+
+            if status != "COMPLETED":
+                return ToolResult(
+                    success=False,
+                    error=(
+                        f"Clipia image generation {status.lower()}"
+                        f"{_result_error_detail(requests, response_url, headers)} "
+                        "(reserved credits are refunded)"
+                    ),
+                )
+
+            # Fetch result (HTTP 200 for terminal statuses, 202 while running).
+            result_resp = requests.get(response_url, headers=headers, timeout=30)
+            result_resp.raise_for_status()
+            result = result_resp.json()
+            cost_credits = result.get("cost", cost_credits)
+
+            images = (result.get("output") or {}).get("images") or []
+            if not images:
+                return ToolResult(
+                    success=False,
+                    error=f"Clipia result for {request_id} is missing image output",
+                )
+
+            output_path = Path(inputs.get("output_path", "clipia_image.png"))
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            saved: list[str] = []
+            for i, image in enumerate(images):
+                # `url` is a display-optimized rendition (usually WebP);
+                # `original_url` is the full-quality PNG/JPG — prefer it.
+                image_url = image.get("original_url") or image.get("url")
+                if not image_url:
+                    continue
+                target = (
+                    output_path
+                    if i == 0
+                    else output_path.with_name(
+                        f"{output_path.stem}_{i + 1}{output_path.suffix}"
+                    )
+                )
+                image_response = requests.get(image_url, timeout=60)
+                image_response.raise_for_status()
+                target.write_bytes(image_response.content)
+                saved.append(str(target))
+
+            if not saved:
+                return ToolResult(
+                    success=False,
+                    error=f"Clipia result for {request_id} contained no downloadable images",
+                )
+
+        except Exception as e:
+            return ToolResult(success=False, error=f"Clipia image generation failed: {e}")
+
+        cost_usd = (
+            round(cost_credits * _CREDIT_USD, 2)
+            if isinstance(cost_credits, (int, float))
+            else self.estimate_cost(inputs)
+        )
+        first_image = images[0]
+        return ToolResult(
+            success=True,
+            data={
+                "provider": "clipia",
+                "model": model,
+                "prompt": inputs["prompt"],
+                "operation": operation,
+                "aspect_ratio": inputs.get("aspect_ratio", "1:1"),
+                "resolution": inputs.get("resolution"),
+                "num_images": len(saved),
+                "width": first_image.get("width"),
+                "height": first_image.get("height"),
+                "request_id": request_id,
+                "cost_credits": cost_credits,
+                "sandbox": api_key.startswith("clipia_test_"),
+                "output": saved[0],
+                "output_path": saved[0],
+                "images": saved,
+            },
+            artifacts=saved,
+            cost_usd=cost_usd,
+            duration_seconds=round(time.time() - start, 2),
+            model=model,
+        )
+
+
+def _api_error(resp: Any) -> str:
+    """Extract Clipia's sanitized error envelope: {"error": {code, message}}."""
+    try:
+        err = resp.json().get("error", {})
+        code = err.get("code") or f"http_{resp.status_code}"
+        message = err.get("message", "")
+        return f"{code}: {message}".rstrip(": ")
+    except Exception:
+        return f"HTTP {resp.status_code}"
+
+
+def _result_error_detail(requests_mod: Any, response_url: str, headers: dict[str, str]) -> str:
+    """Best-effort fetch of error {code, message} from a FAILED result."""
+    try:
+        resp = requests_mod.get(response_url, headers=headers, timeout=15)
+        err = resp.json().get("error") or {}
+        if err.get("message"):
+            return f" — {err.get('code', 'error')}: {err['message']}"
+    except Exception:
+        pass
+    return ""

--- a/tools/video/clipia_video.py
+++ b/tools/video/clipia_video.py
@@ -1,0 +1,396 @@
+"""Clipia multi-model video generation via the Clipia public API.
+
+Clipia (https://clipia.ai) is a generation aggregator: one API key covers
+50+ hosted image and video models — Kling, Veo, Seedance, Wan, Sora and
+more — behind a single fal.ai-shaped queue API (submit -> status -> result).
+Model slugs are discovered dynamically via GET /v1/models, so new models
+become usable without code changes here.
+
+Notable for RU/CIS users: Clipia bills in rubles and accepts Russian bank
+cards (USD/EUR plans exist too), which makes it a practical route to premium
+video models in regions where most Western providers cannot be paid for
+directly.
+
+Keys with the ``clipia_test_`` prefix run in sandbox mode: submit returns a
+deterministic mock COMPLETED result instantly and no credits are spent —
+useful for integration testing. See docs/PROVIDERS.md and the ``clipia``
+agent skill for the full API contract.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+_API_BASE = "https://api.clipia.ai"
+_DEFAULT_T2V_MODEL = "seedance-2-fast-t2v"
+_DEFAULT_I2V_MODEL = "seedance-2-fast-i2v"
+
+_POLL_INTERVAL_SECONDS = 5.0
+_POLL_TIMEOUT_SECONDS = 900.0  # 15 min — long clips on premium models can take a while
+
+# Clipia bills in credits (fixed price per operation, known at submit time).
+# 1 credit ≈ $0.04 derived from public plan pricing ($0.04–0.06 depending on
+# plan); used only to express ToolResult.cost_usd.
+_CREDIT_USD = 0.04
+
+# Approximate public credit prices at 720p (clipia.ai pricing matrix,
+# 2026-07). Keyed by slug prefix so t2v/i2v variants share an entry.
+# The authoritative price for an exact parameter set is
+# POST /v1/models/{slug}/estimate (returns credits without queueing) —
+# not called here because estimate_cost() must stay fast and offline.
+_CREDITS_PER_SECOND_720P = {
+    "seedance-2-fast": 9.4,  # 47 credits / 5 s (480p is ~5.6/s)
+    "kling-3": 7.2,          # 36 credits / 5 s
+    "wan-2-7": 4.8,          # 24 credits / 5 s
+}
+_FLAT_CREDITS_PER_CLIP = {
+    "sora-2-pro": 28.0,
+    "sora-2": 17.0,
+}
+_DEFAULT_CREDITS_PER_SECOND = 9.4
+
+_TERMINAL_STATUSES = ("COMPLETED", "FAILED", "CANCELED")  # note: single L
+
+
+class ClipiaVideo(BaseTool):
+    name = "clipia_video"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "video_generation"
+    provider = "clipia"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = []  # checked dynamically via env var
+    install_instructions = (
+        "Set CLIPIA_API_KEY to your Clipia API key.\n"
+        "  Get one at https://clipia.ai/ru/developer (Developer console -> API keys).\n"
+        "  A key with the clipia_test_ prefix runs in sandbox mode: instant mock\n"
+        "  results, no credits spent — handy for testing this integration."
+    )
+    agent_skills = ["clipia", "ai-video-gen"]
+
+    capabilities = ["text_to_video", "image_to_video"]
+    supports = {
+        "text_to_video": True,
+        "image_to_video": True,
+        "model_selection": True,
+        "aspect_ratio": True,
+        "resolution": True,
+        "sandbox_mode": True,
+        "multi_model_aggregator": True,
+    }
+    best_for = [
+        "one API key covering 50+ video and image models (Kling, Veo, Seedance, Wan, Sora)",
+        "switching video models per shot without opening new provider accounts",
+        "RU/CIS users — billing in rubles with Russian bank cards",
+        "integration testing via sandbox keys (clipia_test_) with zero credit spend",
+    ]
+    not_good_for = [
+        "offline generation",
+        "sub-minute latency demands (queue-based, clips render in 1-10 min)",
+    ]
+    fallback_tools = ["kling_video", "wan_video"]
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+            "prompt": {"type": "string"},
+            "operation": {
+                "type": "string",
+                "enum": ["text_to_video", "image_to_video"],
+                "default": "text_to_video",
+            },
+            "model": {
+                "type": "string",
+                "default": _DEFAULT_T2V_MODEL,
+                "description": (
+                    "Clipia model slug, e.g. seedance-2-fast-t2v, kling-3, wan-2-7, "
+                    "sora-2. Full live catalog: GET https://api.clipia.ai/v1/models. "
+                    "When omitted: seedance-2-fast-t2v for text_to_video, "
+                    "seedance-2-fast-i2v for image_to_video."
+                ),
+            },
+            "duration": {
+                "type": "string",
+                "default": "5",
+                "description": (
+                    "Duration in seconds (model-dependent range, typically 4-15). "
+                    "'auto' omits the field and lets the model decide, e.g. for "
+                    "fixed-length models like sora-2."
+                ),
+            },
+            "aspect_ratio": {
+                "type": "string",
+                "enum": ["16:9", "9:16", "1:1"],
+                "default": "16:9",
+                "description": (
+                    "Some models accept more ratios (see GET /v1/models/{slug}); "
+                    "these three are safe across the catalog."
+                ),
+            },
+            "resolution": {
+                "type": "string",
+                "enum": ["480p", "720p", "1080p"],
+                "description": (
+                    "Only sent when provided. Supported values vary per model "
+                    "(seedance-2-fast: 480p/720p; kling-3, wan-2-7: 720p/1080p)."
+                ),
+            },
+            "image_url": {
+                "type": "string",
+                "description": "Start-frame image URL, required for image_to_video.",
+            },
+            "idempotency_key": {
+                "type": "string",
+                "description": (
+                    "Optional UUID v4 sent as the Idempotency-Key header. Resubmitting "
+                    "with the same key and params within 24h returns the same request "
+                    "instead of generating (and billing) again. Auto-generated per call "
+                    "when omitted."
+                ),
+            },
+            "output_path": {"type": "string"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=512, vram_mb=0, disk_mb=500, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
+    idempotency_key_fields = ["prompt", "model", "operation", "duration", "aspect_ratio"]
+    side_effects = ["writes video file to output_path", "calls the Clipia API (api.clipia.ai)"]
+    user_visible_verification = [
+        "Watch generated clip for motion coherence and visual quality",
+        "Sandbox keys return a fixed sample video — do not judge model quality from it",
+    ]
+
+    def _get_api_key(self) -> str | None:
+        return os.environ.get("CLIPIA_API_KEY")
+
+    def get_status(self) -> ToolStatus:
+        if self._get_api_key():
+            return ToolStatus.AVAILABLE
+        return ToolStatus.UNAVAILABLE
+
+    def _resolve_model(self, inputs: dict[str, Any]) -> str:
+        model = inputs.get("model")
+        if model:
+            return model
+        if inputs.get("operation") == "image_to_video":
+            return _DEFAULT_I2V_MODEL
+        return _DEFAULT_T2V_MODEL
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        """Approximate cost in USD from a static credit table (offline).
+
+        Figures are 720p list prices as of 2026-07; the exact per-call price
+        is available server-side via POST /v1/models/{slug}/estimate.
+        """
+        model = self._resolve_model(inputs)
+        duration = inputs.get("duration", "5")
+        secs = 5 if duration == "auto" else int(duration)
+        for prefix, credits in _FLAT_CREDITS_PER_CLIP.items():
+            if model.startswith(prefix):
+                return round(credits * _CREDIT_USD, 2)
+        rate = _DEFAULT_CREDITS_PER_SECOND
+        for prefix, per_second in _CREDITS_PER_SECOND_720P.items():
+            if model.startswith(prefix):
+                rate = per_second
+                break
+        return round(rate * secs * _CREDIT_USD, 2)
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        return 120.0  # 1-10 min typical; sandbox keys return instantly
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        api_key = self._get_api_key()
+        if not api_key:
+            return ToolResult(
+                success=False,
+                error="CLIPIA_API_KEY not set. " + self.install_instructions,
+            )
+
+        import requests
+
+        start = time.time()
+        operation = inputs.get("operation", "text_to_video")
+        model = self._resolve_model(inputs)
+
+        if operation == "image_to_video" and not inputs.get("image_url"):
+            return ToolResult(
+                success=False,
+                error="image_url is required for operation='image_to_video'",
+            )
+
+        payload: dict[str, Any] = {"prompt": inputs["prompt"]}
+        duration = inputs.get("duration", "5")
+        if duration and duration != "auto":
+            payload["duration"] = int(duration)
+        if inputs.get("aspect_ratio"):
+            payload["aspect_ratio"] = inputs["aspect_ratio"]
+        if inputs.get("resolution"):
+            payload["resolution"] = inputs["resolution"]
+        if operation == "image_to_video":
+            payload["image_url"] = inputs["image_url"]
+
+        headers = {
+            # "Bearer <key>" and "X-Api-Key: <key>" are accepted too.
+            "Authorization": f"Key {api_key}",
+            "Content-Type": "application/json",
+            "Idempotency-Key": inputs.get("idempotency_key") or str(uuid.uuid4()),
+        }
+
+        try:
+            # Submit to the queue API. The response always carries request_id +
+            # absolute status/response URLs; `cost` is the fixed price in
+            # credits, reserved now and refunded in full on failure.
+            submit_resp = requests.post(
+                f"{_API_BASE}/v1/models/{model}",
+                headers=headers,
+                json={"input": payload},
+                timeout=60,
+            )
+            if not submit_resp.ok:
+                return ToolResult(
+                    success=False,
+                    error=f"Clipia submit failed ({_api_error(submit_resp)})",
+                )
+            queue_data = submit_resp.json()
+            request_id = queue_data["request_id"]
+            status_url = queue_data["status_url"]
+            response_url = queue_data["response_url"]
+            cost_credits = queue_data.get("cost")
+            status = queue_data.get("status", "IN_QUEUE")
+
+            # Poll until terminal. Sandbox keys (clipia_test_) return
+            # status=COMPLETED directly from submit, skipping this loop.
+            deadline = start + _POLL_TIMEOUT_SECONDS
+            while status not in _TERMINAL_STATUSES:
+                if time.time() >= deadline:
+                    return ToolResult(
+                        success=False,
+                        error=(
+                            f"Clipia video generation timed out after "
+                            f"{int(_POLL_TIMEOUT_SECONDS)}s (request_id={request_id} "
+                            "may still complete server-side)"
+                        ),
+                    )
+                time.sleep(_POLL_INTERVAL_SECONDS)
+                try:
+                    status_resp = requests.get(status_url, headers=headers, timeout=15)
+                    status_resp.raise_for_status()
+                    status = status_resp.json().get("status", status)
+                except requests.RequestException:
+                    continue  # transient poll error — bounded by the deadline above
+
+            if status != "COMPLETED":
+                # FAILED / CANCELED are terminal; reserved credits are refunded.
+                return ToolResult(
+                    success=False,
+                    error=(
+                        f"Clipia video generation {status.lower()}"
+                        f"{_result_error_detail(requests, response_url, headers)} "
+                        "(reserved credits are refunded)"
+                    ),
+                )
+
+            # Fetch result (HTTP 200 for terminal statuses, 202 while running).
+            result_resp = requests.get(response_url, headers=headers, timeout=30)
+            result_resp.raise_for_status()
+            result = result_resp.json()
+            cost_credits = result.get("cost", cost_credits)
+
+            video = (result.get("output") or {}).get("video") or {}
+            # `url` is a display-optimized rendition; `original_url` is the
+            # full-quality file when available — prefer it for downloads.
+            video_url = video.get("original_url") or video.get("url")
+            if not video_url:
+                return ToolResult(
+                    success=False,
+                    error=f"Clipia result for {request_id} is missing video output",
+                )
+
+            video_response = requests.get(video_url, timeout=180)
+            video_response.raise_for_status()
+
+            output_path = Path(inputs.get("output_path", "clipia_video_output.mp4"))
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(video_response.content)
+
+        except Exception as e:
+            return ToolResult(success=False, error=f"Clipia video generation failed: {e}")
+
+        from tools.video._shared import probe_output
+
+        probed = probe_output(output_path)
+        cost_usd = (
+            round(cost_credits * _CREDIT_USD, 2)
+            if isinstance(cost_credits, (int, float))
+            else self.estimate_cost(inputs)
+        )
+        return ToolResult(
+            success=True,
+            data={
+                "provider": "clipia",
+                "model": model,
+                "prompt": inputs["prompt"],
+                "operation": operation,
+                "aspect_ratio": inputs.get("aspect_ratio", "16:9"),
+                "resolution": inputs.get("resolution"),
+                "request_id": request_id,
+                "cost_credits": cost_credits,
+                "sandbox": api_key.startswith("clipia_test_"),
+                "output": str(output_path),
+                "output_path": str(output_path),
+                "format": "mp4",
+                **probed,
+            },
+            artifacts=[str(output_path)],
+            cost_usd=cost_usd,
+            duration_seconds=round(time.time() - start, 2),
+            model=model,
+        )
+
+
+def _api_error(resp: Any) -> str:
+    """Extract Clipia's sanitized error envelope: {"error": {code, message}}."""
+    try:
+        err = resp.json().get("error", {})
+        code = err.get("code") or f"http_{resp.status_code}"
+        message = err.get("message", "")
+        return f"{code}: {message}".rstrip(": ")
+    except Exception:
+        return f"HTTP {resp.status_code}"
+
+
+def _result_error_detail(requests_mod: Any, response_url: str, headers: dict[str, str]) -> str:
+    """Best-effort fetch of error {code, message} from a FAILED result."""
+    try:
+        resp = requests_mod.get(response_url, headers=headers, timeout=15)
+        err = resp.json().get("error") or {}
+        if err.get("message"):
+            return f" — {err.get('code', 'error')}: {err['message']}"
+    except Exception:
+        pass
+    return ""


### PR DESCRIPTION
### What

Adds **Clipia** (https://clipia.ai, `api.clipia.ai`) as a generation provider:

- `tools/video/clipia_video.py` — `clipia_video`: text_to_video + image_to_video against any Clipia video model slug (default `seedance-2-fast-t2v` / `seedance-2-fast-i2v`). Submit → poll (5 s interval, 15 min cap) → download mp4. Fallbacks: `kling_video`, `wan_video`.
- `tools/graphics/clipia_image.py` — `clipia_image`: text_to_image + image_to_image (+ multi-reference `image_urls`, `num_images` 1–4), default `nano-banana-2`. Fallback: `flux_image`.
- `tests/tools/test_clipia_tools.py` — 17 offline tests (contract/metadata, schema-default guards, status behavior, registry discovery, mocked happy paths, error envelope surfacing).
- `docs/PROVIDERS.md` — new "Clipia — Multi-Model Aggregator (RU-Friendly)" section + env summary/mapping table rows.
- `.agents/skills/clipia/SKILL.md` — Layer-3 skill teaching the API: queue lifecycle, dynamic model discovery (`GET /v1/models`), sandbox keys, idempotency, error codes, webhook signature verification.

Both tools register through normal package discovery (`capability="video_generation"` / `"image_generation"`) — **no selector code changes**.

### Why this provider belongs (viability, per the review guide)

- **Aggregator = one key instead of five.** A single `CLIPIA_API_KEY` covers Kling, Veo, Seedance, Wan, Sora on the video side and Nano Banana, FLUX, GPT-Image on the image side. The catalog is served dynamically by `GET /v1/models`, so new models appear without code changes here.
- **Regionally important (RU/CIS).** Clipia bills in rubles and accepts Russian bank cards (USD/EUR plans exist too). For users in that region, most providers already in this repo (fal.ai, Replicate, OpenAI, Runway) are effectively unpayable — this closes a real coverage gap, in line with the guide's "nationally or regionally important" criterion.
- **Sandbox mode makes it maintainable.** Keys with the `clipia_test_` prefix return an instant mock `COMPLETED` with a fixed sample asset and **zero credit spend** — reviewers and CI can exercise the full submit/poll/download path without anyone paying.
- **Maintained surface:** public REST API with docs (https://clipia.ai/docs), a developer console with request logs, official SDKs (npm `clipia-ai`, PyPI `clipia`), and a remote MCP server (`mcp.clipia.ai`). The API is deliberately fal.ai-shaped (`request_id`/`status_url`/`response_url`), so it matches the queue pattern already used by `kling_video`.

### How to test

**Offline (no key, no network):**

```bash
python -m py_compile tools/video/clipia_video.py tools/graphics/clipia_image.py
python -m pytest tests/tools/test_clipia_tools.py -q          # 17 passed
python -c "from tools.tool_registry import registry; import json; registry.discover(); print(json.dumps(registry.provider_menu_summary(), indent=2))"
```

**Live, spend-free (sandbox):** create a **Test** key at https://clipia.ai/ru/developer → it starts with `clipia_test_` → `CLIPIA_API_KEY=clipia_test_...` in `.env` → run either tool. Submit returns `COMPLETED` immediately, the tool downloads a fixed sample asset, `cost_credits` shows what a live key would have paid, **nothing is billed**. Webhook deliveries (if used) are still HMAC-signed.

**Live, real:** swap to a `clipia_live_` key — no code changes. A 5 s `seedance-2-fast-t2v` clip at 720p costs 47 credits (≈ $1.88); a `nano-banana-2` image costs 4 credits (≈ $0.16).

### Design notes for reviewers

- **Cost accuracy:** `estimate_cost()` is fast/offline per the tool contract, using a static table of public list prices (verified against clipia.ai's public pricing matrix, 2026-07) at ~1 credit ≈ $0.04. The exact server-side quote exists (`POST /v1/models/{slug}/estimate`, returns credits without queueing) and is documented in the skill/docs, but is deliberately **not** called inside `estimate_cost()`. Actual spend is reported from the API's own `cost` field in `ToolResult.cost_usd` + `data.cost_credits`.
- **Statuses:** Clipia uses `CANCELED` (single L, unlike fal's `CANCELLED`); terminal results come with HTTP 200, in-progress result GETs return 202. FAILED/CANCELED refund reserved credits — the error message says so, so users aren't left guessing about spend.
- **Timeouts/retries:** submit 60 s; poll every 5 s with a 15 min cap (video) / 3 s with a 5 min cap (images); transient poll errors are tolerated within the deadline. `RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])`, matching sibling tools.
- **Idempotency:** every submit sends an `Idempotency-Key` (UUID v4, or caller-supplied via the `idempotency_key` input) — Stripe-style semantics on the API side prevent double billing on network retries.
- **No heavyweight imports at module import time** — `requests` is imported inside `execute()`, matching the other API tools.
- **Downloads prefer `original_url`** (full-quality PNG/JPG/mp4) over the display-optimized `url` rendition.
- Honest-limitations metadata: queue-based latency in `not_good_for`, no seed parameter → `Determinism.STOCHASTIC`, sandbox outputs flagged as fixed samples in `user_visible_verification`.

### Scope

New files only, plus one additive section + three one-line rows in `docs/PROVIDERS.md`. No dependency, lockfile, selector, pipeline, or schema changes. Licensed under the repository's AGPL-3.0; written from scratch for this contribution.

### Checklist (mapped to `docs/PR_REVIEW_GUIDE.md` → "New Provider or Tool")

- [x] Real coverage, not duplication: aggregator key model + RU/CIS regional coverage + sandbox testing; complements `fal.ai`/`replicate` rather than duplicating them
- [x] Tool metadata/contract test (`test_contract_metadata`, schema-default guards)
- [x] Registry discovery test (`test_registry_discovers_clipia_tools`)
- [x] Status behavior test with dependencies mocked (`test_status_reflects_api_key`, `test_execute_without_key_fails_cleanly`)
- [x] Selector/routing compatibility: capability-based auto-discovery; selector input names (`prompt`, `operation`, `duration`, `aspect_ratio`, `image_url`, `resolution`, `output_path`) map 1:1 to tool inputs; no selector code changes
- [x] `get_status()` reflects real availability (env key presence)
- [x] `estimate_cost()` / `estimate_runtime()` implemented; paid usage visible (`cost_usd`, `data.cost_credits`, refund behavior stated in error messages)
- [x] Docs updated (`docs/PROVIDERS.md` section incl. pricing and free-tier caveats + `.agents/skills/clipia/SKILL.md`)
- [x] No heavyweight module-import-time dependencies; artifacts written to `output_path` as expected
- [x] Setup docs accurate: key creation path, one-time key display, sandbox toggle, subscription requirement (`402 subscription_required`) stated plainly