### PR TITLE
fix(schema): allow empty source media reviews

### DIFF
--- a/schemas/artifacts/source_media_review.schema.json
+++ b/schemas/artifacts/source_media_review.schema.json
@@ -64,7 +64,7 @@
         },
         "additionalProperties": false
       },
-      "minItems": 1
+      "minItems": 0
     },
     "summary": {
       "type": "string",

--- a/tests/tools/test_source_media_review_schema.py
+++ b/tests/tools/test_source_media_review_schema.py
@@ -1,0 +1,12 @@
+from lib.source_media_review import review_source_media
+from schemas.artifacts import validate_artifact
+
+
+def test_empty_source_media_review_artifact_validates() -> None:
+    artifact = review_source_media([], {})
+
+    validate_artifact("source_media_review", artifact)
+
+    assert artifact["files"] == []
+    assert artifact["summary"] == "No user-supplied media files could be reviewed."
+    assert "No source media available — production is fully generated." in artifact["planning_implications"]


### PR DESCRIPTION
## Summary
- relax `source_media_review.files` schema to allow empty reviewed-file sets
- keep empty-media branch behavior valid for fully generated productions
- add regression coverage for `review_source_media([], {})` artifact validation

## Testing
- `C:\Users\Jayesh\AppData\Local\Programs\Python\Python314\python.exe -m pytest tests/tools/test_source_media_review_schema.py`

Closes #269
