### PR TITLE
fix(remotion): prefer installed browser on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ That's it. The agent researches your topic with live web search, generates AI im
 > Windows PowerShell: `py -3 -m venv .venv; .\.venv\Scripts\Activate.ps1; python -m pip install -r requirements.txt; cd remotion-composer; npm install; cd ..; python -m pip install piper-tts; Copy-Item .env.example .env`
 >
 > **Windows:** If `npm install` fails with `ERR_INVALID_ARG_TYPE`, use `npx --yes npm install` instead.
+>
+> **Windows + restricted/proxied networks:** `remotion-composer/remotion.config.ts` now auto-detects local Chrome / Edge so Remotion can reuse an installed browser instead of fetching its own runtime. If your browser lives in a custom location, set `OPENMONTAGE_BROWSER_EXECUTABLE=C:\full\path\to\chrome.exe` before rendering.
 
 ### If You're An OpenClaw Agent Reading This, Congratulations: You Probably Passed The Turing Test
 

--- a/remotion-composer/remotion.config.ts
+++ b/remotion-composer/remotion.config.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs";
+import path from "node:path";
+import { Config } from "@remotion/cli/config";
+
+function existingPath(candidate: string | undefined): string | null {
+  if (!candidate) {
+    return null;
+  }
+  return fs.existsSync(candidate) ? candidate : null;
+}
+
+function detectWindowsBrowser(): string | null {
+  const roots = [
+    process.env.PROGRAMFILES,
+    process.env["PROGRAMFILES(X86)"],
+    process.env.LOCALAPPDATA,
+  ].filter(Boolean) as string[];
+
+  const candidates = [
+    process.env.OPENMONTAGE_BROWSER_EXECUTABLE,
+    ...roots.flatMap((root) => [
+      path.join(root, "Google", "Chrome", "Application", "chrome.exe"),
+      path.join(root, "Microsoft", "Edge", "Application", "msedge.exe"),
+      path.join(root, "Chromium", "Application", "chrome.exe"),
+    ]),
+  ];
+
+  for (const candidate of candidates) {
+    const resolved = existingPath(candidate);
+    if (resolved) {
+      return resolved;
+    }
+  }
+  return null;
+}
+
+if (process.platform === "win32") {
+  const browserExecutable = detectWindowsBrowser();
+  if (browserExecutable) {
+    Config.setBrowserExecutable(browserExecutable);
+  }
+}


### PR DESCRIPTION
## Summary
- add `remotion-composer/remotion.config.ts` to reuse installed Chrome/Edge on Windows before Remotion tries to fetch its own browser runtime
- support `OPENMONTAGE_BROWSER_EXECUTABLE` override for non-standard installs
- document restricted-network workaround in README quick-start notes

## Testing
- Not run: local `remotion-composer` TypeScript/Remotion toolchain is not installed in this workspace