### PR TITLE
face_tracker: detect missing mediapipe.solutions so OpenCV fallback engages

### DIFF
--- a/tests/tools/test_face_tracker.py
+++ b/tests/tools/test_face_tracker.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from unittest.mock import Mock
+
+from tools.analysis.face_tracker import FaceTracker
+from tools.base_tool import ToolStatus
+
+
+def test_missing_mediapipe_solutions_uses_opencv_fallback(tmp_path, monkeypatch):
+    monkeypatch.setitem(sys.modules, "mediapipe", ModuleType("mediapipe"))
+    monkeypatch.setitem(sys.modules, "cv2", ModuleType("cv2"))
+
+    input_path = tmp_path / "input.mp4"
+    input_path.touch()
+
+    tracker = FaceTracker()
+    opencv_result = {
+        "video_width": 1920,
+        "video_height": 1080,
+        "fps": 30.0,
+        "duration_seconds": 1.0,
+        "frame_count": 1,
+        "face_detected_count": 0,
+        "faces": [],
+    }
+    track_opencv = Mock(return_value=opencv_result)
+    track_mediapipe = Mock()
+    monkeypatch.setattr(tracker, "_track_opencv", track_opencv)
+    monkeypatch.setattr(tracker, "_track_mediapipe", track_mediapipe)
+
+    assert tracker.get_status() == ToolStatus.DEGRADED
+
+    result = tracker.execute({"input_path": str(input_path)})
+
+    assert result.success
+    assert result.data["method"] == "opencv_haar"
+    track_opencv.assert_called_once_with(input_path, 5)
+    track_mediapipe.assert_not_called()

--- a/tools/analysis/face_tracker.py
+++ b/tools/analysis/face_tracker.py
@@ -116,8 +116,10 @@ class FaceTracker(BaseTool):
 
     def _has_mediapipe(self) -> bool:
         try:
-            import mediapipe  # noqa: F401
-            return True
+            import mediapipe
+            # Newer mediapipe wheels no longer ship the legacy solutions API
+            # (verified absent in 0.10.35); without it, fall back to OpenCV.
+            return hasattr(mediapipe, "solutions")
         except ImportError:
             return False
 


### PR DESCRIPTION
## Summary

`face_tracker`'s mediapipe availability check only tests that `import mediapipe` succeeds. newer mediapipe wheels no longer ship the legacy `mediapipe.solutions` module (verified absent in 0.10.35, the current pypi release), so on a fresh install the check reports mediapipe as available and the tool then crashes at use instead of engaging its OpenCV fallback. this PR makes the check `hasattr(mediapipe, "solutions")` so the fallback engages correctly.

## Related issue

Refs # (none found)

## Changes

- `tools/analysis/face_tracker.py`: `_has_mediapipe()` now returns `hasattr(mediapipe, "solutions")` instead of unconditional `True` after import

## Testing

- on mediapipe 0.10.35 (linux x86_64 wheel from pypi): `python -c "import mediapipe; print(hasattr(mediapipe, 'solutions'))"` → `False`; with this fix the tool falls back to OpenCV (`method: opencv_haar`) and completes a real face-tracked 9:16 reframe successfully
- versions that still ship `solutions` keep the mediapipe path by construction (the attribute is present, so the check returns `True` exactly as before)

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable. (contract suite on a clean checkout of main with only this change applied: 325 passed, 6 skipped)
- [x] I updated docs/README if behavior or usage changed. (no usage change — pure fallback correctness)
- [x] No unrelated files (build artifacts, local config) are included in the diff.
