### PR TITLE
fix: check ffmpeg availability via shutil.which instead of hardcoding True

### DIFF
--- a/tests/tools/test_documentary_governance.py
+++ b/tests/tools/test_documentary_governance.py
@@ -112,12 +112,31 @@ def test_documentary_renderer_family_maps_to_remotion():
 
 def test_video_compose_surfaces_all_three_runtimes():
     """Preflight must see remotion, hyperframes, and ffmpeg as separate engines."""
+    import shutil
+
     info = VideoCompose().get_info()
     engines = info["render_engines"]
     assert set(engines.keys()) == {"remotion", "hyperframes", "ffmpeg"}
-    assert engines["ffmpeg"] is True  # always true on this machine
+    assert engines["ffmpeg"] is bool(shutil.which("ffmpeg"))
     assert "hyperframes_note" in info
     assert "runtime_governance" in info
+
+
+def test_video_compose_ffmpeg_engine_reflects_path_availability(monkeypatch):
+    """Regression: `get_info()["render_engines"]["ffmpeg"]` must actually check
+    shutil.which("ffmpeg"), not hardcode True. A machine without ffmpeg on PATH
+    must not have the agent believe render_runtime='ffmpeg' is safe to lock."""
+    import shutil
+
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    info = VideoCompose().get_info()
+    assert info["render_engines"]["ffmpeg"] is False
+
+    monkeypatch.setattr(
+        shutil, "which", lambda name: "/usr/bin/ffmpeg" if name == "ffmpeg" else None
+    )
+    info = VideoCompose().get_info()
+    assert info["render_engines"]["ffmpeg"] is True
 
 
 def test_video_compose_blocks_silent_hyperframes_swap(tmp_path, monkeypatch):

--- a/tools/video/video_compose.py
+++ b/tools/video/video_compose.py
@@ -241,6 +241,12 @@ class VideoCompose(BaseTool):
             return False
         return True
 
+    def _ffmpeg_available(self) -> bool:
+        """Check if the ffmpeg binary is actually resolvable on PATH."""
+        import shutil as _shutil
+
+        return bool(_shutil.which("ffmpeg"))
+
     def _hyperframes_available(self) -> bool:
         """Check if HyperFrames rendering is available.
 
@@ -261,10 +267,11 @@ class VideoCompose(BaseTool):
         fallback between runtimes is forbidden.
         """
         info = super().get_info()
+        ffmpeg_ok = self._ffmpeg_available()
         remotion_ok = self._remotion_available()
         hyperframes_ok = self._hyperframes_available()
         info["render_engines"] = {
-            "ffmpeg": True,
+            "ffmpeg": ffmpeg_ok,
             "remotion": remotion_ok,
             "hyperframes": hyperframes_ok,
         }


### PR DESCRIPTION
## Summary
- `VideoCompose.get_info()` hardcoded `render_engines["ffmpeg"] = True` unconditionally, unlike the real availability checks used for `remotion` and `hyperframes`.
- On a machine without `ffmpeg` on PATH, preflight (`registry.provider_menu_summary()` / `video_compose.get_info()`) falsely reported ffmpeg as available, letting `render_runtime="ffmpeg"` get locked at proposal time and only fail later at compose.
- Added `_ffmpeg_available()` (checks `shutil.which("ffmpeg")`), mirroring `_remotion_available()`/`_hyperframes_available()`, and wired it into `get_info()`.
- Checked `tools/tool_registry.py` and `tools/base_tool.py` for duplicated hardcoding — `provider_menu_summary()` derives `composition_runtimes.ffmpeg` directly from `video_compose.get_info()`, so it inherits the fix automatically; no other hardcoding found.

## Test plan
- [x] Updated `test_video_compose_surfaces_all_three_runtimes` to assert against real `shutil.which` result instead of a hardcoded `True`.
- [x] Added `test_video_compose_ffmpeg_engine_reflects_path_availability`, monkeypatching `shutil.which` to `None` and to a fake path, asserting `render_engines["ffmpeg"]` flips accordingly.
- [x] Ran `tests/tools/test_documentary_governance.py` and `tests/tools/test_hyperframes_compose.py` (55 tests) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)