### PR TITLE
feat(cost): ACE-Step music provider + quality_tier routing

### DIFF
--- a/.agents/skills/acestep/SKILL.md
+++ b/.agents/skills/acestep/SKILL.md
@@ -5,8 +5,19 @@ description: AI music generation with ACE-Step 1.5 — background music, vocal t
 
 # ACE-Step 1.5 Music Generation
 
-Open-source music generation (MIT license) via `tools/music_gen.py`. Runs on RunPod serverless.
-Requires `RUNPOD_API_KEY` and `RUNPOD_ACESTEP_ENDPOINT_ID` in `.env` (run `--setup` to create endpoint).
+Open-source music generation (MIT license) via the `acestep_music` tool
+(`tools/audio/acestep_music.py`), a BaseTool with `capability="music_generation"`.
+Route to it for **bulk / background / instrumental** music — it is near-free versus
+the paid music APIs (ElevenLabs `music_gen`, Suno `suno_music`), which you reserve
+for hero tracks. Runs on a RunPod serverless ACE-Step endpoint.
+Requires `RUNPOD_API_KEY` and `RUNPOD_ACESTEP_ENDPOINT_ID` in `.env`.
+
+> The tool is invoked through the registry
+> (`registry.get_by_capability("music_generation")` → `.execute({...})`), not a CLI.
+> The `python tools/music_gen.py --flag …` snippets below are kept as a **parameter
+> reference**: `--prompt`→`prompt`, `--duration`→`duration_seconds`, `--bpm`→`bpm`,
+> `--key`→`key`, `--lyrics`→`lyrics`, `--seed`→`seed`. Preset rows map to prompt+bpm+key
+> values you pass directly.
 
 ## Quick Reference
 

--- a/.claude/skills/acestep/SKILL.md
+++ b/.claude/skills/acestep/SKILL.md
@@ -5,8 +5,19 @@ description: AI music generation with ACE-Step 1.5 — background music, vocal t
 
 # ACE-Step 1.5 Music Generation
 
-Open-source music generation (MIT license) via `tools/music_gen.py`. Runs on RunPod serverless.
-Requires `RUNPOD_API_KEY` and `RUNPOD_ACESTEP_ENDPOINT_ID` in `.env` (run `--setup` to create endpoint).
+Open-source music generation (MIT license) via the `acestep_music` tool
+(`tools/audio/acestep_music.py`), a BaseTool with `capability="music_generation"`.
+Route to it for **bulk / background / instrumental** music — it is near-free versus
+the paid music APIs (ElevenLabs `music_gen`, Suno `suno_music`), which you reserve
+for hero tracks. Runs on a RunPod serverless ACE-Step endpoint.
+Requires `RUNPOD_API_KEY` and `RUNPOD_ACESTEP_ENDPOINT_ID` in `.env`.
+
+> The tool is invoked through the registry
+> (`registry.get_by_capability("music_generation")` → `.execute({...})`), not a CLI.
+> The `python tools/music_gen.py --flag …` snippets below are kept as a **parameter
+> reference**: `--prompt`→`prompt`, `--duration`→`duration_seconds`, `--bpm`→`bpm`,
+> `--key`→`key`, `--lyrics`→`lyrics`, `--seed`→`seed`. Preset rows map to prompt+bpm+key
+> values you pass directly.
 
 ## Quick Reference
 

--- a/COST_OPTIMIZATION_RESEARCH.md
+++ b/COST_OPTIMIZATION_RESEARCH.md
@@ -1,0 +1,159 @@
+# OpenMontage — Generation Cost Strategy
+
+> **Deep research report: cheaper AI image/video/TTS/music generation without killing quality.**
+> Compiled 2026-07-05. Pricing is a July 2026 snapshot — **verify live before committing money.**
+> Findings tagged `[verified]` passed 3-vote adversarial verification; `[single-source]` / `[derived]` did not — treat as directional, validate before relying on them.
+
+---
+
+## TL;DR — Bottom line first
+
+**Your architecture already won half this battle.** You have `ltx_video_modal`, `ltx_video_local`, `comfyui_image`, `comfyui_video`, `local_diffusion`, `piper_tts`, and `music_gen` wired behind the `image_selector` / `video_selector` / `tts_selector` pattern. This is a **configuration + routing** problem, **not a rewrite.**
+
+The move is a **3-tier router**:
+
+| Tier | Routes to | Tool to light up | Cost/unit | vs. now |
+|---|---|---|---|---|
+| **Premium (keep)** | Hero shots, final client-facing motion, lip-sync | `kling_video`, `seedance_video`, `veo_video` (fal) | $0.30/clip | baseline |
+| **Self-host open (grow)** | Bulk B-roll, drafts, iterations | `ltx_video_modal` / `comfyui_video` | **~$0.02/clip** | **~15-18× cheaper** |
+| **Free local (default now)** | TTS, music, most images | Kokoro/`piper`, ACE-Step/`music_gen`, SDXL | **~$0** marginal | **20-50× cheaper** |
+
+**The single most important verified finding:** the *entire top-15 of the blind human-preference text-to-video leaderboard is proprietary.* The best open video model (LTX-2.3 Fast, Elo 977) trails the #1 closed model (Dreamina Seedance 2.0, Elo 1,222) by **~245 Elo (~80% win-rate for the closed model)**. `[verified]`
+
+➡️ **"Self-host everything" is wrong for video. Tiering is not a compromise — it's the correct answer.**
+
+- **Where cheap wins outright (do first, low risk):** music, TTS, images.
+- **Where cheap is a real tradeoff:** video quality.
+
+---
+
+## 1. The money — break-even at your three volumes
+
+**Verified pricing anchors:**
+- RunPod RTX 4090 **$0.69/hr** on-demand (Secure Cloud); Community tier ~$0.34/hr `[verified / caveat]`
+- Modal serverless A100 80GB **$2.50/hr**, per-second billed `[verified]`
+- A100 80GB: ~$0.60/hr spot, ~$1.07/hr on-demand `[verified]`
+- LTX throughput on a 4090 ≈ **40 clips/hr** (~90s per 5s clip) `[single-source]`
+- Your API baselines: **$0.30/clip, $0.05/image** (from `tools/cost_tracker.py`)
+
+### Video (5-second clips)
+
+| Monthly volume | Current API | Serverless (Modal, pay-per-clip) | On-demand GPU (spin up for batch) | 24/7 rented 4090 | **Cheapest** |
+|---|---|---|---|---|---|
+| **100 clips** (low) | $30 | ~$6 | impractical | $497 | **Keep API** (ops not worth it) or serverless |
+| **2,000 clips** (medium) | $600 | ~$120 | **~$35** (≈50 GPU-hrs) | $497 | **On-demand batch GPU** |
+| **20,000 clips** (high) | $6,000 | ~$1,200 | ~$350 | **~$497** | **24/7 rented → then own hardware** |
+
+**Crossover points** `[derived]`:
+- A 24/7 rented 4090 (~$497/mo) beats per-call video API once you exceed **~1,650 clips/month**.
+- Below that → serverless or spin-up-for-batch.
+- Above ~15-20k/mo → **buy a used 3090/4090** (~$700-1,600 capex, amortizes in 1-3 months at these savings).
+
+### Images / TTS / music
+- Images are fast (SDXL ~5s, FLUX-schnell <2s on a 4090 → 700-1000/hr) → GPU cost **<$0.002/image vs $0.05 API ≈ 25× cheaper.**
+- TTS (Kokoro) and music (ACE-Step) run at **15-30× realtime** → effectively free.
+- **No meaningful quality reason to keep these on paid APIs for bulk work.**
+
+---
+
+## 2. Per-capability verdict (with honest quality labels)
+
+### 🎬 Video — tier it, don't replace it `[verified]`
+- Open models trail closed by ~245 Elo. Real artifacts: **temporal flicker, weaker prompt adherence, less coherent motion.**
+- **LTX is your bulk workhorse** — verified throughput leader (~40 clips/hr on a 4090 vs ~14 for Wan 2.2, ~10 for HunyuanVideo, ~7.5 for Mochi-1). You already have `ltx_video_modal` + `ltx_video_local`.
+- **Route:** drafts / iterations / background B-roll → LTX self-host. Final hero shots the viewer judges → keep Kling/Seedance/Veo.
+- VRAM: A100 80GB fits all major open video models (Wan 2.2 14B FP16 ~54-65GB, or FP8/GGUF at 22-26GB). A 4090 (24GB) runs the quantized variants. `[verified/medium]`
+- License: Wan/Hunyuan/LTX are generally permissive — **verify each before commercial use.**
+
+### 🖼️ Images — big win, one license landmine `[single-source, verify]`
+- On a 4090: FLUX.1-dev ~12s/img, SDXL ~5s.
+- **⚠️ FLUX.1-dev and FLUX.2-dev are NON-COMMERCIAL license only.** For commercial use route to **FLUX.1-schnell (Apache), SDXL, SD3.5, or Qwen-Image.**
+- VRAM: FLUX.1-dev ~33GB FP16 / ~12GB GGUF-Q4; SDXL ~8GB; SD3.5-Large ~18GB.
+- Your `tools/graphics/local_diffusion.py` currently defaults to `stabilityai/stable-diffusion-2-1-base` — **dated.** Repoint to SDXL / FLUX-schnell, or wire `comfyui_image`.
+- Quality gap to FLUX-pro/Imagen exists but is **much smaller than video's** — SDXL/schnell are production-usable for most B-roll and backgrounds.
+
+### 🗣️ TTS — go local now, keep ElevenLabs for hero VO `[single-source, verify]`
+- **Kokoro-82M** (Apache 2.0): RTF ~0.03 on GPU, runs on **CPU**, <0.3s/clip. Effectively free, no GPU needed. Quality: clean, less emotional range than ElevenLabs.
+- **Chatterbox** (MIT): a *vendor-run* blind test claims 65% preference over ElevenLabs Turbo — **treat with salt**, but a credible expressive option, 4-16GB VRAM.
+- You already have `tools/audio/piper_tts.py` (the robotic floor). **Add a Kokoro tool** (one `BaseTool`; auto-registers via `tts_selector`). Keep ElevenLabs only for narration the audience scrutinizes.
+- Break-even to justify a *dedicated GPU* for TTS is ~4-5M chars/mo — but Kokoro-on-CPU sidesteps that entirely.
+
+### 🎵 Music — the cleanest win of all `[verified]`
+- **ACE-Step** (Apache 2.0): renders **4 min of music in ~20s on an A100**, **15.6× realtime on a consumer 4090**, ~8GB VRAM. No license gotcha. **This environment ships an `acestep` skill**, and you already have `tools/audio/music_gen.py` (MusicGen).
+- Caveat: quality-vs-Suno parity is **not proven** (the "between Suno v3 and v3.5" claim was **refuted**). But for background beds it's more than good enough.
+- **Route bulk music → ACE-Step / MusicGen. Keep `suno_music` for hero tracks only.**
+- Other open options: MusicGen (~12GB), Stable Audio Open (~12GB), YuE (~16GB).
+
+---
+
+## 3. Infrastructure — which host, when
+
+| Option | Best when | Notes |
+|---|---|---|
+| **Serverless (Modal)** — pay-per-second, scales to zero | Low / bursty volume where a dedicated GPU would idle | Your `ltx_video_modal` is exactly this. ⚠️ Cold-start latency is **real but unquantified** — budget for model-load overhead, measure it. |
+| **On-demand rented (RunPod / Vast)** — spin up, batch a queue, spin down | Medium volume | RunPod Community 4090 ~$0.34/hr; Vast.ai **spot ~50%+ cheaper** for fault-tolerant batch (needs checkpoint/retry for preemption). |
+| **24/7 rented → owned hardware** | High sustained volume (>~1,650 clips/mo) | Used 3090/4090 amortizes in 1-3 months at these savings. |
+
+**Egress matters `[verified/medium]`:** RunPod / Lambda / Salad / Voltage Park charge **$0 egress**; hyperscalers charge $0.087-0.12/GB (AWS $0.09, Azure $0.087, GCP $0.12). Serving large video off AWS quietly taxes you — **stay on GPU-specialist hosts.**
+
+**Provider price snapshot `[verified where noted]`:**
+- **RunPod on-demand:** RTX 3090 $0.46, RTX 4090 $0.69, RTX 5090 $0.99, L40S $0.99, A100-80GB $1.39-1.49, H100 $2.89-3.29, H200 $4.39 (per hr). Community tier cheaper.
+- **Modal serverless (per-sec → /hr):** L40S $1.95, A100-40GB $2.10, A100-80GB $2.50, H100 $3.95, H200 $4.54.
+- **Lambda on-demand:** A100-80GB $1.99, H100 SXM $4.29 (pricier for single GPUs — use as stable free-egress baseline, not cost floor).
+- **Vast.ai spot:** ~50%+ below on-demand; variable auction, not a guaranteed floor.
+
+---
+
+## 4. Where "cheap" actually loses (be honest)
+
+1. **Video quality** — the 245-Elo gap is real and visible. Don't downgrade hero shots.
+2. **Cold starts** — serverless first-request latency is unquantified; can add minutes with model-load. Bad for interactive, fine for queued batch.
+3. **Ops burden** — self-hosting adds a GPU/queue/retry surface your per-call APIs hide. Real engineering time.
+4. **Spot preemption** — cheapest tier, but jobs die mid-render. Needs idempotent retry.
+5. **Licenses** — FLUX-dev non-commercial is the trap. Audit every open weight before commercial use.
+
+---
+
+## 5. Concrete next steps — mapped to your repo
+
+| # | Step | Effort | Payoff |
+|---|---|---|---|
+| 1 | **Music (do today):** wire ACE-Step via the `acestep` skill alongside `music_gen`; make `suno_music` hero-only in the asset director | small | zero-risk win |
+| 2 | **TTS (this week):** add a Kokoro `BaseTool` (CPU-capable, auto-registers via `tts_selector`); demote ElevenLabs to hero VO | small | ~free TTS |
+| 3 | **Images (this week):** repoint `local_diffusion` default SD-2.1 → **SDXL / FLUX-schnell** (commercial-safe), or stand up `comfyui_image` | small | ~25× cheaper images |
+| 4 | **Video (the big one):** deploy `ltx_video_modal` to a Modal endpoint (`MODAL_LTX2_ENDPOINT_URL`); add a `quality_tier: draft\|hero` field so `video_selector` routes draft→LTX, hero→Kling/Seedance | medium | ~15× cheaper bulk video |
+| 5 | **Router policy:** add `tier → provider` to the selectors; extend `cost_tracker` to log tier so savings are visible | medium | measurable ROI |
+
+**Recommended order:** 1 → 2 → 3 → 4/5. Step 1 is the smallest diff with the clearest payoff.
+
+---
+
+## 6. What this research did NOT establish (don't over-trust)
+
+- **Serverless cold-start latencies** — *every* specific number was refuted in verification. Measure yours.
+- **Image / TTS quality parity** — single-source only; validate with your own eval before cutting over hero work.
+- **A100/H100 video throughput** — only 4090 clip-times are verified; serverless video pricing is extrapolated.
+- **ACE-Step vs Suno quality** — the "between Suno v3/v3.5" claim was **refuted**; open music is fast/cheap/licensable but quality parity is unproven.
+- All GPU prices are a **July 2026 snapshot** — RunPod Community + Vast.ai lows push the real floor *below* the quoted numbers.
+
+---
+
+## Sources
+
+**Primary (vendor / leaderboard):**
+- Modal pricing — https://modal.com/pricing
+- RunPod pricing — https://www.runpod.io/pricing
+- Lambda pricing — https://lambda.ai/pricing
+- Vast.ai pricing — https://vast.ai/pricing
+- Text-to-video Elo leaderboard — https://artificialanalysis.ai/video/leaderboard/text-to-video
+- ACE-Step technical report — https://arxiv.org/html/2506.00045v1 · https://ace-step.github.io/
+
+**Secondary / blog (directional):**
+- GPU cloud pricing 2026 — https://www.spheron.network/blog/gpu-cloud-pricing-comparison-2026/
+- Local AI video generation — https://localaimaster.com/blog/local-ai-video-generation
+- Open image models compared — https://willitrunai.com/blog/flux-vs-sdxl-vs-sd35-comparison · https://localaimaster.com/blog/best-local-image-models-compared
+- Open TTS on GPU cloud — https://www.spheron.network/blog/deploy-open-source-tts-gpu-cloud-2026/
+- Data egress reference — https://gpuperhour.com/reference/data-egress
+- ComfyUI self-host vs serverless — https://www.runflow.io/blog/comfyui-deploy-self-host-serverless-managed
+
+*Research method: 5 search angles → 24 sources fetched → 115 claims extracted → 25 verified via 3-vote adversarial check (15 confirmed, 10 refuted).*

--- a/lib/scoring.py
+++ b/lib/scoring.py
@@ -18,6 +18,32 @@ from typing import Any
 # Provider Score
 # ---------------------------------------------------------------------------
 
+# Weight vectors by quality tier. Each sums to 1.0. The tier changes the
+# *philosophy* of selection, not any hardcoded provider name:
+#   ""      standard/balanced — the historical default weights
+#   "hero"  output quality dominates, cost all but ignored (premium APIs win)
+#   "draft" cost + speed dominate (cheap self-hosted / local models win)
+# This is what routes bulk/draft work to open models and hero shots to premium
+# APIs — see COST_OPTIMIZATION_RESEARCH.md.
+_TIER_WEIGHTS: dict[str, dict[str, float]] = {
+    "": {
+        "task_fit": 0.30, "output_quality": 0.20, "control": 0.15,
+        "reliability": 0.15, "cost_efficiency": 0.10, "latency": 0.05,
+        "continuity": 0.05,
+    },
+    "hero": {
+        "task_fit": 0.25, "output_quality": 0.35, "control": 0.15,
+        "reliability": 0.13, "cost_efficiency": 0.02, "latency": 0.02,
+        "continuity": 0.08,
+    },
+    "draft": {
+        "task_fit": 0.20, "output_quality": 0.08, "control": 0.05,
+        "reliability": 0.12, "cost_efficiency": 0.35, "latency": 0.17,
+        "continuity": 0.03,
+    },
+}
+
+
 @dataclass
 class ProviderScore:
     """Scored evaluation of a provider against a specific task context."""
@@ -31,17 +57,23 @@ class ProviderScore:
     cost_efficiency: float = 0.0  # 0-1: quality per dollar
     latency: float = 0.0        # 0-1: acceptable turnaround
     continuity: float = 0.0     # 0-1: fits already locked decisions
+    quality_tier: str = ""      # "" | "hero" | "draft" — selects the weight vector
+
+    @property
+    def _weights(self) -> dict[str, float]:
+        return _TIER_WEIGHTS.get(self.quality_tier, _TIER_WEIGHTS[""])
 
     @property
     def weighted_score(self) -> float:
+        w = self._weights
         return (
-            self.task_fit * 0.30
-            + self.output_quality * 0.20
-            + self.control * 0.15
-            + self.reliability * 0.15
-            + self.cost_efficiency * 0.10
-            + self.latency * 0.05
-            + self.continuity * 0.05
+            self.task_fit * w["task_fit"]
+            + self.output_quality * w["output_quality"]
+            + self.control * w["control"]
+            + self.reliability * w["reliability"]
+            + self.cost_efficiency * w["cost_efficiency"]
+            + self.latency * w["latency"]
+            + self.continuity * w["continuity"]
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -51,16 +83,18 @@ class ProviderScore:
 
     def explain(self) -> str:
         """Human-readable explanation of this score."""
-        parts = [f"{self.tool_name} ({self.provider}): {self.weighted_score:.2f}"]
+        tier_note = f" tier={self.quality_tier}" if self.quality_tier else ""
+        parts = [f"{self.tool_name} ({self.provider}): {self.weighted_score:.2f}{tier_note}"]
+        w = self._weights
         top = sorted(
             [
-                ("task_fit", self.task_fit, 0.30),
-                ("output_quality", self.output_quality, 0.20),
-                ("control", self.control, 0.15),
-                ("reliability", self.reliability, 0.15),
-                ("cost_efficiency", self.cost_efficiency, 0.10),
-                ("latency", self.latency, 0.05),
-                ("continuity", self.continuity, 0.05),
+                ("task_fit", self.task_fit, w["task_fit"]),
+                ("output_quality", self.output_quality, w["output_quality"]),
+                ("control", self.control, w["control"]),
+                ("reliability", self.reliability, w["reliability"]),
+                ("cost_efficiency", self.cost_efficiency, w["cost_efficiency"]),
+                ("latency", self.latency, w["latency"]),
+                ("continuity", self.continuity, w["continuity"]),
             ],
             key=lambda x: x[1] * x[2],
             reverse=True,
@@ -294,15 +328,33 @@ def _compute_continuity(
     return 0.4  # Different provider = possible style break
 
 
+def _normalize_quality_tier(value: str) -> str:
+    """Collapse loose tier synonyms to the canonical "" | "hero" | "draft"."""
+    v = (value or "").strip().lower()
+    if v in {"hero", "final", "premium", "high", "master", "showcase"}:
+        return "hero"
+    if v in {"draft", "bulk", "preview", "low", "cheap", "iteration", "batch"}:
+        return "draft"
+    return ""  # standard / balanced / unknown
+
+
 def normalize_task_context(
     task_context: dict[str, Any] | None,
     *,
     prompt: str = "",
     capability: str = "",
     operation: str = "",
+    quality_tier: str = "",
 ) -> dict[str, Any]:
     """Normalize loose task context into the scorer's expected shape."""
     context = dict(task_context or {})
+
+    # Quality tier: explicit kwarg wins, else an existing context key. Idempotent
+    # under the double-normalize that score_provider performs (canonical values
+    # map to themselves), so passing it once at the selector survives re-scoring.
+    context["quality_tier"] = _normalize_quality_tier(
+        quality_tier or context.get("quality_tier", "")
+    )
 
     needs = context.get("needs") or []
     if isinstance(needs, str):
@@ -527,6 +579,7 @@ def score_provider(tool, task_context: dict[str, Any]) -> ProviderScore:
         cost_efficiency=cost_efficiency,
         latency=latency,
         continuity=continuity,
+        quality_tier=task_context.get("quality_tier", ""),
     )
 
 

--- a/tests/tools/test_acestep_music.py
+++ b/tests/tools/test_acestep_music.py
@@ -1,0 +1,71 @@
+"""Tests for the ACE-Step open-weight music tool (tools/audio/acestep_music.py).
+
+Network-free: exercises availability gating, near-free cost, the input mapping,
+and the worker-output extraction — none of which touch RunPod.
+"""
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from tools.audio.acestep_music import AceStepMusic
+from tools.base_tool import ToolStatus
+
+
+@pytest.fixture
+def tool():
+    return AceStepMusic()
+
+
+def test_unavailable_without_env(tool, monkeypatch):
+    monkeypatch.delenv("RUNPOD_API_KEY", raising=False)
+    monkeypatch.delenv("RUNPOD_ACESTEP_ENDPOINT_ID", raising=False)
+    assert tool.get_status() == ToolStatus.UNAVAILABLE
+    # Never breaks a flow — it fails cleanly with guidance instead of raising.
+    result = tool.execute({"prompt": "anything"})
+    assert result.success is False
+    assert "not configured" in result.error.lower()
+
+
+def test_available_with_env(tool, monkeypatch):
+    monkeypatch.setenv("RUNPOD_API_KEY", "k")
+    monkeypatch.setenv("RUNPOD_ACESTEP_ENDPOINT_ID", "e")
+    assert tool.get_status() == ToolStatus.AVAILABLE
+
+
+def test_cost_is_near_free(tool):
+    # ~$0.05/30s is the paid-music baseline; ACE-Step must be far below it.
+    assert tool.estimate_cost({"duration_seconds": 60}) < 0.01
+    assert tool.estimate_cost({"duration_seconds": 300}) < 0.05
+
+
+def test_build_input_instrumental_and_params(tool):
+    payload = tool._build_input({"prompt": "lofi", "duration_seconds": 30, "bpm": 85, "key": "F Major"})
+    assert payload["task"] == "text2music"
+    assert payload["force_instrumental"] is True  # no lyrics => instrumental
+    assert payload["bpm"] == 85
+    assert payload["key"] == "F Major"
+    assert payload["duration"] == 30
+
+
+def test_build_input_with_lyrics_is_not_instrumental(tool):
+    payload = tool._build_input({"prompt": "indie pop", "lyrics": "[Verse]\nhello"})
+    assert payload["force_instrumental"] is False
+    assert payload["lyrics"] == "[Verse]\nhello"
+
+
+def test_extract_audio_base64_string(tool):
+    raw = b"ID3fake-audio-bytes"
+    assert tool._extract_audio(base64.b64encode(raw).decode()) == (raw, "mp3")
+
+
+def test_extract_audio_dict_with_format(tool):
+    raw = b"RIFFfake-wav"
+    out = {"audio": base64.b64encode(raw).decode(), "format": "wav"}
+    assert tool._extract_audio(out) == (raw, "wav")
+
+
+def test_extract_audio_raises_on_unknown_shape(tool):
+    with pytest.raises(RuntimeError):
+        tool._extract_audio({"unexpected": "shape"})

--- a/tests/tools/test_quality_tier_routing.py
+++ b/tests/tools/test_quality_tier_routing.py
@@ -1,0 +1,100 @@
+"""Tests for quality-tier routing in the provider scorer (lib/scoring.py).
+
+The tier changes the *weighting philosophy*, not any hardcoded provider name:
+'draft' makes cost+speed dominate (cheap local wins), 'hero' makes quality
+dominate (premium API wins). These tests prove the ranking flips accordingly.
+"""
+from __future__ import annotations
+
+import pytest
+
+from lib.scoring import (
+    _TIER_WEIGHTS,
+    _normalize_quality_tier,
+    normalize_task_context,
+    rank_providers,
+)
+
+
+class _Status:
+    def __init__(self, value: str):
+        self.value = value
+
+
+class _FakeTool:
+    """Minimal stand-in satisfying score_provider's tool contract."""
+
+    def __init__(self, name, provider, runtime, stability, cost):
+        self._info = {
+            "name": name,
+            "provider": provider,
+            "runtime": runtime,
+            "stability": stability,
+            "capability": "music_generation",
+            "best_for": ["background music generation"],
+            "supports": {},
+        }
+        self._cost = cost
+
+    def get_info(self):
+        return self._info
+
+    def get_status(self):
+        return _Status("available")
+
+    def estimate_cost(self, _ctx):
+        return self._cost
+
+
+@pytest.fixture
+def providers():
+    cheap_local = _FakeTool("acestep_music", "acestep", "local_gpu", "experimental", 0.003)
+    premium_api = _FakeTool("suno_music", "suno", "api", "production", 0.30)
+    return cheap_local, premium_api
+
+
+def test_weight_vectors_sum_to_one():
+    for tier, weights in _TIER_WEIGHTS.items():
+        assert abs(sum(weights.values()) - 1.0) < 1e-9, f"{tier} weights sum to {sum(weights.values())}"
+
+
+@pytest.mark.parametrize(
+    "alias,expected",
+    [
+        ("hero", "hero"), ("final", "hero"), ("premium", "hero"),
+        ("draft", "draft"), ("bulk", "draft"), ("preview", "draft"),
+        ("", ""), ("standard", ""), ("nonsense", ""),
+    ],
+)
+def test_tier_alias_normalization(alias, expected):
+    assert _normalize_quality_tier(alias) == expected
+
+
+def test_draft_routes_to_cheap_local(providers):
+    cheap, prem = providers
+    ctx = {"intent": "background music", "asset_type": "music", "quality_tier": "draft"}
+    ranked = rank_providers([cheap, prem], ctx)
+    assert ranked[0].provider == "acestep"
+
+
+def test_hero_routes_to_premium(providers):
+    cheap, prem = providers
+    ctx = {"intent": "background music", "asset_type": "music", "quality_tier": "hero"}
+    ranked = rank_providers([cheap, prem], ctx)
+    assert ranked[0].provider == "suno"
+
+
+def test_tier_survives_double_normalize():
+    # Selectors normalize once (via kwarg), then score_provider normalizes again
+    # (no kwarg). The tier must survive that second pass unchanged.
+    once = normalize_task_context({}, quality_tier="bulk")
+    assert once["quality_tier"] == "draft"
+    twice = normalize_task_context(once)
+    assert twice["quality_tier"] == "draft"
+
+
+def test_score_carries_tier_for_explainability(providers):
+    cheap, _ = providers
+    ranked = rank_providers([cheap], {"intent": "x", "quality_tier": "draft"})
+    assert ranked[0].quality_tier == "draft"
+    assert "tier=draft" in ranked[0].explain()

--- a/tools/audio/acestep_music.py
+++ b/tools/audio/acestep_music.py
@@ -1,0 +1,315 @@
+"""ACE-Step open-weight music generation (self-hosted, ~free at scale).
+
+ACE-Step 1.5 (MIT license) renders full instrumental/vocal tracks on a GPU in
+seconds — ~2-3s of inference on an A100, 15x+ realtime on a consumer 4090.
+Run as a RunPod serverless endpoint, it costs fractions of a cent per track
+versus paid music APIs (ElevenLabs `music_gen`, Suno `suno_music`), so it is
+the bulk/background-music default. Reserve the paid APIs for hero tracks.
+
+Backend: a RunPod serverless endpoint running an ACE-Step worker. The tool
+reports UNAVAILABLE until both env vars are set, so it never disturbs existing
+flows — it simply joins the `music_generation` menu once configured.
+
+    RUNPOD_API_KEY            — RunPod account key
+    RUNPOD_ACESTEP_ENDPOINT_ID — the deployed ACE-Step serverless endpoint id
+
+The RunPod REST envelope (runsync + status, Bearer auth, {"input": ...} /
+{"output": ...}) is standard. The *inner* input/output field names are
+worker-specific — they are isolated in `_build_input` / `_extract_audio` and
+marked with `ponytail:` so they are the one knob to confirm against your
+deployed worker on first run.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+_RUNPOD_BASE = "https://api.runpod.ai/v2"
+# A100 80GB serverless ≈ $2.50/hr; a track needs only a few GPU-seconds.
+_SERVERLESS_USD_PER_HOUR = 2.50
+
+
+class AceStepMusic(BaseTool):
+    name = "acestep_music"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "music_generation"
+    provider = "acestep"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.HYBRID  # self-hosted GPU reached over the RunPod API
+
+    dependencies = []  # checked dynamically via env vars
+    install_instructions = (
+        "Deploy an ACE-Step RunPod serverless endpoint, then set:\n"
+        "  export RUNPOD_API_KEY=your_runpod_key\n"
+        "  export RUNPOD_ACESTEP_ENDPOINT_ID=your_endpoint_id\n"
+        "ACE-Step is MIT-licensed and open-weight — https://ace-step.github.io/"
+    )
+
+    agent_skills = ["acestep", "music", "sound-effects"]
+
+    capabilities = [
+        "generate_background_music",
+        "generate_instrumental",
+        "generate_vocal_track",
+    ]
+
+    # best_for drives task_fit + signals the bulk/cheap lane to the scorer.
+    best_for = [
+        "bulk background music generation",
+        "instrumental underscore for narration",
+        "high-volume music at near-zero cost",
+        "self-hosted open-weight music (MIT license)",
+        "draft and iteration music",
+    ]
+    supports = {
+        "instrumental": True,
+        "lyrics": True,
+        "bpm_control": True,
+        "key_control": True,
+        "seed": True,
+    }
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": (
+                    "Caption = overall style: genre, instruments, mood, "
+                    "production quality. Do NOT write BPM/key here — use the "
+                    "dedicated params. See the `acestep` skill for prompt craft."
+                ),
+            },
+            "duration_seconds": {
+                "type": "number",
+                "minimum": 10,
+                "maximum": 600,
+                "description": (
+                    "Target duration in seconds (10-600). Match the target "
+                    "video/scene duration from the script/proposal."
+                ),
+            },
+            "bpm": {
+                "type": "number",
+                "minimum": 30,
+                "maximum": 300,
+                "description": "Tempo. Pass as metadata, not in the prompt.",
+            },
+            "key": {
+                "type": "string",
+                "description": "Musical key/mode, e.g. 'C Major', 'A Minor'.",
+            },
+            "lyrics": {
+                "type": "string",
+                "description": (
+                    "Optional. Structure tags ([Verse]/[Chorus]) drive temporal "
+                    "flow; omit for instrumental. Empty => force_instrumental."
+                ),
+            },
+            "force_instrumental": {
+                "type": "boolean",
+                "default": True,
+                "description": "True for background beds under narration.",
+            },
+            "seed": {
+                "type": "integer",
+                "description": "Lock randomness when iterating on prompt/lyrics.",
+            },
+            "output_path": {"type": "string"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=50, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
+    idempotency_key_fields = ["prompt", "duration_seconds", "bpm", "key", "lyrics", "seed"]
+    side_effects = ["writes audio file to output_path", "calls RunPod ACE-Step endpoint"]
+    user_visible_verification = [
+        "Listen to generated music for mood, tempo, and quality",
+    ]
+
+    # ---- availability ----
+
+    def get_status(self) -> ToolStatus:
+        if os.environ.get("RUNPOD_API_KEY") and os.environ.get("RUNPOD_ACESTEP_ENDPOINT_ID"):
+            return ToolStatus.AVAILABLE
+        return ToolStatus.UNAVAILABLE
+
+    # ---- estimates ----
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        """Near-free: a few serverless GPU-seconds per track.
+
+        ACE-Step needs roughly a tenth of the target duration in inference time
+        (a 60s track ≈ ~6s of GPU). That is fractions of a cent — which is the
+        whole point: the scorer's cost_efficiency lane ranks this above the
+        paid music APIs for bulk work.
+        """
+        duration = inputs.get("duration_seconds") or 60
+        inference_seconds = max(3.0, float(duration) * 0.1)
+        return round(inference_seconds / 3600.0 * _SERVERLESS_USD_PER_HOUR, 4)
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        # A few seconds of inference, plus serverless queue/cold-start headroom.
+        return 12.0
+
+    # ---- execution ----
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        api_key = os.environ.get("RUNPOD_API_KEY")
+        endpoint_id = os.environ.get("RUNPOD_ACESTEP_ENDPOINT_ID")
+        if not (api_key and endpoint_id):
+            return ToolResult(
+                success=False,
+                error="ACE-Step not configured. " + self.install_instructions,
+            )
+
+        start = time.time()
+        try:
+            audio_bytes, fmt = self._run_runpod(inputs, api_key, endpoint_id)
+        except Exception as e:  # noqa: BLE001 - surface any backend failure to the agent
+            return ToolResult(success=False, error=f"ACE-Step generation failed: {e}")
+
+        output_path = Path(inputs.get("output_path", f"acestep_music.{fmt}"))
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(audio_bytes)
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": "acestep",
+                "prompt": inputs["prompt"],
+                "duration_seconds": inputs.get("duration_seconds"),
+                "output": str(output_path),
+                "format": fmt,
+            },
+            artifacts=[str(output_path)],
+            cost_usd=self.estimate_cost(inputs),
+            seed=inputs.get("seed"),
+            model="ace-step-1.5",
+            duration_seconds=round(time.time() - start, 2),
+        )
+
+    # ---- RunPod plumbing ----
+
+    def _run_runpod(
+        self, inputs: dict[str, Any], api_key: str, endpoint_id: str
+    ) -> tuple[bytes, str]:
+        import requests
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        payload = {"input": self._build_input(inputs)}
+
+        resp = requests.post(
+            f"{_RUNPOD_BASE}/{endpoint_id}/runsync",
+            headers=headers,
+            json=payload,
+            timeout=180,
+        )
+        resp.raise_for_status()
+        body = resp.json()
+
+        # runsync may still return before completion for a queued job — poll status.
+        status = body.get("status")
+        job_id = body.get("id")
+        deadline = time.time() + 180
+        while status in {"IN_QUEUE", "IN_PROGRESS"} and job_id and time.time() < deadline:
+            time.sleep(2)
+            s = requests.get(
+                f"{_RUNPOD_BASE}/{endpoint_id}/status/{job_id}",
+                headers=headers,
+                timeout=30,
+            )
+            s.raise_for_status()
+            body = s.json()
+            status = body.get("status")
+
+        if status and status != "COMPLETED":
+            raise RuntimeError(f"RunPod job status={status}: {body.get('error', body)}")
+
+        return self._extract_audio(body.get("output", body))
+
+    @staticmethod
+    def _build_input(inputs: dict[str, Any]) -> dict[str, Any]:
+        """Map tool inputs to the ACE-Step worker's input schema.
+
+        ponytail: worker-specific field names — this is the one knob to confirm
+        against your deployed ACE-Step RunPod worker. The envelope around it
+        (runsync/status, Bearer auth) is standard RunPod and needs no changes.
+        """
+        lyrics = (inputs.get("lyrics") or "").strip()
+        payload: dict[str, Any] = {
+            "task": "text2music",
+            "prompt": inputs["prompt"],
+            "duration": inputs.get("duration_seconds") or 60,
+            "force_instrumental": inputs.get("force_instrumental", not lyrics),
+            "format": "mp3",
+        }
+        if inputs.get("bpm") is not None:
+            payload["bpm"] = inputs["bpm"]
+        if inputs.get("key"):
+            payload["key"] = inputs["key"]
+        if lyrics:
+            payload["lyrics"] = lyrics
+        if inputs.get("seed") is not None:
+            payload["seed"] = inputs["seed"]
+        return payload
+
+    @staticmethod
+    def _extract_audio(output: Any) -> tuple[bytes, str]:
+        """Pull audio bytes + format from a worker output.
+
+        ponytail: handles the common worker shapes — base64 string, a dict with
+        an audio/audio_base64 field, or a downloadable URL. Confirm which your
+        worker emits and this covers it; extend here if it returns something else.
+        """
+        import requests
+
+        def _from_value(val: Any, fmt: str) -> tuple[bytes, str] | None:
+            if isinstance(val, str):
+                if val.startswith("http://") or val.startswith("https://"):
+                    r = requests.get(val, timeout=120)
+                    r.raise_for_status()
+                    return r.content, val.rsplit(".", 1)[-1].split("?")[0] or fmt
+                # assume base64-encoded audio
+                return base64.b64decode(val), fmt
+            return None
+
+        if isinstance(output, dict):
+            fmt = output.get("format", "mp3")
+            for key in ("audio", "audio_base64", "audio_url", "url", "output"):
+                if key in output and output[key]:
+                    got = _from_value(output[key], fmt)
+                    if got:
+                        return got
+        else:
+            got = _from_value(output, "mp3")
+            if got:
+                return got
+
+        raise RuntimeError(f"Could not find audio in ACE-Step output: {type(output)}")

--- a/tools/audio/tts_selector.py
+++ b/tools/audio/tts_selector.py
@@ -102,6 +102,17 @@ class TTSSelector(BaseTool):
                 "type": "string",
                 "description": "Audio output format (e.g. mp3_44100_128). Passed through to provider.",
             },
+            "quality_tier": {
+                "type": "string",
+                "enum": ["hero", "draft", ""],
+                "default": "",
+                "description": (
+                    "Cost/quality routing lane. 'hero' = quality-first (premium "
+                    "providers win, cost ignored); 'draft'/'bulk' = cost+speed-first "
+                    "(cheap self-hosted/local models win); '' = balanced default. "
+                    "See COST_OPTIMIZATION_RESEARCH.md."
+                ),
+            },
             "preferred_provider": {
                 "type": "string",
                 "description": "Provider name or 'auto'. Valid values are discovered at runtime from the registry.",
@@ -231,6 +242,7 @@ class TTSSelector(BaseTool):
             prompt=inputs.get("text", ""),
             capability=self.capability,
             operation=inputs.get("operation", "generate"),
+            quality_tier=inputs.get("quality_tier", ""),
         )
 
     @staticmethod

--- a/tools/graphics/image_selector.py
+++ b/tools/graphics/image_selector.py
@@ -79,6 +79,17 @@ class ImageSelector(BaseTool):
                 "items": {"type": "string"},
                 "description": "Multiple local source image paths for compositing edits.",
             },
+            "quality_tier": {
+                "type": "string",
+                "enum": ["hero", "draft", ""],
+                "default": "",
+                "description": (
+                    "Cost/quality routing lane. 'hero' = quality-first (premium "
+                    "providers win, cost ignored); 'draft'/'bulk' = cost+speed-first "
+                    "(cheap self-hosted/local models win); '' = balanced default. "
+                    "See COST_OPTIMIZATION_RESEARCH.md."
+                ),
+            },
             "preferred_provider": {
                 "type": "string",
                 "description": "Provider name or 'auto'. Valid values are discovered at runtime from the registry.",
@@ -286,6 +297,7 @@ class ImageSelector(BaseTool):
             prompt=inputs.get("prompt", ""),
             capability=self.capability,
             operation=inputs.get("generation_mode", inputs.get("operation", "generate")),
+            quality_tier=inputs.get("quality_tier", ""),
         )
 
     @staticmethod

--- a/tools/video/video_selector.py
+++ b/tools/video/video_selector.py
@@ -43,6 +43,17 @@ class VideoSelector(BaseTool):
         "required": ["prompt"],
         "properties": {
             "prompt": {"type": "string"},
+            "quality_tier": {
+                "type": "string",
+                "enum": ["hero", "draft", ""],
+                "default": "",
+                "description": (
+                    "Cost/quality routing lane. 'hero' = quality-first (premium "
+                    "providers win, cost ignored); 'draft'/'bulk' = cost+speed-first "
+                    "(cheap self-hosted/local models win); '' = balanced default. "
+                    "See COST_OPTIMIZATION_RESEARCH.md."
+                ),
+            },
             "preferred_provider": {
                 "type": "string",
                 "description": "Provider name or 'auto'. Valid values are discovered at runtime from the registry.",
@@ -291,6 +302,7 @@ class VideoSelector(BaseTool):
             prompt=str(inputs.get("prompt", "")),
             capability=self.capability,
             operation=str(inputs.get("operation", "text_to_video")),
+            quality_tier=str(inputs.get("quality_tier", "")),
         )
 
     @staticmethod


### PR DESCRIPTION
## Why

We pay per-call APIs for all generation (fal.ai, ElevenLabs, Suno). Deep-research (see `COST_OPTIMIZATION_RESEARCH.md`, included) found two low-risk, high-leverage wins that our provider-agnostic architecture is already built for. This PR ships both.

## (a) ACE-Step music provider — the zero-risk win

`tools/audio/acestep_music.py` — a new `BaseTool` (`capability="music_generation"`, `provider="acestep"`) for MIT-licensed **ACE-Step 1.5** on a RunPod serverless endpoint.

- **Both existing music tools are paid** (`music_gen` = ElevenLabs, `suno_music` = Suno). This adds the missing free/open option: **~$0.004 per 60s** vs paid.
- **Zero-risk:** reports `UNAVAILABLE` until `RUNPOD_API_KEY` + `RUNPOD_ACESTEP_ENDPOINT_ID` are set — it simply joins the music menu once configured, disturbing nothing.
- Worker input/output field mapping is isolated + `ponytail:`-marked (the one knob to confirm against a deployed worker); the RunPod REST envelope (runsync/status, Bearer auth) is standard.
- **Fixes the stale `acestep` skill**, which pointed at a nonexistent `tools/music_gen.py` (the real `music_gen.py` is the ElevenLabs tool).

## (b) `quality_tier` routing across the three selectors

`lib/scoring.py` + `tts_selector` / `image_selector` / `video_selector`.

- Tier-aware weight vectors — **no hardcoded provider names**:
  - `hero` → output quality dominates, cost ignored (premium APIs win)
  - `draft`/`bulk` → cost + speed dominate (cheap self-hosted/local win)
  - `""` → unchanged balanced default
- `quality_tier` threads through each selector into `normalize_task_context`; idempotent under `score_provider`'s second normalize pass.
- This is the mechanism to keep Kling/Seedance for hero shots while routing bulk B-roll to LTX, images to SDXL, TTS to Piper/Kokoro, and music to ACE-Step.

## Tests / verification

- 22 new tests (`tests/tools/test_acestep_music.py`, `tests/tools/test_quality_tier_routing.py`): tool gating/cost/IO mapping; tier alias normalization; weight vectors sum to 1.0; **ranking flips** (draft→cheap-local, hero→premium); tier survives double-normalize.
- Full suite green: **243 passed** incl. contract tests. No behavior change at the default tier.
- Registry confirmed discovering `acestep_music` alongside `music_gen`/`suno_music`.

## Follow-ups (not in this PR)

- Point `local_diffusion` default from SD-2.1 → SDXL/FLUX-schnell (commercial-safe).
- Add a Kokoro TTS tool (CPU-capable, near-free).
- Deploy `ltx_video_modal` and route draft video → LTX via `quality_tier`.
- The two `RUNPOD_*` vars are documented in the tool's `install_instructions` and the skill; add them to `.env.example` when the in-flight `.env.example` reformat lands (kept out of this PR to stay surgical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)