### PR TITLE
Clamp Pixabay per_page to API-required 3-200 range

### DIFF
--- a/tests/tools/test_pixabay_per_page_clamp.py
+++ b/tests/tools/test_pixabay_per_page_clamp.py
@@ -1,0 +1,62 @@
+"""Pixabay rejects per_page outside 3-200 with HTTP 400, so every
+Pixabay caller must clamp before building the request."""
+
+import requests
+
+from tools.graphics.pixabay_image import PixabayImage
+from tools.video.pixabay_video import PixabayVideo
+from tools.video.stock_sources.base import SearchFilters
+from tools.video.stock_sources.pixabay_video import PixabayVideoSource
+
+
+class _FakeResponse:
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return {"hits": [], "total": 0}
+
+
+def _capture_get(captured):
+    def fake_get(url, params=None, timeout=None, **kwargs):
+        captured["params"] = params
+        return _FakeResponse()
+
+    return fake_get
+
+
+def test_pixabay_video_tool_clamps_per_page(monkeypatch):
+    monkeypatch.setenv("PIXABAY_API_KEY", "test-key")
+    captured = {}
+    monkeypatch.setattr(requests, "get", _capture_get(captured))
+
+    PixabayVideo().execute({"query": "sky", "per_page": 1})
+    assert captured["params"]["per_page"] == 3
+
+    PixabayVideo().execute({"query": "sky", "per_page": 500})
+    assert captured["params"]["per_page"] == 200
+
+
+def test_pixabay_image_tool_clamps_per_page(monkeypatch):
+    monkeypatch.setenv("PIXABAY_API_KEY", "test-key")
+    captured = {}
+    monkeypatch.setattr(requests, "get", _capture_get(captured))
+
+    PixabayImage().execute({"query": "sky", "per_page": 1})
+    assert captured["params"]["per_page"] == 3
+
+    PixabayImage().execute({"query": "sky", "per_page": 500})
+    assert captured["params"]["per_page"] == 200
+
+
+def test_pixabay_stock_source_clamps_per_page(monkeypatch):
+    monkeypatch.setenv("PIXABAY_API_KEY", "test-key")
+    captured = {}
+    monkeypatch.setattr(requests, "get", _capture_get(captured))
+
+    source = PixabayVideoSource()
+    source.search("sky", SearchFilters(per_page=1))
+    assert captured["params"]["per_page"] == 3
+
+    source.search("sky", SearchFilters(per_page=500))
+    assert captured["params"]["per_page"] == 200

--- a/tools/graphics/pixabay_image.py
+++ b/tools/graphics/pixabay_image.py
@@ -127,7 +127,8 @@ class PixabayImage(BaseTool):
         params: dict[str, Any] = {
             "key": api_key,
             "q": query,
-            "per_page": inputs.get("per_page", 5),
+            # Pixabay rejects per_page outside 3-200 with HTTP 400
+            "per_page": max(3, min(inputs.get("per_page", 5), 200)),
             "page": inputs.get("page", 1),
             "safesearch": str(inputs.get("safesearch", True)).lower(),
         }

--- a/tools/video/pixabay_video.py
+++ b/tools/video/pixabay_video.py
@@ -130,7 +130,8 @@ class PixabayVideo(BaseTool):
         params: dict[str, Any] = {
             "key": api_key,
             "q": query,
-            "per_page": inputs.get("per_page", 5),
+            # Pixabay rejects per_page outside 3-200 with HTTP 400
+            "per_page": max(3, min(inputs.get("per_page", 5), 200)),
             "page": inputs.get("page", 1),
             "safesearch": str(inputs.get("safesearch", True)).lower(),
         }


### PR DESCRIPTION
Pixabay rejects `per_page` outside 3-200 with HTTP 400. The shared `stock_sources/pixabay_video.py` adapter already clamped the value, but the `PixabayVideo` and `PixabayImage` BaseTool wrappers passed it through raw, so callers using `per_page < 3` got a 400 from the API.

## Changes
- `tools/video/pixabay_video.py` — clamp `per_page` to `max(3, min(per_page, 200))` before building the request
- `tools/graphics/pixabay_image.py` — same clamp
- `tests/tools/test_pixabay_per_page_clamp.py` — new tests covering both tools and the stock-source adapter (stubs `requests.get`, asserts `1 -> 3` and `500 -> 200`)

The music tool doesn't send `per_page`, and the Pexels tools accept `per_page=1` (range 1-80), so neither needed changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)