### PR TITLE
fix(delivery_promise): motion_required derived before has_footage reclassification (#277)

### DIFF
--- a/lib/delivery_promise.py
+++ b/lib/delivery_promise.py
@@ -227,13 +227,19 @@ def classify_from_brief(
     if user_intent.get("motion_required") is False and promise_type == PromiseType.MOTION_LED:
         promise_type = PromiseType.HYBRID
 
-    motion_required = user_intent.get("motion_required", promise_type in (
-        PromiseType.MOTION_LED, PromiseType.AVATAR_PRESENTER,
-    ))
-
     source_required = user_intent.get("has_footage", False)
     if source_required and promise_type not in (PromiseType.SOURCE_LED, PromiseType.LOCALIZATION):
         promise_type = PromiseType.SOURCE_LED
+
+    # Derive motion_required AFTER any has_footage reclassification, so a
+    # source-led production doesn't inherit a motion floor from the pre-
+    # reclassification type (e.g. talking-head -> AVATAR_PRESENTER -> SOURCE_LED
+    # would otherwise default motion_required=True and trip validate_cuts'
+    # motion-ratio check against a user-footage edit). Explicit user intent
+    # still wins.
+    motion_required = user_intent.get("motion_required", promise_type in (
+        PromiseType.MOTION_LED, PromiseType.AVATAR_PRESENTER,
+    ))
 
     tone_mode = user_intent.get("tone", "corporate")
     quality_floor = user_intent.get("quality", "presentable")

--- a/tests/lib/test_delivery_promise_classify.py
+++ b/tests/lib/test_delivery_promise_classify.py
@@ -1,0 +1,39 @@
+"""Regression tests for classify_from_brief motion_required derivation.
+
+motion_required was computed from promise_type BEFORE the has_footage branch
+could reclassify promise_type to SOURCE_LED, so a source-led production (e.g.
+talking-head + user footage) inherited motion_required=True and then tripped
+validate_cuts' motion-ratio floor against a legitimate user-footage edit.
+"""
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from lib.delivery_promise import PromiseType, classify_from_brief  # noqa: E402
+
+
+def test_source_led_via_footage_is_not_motion_required():
+    p = classify_from_brief("talking-head", {"has_footage": True})
+    assert p.promise_type is PromiseType.SOURCE_LED
+    assert p.motion_required is False
+
+
+def test_explicit_motion_required_still_wins_with_footage():
+    p = classify_from_brief("talking-head", {"has_footage": True, "motion_required": True})
+    assert p.promise_type is PromiseType.SOURCE_LED
+    assert p.motion_required is True
+
+
+def test_avatar_presenter_without_footage_stays_motion_required():
+    p = classify_from_brief("talking-head", {})
+    assert p.promise_type is PromiseType.AVATAR_PRESENTER
+    assert p.motion_required is True
+
+
+def test_motion_led_pipeline_unaffected():
+    p = classify_from_brief("cinematic", {})
+    assert p.promise_type is PromiseType.MOTION_LED
+    assert p.motion_required is True


### PR DESCRIPTION
## Summary

Closes #277. `classify_from_brief()` derived `motion_required` from `promise_type` *before* the `has_footage` branch reclassified `promise_type` to `SOURCE_LED`, so a source-led production inherited a motion floor from the pre-reclassification type.

## Root cause

`talking-head` -> `AVATAR_PRESENTER` (so `motion_required` defaults `True`) -> `has_footage` flips `promise_type` to `SOURCE_LED`, leaving `motion_required=True`. `DeliveryPromise.validate_cuts` then trips `if self.motion_required and motion_ratio < min_ratio` on a legitimate user-footage edit, and that violation feeds `video_compose`'s pre-compose gate. (`podcast-repurpose`, which is `SOURCE_LED` from the default, correctly yields `motion_required=False` — confirming ordering is the cause.)

## Fix

Derive `motion_required` after the `has_footage` reclassification block. Explicit `user_intent['motion_required']` still wins.

## Testing

- Reproduced: `classify_from_brief('talking-head', {'has_footage': True})` -> `SOURCE_LED, motion_required=True` before; `motion_required=False` after.
- `tests/lib/test_delivery_promise_classify.py` (new, 4 tests): source-led-via-footage not motion-required (fails before, passes after); explicit override preserved; avatar-without-footage and motion-led pipelines unchanged.
- Full suite: 452 passed, 8 skipped.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally.
- [x] No unrelated files included.

Closes #277