### PR TITLE
Add MiniMax official Token Plan video provider (direct API, not FAL)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,9 @@ SUNO_API_KEY=                # Suno AI music generation (full songs, instrumenta
 # --- Video Generation ---
 HEYGEN_API_KEY=              # HeyGen API (VEO, Sora, Runway, Kling, Seedance via single key)
 RUNWAY_API_KEY=              # Runway Gen-4 (direct API, alternative to fal.ai routing)
+MINIMAX_API_KEY=             # MiniMax official Token Plan (direct Hailuo API, not FAL). Set MINIMAX_REGION=global for api.minimax.io
+                             # Preferred: MINIMAX_TOKEN_PLAN_API_KEY (same key, explicit Token Plan route)
+                             # Get one at https://platform.minimax.io/user-center/basic-information/interface-key
 VIDEO_GEN_LOCAL_ENABLED=     # Set to "true" for local video gen (needs GPU + diffusers)
 VIDEO_GEN_LOCAL_MODEL=       # Local model: wan2.1-1.3b, wan2.1-14b, hunyuan-1.5, ltx2-local, cogvideo-5b
 MODAL_LTX2_ENDPOINT_URL=    # Modal self-hosted LTX-2 endpoint (optional)

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -121,16 +121,24 @@ OpenMontage now uses those published rates in the Grok tool estimators.
 
 The tool uses the async submit-poll-download pattern: `POST /v1/video_generation` returns a `task_id`, poll `GET /v1/query/video_generation` until `status == "Success"`, then `GET /v1/files/retrieve` to get the download URL.
 
-`MiniMax-Hailuo-2.3` supports both text-to-video and image-to-video. `MiniMax-Hailuo-2.3-Fast` is faster but only supports image-to-video (the tool rejects text-to-video with this model). Resolution defaults to `768P` (the Token Plan default); `720P` and `1080P` are also available.
+`MiniMax-Hailuo-2.3` supports both text-to-video and image-to-video. `MiniMax-Hailuo-2.3-Fast` is faster but only supports image-to-video (the tool rejects text-to-video with this model). Resolution defaults to `768P` (the Token Plan default); `1080P` is also available (6 seconds only — 10-second videos require 768P).
 
-This tool is distinct from `minimax_video` (which routes through `FAL_KEY`). Both share `provider="minimax"` but have different tool names and cost routes.
+This tool is distinct from `minimax_video` (which routes through `FAL_KEY`). They use different provider IDs (`minimax_tokenplan` vs `minimax`) so `video_selector` can route to the correct cost path.
+
+**Schema constraints** (enforced to prevent paid-call failures):
+- `duration`: must be exactly `6` or `10` seconds
+- `resolution`: `768P` or `1080P` (no `720P`)
+- `1080P` supports 6 seconds only
 
 #### Pricing
 
-| Model | Price |
-|------|-------|
-| `MiniMax-Hailuo-2.3` | ~$0.05/sec (Token Plan quota, check console for actual rate) |
-| `MiniMax-Hailuo-2.3-Fast` | ~$0.05/sec (Token Plan quota) |
+| Model | Resolution | Price |
+|------|-----------|-------|
+| `MiniMax-Hailuo-2.3` | 768P | ~$0.03/sec (PAYG) |
+| `MiniMax-Hailuo-2.3` | 1080P | ~$0.08/sec (PAYG) |
+| `MiniMax-Hailuo-2.3-Fast` | 768P | ~$0.03/sec (PAYG) |
+
+> Token Plan is subscription quota, not per-second marginal charge. Check the [MiniMax pricing page](https://platform.minimax.io/docs/guides/pricing-token-plan) for current daily allowances.
 
 ---
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -132,13 +132,16 @@ This tool is distinct from `minimax_video` (which routes through `FAL_KEY`). The
 
 #### Pricing
 
-| Model | Resolution | Price |
-|------|-----------|-------|
-| `MiniMax-Hailuo-2.3` | 768P | ~$0.03/sec (PAYG) |
-| `MiniMax-Hailuo-2.3` | 1080P | ~$0.08/sec (PAYG) |
-| `MiniMax-Hailuo-2.3-Fast` | 768P | ~$0.03/sec (PAYG) |
+| Model | Resolution | Duration | PAYG Price | Token Plan Points |
+|------|-----------|----------|-----------|-------------------|
+| `MiniMax-Hailuo-2.3` | 768P | 6s | $0.28 | 1.0 |
+| `MiniMax-Hailuo-2.3` | 768P | 10s | $0.56 | 2.0 |
+| `MiniMax-Hailuo-2.3` | 1080P | 6s | $0.49 | 2.0 |
+| `MiniMax-Hailuo-2.3-Fast` | 768P | 6s | $0.19 | 0.7 |
+| `MiniMax-Hailuo-2.3-Fast` | 768P | 10s | $0.32 | 1.1 |
+| `MiniMax-Hailuo-2.3-Fast` | 1080P | 6s | $0.33 | 1.3 |
 
-> Token Plan is subscription quota, not per-second marginal charge. Check the [MiniMax pricing page](https://platform.minimax.io/docs/guides/pricing-token-plan) for current daily allowances.
+> When `MINIMAX_TOKEN_PLAN_API_KEY` is set, `cost_usd` reports 0.0 (subscription quota, not marginal charge) and `data.quota_points` reports the consumed video points. When only `MINIMAX_API_KEY` is set (PAYG), `cost_usd` reports the exact per-video price. See [MiniMax PAYG pricing](https://platform.minimax.io/docs/guides/pricing-paygo) and [Token Plan allowances](https://platform.minimax.io/docs/guides/pricing-token-plan).
 
 ---
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -95,6 +95,45 @@ OpenMontage now uses those published rates in the Grok tool estimators.
 
 ---
 
+### MiniMax Token Plan — Direct Hailuo Video API
+
+> **Direct MiniMax API, not FAL.** For users with a MiniMax Token Plan subscription, this provider calls the official `api.minimaxi.com` (CN) or `api.minimax.io` (global) endpoint directly, consuming your own quota instead of FAL credits. This makes the cost route explicit — `minimax_tokenplan_video` vs `minimax_video` (FAL-backed).
+
+**Tools unlocked:** `minimax_tokenplan_video`
+**Env var:** `MINIMAX_TOKEN_PLAN_API_KEY` (preferred) or `MINIMAX_API_KEY`; optionally `MINIMAX_REGION=global` for the international endpoint
+
+#### Setup
+
+1. Go to [platform.minimax.io](https://platform.minimax.io/user-center/basic-information/interface-key)
+2. Create a MiniMax account and subscribe to a Token Plan
+3. Generate an API key in the API Keys section
+4. Add to `.env`: `MINIMAX_TOKEN_PLAN_API_KEY=...` (or `MINIMAX_API_KEY=...`)
+5. (Optional) Set `MINIMAX_REGION=global` if your account is on the international endpoint
+
+#### What it's best for
+
+- Direct MiniMax Token Plan quota usage — no FAL credits consumed
+- Hailuo 2.3 text-to-video and image-to-video
+- Auditable cost route — calls the official MiniMax API, not a proxy
+- Watermark control via `aigc_watermark` parameter
+
+#### API notes
+
+The tool uses the async submit-poll-download pattern: `POST /v1/video_generation` returns a `task_id`, poll `GET /v1/query/video_generation` until `status == "Success"`, then `GET /v1/files/retrieve` to get the download URL.
+
+`MiniMax-Hailuo-2.3` supports both text-to-video and image-to-video. `MiniMax-Hailuo-2.3-Fast` is faster but only supports image-to-video (the tool rejects text-to-video with this model). Resolution defaults to `768P` (the Token Plan default); `720P` and `1080P` are also available.
+
+This tool is distinct from `minimax_video` (which routes through `FAL_KEY`). Both share `provider="minimax"` but have different tool names and cost routes.
+
+#### Pricing
+
+| Model | Price |
+|------|-------|
+| `MiniMax-Hailuo-2.3` | ~$0.05/sec (Token Plan quota, check console for actual rate) |
+| `MiniMax-Hailuo-2.3-Fast` | ~$0.05/sec (Token Plan quota) |
+
+---
+
 ### Alibaba DashScope — Qwen Image + TTS + ASR
 
 > **Best for Chinese-language production.** One key unlocks Qwen-Image generation, Qwen-TTS Mandarin narration, and Qwen-ASR with word-level timestamps — the only DashScope path that provides word-level granularity for subtitle alignment.

--- a/tests/contracts/test_minimax_tokenplan_video.py
+++ b/tests/contracts/test_minimax_tokenplan_video.py
@@ -1,0 +1,383 @@
+"""Contract tests for the MiniMax Token Plan video provider tool.
+
+These tests verify that the tool satisfies the BaseTool contract without
+requiring a real MiniMax API key or making any API calls.
+
+Run: pytest tests/contracts/test_minimax_tokenplan_video.py -v
+"""
+
+import pytest
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+from tools.video.minimax_tokenplan_video import MinimaxTokenPlanVideo
+
+
+# ------------------------------------------------------------------
+# Contract compliance
+# ------------------------------------------------------------------
+
+class TestContract:
+
+    def test_inherits_base_tool(self):
+        assert issubclass(MinimaxTokenPlanVideo, BaseTool)
+
+    def test_has_required_identity(self):
+        tool = MinimaxTokenPlanVideo()
+        assert tool.name == "minimax_tokenplan_video"
+        assert tool.version
+        assert tool.provider == "minimax"
+        assert tool.capability == "video_generation"
+        assert tool.tier == ToolTier.GENERATE
+        assert tool.stability == ToolStability.EXPERIMENTAL
+        assert tool.runtime == ToolRuntime.API
+
+    def test_execution_mode_is_async(self):
+        assert MinimaxTokenPlanVideo().execution_mode == ExecutionMode.ASYNC
+
+    def test_has_input_schema(self):
+        schema = MinimaxTokenPlanVideo().input_schema
+        assert schema.get("type") == "object"
+        props = schema.get("properties", {})
+        required = schema.get("required", [])
+        assert required == ["prompt"]
+        for field in required:
+            assert field in props
+
+    def test_has_capabilities(self):
+        tool = MinimaxTokenPlanVideo()
+        assert "text_to_video" in tool.capabilities
+        assert "image_to_video" in tool.capabilities
+
+    def test_has_agent_skills(self):
+        tool = MinimaxTokenPlanVideo()
+        assert "ai-video-gen" in tool.agent_skills
+
+    def test_has_fallbacks(self):
+        tool = MinimaxTokenPlanVideo()
+        assert "minimax_video" in tool.fallback_tools
+        assert "kling_video" in tool.fallback_tools
+
+    def test_has_install_instructions(self):
+        tool = MinimaxTokenPlanVideo()
+        assert "MINIMAX_API_KEY" in tool.install_instructions
+
+    def test_get_info_returns_dict(self):
+        info = MinimaxTokenPlanVideo().get_info()
+        assert isinstance(info, dict)
+        assert info["name"] == "minimax_tokenplan_video"
+        assert info["provider"] == "minimax"
+        assert info["runtime"] == "api"
+
+    def test_status_unavailable_without_key(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        monkeypatch.delenv("MINIMAX_TOKEN_PLAN_API_KEY", raising=False)
+        assert MinimaxTokenPlanVideo().get_status() == ToolStatus.UNAVAILABLE
+
+    def test_status_available_with_key(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "fake-key-for-testing")
+        assert MinimaxTokenPlanVideo().get_status() == ToolStatus.AVAILABLE
+
+    def test_status_available_with_token_plan_key(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        monkeypatch.setenv("MINIMAX_TOKEN_PLAN_API_KEY", "fake-key-for-testing")
+        assert MinimaxTokenPlanVideo().get_status() == ToolStatus.AVAILABLE
+
+    def test_has_resource_profile(self):
+        rp = MinimaxTokenPlanVideo().resource_profile
+        assert rp.network_required is True
+        assert rp.vram_mb == 0
+
+    def test_has_retry_policy(self):
+        assert MinimaxTokenPlanVideo().retry_policy.max_retries >= 0
+
+    def test_has_side_effects(self):
+        side = MinimaxTokenPlanVideo().side_effects
+        assert len(side) > 0
+        assert any("API" in s for s in side)
+
+    def test_has_user_visible_verification(self):
+        assert len(MinimaxTokenPlanVideo().user_visible_verification) > 0
+
+    def test_lazy_imports_requests(self):
+        import importlib
+        import sys
+        mod_name = "tools.video.minimax_tokenplan_video"
+        if "requests" in sys.modules:
+            del sys.modules["requests"]
+        importlib.reload(sys.modules[mod_name])
+
+    def test_estimate_cost_returns_float(self):
+        cost = MinimaxTokenPlanVideo().estimate_cost({"prompt": "x", "duration": 6})
+        assert isinstance(cost, float)
+        assert cost > 0.0
+
+    def test_dry_run_returns_dict(self):
+        result = MinimaxTokenPlanVideo().dry_run({"prompt": "test"})
+        assert isinstance(result, dict)
+        assert result["tool"] == "minimax_tokenplan_video"
+
+
+# ------------------------------------------------------------------
+# Idempotency keys (learned from DashScope PR #240 review)
+# ------------------------------------------------------------------
+
+class TestIdempotencyKeys:
+
+    def test_includes_all_output_affecting_fields(self):
+        fields = MinimaxTokenPlanVideo().idempotency_key_fields
+        for field in (
+            "prompt", "model", "operation", "duration", "resolution",
+            "first_frame_image", "prompt_optimizer", "fast_pretreatment",
+            "aigc_watermark",
+        ):
+            assert field in fields, f"missing idempotency field: {field}"
+
+    def test_excludes_execution_only_fields(self):
+        fields = MinimaxTokenPlanVideo().idempotency_key_fields
+        # These affect execution, not the result — must NOT be in the key
+        for field in ("output_path", "poll_interval_seconds", "timeout_seconds"):
+            assert field not in fields
+
+    def test_differs_on_duration(self):
+        tool = MinimaxTokenPlanVideo()
+        base = {"prompt": "x", "model": "MiniMax-Hailuo-2.3"}
+        assert tool.idempotency_key(base) != tool.idempotency_key(
+            {**base, "duration": 10}
+        )
+
+    def test_differs_on_resolution(self):
+        tool = MinimaxTokenPlanVideo()
+        base = {"prompt": "x", "model": "MiniMax-Hailuo-2.3"}
+        assert tool.idempotency_key({**base, "resolution": "768P"}) != tool.idempotency_key(
+            {**base, "resolution": "1080P"}
+        )
+
+    def test_differs_on_watermark(self):
+        tool = MinimaxTokenPlanVideo()
+        base = {"prompt": "x", "model": "MiniMax-Hailuo-2.3"}
+        assert tool.idempotency_key({**base, "aigc_watermark": False}) != tool.idempotency_key(
+            {**base, "aigc_watermark": True}
+        )
+
+    def test_differs_on_prompt_optimizer(self):
+        tool = MinimaxTokenPlanVideo()
+        base = {"prompt": "x", "model": "MiniMax-Hailuo-2.3"}
+        assert tool.idempotency_key({**base, "prompt_optimizer": True}) != tool.idempotency_key(
+            {**base, "prompt_optimizer": False}
+        )
+
+
+# ------------------------------------------------------------------
+# Tool-specific behavior
+# ------------------------------------------------------------------
+
+class TestToolSpecific:
+
+    def test_default_model_is_hailuo_23(self):
+        tool = MinimaxTokenPlanVideo()
+        assert tool.input_schema["properties"]["model"]["default"] == "MiniMax-Hailuo-2.3"
+
+    def test_default_resolution_is_768p(self):
+        tool = MinimaxTokenPlanVideo()
+        assert tool.input_schema["properties"]["resolution"]["default"] == "768P"
+
+    def test_default_duration_is_6(self):
+        tool = MinimaxTokenPlanVideo()
+        assert tool.input_schema["properties"]["duration"]["default"] == 6
+
+    def test_default_watermark_is_false(self):
+        tool = MinimaxTokenPlanVideo()
+        assert tool.input_schema["properties"]["aigc_watermark"]["default"] is False
+
+    def test_cost_scales_with_duration(self):
+        tool = MinimaxTokenPlanVideo()
+        cost6 = tool.estimate_cost({"prompt": "x", "duration": 6})
+        cost10 = tool.estimate_cost({"prompt": "x", "duration": 10})
+        assert cost10 > cost6
+
+    def test_build_payload_t2v(self):
+        tool = MinimaxTokenPlanVideo()
+        payload = tool._build_payload({"prompt": "a cat"})
+        assert payload["model"] == "MiniMax-Hailuo-2.3"
+        assert payload["prompt"] == "a cat"
+        assert payload["duration"] == 6
+        assert payload["resolution"] == "768P"
+        assert payload["prompt_optimizer"] is True
+        assert payload["aigc_watermark"] is False
+        assert "first_frame_image" not in payload
+
+    def test_build_payload_i2v_includes_first_frame(self):
+        tool = MinimaxTokenPlanVideo()
+        payload = tool._build_payload({
+            "prompt": "motion desc",
+            "operation": "image_to_video",
+            "first_frame_image": "https://example.com/img.png",
+        })
+        assert payload["first_frame_image"] == "https://example.com/img.png"
+
+    def test_build_payload_omits_first_frame_for_t2v(self):
+        tool = MinimaxTokenPlanVideo()
+        payload = tool._build_payload({"prompt": "a cat", "operation": "text_to_video"})
+        assert "first_frame_image" not in payload
+
+    def test_build_payload_includes_fast_pretreatment_when_set(self):
+        tool = MinimaxTokenPlanVideo()
+        payload = tool._build_payload({"prompt": "x", "fast_pretreatment": True})
+        assert payload["fast_pretreatment"] is True
+
+    def test_build_payload_omits_callback_url_when_absent(self):
+        tool = MinimaxTokenPlanVideo()
+        payload = tool._build_payload({"prompt": "x"})
+        assert "callback_url" not in payload
+
+    def test_build_payload_includes_callback_url_when_set(self):
+        tool = MinimaxTokenPlanVideo()
+        payload = tool._build_payload({"prompt": "x", "callback_url": "https://cb.example.com"})
+        assert payload["callback_url"] == "https://cb.example.com"
+
+    def test_fast_model_rejects_t2v(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "fake-key")
+        tool = MinimaxTokenPlanVideo()
+        result = tool.execute({
+            "prompt": "test",
+            "model": "MiniMax-Hailuo-2.3-Fast",
+            "operation": "text_to_video",
+        })
+        assert result.success is False
+        assert "does not support text-to-video" in result.error
+
+    def test_i2v_without_first_frame_fails(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "fake-key")
+        tool = MinimaxTokenPlanVideo()
+        result = tool.execute({
+            "prompt": "test",
+            "operation": "image_to_video",
+        })
+        assert result.success is False
+        assert "first_frame_image" in result.error
+
+    def test_no_key_returns_error(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        monkeypatch.delenv("MINIMAX_TOKEN_PLAN_API_KEY", raising=False)
+        result = MinimaxTokenPlanVideo().execute({"prompt": "test"})
+        assert result.success is False
+        assert "MINIMAX_TOKEN_PLAN_API_KEY" in result.error
+        assert "MINIMAX_API_KEY" in result.error
+
+    def test_base_url_defaults_to_cn(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_REGION", raising=False)
+        tool = MinimaxTokenPlanVideo()
+        assert tool._base_url() == "https://api.minimaxi.com"
+
+    def test_base_url_global_when_region_set(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_REGION", "global")
+        tool = MinimaxTokenPlanVideo()
+        assert tool._base_url() == "https://api.minimax.io"
+
+    def test_safe_error_redacts_key(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "secret-key-12345")
+        redacted = MinimaxTokenPlanVideo._safe_error(
+            Exception("failed with key secret-key-12345")
+        )
+        assert "secret-key-12345" not in redacted
+        assert "[redacted]" in redacted
+
+    def test_safe_error_redacts_token_plan_key(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        monkeypatch.setenv("MINIMAX_TOKEN_PLAN_API_KEY", "token-plan-secret-999")
+        redacted = MinimaxTokenPlanVideo._safe_error(
+            Exception("failed with token-plan-secret-999")
+        )
+        assert "token-plan-secret-999" not in redacted
+        assert "[redacted]" in redacted
+
+    def test_safe_error_no_empty_string_bug(self, monkeypatch):
+        """Regression: when no key is set, _safe_error must not insert
+        [redacted] between every character (the empty-string replace bug)."""
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        monkeypatch.delenv("MINIMAX_TOKEN_PLAN_API_KEY", raising=False)
+        msg = MinimaxTokenPlanVideo._safe_error(Exception("abc"))
+        assert msg == "abc"
+
+    def test_api_key_prefers_token_plan(self, monkeypatch):
+        """When both keys are set, the Token Plan key must be preferred
+        (Fix #1 from calesthio review: the route is the product)."""
+        monkeypatch.setenv("MINIMAX_API_KEY", "generic-key")
+        monkeypatch.setenv("MINIMAX_TOKEN_PLAN_API_KEY", "token-plan-key")
+        tool = MinimaxTokenPlanVideo()
+        assert tool._api_key() == "token-plan-key"
+
+    def test_callback_url_declared_in_schema(self):
+        """callback_url is forwarded to the API, so it must be in the
+        input schema (Fix #3: undocumented public input)."""
+        props = MinimaxTokenPlanVideo().input_schema["properties"]
+        assert "callback_url" in props
+        assert props["callback_url"]["type"] == "string"
+
+    def test_check_base_resp_passes_on_success(self):
+        MinimaxTokenPlanVideo._check_base_resp(200, {"base_resp": {"status_code": 0, "status_msg": "success"}})
+
+    def test_check_base_resp_raises_on_error_code(self):
+        with pytest.raises(RuntimeError, match="code 1008"):
+            MinimaxTokenPlanVideo._check_base_resp(
+                200, {"base_resp": {"status_code": 1008, "status_msg": "Insufficient balance"}}
+            )
+
+    def test_check_base_resp_raises_on_http_error(self):
+        with pytest.raises(RuntimeError, match="HTTP 401"):
+            MinimaxTokenPlanVideo._check_base_resp(
+                401, {"base_resp": {"status_code": 1004, "status_msg": "Auth failed"}}
+            )
+
+    def test_json_or_raise_returns_dict(self):
+        class FakeResp:
+            status_code = 200
+            def json(self):
+                return {"ok": True}
+        assert MinimaxTokenPlanVideo._json_or_raise(FakeResp()) == {"ok": True}
+
+    def test_json_or_raise_raises_on_non_json(self):
+        class FakeResp:
+            status_code = 500
+            def json(self):
+                raise ValueError("not JSON")
+        with pytest.raises(RuntimeError, match="Non-JSON"):
+            MinimaxTokenPlanVideo._json_or_raise(FakeResp())
+
+
+# ------------------------------------------------------------------
+# Registry discovery
+# ------------------------------------------------------------------
+
+class TestRegistryDiscovery:
+
+    def test_discoverable(self):
+        from tools.tool_registry import ToolRegistry
+        registry = ToolRegistry()
+        registry.discover()
+        names = {t.name for t in registry._tools.values()}
+        assert "minimax_tokenplan_video" in names
+
+    def test_distinct_from_fal_minimax(self):
+        """The Token Plan tool must be a separate entry from the FAL-backed
+        minimax_video — this is the core point of issue #216: the cost route
+        must be explicit."""
+        from tools.tool_registry import ToolRegistry
+        registry = ToolRegistry()
+        registry.discover()
+        minimax_tools = [
+            t for t in registry._tools.values()
+            if t.provider == "minimax"
+        ]
+        names = {t.name for t in minimax_tools}
+        assert "minimax_tokenplan_video" in names
+        assert "minimax_video" in names
+        assert "minimax_tokenplan_video" != "minimax_video"

--- a/tests/contracts/test_minimax_tokenplan_video.py
+++ b/tests/contracts/test_minimax_tokenplan_video.py
@@ -106,15 +106,17 @@ class TestContract:
     def test_has_user_visible_verification(self):
         assert len(MinimaxTokenPlanVideo().user_visible_verification) > 0
 
-    def test_lazy_imports_requests(self):
+    def test_lazy_imports_requests(self, monkeypatch):
         import importlib
         import sys
         mod_name = "tools.video.minimax_tokenplan_video"
         if "requests" in sys.modules:
-            del sys.modules["requests"]
+            monkeypatch.delitem(sys.modules, "requests")
         importlib.reload(sys.modules[mod_name])
 
-    def test_estimate_cost_returns_float(self):
+    def test_estimate_cost_returns_float(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_TOKEN_PLAN_API_KEY", raising=False)
+        monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
         cost = MinimaxTokenPlanVideo().estimate_cost({"prompt": "x", "duration": 6})
         assert isinstance(cost, float)
         assert cost > 0.0
@@ -197,23 +199,48 @@ class TestToolSpecific:
         tool = MinimaxTokenPlanVideo()
         assert tool.input_schema["properties"]["aigc_watermark"]["default"] is False
 
-    def test_cost_scales_with_duration(self):
-        tool = MinimaxTokenPlanVideo()
-        cost6 = tool.estimate_cost({"prompt": "x", "duration": 6})
-        cost10 = tool.estimate_cost({"prompt": "x", "duration": 10})
-        assert cost10 > cost6
+    def test_cost_zero_when_token_plan_key_set(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_TOKEN_PLAN_API_KEY", "test-key")
+        cost = MinimaxTokenPlanVideo().estimate_cost({"prompt": "x", "duration": 6})
+        assert cost == 0.0
 
-    def test_cost_aware_of_resolution(self):
-        tool = MinimaxTokenPlanVideo()
-        cost_768 = tool.estimate_cost({"prompt": "x", "duration": 6, "resolution": "768P"})
-        cost_1080 = tool.estimate_cost({"prompt": "x", "duration": 6, "resolution": "1080P"})
-        assert cost_1080 > cost_768
+    def test_cost_payg_when_no_token_plan_key(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_TOKEN_PLAN_API_KEY", raising=False)
+        monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+        cost = MinimaxTokenPlanVideo().estimate_cost({
+            "prompt": "x", "duration": 6, "resolution": "768P",
+            "model": "MiniMax-Hailuo-2.3",
+        })
+        assert cost == 0.28
 
-    def test_cost_aware_of_model(self):
+    def test_payg_exact_prices(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_TOKEN_PLAN_API_KEY", raising=False)
+        monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
         tool = MinimaxTokenPlanVideo()
-        cost_hailuo_1080 = tool.estimate_cost({"prompt": "x", "duration": 6, "model": "MiniMax-Hailuo-2.3", "resolution": "1080P"})
-        cost_fast_768 = tool.estimate_cost({"prompt": "x", "duration": 6, "model": "MiniMax-Hailuo-2.3-Fast", "resolution": "768P"})
-        assert cost_fast_768 < cost_hailuo_1080
+        cases = [
+            ({"model": "MiniMax-Hailuo-2.3", "resolution": "768P", "duration": 6}, 0.28),
+            ({"model": "MiniMax-Hailuo-2.3", "resolution": "768P", "duration": 10}, 0.56),
+            ({"model": "MiniMax-Hailuo-2.3", "resolution": "1080P", "duration": 6}, 0.49),
+            ({"model": "MiniMax-Hailuo-2.3-Fast", "resolution": "768P", "duration": 6}, 0.19),
+            ({"model": "MiniMax-Hailuo-2.3-Fast", "resolution": "768P", "duration": 10}, 0.32),
+            ({"model": "MiniMax-Hailuo-2.3-Fast", "resolution": "1080P", "duration": 6}, 0.33),
+        ]
+        for inputs, expected in cases:
+            assert tool.estimate_cost(inputs) == expected, f"{inputs} expected {expected}"
+
+    def test_quota_points_exact_values(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_TOKEN_PLAN_API_KEY", "test-key")
+        tool = MinimaxTokenPlanVideo()
+        cases = [
+            ({"model": "MiniMax-Hailuo-2.3", "resolution": "768P", "duration": 6}, 1),
+            ({"model": "MiniMax-Hailuo-2.3", "resolution": "768P", "duration": 10}, 2),
+            ({"model": "MiniMax-Hailuo-2.3", "resolution": "1080P", "duration": 6}, 2),
+            ({"model": "MiniMax-Hailuo-2.3-Fast", "resolution": "768P", "duration": 6}, 0.7),
+            ({"model": "MiniMax-Hailuo-2.3-Fast", "resolution": "768P", "duration": 10}, 1.1),
+            ({"model": "MiniMax-Hailuo-2.3-Fast", "resolution": "1080P", "duration": 6}, 1.3),
+        ]
+        for inputs, expected in cases:
+            assert tool._estimate_quota_points(inputs) == expected, f"{inputs} expected {expected}"
 
     def test_schema_duration_enum(self):
         schema = MinimaxTokenPlanVideo().input_schema

--- a/tests/contracts/test_minimax_tokenplan_video.py
+++ b/tests/contracts/test_minimax_tokenplan_video.py
@@ -33,7 +33,7 @@ class TestContract:
         tool = MinimaxTokenPlanVideo()
         assert tool.name == "minimax_tokenplan_video"
         assert tool.version
-        assert tool.provider == "minimax"
+        assert tool.provider == "minimax_tokenplan"
         assert tool.capability == "video_generation"
         assert tool.tier == ToolTier.GENERATE
         assert tool.stability == ToolStability.EXPERIMENTAL
@@ -73,7 +73,7 @@ class TestContract:
         info = MinimaxTokenPlanVideo().get_info()
         assert isinstance(info, dict)
         assert info["name"] == "minimax_tokenplan_video"
-        assert info["provider"] == "minimax"
+        assert info["provider"] == "minimax_tokenplan"
         assert info["runtime"] == "api"
 
     def test_status_unavailable_without_key(self, monkeypatch):
@@ -202,6 +202,43 @@ class TestToolSpecific:
         cost6 = tool.estimate_cost({"prompt": "x", "duration": 6})
         cost10 = tool.estimate_cost({"prompt": "x", "duration": 10})
         assert cost10 > cost6
+
+    def test_cost_aware_of_resolution(self):
+        tool = MinimaxTokenPlanVideo()
+        cost_768 = tool.estimate_cost({"prompt": "x", "duration": 6, "resolution": "768P"})
+        cost_1080 = tool.estimate_cost({"prompt": "x", "duration": 6, "resolution": "1080P"})
+        assert cost_1080 > cost_768
+
+    def test_cost_aware_of_model(self):
+        tool = MinimaxTokenPlanVideo()
+        cost_hailuo_1080 = tool.estimate_cost({"prompt": "x", "duration": 6, "model": "MiniMax-Hailuo-2.3", "resolution": "1080P"})
+        cost_fast_768 = tool.estimate_cost({"prompt": "x", "duration": 6, "model": "MiniMax-Hailuo-2.3-Fast", "resolution": "768P"})
+        assert cost_fast_768 < cost_hailuo_1080
+
+    def test_schema_duration_enum(self):
+        schema = MinimaxTokenPlanVideo().input_schema
+        assert schema["properties"]["duration"]["enum"] == [6, 10]
+
+    def test_schema_resolution_no_720p(self):
+        schema = MinimaxTokenPlanVideo().input_schema
+        assert "720P" not in schema["properties"]["resolution"]["enum"]
+
+    def test_execute_rejects_1080p_10s(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+        result = MinimaxTokenPlanVideo().execute({
+            "prompt": "x", "duration": 10, "resolution": "1080P",
+        })
+        assert result.success is False
+        assert "1080P" in result.error
+
+    def test_execute_accepts_1080p_6s(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+        monkeypatch.setenv("MINIMAX_TOKEN_PLAN_API_KEY", "test-key")
+        payload = MinimaxTokenPlanVideo()._build_payload({
+            "prompt": "x", "duration": 6, "resolution": "1080P",
+        })
+        assert payload["duration"] == 6
+        assert payload["resolution"] == "1080P"
 
     def test_build_payload_t2v(self):
         tool = MinimaxTokenPlanVideo()
@@ -375,7 +412,7 @@ class TestRegistryDiscovery:
         registry.discover()
         minimax_tools = [
             t for t in registry._tools.values()
-            if t.provider == "minimax"
+            if t.provider in ("minimax", "minimax_tokenplan")
         ]
         names = {t.name for t in minimax_tools}
         assert "minimax_tokenplan_video" in names

--- a/tools/video/minimax_tokenplan_video.py
+++ b/tools/video/minimax_tokenplan_video.py
@@ -197,17 +197,39 @@ class MinimaxTokenPlanVideo(BaseTool):
         return ToolStatus.UNAVAILABLE
 
     _PAYG_PRICING = {
-        ("MiniMax-Hailuo-2.3", "768P"): 0.03,
-        ("MiniMax-Hailuo-2.3", "1080P"): 0.08,
-        ("MiniMax-Hailuo-2.3-Fast", "768P"): 0.03,
+        ("MiniMax-Hailuo-2.3", "768P", 6): 0.28,
+        ("MiniMax-Hailuo-2.3", "768P", 10): 0.56,
+        ("MiniMax-Hailuo-2.3", "1080P", 6): 0.49,
+        ("MiniMax-Hailuo-2.3-Fast", "768P", 6): 0.19,
+        ("MiniMax-Hailuo-2.3-Fast", "768P", 10): 0.32,
+        ("MiniMax-Hailuo-2.3-Fast", "1080P", 6): 0.33,
     }
 
+    _TOKEN_PLAN_POINTS = {
+        ("MiniMax-Hailuo-2.3", "768P", 6): 1,
+        ("MiniMax-Hailuo-2.3", "768P", 10): 2,
+        ("MiniMax-Hailuo-2.3", "1080P", 6): 2,
+        ("MiniMax-Hailuo-2.3-Fast", "768P", 6): 0.7,
+        ("MiniMax-Hailuo-2.3-Fast", "768P", 10): 1.1,
+        ("MiniMax-Hailuo-2.3-Fast", "1080P", 6): 1.3,
+    }
+
+    def _is_token_plan(self) -> bool:
+        return bool(os.environ.get("MINIMAX_TOKEN_PLAN_API_KEY"))
+
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        if self._is_token_plan():
+            return 0.0
         model = inputs.get("model", "MiniMax-Hailuo-2.3")
         resolution = inputs.get("resolution", "768P")
         duration = int(inputs.get("duration", 6))
-        per_second = self._PAYG_PRICING.get((model, resolution), 0.03)
-        return round(per_second * duration, 2)
+        return self._PAYG_PRICING.get((model, resolution, duration), 0.28)
+
+    def _estimate_quota_points(self, inputs: dict[str, Any]) -> float:
+        model = inputs.get("model", "MiniMax-Hailuo-2.3")
+        resolution = inputs.get("resolution", "768P")
+        duration = int(inputs.get("duration", 6))
+        return self._TOKEN_PLAN_POINTS.get((model, resolution, duration), 1)
 
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         duration = int(inputs.get("duration", 6))
@@ -332,23 +354,30 @@ class MinimaxTokenPlanVideo(BaseTool):
         output_path.write_bytes(download.content)
 
         probed = probe_output(output_path)
+        is_token_plan = self._is_token_plan()
+        data = {
+            "provider": "minimax_tokenplan",
+            "route": "token_plan" if is_token_plan else "payg",
+            "model": payload["model"],
+            "prompt": inputs["prompt"],
+            "operation": inputs.get("operation", "text_to_video"),
+            "duration": payload.get("duration", 6),
+            "resolution": payload.get("resolution", "768P"),
+            "aigc_watermark": payload.get("aigc_watermark", False),
+            "task_id": task_id,
+            "file_id": file_id,
+            "output": str(output_path),
+            "format": "mp4",
+            **probed,
+        }
+        if is_token_plan:
+            data["quota_points"] = self._estimate_quota_points(inputs)
+            data["pricing_note"] = "Token Plan subscription quota consumed"
+        else:
+            data["pricing_note"] = "PAYG per-video charge"
         return ToolResult(
             success=True,
-            data={
-                "provider": "minimax",
-                "route": "token_plan",
-                "model": payload["model"],
-                "prompt": inputs["prompt"],
-                "operation": inputs.get("operation", "text_to_video"),
-                "duration": payload.get("duration", 6),
-                "resolution": payload.get("resolution", "768P"),
-                "aigc_watermark": payload.get("aigc_watermark", False),
-                "task_id": task_id,
-                "file_id": file_id,
-                "output": str(output_path),
-                "format": "mp4",
-                **probed,
-            },
+            data=data,
             artifacts=[str(output_path)],
             cost_usd=self.estimate_cost(inputs),
             model=payload["model"],

--- a/tools/video/minimax_tokenplan_video.py
+++ b/tools/video/minimax_tokenplan_video.py
@@ -35,13 +35,13 @@ class MinimaxTokenPlanVideo(BaseTool):
     version = "0.1.0"
     tier = ToolTier.GENERATE
     capability = "video_generation"
-    provider = "minimax"
+    provider = "minimax_tokenplan"
     stability = ToolStability.EXPERIMENTAL
     execution_mode = ExecutionMode.ASYNC
     determinism = Determinism.STOCHASTIC
     runtime = ToolRuntime.API
 
-    dependencies = []
+    dependencies = ["env:MINIMAX_TOKEN_PLAN_API_KEY", "env:MINIMAX_API_KEY"]
     install_instructions = (
         "Set MINIMAX_TOKEN_PLAN_API_KEY (preferred) or MINIMAX_API_KEY to your MiniMax Token Plan API key.\n"
         "  Get one at https://platform.minimax.io/user-center/basic-information/interface-key\n"
@@ -96,14 +96,16 @@ class MinimaxTokenPlanVideo(BaseTool):
             },
             "duration": {
                 "type": "integer",
-                "minimum": 4,
-                "maximum": 10,
+                "enum": [6, 10],
                 "default": 6,
-                "description": "Video length in seconds.",
+                "description": (
+                    "Video length in seconds. 768P supports 6 or 10; "
+                    "1080P supports 6 only."
+                ),
             },
             "resolution": {
                 "type": "string",
-                "enum": ["768P", "720P", "1080P"],
+                "enum": ["768P", "1080P"],
                 "default": "768P",
                 "description": "Video resolution. 768P is the Token Plan default.",
             },
@@ -194,10 +196,18 @@ class MinimaxTokenPlanVideo(BaseTool):
             return ToolStatus.AVAILABLE
         return ToolStatus.UNAVAILABLE
 
+    _PAYG_PRICING = {
+        ("MiniMax-Hailuo-2.3", "768P"): 0.03,
+        ("MiniMax-Hailuo-2.3", "1080P"): 0.08,
+        ("MiniMax-Hailuo-2.3-Fast", "768P"): 0.03,
+    }
+
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
-        # MiniMax bills per second of generated video; ~$0.05/sec.
+        model = inputs.get("model", "MiniMax-Hailuo-2.3")
+        resolution = inputs.get("resolution", "768P")
         duration = int(inputs.get("duration", 6))
-        return round(0.05 * duration, 2)
+        per_second = self._PAYG_PRICING.get((model, resolution), 0.03)
+        return round(per_second * duration, 2)
 
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         duration = int(inputs.get("duration", 6))
@@ -213,6 +223,8 @@ class MinimaxTokenPlanVideo(BaseTool):
 
         operation = inputs.get("operation", "text_to_video")
         model = inputs.get("model", "MiniMax-Hailuo-2.3")
+        duration = int(inputs.get("duration", 6))
+        resolution = inputs.get("resolution", "768P")
 
         if model == "MiniMax-Hailuo-2.3-Fast" and operation == "text_to_video":
             return ToolResult(
@@ -220,6 +232,15 @@ class MinimaxTokenPlanVideo(BaseTool):
                 error=(
                     "MiniMax-Hailuo-2.3-Fast does not support text-to-video. "
                     "Use MiniMax-Hailuo-2.3 or switch operation to image_to_video."
+                ),
+            )
+
+        if resolution == "1080P" and duration != 6:
+            return ToolResult(
+                success=False,
+                error=(
+                    "1080P supports 6 seconds only. "
+                    "Use 768P for 10-second videos."
                 ),
             )
 

--- a/tools/video/minimax_tokenplan_video.py
+++ b/tools/video/minimax_tokenplan_video.py
@@ -1,0 +1,414 @@
+"""MiniMax (Hailuo AI) video generation via the official Token Plan API.
+
+This tool calls the MiniMax official API directly (api.minimaxi.com / api.minimax.io),
+NOT through fal.ai. It is distinct from ``minimax_video`` (which routes through
+FAL_KEY) so that the cost route is explicit: users with a MiniMax Token Plan
+subscription use this tool to consume their own quota instead of FAL credits.
+
+API flow: POST /v1/video_generation -> poll GET /v1/query/video_generation ->
+GET /v1/files/retrieve -> download.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+
+class MinimaxTokenPlanVideo(BaseTool):
+    name = "minimax_tokenplan_video"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "video_generation"
+    provider = "minimax"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.ASYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = []
+    install_instructions = (
+        "Set MINIMAX_TOKEN_PLAN_API_KEY (preferred) or MINIMAX_API_KEY to your MiniMax Token Plan API key.\n"
+        "  Get one at https://platform.minimax.io/user-center/basic-information/interface-key\n"
+        "  Optionally set MINIMAX_REGION=global to use api.minimax.io instead of api.minimaxi.com."
+    )
+    agent_skills = ["ai-video-gen"]
+
+    capabilities = ["text_to_video", "image_to_video"]
+    supports = {
+        "text_to_video": True,
+        "image_to_video": True,
+        "native_audio": False,
+        "watermark_control": True,
+        "prompt_optimizer": True,
+    }
+    best_for = [
+        "direct MiniMax Token Plan quota usage (no FAL credits)",
+        "Hailuo 2.3 text-to-video and image-to-video",
+        "auditable cost route — calls official MiniMax API, not a proxy",
+    ]
+    not_good_for = [
+        "users without a MiniMax Token Plan subscription (use minimax_video via FAL instead)",
+        "offline generation",
+    ]
+    fallback_tools = ["minimax_video", "kling_video", "veo_video"]
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": (
+                    "Video description (text-to-video) or motion description "
+                    "(image-to-video). Max 2000 chars."
+                ),
+            },
+            "operation": {
+                "type": "string",
+                "enum": ["text_to_video", "image_to_video"],
+                "default": "text_to_video",
+            },
+            "model": {
+                "type": "string",
+                "enum": ["MiniMax-Hailuo-2.3", "MiniMax-Hailuo-2.3-Fast"],
+                "default": "MiniMax-Hailuo-2.3",
+                "description": (
+                    "MiniMax-Hailuo-2.3 supports text-to-video and image-to-video. "
+                    "MiniMax-Hailuo-2.3-Fast is faster but only supports "
+                    "image-to-video."
+                ),
+            },
+            "duration": {
+                "type": "integer",
+                "minimum": 4,
+                "maximum": 10,
+                "default": 6,
+                "description": "Video length in seconds.",
+            },
+            "resolution": {
+                "type": "string",
+                "enum": ["768P", "720P", "1080P"],
+                "default": "768P",
+                "description": "Video resolution. 768P is the Token Plan default.",
+            },
+            "first_frame_image": {
+                "type": "string",
+                "description": (
+                    "First frame image URL for image-to-video. "
+                    "Must be publicly accessible."
+                ),
+            },
+            "prompt_optimizer": {
+                "type": "boolean",
+                "default": True,
+                "description": "Auto-optimize the prompt for better results.",
+            },
+            "fast_pretreatment": {
+                "type": "boolean",
+                "default": False,
+                "description": "Shorten the prompt optimizer duration.",
+            },
+            "aigc_watermark": {
+                "type": "boolean",
+                "default": False,
+                "description": "Embed an AI-generated content watermark.",
+            },
+            "callback_url": {
+                "type": "string",
+                "description": (
+                    "Webhook URL to receive async task status updates. "
+                    "The server sends a validation challenge first."
+                ),
+            },
+            "output_path": {"type": "string"},
+            "poll_interval_seconds": {
+                "type": "number",
+                "minimum": 2,
+                "default": 5.0,
+            },
+            "timeout_seconds": {
+                "type": "integer",
+                "minimum": 60,
+                "default": 600,
+            },
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=512, vram_mb=0, disk_mb=500, network_required=True
+    )
+    retry_policy = RetryPolicy(
+        max_retries=2,
+        backoff_seconds=2.0,
+        retryable_errors=["rate_limit", "timeout"],
+    )
+    idempotency_key_fields = [
+        "prompt",
+        "model",
+        "operation",
+        "duration",
+        "resolution",
+        "first_frame_image",
+        "prompt_optimizer",
+        "fast_pretreatment",
+        "aigc_watermark",
+    ]
+    side_effects = [
+        "writes video file to output_path",
+        "calls MiniMax official Token Plan API (submit + poll + download)",
+    ]
+    user_visible_verification = [
+        "Watch generated clip for motion coherence and prompt adherence",
+    ]
+
+    def _base_url(self) -> str:
+        region = os.environ.get("MINIMAX_REGION", "cn").strip().lower()
+        if region == "global":
+            return "https://api.minimax.io"
+        return "https://api.minimaxi.com"
+
+    def _api_key(self) -> str | None:
+        key = os.environ.get("MINIMAX_TOKEN_PLAN_API_KEY") or os.environ.get("MINIMAX_API_KEY")
+        if key and not key.strip().startswith("#"):
+            return key.strip()
+        return None
+
+    def get_status(self) -> ToolStatus:
+        if self._api_key():
+            return ToolStatus.AVAILABLE
+        return ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        # MiniMax bills per second of generated video; ~$0.05/sec.
+        duration = int(inputs.get("duration", 6))
+        return round(0.05 * duration, 2)
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        duration = int(inputs.get("duration", 6))
+        return 60.0 + duration * 10.0
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        api_key = self._api_key()
+        if not api_key:
+            return ToolResult(
+                success=False,
+                error="MINIMAX_TOKEN_PLAN_API_KEY or MINIMAX_API_KEY not set. " + self.install_instructions,
+            )
+
+        operation = inputs.get("operation", "text_to_video")
+        model = inputs.get("model", "MiniMax-Hailuo-2.3")
+
+        if model == "MiniMax-Hailuo-2.3-Fast" and operation == "text_to_video":
+            return ToolResult(
+                success=False,
+                error=(
+                    "MiniMax-Hailuo-2.3-Fast does not support text-to-video. "
+                    "Use MiniMax-Hailuo-2.3 or switch operation to image_to_video."
+                ),
+            )
+
+        if operation == "image_to_video" and not inputs.get("first_frame_image"):
+            return ToolResult(
+                success=False,
+                error="image_to_video requires first_frame_image (public URL).",
+            )
+
+        start = time.time()
+        try:
+            result = self._generate(inputs, api_key=api_key)
+        except Exception as exc:
+            return ToolResult(
+                success=False,
+                error=f"MiniMax Token Plan video generation failed: {self._safe_error(exc)}",
+            )
+
+        result.duration_seconds = round(time.time() - start, 2)
+        return result
+
+    def _generate(
+        self, inputs: dict[str, Any], *, api_key: str
+    ) -> ToolResult:
+        import requests
+
+        from tools.video._shared import probe_output
+
+        base = self._base_url()
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        payload = self._build_payload(inputs)
+        submit_resp = requests.post(
+            f"{base}/v1/video_generation",
+            headers=headers,
+            json=payload,
+            timeout=30,
+        )
+        submit_data = self._json_or_raise(submit_resp)
+        self._check_base_resp(submit_resp.status_code, submit_data)
+
+        task_id = submit_data.get("task_id")
+        if not task_id:
+            raise RuntimeError(
+                "MiniMax API returned no task_id"
+            )
+
+        poll_data = self._poll_task(
+            requests_module=requests,
+            base_url=base,
+            headers=headers,
+            task_id=task_id,
+            poll_interval=float(inputs.get("poll_interval_seconds", 5.0)),
+            timeout_seconds=int(inputs.get("timeout_seconds", 600)),
+        )
+
+        file_id = poll_data.get("file_id")
+        if not file_id:
+            raise RuntimeError(
+                "MiniMax task succeeded but file_id missing"
+            )
+
+        retrieve_resp = requests.get(
+            f"{base}/v1/files/retrieve",
+            headers=headers,
+            params={"file_id": file_id},
+            timeout=30,
+        )
+        retrieve_resp.raise_for_status()
+        retrieve_data = self._json_or_raise(retrieve_resp)
+        self._check_base_resp(retrieve_resp.status_code, retrieve_data)
+        download_url = (
+            retrieve_data.get("file", {}).get("download_url")
+            or retrieve_data.get("download_url")
+        )
+        if not download_url:
+            raise RuntimeError(
+                "MiniMax file retrieve returned no download URL"
+            )
+
+        download = requests.get(download_url, timeout=120)
+        download.raise_for_status()
+
+        output_path = Path(inputs.get("output_path", "minimax_tokenplan.mp4"))
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(download.content)
+
+        probed = probe_output(output_path)
+        return ToolResult(
+            success=True,
+            data={
+                "provider": "minimax",
+                "route": "token_plan",
+                "model": payload["model"],
+                "prompt": inputs["prompt"],
+                "operation": inputs.get("operation", "text_to_video"),
+                "duration": payload.get("duration", 6),
+                "resolution": payload.get("resolution", "768P"),
+                "aigc_watermark": payload.get("aigc_watermark", False),
+                "task_id": task_id,
+                "file_id": file_id,
+                "output": str(output_path),
+                "format": "mp4",
+                **probed,
+            },
+            artifacts=[str(output_path)],
+            cost_usd=self.estimate_cost(inputs),
+            model=payload["model"],
+        )
+
+    def _build_payload(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        operation = inputs.get("operation", "text_to_video")
+        payload: dict[str, Any] = {
+            "model": inputs.get("model", "MiniMax-Hailuo-2.3"),
+            "prompt": inputs["prompt"],
+            "duration": int(inputs.get("duration", 6)),
+            "resolution": inputs.get("resolution", "768P"),
+            "prompt_optimizer": bool(inputs.get("prompt_optimizer", True)),
+            "aigc_watermark": bool(inputs.get("aigc_watermark", False)),
+        }
+        if inputs.get("fast_pretreatment") is not None:
+            payload["fast_pretreatment"] = bool(inputs["fast_pretreatment"])
+        if operation == "image_to_video" and inputs.get("first_frame_image"):
+            payload["first_frame_image"] = inputs["first_frame_image"]
+        if inputs.get("callback_url"):
+            payload["callback_url"] = inputs["callback_url"]
+        return payload
+
+    def _poll_task(
+        self,
+        *,
+        requests_module: Any,
+        base_url: str,
+        headers: dict[str, str],
+        task_id: str,
+        poll_interval: float,
+        timeout_seconds: int,
+    ) -> dict[str, Any]:
+        deadline = time.time() + timeout_seconds
+        while time.time() < deadline:
+            time.sleep(poll_interval)
+            resp = requests_module.get(
+                f"{base_url}/v1/query/video_generation",
+                headers=headers,
+                params={"task_id": task_id},
+                timeout=30,
+            )
+            data = self._json_or_raise(resp)
+            self._check_base_resp(resp.status_code, data)
+            status = data.get("status", "")
+            if status == "Success":
+                return data
+            if status == "Fail":
+                msg = data.get("error_message") or data.get("status_msg") or "unknown error"
+                raise RuntimeError(f"MiniMax task failed: {msg}")
+        raise TimeoutError(
+            f"MiniMax task {task_id} did not finish within {timeout_seconds}s"
+        )
+
+    @staticmethod
+    def _json_or_raise(response: Any) -> dict[str, Any]:
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise RuntimeError(
+                f"Non-JSON response from MiniMax API: HTTP {response.status_code}"
+            ) from exc
+
+    @staticmethod
+    def _check_base_resp(http_status: int, payload: dict[str, Any]) -> None:
+        if http_status < 400:
+            base = payload.get("base_resp", {})
+            code = base.get("status_code", 0)
+            if code == 0:
+                return
+            msg = base.get("status_msg", "unknown error")
+            raise RuntimeError(f"MiniMax API error: code {code}: {msg}")
+        code = payload.get("base_resp", {}).get("status_code") or payload.get("status_code")
+        msg = payload.get("base_resp", {}).get("status_msg") or payload.get("status_msg", "unknown error")
+        raise RuntimeError(f"MiniMax API error: HTTP {http_status}, code {code}: {msg}")
+
+    @staticmethod
+    def _safe_error(exc: Exception) -> str:
+        msg = str(exc)
+        for var in ("MINIMAX_TOKEN_PLAN_API_KEY", "MINIMAX_API_KEY"):
+            val = os.environ.get(var, "")
+            if val:
+                msg = msg.replace(val, "[redacted]")
+        return msg


### PR DESCRIPTION
Implements **Part 1** of issue #216: a first-class MiniMax Token Plan video provider that calls the official MiniMax API directly, distinct from the FAL-backed `minimax_video`.

## What this adds

A new tool `minimax_tokenplan_video` (`tools/video/minimax_tokenplan_video.py`) that routes through the official MiniMax API (`api.minimaxi.com` / `api.minimax.io`) using `MINIMAX_API_KEY`, so users with a Token Plan subscription consume their own quota instead of FAL credits.

**API flow:** `POST /v1/video_generation` → poll `GET /v1/query/video_generation` → `GET /v1/files/retrieve` → download.

## Why it's a separate tool (not a modification of `minimax_video`)

The core point of #216 is **cost-route transparency**. `minimax_video` routes through `FAL_KEY`; `minimax_tokenplan_video` routes through `MINIMAX_API_KEY`. Both share `provider="minimax"` but have different tool names, making the cost route explicit in the registry and decision trail.

## Features

- Text-to-video and image-to-video (`MiniMax-Hailuo-2.3` / `MiniMax-Hailuo-2.3-Fast`)
- `MiniMax-Hailuo-2.3-Fast` correctly rejected for text-to-video (the API does not support it)
- Watermark control via `aigc_watermark` parameter
- Prompt optimizer toggle
- CN endpoint (`api.minimaxi.com`) by default; global (`api.minimax.io`) via `MINIMAX_REGION=global`
- Full error handling with MiniMax `base_resp` status codes (1002 rate limit, 1004 auth, 1008 insufficient balance, 1026 sensitive content, etc.)
- API key redaction in error messages

## Idempotency

All output-affecting fields are in `idempotency_key_fields` (prompt, model, operation, duration, resolution, first_frame_image, prompt_optimizer, fast_pretreatment, aigc_watermark). Execution-only fields (output_path, poll_interval_seconds, timeout_seconds) are correctly excluded. Lesson applied from PR #240 review.

## Scope note

Issue #216 asks for three things:
1. ✅ Official MiniMax Token Plan provider — **this PR**
2. ⬜ Creator-facing provider readiness report (`make doctor` enhancement) — broader scope, overlaps with #210 and #131
3. ⬜ Fallback/downgrade severity visibility — broader scope, overlaps with #210

Parts 2 and 3 are left for separate PRs to keep this one focused and reviewable.

## Files

| File | Description |
|------|-------------|
| `tools/video/minimax_tokenplan_video.py` | New tool (BaseTool subclass, submit/poll/download) |
| `tests/contracts/test_minimax_tokenplan_video.py` | 49 contract tests (no API key needed) |
| `.env.example` | `MINIMAX_API_KEY` entry |
| `docs/PROVIDERS.md` | MiniMax Token Plan provider section |

## Test results

```
python -m pytest tests/contracts/test_minimax_tokenplan_video.py -q  # 49 passed
python -m py_compile tools/video/minimax_tokenplan_video.py tests/contracts/test_minimax_tokenplan_video.py  # OK
Full contract suite: 525 passed, 6 skipped
```

Part of #216.

