### PR TITLE
fix(delivery): recompute motion requirement after source-led override

### DIFF
--- a/lib/delivery_promise.py
+++ b/lib/delivery_promise.py
@@ -227,13 +227,13 @@ def classify_from_brief(
     if user_intent.get("motion_required") is False and promise_type == PromiseType.MOTION_LED:
         promise_type = PromiseType.HYBRID
 
-    motion_required = user_intent.get("motion_required", promise_type in (
-        PromiseType.MOTION_LED, PromiseType.AVATAR_PRESENTER,
-    ))
-
     source_required = user_intent.get("has_footage", False)
     if source_required and promise_type not in (PromiseType.SOURCE_LED, PromiseType.LOCALIZATION):
         promise_type = PromiseType.SOURCE_LED
+
+    motion_required = user_intent.get("motion_required", promise_type in (
+        PromiseType.MOTION_LED, PromiseType.AVATAR_PRESENTER,
+    ))
 
     tone_mode = user_intent.get("tone", "corporate")
     quality_floor = user_intent.get("quality", "presentable")

--- a/tests/tools/test_delivery_promise.py
+++ b/tests/tools/test_delivery_promise.py
@@ -1,0 +1,26 @@
+from lib.delivery_promise import PromiseType, classify_from_brief
+
+
+def test_classify_from_brief_source_led_reclassification_clears_motion_requirement() -> None:
+    promise = classify_from_brief("talking-head", {"has_footage": True})
+
+    assert promise.promise_type == PromiseType.SOURCE_LED
+    assert promise.source_required is True
+    assert promise.motion_required is False
+
+
+def test_classify_from_brief_explicit_motion_override_survives_reclassification() -> None:
+    promise = classify_from_brief(
+        "talking-head",
+        {"has_footage": True, "motion_required": True},
+    )
+
+    assert promise.promise_type == PromiseType.SOURCE_LED
+    assert promise.motion_required is True
+
+
+def test_classify_from_brief_avatar_defaults_stay_motion_required_without_footage() -> None:
+    promise = classify_from_brief("talking-head", {})
+
+    assert promise.promise_type == PromiseType.AVATAR_PRESENTER
+    assert promise.motion_required is True


### PR DESCRIPTION
## Summary
- move default `motion_required` derivation after `has_footage` source-led reclassification
- preserve explicit `motion_required` overrides from user intent
- add regression tests for source-led reclassification and talking-head defaults

## Testing
- `C:\Users\Jayesh\AppData\Local\Programs\Python\Python314\python.exe -m pytest tests/tools/test_delivery_promise.py`

Closes #277
