### PR TITLE
fix(remotion): unblock local zero-key rendering

### DIFF
--- a/remotion-composer/src/Explainer.tsx
+++ b/remotion-composer/src/Explainer.tsx
@@ -17,13 +17,19 @@ function resolveAsset(src: string): string {
   if (src.startsWith("http://") || src.startsWith("https://") || src.startsWith("data:")) {
     return src;
   }
-  // Strip any file:// prefix
-  const clean = src.replace(/^file:\/\/\/?/, "");
-  // Absolute paths (Unix: /foo, Windows: C:\foo or C:/foo) — convert to file:// URI
-  // staticFile() only accepts relative paths within public/, so absolute paths must bypass it
-  if (clean.startsWith("/") || /^[A-Za-z]:[\\/]/.test(clean)) {
+
+  // Strip scheme only; keep leading slash so absolute Unix paths stay absolute.
+  const clean = src.startsWith("file://") ? src.slice("file://".length) : src;
+
+  // staticFile() only accepts relative paths within public/, so absolute paths
+  // must stay as file:// URIs for Remotion to load them directly.
+  if (/^[A-Za-z]:[\\/]/.test(clean)) {
     return `file:///${clean.replace(/\\/g, "/")}`;
   }
+  if (clean.startsWith("/")) {
+    return `file://${clean.replace(/\\/g, "/")}`;
+  }
+
   return staticFile(clean);
 }
 import { TextCard } from "./components/TextCard";

--- a/tests/contracts/test_phase3_contracts.py
+++ b/tests/contracts/test_phase3_contracts.py
@@ -91,6 +91,21 @@ class TestPiperTTS:
 
         assert PiperTTS().get_status() == ToolStatus.UNAVAILABLE
 
+    def test_status_is_degraded_without_default_voice_model(self, monkeypatch):
+        monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/piper" if cmd == "piper" else None)
+        monkeypatch.setattr(PiperTTS, "_resolve_model_arg", lambda self, model: None)
+
+        assert PiperTTS().get_status() == ToolStatus.DEGRADED
+
+    def test_execute_surfaces_actionable_voice_download_hint(self, monkeypatch):
+        monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/piper" if cmd == "piper" else None)
+        monkeypatch.setattr(PiperTTS, "_resolve_model_arg", lambda self, model: None)
+
+        result = PiperTTS().execute({"text": "hello"})
+
+        assert result.success is False
+        assert "python -m piper.download_voices en_US-lessac-medium" in result.error
+
 
 class TestMusicGen:
     def test_identity(self):

--- a/tests/tools/test_remotion_local_asset_paths.py
+++ b/tests/tools/test_remotion_local_asset_paths.py
@@ -1,0 +1,52 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.video.video_compose import VideoCompose  # noqa: E402
+
+
+@pytest.fixture
+def tool(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/npx")
+    return VideoCompose()
+
+
+def test_remotion_render_normalizes_absolute_cut_and_audio_paths(tool, tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_run_command(cmd, *a, **k):
+        props_arg = next(part for part in cmd if str(part).startswith("--props="))
+        props_path = Path(str(props_arg).split("=", 1)[1])
+        captured["props"] = json.loads(props_path.read_text(encoding="utf-8"))
+        Path(cmd[5]).write_bytes(b"fake mp4")
+
+    monkeypatch.setattr(tool, "run_command", fake_run_command)
+
+    result = tool._remotion_render(
+        {
+            "composition_data": {
+                "cuts": [
+                    {"source": "/tmp/shot-a.mp4"},
+                    {"source": r"C:\media\shot-b.mp4"},
+                    {"source": "public/relative.png"},
+                ],
+                "audio": {
+                    "narration": {"src": "/tmp/narration.wav"},
+                    "music": {"src": r"C:\media\music.wav"},
+                },
+            },
+            "output_path": str(tmp_path / "out.mp4"),
+        }
+    )
+
+    assert result.success is True
+    assert captured["props"]["cuts"][0]["source"] == "file:///tmp/shot-a.mp4"
+    assert captured["props"]["cuts"][1]["source"] == "file:///C:/media/shot-b.mp4"
+    assert captured["props"]["cuts"][2]["source"] == "public/relative.png"
+    assert captured["props"]["audio"]["narration"]["src"] == "file:///tmp/narration.wav"
+    assert captured["props"]["audio"]["music"]["src"] == "file:///C:/media/music.wav"

--- a/tools/audio/piper_tts.py
+++ b/tools/audio/piper_tts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import time
@@ -39,7 +40,7 @@ class PiperTTS(BaseTool):
         "  pip install piper-tts\n"
         "Or download from https://github.com/rhasspy/piper/releases\n"
         "Then download a voice model:\n"
-        "  piper --download-dir ~/.piper/models --model en_US-lessac-medium"
+        "  python -m piper.download_voices en_US-lessac-medium"
     )
     agent_skills = ["text-to-speech"]
 
@@ -96,17 +97,75 @@ class PiperTTS(BaseTool):
     user_visible_verification = ["Listen to generated audio for intelligibility"]
 
     def get_status(self) -> ToolStatus:
-        if shutil.which("piper"):
+        if not shutil.which("piper"):
+            return ToolStatus.UNAVAILABLE
+        if self._resolve_model_arg(self.input_schema["properties"]["model"]["default"]):
             return ToolStatus.AVAILABLE
-        return ToolStatus.UNAVAILABLE
+        return ToolStatus.DEGRADED
+
+    def _candidate_model_paths(self, model: str) -> list[Path]:
+        raw = Path(model).expanduser()
+        candidates = [raw]
+        if raw.suffix != ".onnx":
+            candidates.append(raw.with_suffix(".onnx"))
+
+        voice_roots = [
+            Path.home() / ".piper" / "models",
+            Path.home() / ".local" / "share" / "piper" / "voices",
+            Path.home() / ".cache" / "piper" / "voices",
+            Path.cwd(),
+        ]
+        if "APPDATA" in os.environ:
+            voice_roots.append(Path(os.environ["APPDATA"]) / "piper" / "voices")
+
+        for root in voice_roots:
+            candidates.append(root / raw.name)
+            if raw.suffix != ".onnx":
+                candidates.append(root / f"{model}.onnx")
+                candidates.append(root / model / f"{model}.onnx")
+
+        # Preserve order, drop duplicates.
+        seen: set[str] = set()
+        unique: list[Path] = []
+        for candidate in candidates:
+            key = str(candidate)
+            if key not in seen:
+                seen.add(key)
+                unique.append(candidate)
+        return unique
+
+    def _resolve_model_arg(self, model: str) -> str | None:
+        for candidate in self._candidate_model_paths(model):
+            if candidate.exists():
+                return str(candidate)
+        return None
+
+    def _missing_model_error(self, model: str) -> str:
+        return (
+            f"Piper executable found, but voice model {model!r} is not installed. "
+            f"Download it with `python -m piper.download_voices {model}` or pass "
+            "an explicit local `.onnx` model path."
+        )
+
+    def _status_error(self, model: str) -> str:
+        status = self.get_status()
+        if status == ToolStatus.UNAVAILABLE:
+            return "Piper TTS not available. " + self.install_instructions
+        if self._resolve_model_arg(model):
+            return ""
+        return self._missing_model_error(model)
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
         return 0.0
 
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
-        if self.get_status() != ToolStatus.AVAILABLE:
-            return ToolResult(success=False, error="Piper TTS not available. " + self.install_instructions)
+        model = inputs.get("model", "en_US-lessac-medium")
+        status_error = self._status_error(model)
+        if status_error:
+            return ToolResult(success=False, error=status_error)
 
+        inputs = dict(inputs)
+        inputs["model"] = self._resolve_model_arg(model) or model
         start = time.time()
         try:
             result = self._generate(inputs)

--- a/tools/video/video_compose.py
+++ b/tools/video/video_compose.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import subprocess
 import time
 from pathlib import Path
@@ -1693,15 +1694,28 @@ class VideoCompose(BaseTool):
         # Deep-copy props so we don't mutate the original
         props = json.loads(json.dumps(composition_data))
 
-        # Convert absolute file paths to file:// URIs for Remotion's
-        # Img and OffthreadVideo components
+        def normalize_local_asset(src: str) -> str:
+            if not src or src.startswith(("http://", "https://", "data:", "file://")):
+                return src
+            if re.match(r"^[A-Za-z]:[\\/]", src):
+                return f"file:///{src.replace('\\', '/')}"
+            if src.startswith("/"):
+                return f"file://{src}"
+            candidate = Path(src)
+            if candidate.is_absolute():
+                return f"file://{candidate.as_posix()}"
+            return src
+
+        # Convert absolute local file paths to file:// URIs for Remotion's
+        # Img, OffthreadVideo, and Audio components.
         for cut in props.get("cuts", []):
             source = cut.get("source", "")
-            if source and not source.startswith(("http://", "https://", "file://")):
-                resolved = Path(source).resolve()
-                if resolved.exists():
-                    posix = resolved.as_posix()
-                    cut["source"] = f"file:///{posix}" if not posix.startswith("/") else f"file://{posix}"
+            cut["source"] = normalize_local_asset(source)
+        for key in ("narration", "music"):
+            audio = (props.get("audio") or {}).get(key) or {}
+            src = audio.get("src")
+            if src:
+                audio["src"] = normalize_local_asset(src)
 
         # Build a custom themeConfig from the playbook's actual colors.
         # This ensures every video gets a unique visual identity derived


### PR DESCRIPTION
## Summary
- fix `Explainer` local asset resolution so `file://` and absolute Unix/Windows paths stay valid Remotion URIs
- normalize local narration/music paths before writing Remotion props
- mark Piper as `DEGRADED` when no voice model is installed and surface current `piper.download_voices` guidance

## Testing
- `C:\Users\Jayesh\AppData\Local\Programs\Python\Python314\python.exe -m pytest tests\tools\test_remotion_local_asset_paths.py tests\tools\test_remotion_diagnostics.py tests\contracts\test_phase3_contracts.py -k "PiperTTS or remotion"`