### PR TITLE
fix(comfyui): use 14B-compatible VAE for wan22 t2v

### DIFF
--- a/tests/contracts/test_comfyui_tools.py
+++ b/tests/contracts/test_comfyui_tools.py
@@ -174,6 +174,20 @@ def test_t2v_workflow_has_templated_nodes():
     assert "16" in w  # SaveVideo (output)
 
 
+def test_t2v_workflow_uses_14b_compatible_vae():
+    with open(WORKFLOW_DIR / "wan22-t2v-4step.json") as f:
+        w = json.load(f)
+    assert w["4"]["inputs"]["vae_name"] == "wan_2.1_vae.safetensors"
+
+
+def test_t2v_metadata_stack_uses_14b_compatible_vae():
+    from tools._comfyui.metadata import BUNDLED_MODEL_STACKS
+
+    vae_entry = next(item for item in BUNDLED_MODEL_STACKS["wan22-t2v-4step"] if item["role"] == "vae")
+    assert vae_entry["name"] == "wan_2.1_vae.safetensors"
+    assert "Wan_2.1_ComfyUI_repackaged" in vae_entry["download_url"]
+
+
 # ------------------------------------------------------------------
 # Client unit tests
 # ------------------------------------------------------------------

--- a/tools/_comfyui/metadata.py
+++ b/tools/_comfyui/metadata.py
@@ -86,10 +86,10 @@ BUNDLED_MODEL_STACKS: dict[str, list[dict[str, Any]]] = {
         },
         {
             "role": "vae",
-            "name": "wan2.2_vae.safetensors",
+            "name": "wan_2.1_vae.safetensors",
             "destination_hint": "ComfyUI/models/vae/",
             "download_url": (
-                "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged/"
+                "https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/"
                 "tree/main/split_files/vae"
             ),
         },

--- a/tools/_comfyui/workflows/wan22-t2v-4step.json
+++ b/tools/_comfyui/workflows/wan22-t2v-4step.json
@@ -24,7 +24,7 @@
   "4": {
     "class_type": "VAELoader",
     "inputs": {
-      "vae_name": "wan2.2_vae.safetensors"
+      "vae_name": "wan_2.1_vae.safetensors"
     }
   },
   "5": {


### PR DESCRIPTION
## Summary
- switch bundled WAN 2.2 t2v workflow to `wan_2.1_vae.safetensors`
- align bundled model-stack metadata with the same 14B-compatible VAE and download source
- add focused contract coverage for both workflow JSON and metadata stack

## Testing
- `C:\Users\Jayesh\AppData\Local\Programs\Python\Python314\python.exe -m pytest tests/contracts/test_comfyui_tools.py -k "t2v_workflow_uses_14b_compatible_vae or t2v_metadata_stack_uses_14b_compatible_vae"`

Closes #284
