### PR TITLE
fix(hyperframes): style bridge reads schema-correct playbook keys

### DIFF
--- a/lib/hyperframes_style_bridge.py
+++ b/lib/hyperframes_style_bridge.py
@@ -96,13 +96,27 @@ def style_bridge(
         typo = playbook.get("typography", {}) or {}
         motion = playbook.get("motion", {}) or {}
 
+        prim_list = palette.get("primary")
         bg = _first(palette.get("background"), css["--color-bg"])
         fg = _first(palette.get("text"), css["--color-fg"])
         accent = _first(palette.get("accent"), css["--color-accent"])
-        primary = _first(palette.get("primary"), css["--color-primary"])
-        secondary = _first(palette.get("secondary"), css["--color-secondary"])
-        surface = _first(palette.get("surface"), css["--color-surface"])
-        muted = _first(palette.get("muted_text"), css["--color-muted"])
+        primary = _first(prim_list, css["--color-primary"])
+        # Schema `color_palette` only defines primary/accent/background/text/muted
+        # (additionalProperties:false). Derive the rest instead of reading keys
+        # that can never be set: secondary → 2nd primary if present; surface →
+        # the background (light-safe — never a dark fallback under a light brand);
+        # muted → the schema's `muted` (older bridges read `muted_text`).
+        if palette.get("secondary"):
+            secondary = _first(palette.get("secondary"), css["--color-secondary"])
+        elif isinstance(prim_list, list) and len(prim_list) > 1:
+            secondary = str(prim_list[1])
+        else:
+            secondary = css["--color-secondary"]
+        surface = _first(palette.get("surface"), bg)
+        muted = _first(palette.get("muted") or palette.get("muted_text"), css["--color-muted"])
+
+        # Typography: the schema uses `headings` (plural); accept `heading` too.
+        heading_font = _font(typo, "headings", _font(typo, "heading", css["--font-heading"]))
 
         duration, ease = _motion_easing(motion)
 
@@ -115,7 +129,7 @@ def style_bridge(
                 "--color-secondary": secondary,
                 "--color-surface": surface,
                 "--color-muted": muted,
-                "--font-heading": _font(typo, "heading", css["--font-heading"]),
+                "--font-heading": heading_font,
                 "--font-body": _font(typo, "body", css["--font-body"]),
                 "--font-mono": _font(typo, "code", css["--font-mono"]),
                 "--ease-primary": ease,


### PR DESCRIPTION
## Problem

`lib/hyperframes_style_bridge.py` reads playbook keys the playbook schema doesn't define, so they silently fall back to the wrong value:

- `typo.get("heading")` — but `schemas/styles/playbook.schema.json` defines `typography.headings` (plural), with `additionalProperties: false`. So **every playbook's heading font falls back to Inter** in HyperFrames output — e.g. `flat-motion-graphics` (Space Grotesk) and `anime-ghibli` (Noto Serif JP) silently render as Inter.
- `palette.get("surface")` and `palette.get("muted_text")` — `color_palette` only defines `primary/accent/background/text/muted` (also `additionalProperties: false`); there is no `surface`/`muted_text`. So `--color-surface` **always falls back to `#111827` (dark)** — wrong under any light-background brand (`clean-professional`, `minimalist-diagram`) — and `--color-muted` ignores the playbook's `muted`.

These fail silently: no error, just wrong CSS custom properties emitted to the HyperFrames `:root`.

## Fix

Read the schema-correct keys, and derive the rest rather than reading keys that can never be set:

- `headings` (with `heading` kept as a back-compat fallback) and `muted`.
- `surface` → derive from the background (light-safe — never a dark fallback under a light brand).
- `secondary` → the 2nd `primary` entry when present (playbooks list `primary: [action, anchor]`), else the existing fallback.

No behavior change for dark themes (their `surface` already resolved to ~their background). Light themes now get light surfaces, and all playbooks emit their real heading font.

## Testing

The existing style-bridge tests in `tests/tools/test_hyperframes_compose.py` still pass — including `test_style_bridge_picks_up_playbook_palette`, which uses singular `heading` (now read via the fallback → still `Space Grotesk`). Spot-checked `clean-professional`, `flat-motion-graphics`, and a custom playbook: heading fonts and light surfaces now emit correctly.

Found while adding a custom playbook on the `animation` pipeline.
