### PR TITLE
fix(audio): drop dead ducking filtergraph pad

### DIFF
--- a/tests/tools/test_audio_mixer_full_mix.py
+++ b/tests/tools/test_audio_mixer_full_mix.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+from tools.audio.audio_mixer import AudioMixer
+from tools.base_tool import ToolResult
+
+
+class _CmdResult:
+    def __init__(self, stdout: str = "") -> None:
+        self.stdout = stdout
+
+
+def test_full_mix_single_speech_ducking_does_not_emit_dead_speech_dup_pad(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    speech = tmp_path / "speech.wav"
+    music = tmp_path / "music.wav"
+    speech.write_bytes(b"speech")
+    music.write_bytes(b"music")
+
+    captured: dict[str, str] = {}
+
+    def fake_run_command(self, cmd):  # noqa: ANN001
+        if "-filter_complex" in cmd:
+            captured["filter_complex"] = cmd[cmd.index("-filter_complex") + 1]
+        return _CmdResult()
+
+    monkeypatch.setattr(AudioMixer, "run_command", fake_run_command, raising=True)
+
+    result = AudioMixer().execute(
+        {
+            "operation": "full_mix",
+            "tracks": [
+                {"path": str(speech), "role": "speech"},
+                {"path": str(music), "role": "music"},
+            ],
+            "ducking": {"enabled": True},
+            "normalize": False,
+            "output_path": str(tmp_path / "out.wav"),
+        }
+    )
+
+    assert result.success is True
+    assert isinstance(result, ToolResult)
+    assert "speech_dup" not in captured["filter_complex"]
+    assert "[a0]acopy[speech_out]" in captured["filter_complex"]

--- a/tools/audio/audio_mixer.py
+++ b/tools/audio/audio_mixer.py
@@ -530,10 +530,6 @@ class AudioMixer(BaseTool):
                 f"[ducked_music]volume={music_vol * 3}[music_out]"
             )
 
-            # Duplicate speech for final mix (sidechain consumes it as key)
-            filter_parts.append(
-                f"{speech_out}acopy[speech_dup]" if speech_out.startswith("[a") else ""
-            )
             # Re-mix speech path: we need speech audio in the output too
             # Simpler approach: use amix on original speech and ducked music
             # Reset: use a cleaner approach — amerge the speech mix and ducked music
@@ -541,10 +537,6 @@ class AudioMixer(BaseTool):
             # the key signal but doesn't consume it from the output chain.
             # FFmpeg sidechaincompress: input 0 = audio to compress, input 1 = key signal
             # So music is compressed, speech signal is the key. We need to mix them.
-            # Remove the last filter_part (the acopy that may be empty)
-            if filter_parts and filter_parts[-1] == "":
-                filter_parts.pop()
-
             # Build speech mix for output separately
             if len(speech_tracks) > 1:
                 # speech_mix already exists, make a copy for output


### PR DESCRIPTION
## Summary
- remove dead `speech_dup` filtergraph branch from `full_mix` ducking path
- keep single-speech narration routed back through `[speech_out]` for final mix
- add regression coverage that inspects generated filtergraph for single-speech ducking

## Testing
- `C:\Users\Jayesh\AppData\Local\Programs\Python\Python314\python.exe -m pytest tests/tools/test_audio_mixer_full_mix.py`

Closes #265
