### PR TITLE
feat(cost): local_diffusion_xl — modern commercial-safe local image models

### DIFF
--- a/tests/tools/test_local_diffusion_xl.py
+++ b/tests/tools/test_local_diffusion_xl.py
@@ -1,0 +1,72 @@
+"""Tests for the modern local image tool (tools/graphics/local_diffusion_xl.py).
+
+Weight-free: exercises availability gating, free cost, and the per-model call-kwarg
+logic (the FLUX-vs-SDXL knob) without loading any diffusion model. Also asserts the
+tool is purely additive — it does not touch the existing SD-2.1 local_diffusion.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tools.graphics.local_diffusion_xl import (
+    COMMERCIAL_SAFE_MODELS,
+    LocalDiffusionXL,
+    _DEFAULT_MODEL,
+    _is_flux_schnell,
+)
+
+
+@pytest.fixture
+def tool():
+    return LocalDiffusionXL()
+
+
+def test_default_model_is_commercial_safe_sdxl():
+    assert _DEFAULT_MODEL == "stabilityai/stable-diffusion-xl-base-1.0"
+    assert _DEFAULT_MODEL in COMMERCIAL_SAFE_MODELS
+    # The non-commercial FLUX-dev must never be a suggested default.
+    assert not any("dev" in m.lower() for m in COMMERCIAL_SAFE_MODELS)
+
+
+def test_free_cost(tool):
+    assert tool.estimate_cost({"prompt": "a fox"}) == 0.0
+
+
+def test_flux_detection():
+    assert _is_flux_schnell("black-forest-labs/FLUX.1-schnell")
+    assert not _is_flux_schnell("black-forest-labs/FLUX.1-dev")  # dev is not schnell
+    assert not _is_flux_schnell("stabilityai/stable-diffusion-xl-base-1.0")
+
+
+def test_sdxl_call_kwargs_include_negative_and_full_steps(tool):
+    kw = tool._build_call_kwargs(_DEFAULT_MODEL, {"prompt": "castle", "negative_prompt": "blurry"})
+    assert kw["negative_prompt"] == "blurry"
+    assert kw["num_inference_steps"] == 30
+    assert kw["guidance_scale"] == 7.0
+    assert kw["width"] == 1024 and kw["height"] == 1024
+
+
+def test_flux_call_kwargs_omit_negative_and_use_distilled_defaults(tool):
+    # FLUX-schnell has no negative_prompt and wants guidance 0 / ~4 steps.
+    kw = tool._build_call_kwargs("black-forest-labs/FLUX.1-schnell",
+                                 {"prompt": "castle", "negative_prompt": "blurry"})
+    assert "negative_prompt" not in kw
+    assert kw["num_inference_steps"] == 4
+    assert kw["guidance_scale"] == 0.0
+
+
+def test_explicit_overrides_win_over_model_defaults(tool):
+    kw = tool._build_call_kwargs("black-forest-labs/FLUX.1-schnell",
+                                 {"prompt": "x", "num_inference_steps": 8, "guidance_scale": 1.5})
+    assert kw["num_inference_steps"] == 8
+    assert kw["guidance_scale"] == 1.5
+
+
+def test_additive_does_not_replace_sd21_local_diffusion():
+    # The original SD-2.1 tool must still exist, untouched, as a separate provider.
+    from tools.graphics.local_diffusion import LocalDiffusion
+    assert LocalDiffusion.provider == "local_diffusion"
+    assert LocalDiffusionXL.provider == "local_diffusion_xl"
+    assert LocalDiffusion().input_schema["properties"]["model"]["default"] == (
+        "stabilityai/stable-diffusion-2-1-base"
+    )

--- a/tools/graphics/local_diffusion_xl.py
+++ b/tools/graphics/local_diffusion_xl.py
@@ -1,0 +1,218 @@
+"""Modern commercial-safe local image generation (SDXL / FLUX-schnell / SD3.5).
+
+A NEW alternative alongside `local_diffusion` (which stays on SD-2.1) — it does
+not replace it. Uses diffusers' AutoPipelineForText2Image so one tool loads
+whichever modern model you point it at:
+
+    stabilityai/stable-diffusion-xl-base-1.0   default — commercial-safe, ~8GB VRAM
+    black-forest-labs/FLUX.1-schnell           Apache 2.0, highest quality, ~12GB+
+    stabilityai/stable-diffusion-3.5-large     commercial-safe, ~18GB
+
+LICENSE NOTE: FLUX.1-dev / FLUX.2-dev are NON-COMMERCIAL. For commercial work use
+the models above (SDXL, FLUX.1-schnell, SD3.5, Qwen-Image) — never FLUX-dev.
+
+Free (no API cost). Reports UNAVAILABLE until diffusers is installed, so it never
+disturbs existing flows and auto-joins the image menu via image_selector.
+
+FLUX and SDXL take different call arguments (FLUX has no negative_prompt and wants
+guidance≈0 with ~4 steps); that per-model difference is the one calibration knob,
+isolated + `ponytail:`-marked in `_build_call_kwargs`. Everything else is shared.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+_DEFAULT_MODEL = "stabilityai/stable-diffusion-xl-base-1.0"
+
+# Commercial-safe defaults surfaced to the agent. FLUX.1-dev deliberately excluded.
+COMMERCIAL_SAFE_MODELS = [
+    "stabilityai/stable-diffusion-xl-base-1.0",
+    "black-forest-labs/FLUX.1-schnell",
+    "stabilityai/stable-diffusion-3.5-large",
+    "Qwen/Qwen-Image",
+]
+
+
+def _is_flux_schnell(model_id: str) -> bool:
+    m = (model_id or "").lower()
+    return "flux" in m and "schnell" in m
+
+
+class LocalDiffusionXL(BaseTool):
+    name = "local_diffusion_xl"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "image_generation"
+    provider = "local_diffusion_xl"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.SEEDED
+    runtime = ToolRuntime.LOCAL_GPU
+
+    dependencies = []  # checked dynamically
+    install_instructions = (
+        "Install diffusers for modern local image models:\n"
+        "  pip install 'diffusers>=0.30' transformers accelerate torch safetensors\n"
+        "First run downloads the model weights (SDXL ~7GB, FLUX-schnell ~24GB)."
+    )
+    agent_skills = ["flux-best-practices", "bfl-api"]
+
+    capabilities = ["generate_image", "generate_illustration", "text_to_image"]
+    supports = {
+        "negative_prompt": True,  # SDXL/SD3.5 (ignored for FLUX-schnell)
+        "seed": True,
+        "offline": True,
+        "custom_size": True,
+    }
+    best_for = [
+        "high-quality free local image generation",
+        "commercial-safe open image models (SDXL, FLUX-schnell, SD3.5)",
+        "bulk and draft image generation without API cost",
+        "offline/air-gapped generation",
+    ]
+    not_good_for = [
+        "CPU-only machines (SDXL/FLUX are impractically slow without a GPU)",
+        "FLUX.1-dev (non-commercial license — use FLUX.1-schnell or SDXL instead)",
+    ]
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+            "prompt": {"type": "string"},
+            "negative_prompt": {
+                "type": "string",
+                "default": "",
+                "description": "Used by SDXL/SD3.5; ignored for FLUX-schnell (no negative prompt).",
+            },
+            "width": {"type": "integer", "default": 1024},
+            "height": {"type": "integer", "default": 1024},
+            "model": {
+                "type": "string",
+                "default": _DEFAULT_MODEL,
+                "description": (
+                    "Commercial-safe: stable-diffusion-xl-base-1.0 (default), FLUX.1-schnell, "
+                    "stable-diffusion-3.5-large, Qwen-Image. Do NOT use FLUX.1-dev/FLUX.2-dev "
+                    "(non-commercial)."
+                ),
+            },
+            "seed": {"type": "integer"},
+            "num_inference_steps": {
+                "type": "integer",
+                "description": "Default adapts to model: ~30 for SDXL, ~4 for FLUX-schnell.",
+            },
+            "guidance_scale": {
+                "type": "number",
+                "description": "Default adapts to model: ~7.0 for SDXL, 0.0 for FLUX-schnell.",
+            },
+            "output_path": {"type": "string"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=4, ram_mb=16000, vram_mb=12000, disk_mb=25000, network_required=False
+    )
+    retry_policy = RetryPolicy(max_retries=1)
+    idempotency_key_fields = ["prompt", "width", "height", "seed", "model"]
+    side_effects = ["writes image file to output_path", "may download model weights on first run"]
+    user_visible_verification = ["Inspect generated image for relevance and quality"]
+
+    def get_status(self) -> ToolStatus:
+        try:
+            import diffusers  # noqa: F401
+            return ToolStatus.AVAILABLE
+        except ImportError:
+            return ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        return 0.0
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        model_id = inputs.get("model", _DEFAULT_MODEL)
+        return 6.0 if _is_flux_schnell(model_id) else 25.0
+
+    @staticmethod
+    def _build_call_kwargs(model_id: str, inputs: dict[str, Any]) -> dict[str, Any]:
+        """Build model-appropriate pipeline call kwargs (no generator — added in execute).
+
+        ponytail: FLUX-schnell vs SDXL is the one real per-model difference —
+        FLUX has no negative_prompt and is distilled (guidance≈0, ~4 steps). This
+        is the knob to tune; the rest of the flow is model-agnostic. Pure function,
+        so it's unit-tested without loading any weights.
+        """
+        flux = _is_flux_schnell(model_id)
+        kwargs: dict[str, Any] = {
+            "prompt": inputs["prompt"],
+            "width": inputs.get("width", 1024),
+            "height": inputs.get("height", 1024),
+            "num_inference_steps": inputs.get("num_inference_steps", 4 if flux else 30),
+            "guidance_scale": inputs.get("guidance_scale", 0.0 if flux else 7.0),
+        }
+        if not flux:
+            kwargs["negative_prompt"] = inputs.get("negative_prompt", "")
+        return kwargs
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        if self.get_status() != ToolStatus.AVAILABLE:
+            return ToolResult(
+                success=False,
+                error="diffusers not installed. " + self.install_instructions,
+            )
+
+        import torch
+        from diffusers import AutoPipelineForText2Image
+
+        start = time.time()
+        model_id = inputs.get("model", _DEFAULT_MODEL)
+        seed = inputs.get("seed")
+
+        try:
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+            dtype = torch.float16 if device == "cuda" else torch.float32
+
+            pipe = AutoPipelineForText2Image.from_pretrained(model_id, torch_dtype=dtype)
+            pipe = pipe.to(device)
+
+            call_kwargs = self._build_call_kwargs(model_id, inputs)
+            if seed is not None:
+                call_kwargs["generator"] = torch.Generator(device=device).manual_seed(seed)
+
+            image = pipe(**call_kwargs).images[0]
+
+            output_path = Path(inputs.get("output_path", "generated_image.png"))
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            image.save(str(output_path))
+
+        except Exception as e:  # noqa: BLE001 - surface generation failure to the agent
+            return ToolResult(success=False, error=f"Local diffusion (XL) generation failed: {e}")
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": self.provider,
+                "model": model_id,
+                "prompt": inputs["prompt"],
+                "output": str(output_path),
+            },
+            artifacts=[str(output_path)],
+            cost_usd=0.0,
+            duration_seconds=round(time.time() - start, 2),
+            seed=seed,
+            model=model_id,
+        )


### PR DESCRIPTION
## Why

Third step in the cost-tiering initiative (`COST_OPTIMIZATION_RESEARCH.md`). The existing local image tool `local_diffusion` defaults to SD-2.1 (dated), and the research flagged a **license landmine**: FLUX.1-dev / FLUX.2-dev are *non-commercial*. This adds a modern, **commercial-safe** local option — free at ~$0.002/image vs the $0.05 API baseline.

## Purely additive — nothing removed

Per the explicit ask: **no existing image/video/audio path is removed.** `local_diffusion` (SD-2.1) is left byte-for-byte untouched and still registers. This adds a *new* sibling provider next to it. A test asserts that invariant.

## What

`tools/graphics/local_diffusion_xl.py` — new `BaseTool` (`capability="image_generation"`, `provider="local_diffusion_xl"`, `runtime=LOCAL_GPU`, free).

- One tool, many models via diffusers' `AutoPipelineForText2Image`:
  - **`stable-diffusion-xl-base-1.0`** — default, commercial-safe, ~8GB VRAM
  - `FLUX.1-schnell` — Apache 2.0, highest quality, ~12GB+
  - `stable-diffusion-3.5-large`, `Qwen-Image`
- **FLUX.1-dev/FLUX.2-dev are excluded and warned against** (non-commercial) in the schema + `not_good_for`.
- The one real per-model difference — FLUX has no `negative_prompt` and is distilled (guidance≈0, ~4 steps) vs SDXL (guidance ~7, ~30 steps) — is isolated in the pure, unit-tested `_build_call_kwargs` (`ponytail:` knob).
- Dependency-gated on diffusers: `UNAVAILABLE` until installed, so it never disturbs existing flows; auto-joins the image menu via `image_selector`.

## Relationship to #299 / #300

Independent (branches off `main`). Registers as an image provider immediately; once **#299**'s `quality_tier` merges, draft/bulk images auto-route here and hero images stay on premium APIs.

## Tests / verification

- 7 new tests (`tests/tools/test_local_diffusion_xl.py`): default is commercial-safe SDXL, FLUX detection, per-model call kwargs, override precedence, and an explicit **"SD-2.1 local_diffusion unchanged"** assertion.
- Green: **71 passed** (tool + phase-3 contracts). Registry shows both `local_diffusion` and `local_diffusion_xl`.
- Note: actual image quality needs a GPU to eyeball — the model load/run path can't be unit-tested here, so the pure logic is covered and the diffusion call is a marked calibration knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)