### PR TITLE
fix(scoring): tokenizer swallows trailing punctuation; cinematic bonus uses raw split() (#279)

### DIFF
--- a/lib/scoring.py
+++ b/lib/scoring.py
@@ -147,7 +147,10 @@ _SYNONYM_CLUSTERS: list[set[str]] = [
     {"music", "soundtrack", "background-music", "score", "ambient"},
 ]
 
-_TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9+._-]*")
+# Allow internal +._- so model-name-like tokens survive (gpt-4.1, film-noir,
+# multi_shot), but require the token to END on an alphanumeric so trailing
+# punctuation is not swallowed ("cinematic." -> "cinematic", not "cinematic.").
+_TOKEN_RE = re.compile(r"[a-z0-9](?:[a-z0-9+._-]*[a-z0-9])?")
 _GENERATED_VISUAL_TERMS = {
     "animated",
     "animation",
@@ -498,7 +501,11 @@ def score_provider(tool, task_context: dict[str, Any]) -> ProviderScore:
     # lip-sync from quoted dialogue. This is what makes Seedance 2.0 (and
     # peer premium APIs) meaningfully better than generic clip providers.
     if asset_type == "video":
-        intent_words = _expand_synonyms(set(intent.lower().split())) | set(style_keywords)
+        # Use the shared tokenizer (strips punctuation) like every other call
+        # site — a raw str.split() keeps trailing punctuation, so an intent that
+        # ends on a signal word (e.g. "make it cinematic.") yields "cinematic."
+        # and silently misses the cinematic-signal set and synonym clusters.
+        intent_words = _expand_synonyms(set(_tokenize_text(intent))) | set(style_keywords)
         cinematic_signal = bool(
             intent_words & {"cinematic", "film", "movie", "trailer", "teaser", "dramatic", "epic", "premium"}
         )

--- a/tests/lib/test_scoring_tokenizer.py
+++ b/tests/lib/test_scoring_tokenizer.py
@@ -1,0 +1,70 @@
+"""Regression tests for scoring tokenization vs. punctuation.
+
+Two related defects:
+  1. `_tokenize_text` swallowed trailing punctuation ("cinematic." -> "cinematic.")
+     because the regex allowed a token to end on '. _ - +'.
+  2. The premium-cinematic bonus in score_provider used a raw str.split() (unlike
+     every other call site), so a comma-adjacent signal word ("cinematic,") was
+     never stripped.
+
+Together these meant an intent whose only cinematic-signal word carried adjacent
+punctuation silently lost the premium-provider bonus and could be out-ranked.
+"""
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from lib import scoring  # noqa: E402
+
+
+def test_tokenizer_strips_trailing_punctuation():
+    assert scoring._tokenize_text("cinematic.") == ["cinematic"]
+    assert scoring._tokenize_text("epic, dramatic") == ["epic", "dramatic"]
+    assert scoring._tokenize_text("a trailer!") == ["a", "trailer"]
+
+
+def test_tokenizer_preserves_model_name_tokens():
+    # Internal punctuation must survive so model-name-like tokens still match.
+    assert scoring._tokenize_text("gpt-4.1") == ["gpt-4.1"]
+    assert scoring._tokenize_text("film-noir") == ["film-noir"]
+    assert scoring._tokenize_text("multi_shot") == ["multi_shot"]
+    assert scoring._tokenize_text("v1.5.") == ["v1.5"]
+
+
+class _FakeStatus:
+    value = "available"
+
+
+class _FakeTool:
+    def get_status(self):
+        return _FakeStatus()
+
+    def get_info(self):
+        return {
+            "name": "premium_video",
+            "provider": "premium",
+            "capability": "video_generation",
+            "best_for": ["cinematic trailer"],
+            "stability": "production",
+            "supports": {
+                "native_audio": True,
+                "multi_shot": True,
+                "camera_direction": True,
+                "lip_sync": True,
+            },
+        }
+
+
+def _fit(intent):
+    return scoring.score_provider(
+        _FakeTool(), {"asset_type": "video", "intent": intent}
+    ).task_fit
+
+
+def test_cinematic_bonus_ignores_adjacent_punctuation():
+    baseline = _fit("make it cinematic and fast")
+    assert _fit("make it cinematic, and fast") == baseline  # comma-adjacent
+    assert _fit("make it cinematic.") == baseline           # trailing period


### PR DESCRIPTION
## Summary

Closes #279. Two related tokenization defects in `lib/scoring.py` let punctuation silently change provider ranking.

### 1. `_tokenize_text` swallowed trailing punctuation
`_TOKEN_RE = [a-z0-9][a-z0-9+._-]*` lets a token *end* on `. _ - +`, so `"cinematic."` -> `['cinematic.']` and `"v1.5."` -> `['v1.5.']`. Any keyword ending a sentence then fails to match wherever the tokenizer is used. Tightened to `[a-z0-9](?:[a-z0-9+._-]*[a-z0-9])?` — model-name tokens (`gpt-4.1`, `film-noir`, `multi_shot`) still survive; trailing punctuation is dropped.

### 2. Premium-cinematic bonus used `str.split()`
Unlike every other call site (which uses `_tokenize_text`), the cinematic-signal check used raw `intent.lower().split()`, so comma/exclamation-adjacent signal words stayed attached (`"cinematic,"`) and missed the signal set + synonym clusters, dropping the `+0.15 task_fit / +0.10 output_quality` premium bonus. Switched to `_tokenize_text`.

## Testing

- `tests/lib/test_scoring_tokenizer.py` (new, 3 tests): trailing punctuation stripped; `gpt-4.1`/`film-noir`/`multi_shot`/`v1.5` preserved; cinematic bonus invariant across `"...cinematic and fast"`, `"...cinematic, and fast"`, `"...cinematic."` (all fail before, pass after).
- Full suite: 452 passed, 8 skipped — the tokenizer change shifts no existing scores.

## Checklist

- [x] The change is focused on a single logical concern (scoring tokenization).
- [x] I ran the relevant tests locally.
- [x] No unrelated files included.

Closes #279