### PR TITLE
video_downloader: optional cookies_file input + enable node JS runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ venv/
 
 # Backlot local cache (thumbnails)
 .backlot/
+
+# yt-dlp browser-session cookies for video_downloader (never commit these)
+/cookies.txt

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ venv/
 
 # Local Wan / diffusers GPU environment
 .venv-wan/
+
+# yt-dlp browser-session cookies for video_downloader (never commit these)
+/cookies.txt

--- a/tests/tools/test_video_downloader.py
+++ b/tests/tools/test_video_downloader.py
@@ -1,0 +1,52 @@
+import sys
+from types import SimpleNamespace
+
+from tools.analysis.video_downloader import VideoDownloader
+
+
+def test_cookies_file_reaches_every_yt_dlp_invocation(monkeypatch, tmp_path) -> None:
+    options = []
+
+    class FakeYoutubeDL:
+        def __init__(self, opts):
+            options.append(opts)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def extract_info(self, url, *, download):
+            return {}
+
+        def download(self, urls):
+            return None
+
+    monkeypatch.setitem(
+        sys.modules,
+        "yt_dlp",
+        SimpleNamespace(YoutubeDL=FakeYoutubeDL),
+    )
+    tool = VideoDownloader()
+    cookies_file = str(tmp_path / "cookies.txt")
+
+    tool._extract_metadata("https://example.com/video", cookies_file)
+    tool._download_video("https://example.com/video", tmp_path, "720p", cookies_file)
+    tool._download_audio("https://example.com/video", tmp_path, cookies_file)
+    tool._download_subtitles("https://example.com/video", tmp_path, cookies_file)
+
+    assert [opts["cookiefile"] for opts in options] == [cookies_file] * 4
+
+
+def test_cookies_file_changes_idempotency_key() -> None:
+    tool = VideoDownloader()
+    inputs = {
+        "url": "https://example.com/video",
+        "format": "video",
+        "max_resolution": "720p",
+    }
+
+    assert tool.idempotency_key(inputs) != tool.idempotency_key(
+        {**inputs, "cookies_file": "/cookies.txt"}
+    )

--- a/tests/tools/test_video_downloader.py
+++ b/tests/tools/test_video_downloader.py
@@ -46,7 +46,10 @@ def test_cookies_file_changes_idempotency_key() -> None:
         "format": "video",
         "max_resolution": "720p",
     }
+    inputs_with_cookies = {**inputs, "cookies_file": "/cookies.txt"}
 
-    assert tool.idempotency_key(inputs) != tool.idempotency_key(
-        {**inputs, "cookies_file": "/cookies.txt"}
+    assert tool.idempotency_key(inputs) != tool.idempotency_key(inputs_with_cookies)
+    assert tool.idempotency_key(inputs) == tool.idempotency_key(dict(inputs))
+    assert tool.idempotency_key(inputs_with_cookies) == tool.idempotency_key(
+        dict(inputs_with_cookies)
     )

--- a/tools/analysis/video_downloader.py
+++ b/tools/analysis/video_downloader.py
@@ -88,6 +88,14 @@ class VideoDownloader(BaseTool):
                 "default": 600,
                 "description": "Reject videos longer than this (safety limit)",
             },
+            "cookies_file": {
+                "type": "string",
+                "description": (
+                    "Path to a Netscape-format cookies.txt file passed to yt-dlp. "
+                    "Needed when the site blocks anonymous requests (e.g. YouTube "
+                    "bot-checks on datacenter IPs)."
+                ),
+            },
         },
     }
 
@@ -150,13 +158,25 @@ class VideoDownloader(BaseTool):
             return "twitter"
         return "other_url"
 
-    def _extract_metadata(self, url: str) -> dict:
+    def _common_ydl_opts(self, cookies_file: str | None) -> dict:
+        """Options shared by every yt-dlp invocation."""
+        opts = {
+            "quiet": True,
+            "no_warnings": True,
+            # Enable whichever JS runtime is installed; unsupported entries are
+            # dropped by yt-dlp with a warning.
+            "js_runtimes": {"deno": {}, "node": {}},
+        }
+        if cookies_file:
+            opts["cookiefile"] = cookies_file
+        return opts
+
+    def _extract_metadata(self, url: str, cookies_file: str | None = None) -> dict:
         """Extract metadata without downloading."""
         import yt_dlp
 
         ydl_opts = {
-            "quiet": True,
-            "no_warnings": True,
+            **self._common_ydl_opts(cookies_file),
             "skip_download": True,
         }
         try:
@@ -184,13 +204,14 @@ class VideoDownloader(BaseTool):
         dl_format = inputs.get("format", "video")
         max_res = inputs.get("max_resolution", "720p")
         max_duration = inputs.get("max_duration_seconds", 600)
+        cookies_file = inputs.get("cookies_file")
 
         output_dir.mkdir(parents=True, exist_ok=True)
         platform = self._detect_platform(url)
         start = time.time()
 
         # Step 1: Always get metadata first
-        metadata = self._extract_metadata(url)
+        metadata = self._extract_metadata(url, cookies_file)
 
         # Check duration limit
         duration = metadata.get("duration", 0)
@@ -224,12 +245,12 @@ class VideoDownloader(BaseTool):
         try:
             if dl_format == "video":
                 video_path, audio_path = self._download_video(
-                    url, output_dir, max_res
+                    url, output_dir, max_res, cookies_file
                 )
             elif dl_format == "audio_only":
-                audio_path = self._download_audio(url, output_dir)
+                audio_path = self._download_audio(url, output_dir, cookies_file)
             elif dl_format == "subtitles_only":
-                subtitle_path = self._download_subtitles(url, output_dir)
+                subtitle_path = self._download_subtitles(url, output_dir, cookies_file)
         except Exception as e:
             elapsed = time.time() - start
             return ToolResult(
@@ -256,7 +277,7 @@ class VideoDownloader(BaseTool):
         )
 
     def _download_video(
-        self, url: str, output_dir: Path, max_res: str
+        self, url: str, output_dir: Path, max_res: str, cookies_file: str | None = None
     ) -> tuple[str | None, str | None]:
         """Download video + extract audio track."""
         import yt_dlp
@@ -265,12 +286,11 @@ class VideoDownloader(BaseTool):
         video_out = str(output_dir / "reference_video.%(ext)s")
 
         ydl_opts = {
+            **self._common_ydl_opts(cookies_file),
             "format": f"bestvideo[height<={height}]+bestaudio/best[height<={height}]/best",
             "merge_output_format": "mp4",
             "outtmpl": video_out,
             "noplaylist": True,
-            "quiet": True,
-            "no_warnings": True,
         }
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             ydl.download([url])
@@ -300,12 +320,15 @@ class VideoDownloader(BaseTool):
 
         return video_path, audio_path
 
-    def _download_audio(self, url: str, output_dir: Path) -> str | None:
+    def _download_audio(
+        self, url: str, output_dir: Path, cookies_file: str | None = None
+    ) -> str | None:
         """Download audio only."""
         import yt_dlp
 
         audio_out = str(output_dir / "reference_audio.%(ext)s")
         ydl_opts = {
+            **self._common_ydl_opts(cookies_file),
             "format": "bestaudio/best",
             "postprocessors": [{
                 "key": "FFmpegExtractAudio",
@@ -314,19 +337,20 @@ class VideoDownloader(BaseTool):
             }],
             "outtmpl": audio_out,
             "noplaylist": True,
-            "quiet": True,
-            "no_warnings": True,
         }
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             ydl.download([url])
         return self._find_downloaded(output_dir, "reference_audio", ["wav", "mp3", "m4a", "opus"])
 
-    def _download_subtitles(self, url: str, output_dir: Path) -> str | None:
+    def _download_subtitles(
+        self, url: str, output_dir: Path, cookies_file: str | None = None
+    ) -> str | None:
         """Download subtitles only."""
         import yt_dlp
 
         sub_out = str(output_dir / "reference_subs.%(ext)s")
         ydl_opts = {
+            **self._common_ydl_opts(cookies_file),
             "writesubtitles": True,
             "writeautomaticsub": True,
             "subtitleslangs": ["en"],
@@ -334,8 +358,6 @@ class VideoDownloader(BaseTool):
             "skip_download": True,
             "outtmpl": sub_out,
             "noplaylist": True,
-            "quiet": True,
-            "no_warnings": True,
         }
         try:
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:

--- a/tools/analysis/video_downloader.py
+++ b/tools/analysis/video_downloader.py
@@ -125,7 +125,7 @@ class VideoDownloader(BaseTool):
         cpu_cores=1, ram_mb=512, vram_mb=0, disk_mb=2000,
         network_required=True,
     )
-    idempotency_key_fields = ["url", "format", "max_resolution"]
+    idempotency_key_fields = ["url", "format", "max_resolution", "cookies_file"]
     side_effects = ["downloads media files to output_dir"]
     resume_support_value = "from_start"
     user_visible_verification = [

--- a/tools/analysis/video_downloader.py
+++ b/tools/analysis/video_downloader.py
@@ -40,9 +40,9 @@ class VideoDownloader(BaseTool):
     dependencies = ["python:yt_dlp"]
     install_instructions = (
         "Install yt-dlp: pip install yt-dlp\n"
-        "For YouTube support, also install Deno (JS runtime): "
-        "https://deno.land/#installation\n"
-        "Without Deno, YouTube downloads may fail but other platforms still work."
+        "For YouTube support, also install a JS runtime: Deno "
+        "(https://deno.land/#installation) or Node.js (https://nodejs.org/).\n"
+        "Without Deno or Node.js, YouTube downloads may fail but other platforms still work."
     )
     agent_skills = ["video-download"]
 
@@ -93,7 +93,8 @@ class VideoDownloader(BaseTool):
                 "description": (
                     "Path to a Netscape-format cookies.txt file passed to yt-dlp. "
                     "Needed when the site blocks anonymous requests (e.g. YouTube "
-                    "bot-checks on datacenter IPs)."
+                    "bot-checks on datacenter IPs). Cookie files contain authentication "
+                    "credentials; never commit them (/cookies.txt is gitignored)."
                 ),
             },
         },


### PR DESCRIPTION
## Summary

youtube downloads via `video_downloader` currently fail on a lot of boxes — youtube now serves "Sign in to confirm you're not a bot" to anonymous requests (datacenter IPs get it consistently, residential increasingly too), and yt-dlp's n-challenge solving needs a JS runtime that isn't enabled by default when only node is installed. this PR adds an optional `cookies_file` input (netscape-format cookies.txt, passed through as yt-dlp's `cookiefile`) and enables node alongside deno in `js_runtimes` so the EJS challenge solver works on node-only machines. to be precise about the second part: the node runtime is enabled unconditionally (not only when cookies are passed) — yt-dlp's embedded API documents `js_runtimes` as a dict of runtimes to enable, defaulting to `{'deno': {}}` (`yt_dlp/YoutubeDL.py` lines 539–545 and 736), so on machines that have deno nothing changes, and on node-only machines the solver starts working instead of failing.

also adds `/cookies.txt` (anchored to repo root) to `.gitignore` so nobody accidentally commits their session cookies to a fork.

## Related issue

Refs # (none found — happy to open one first if you prefer)

## Changes

- `tools/analysis/video_downloader.py`: new optional `cookies_file` input on the schema, threaded through metadata extraction, video/audio/subtitle download paths via a shared `_common_ydl_opts`; `js_runtimes` now `{"deno": {}, "node": {}}`
- `.gitignore`: ignore `/cookies.txt` at repo root

## Testing

- on a debian 12 server (datacenter IP, node 22, no deno): without cookies, downloads fail with youtube's bot-check; with a cookies.txt exported from a logged-in browser, metadata + video + audio + subtitles all succeed end-to-end
- same box: without node in `js_runtimes`, formats fail with "n challenge solving failed" / "No video formats found"; with it, formats resolve

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable. (contract suite on a clean checkout of main with only this change applied: 325 passed, 6 skipped)
- [x] I updated docs/README if behavior or usage changed. (the tool's schema description documents the new input; happy to add a README note if wanted)
- [x] No unrelated files (build artifacts, local config) are included in the diff.
