### PR TITLE
feat(cost): self-hosted LTX-Video Modal endpoint + draft-video routing

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,54 @@
+# Modal deploy — self-hosted LTX-Video endpoint
+
+Stands up the cheap draft/bulk video GPU that `tools/video/ltx_video_modal.py` calls.
+Once deployed, the `quality_tier` router (PR #299) sends `draft` video here and keeps
+premium APIs (Kling/Seedance/Veo) for `hero` shots.
+
+## One-time
+
+```bash
+pip install modal
+python3 -m modal setup      # opens a browser to authenticate; nothing to paste
+```
+
+## Deploy
+
+```bash
+modal deploy deploy/modal_ltx_endpoint.py
+```
+
+Modal prints a web URL for the `generate` endpoint. Point the app at it (the tool
+reads this env var; it's already listed in `.env.example`):
+
+```bash
+export MODAL_LTX2_ENDPOINT_URL="https://<workspace>--openmontage-ltx-ltx-generate.modal.run"
+# or add it to your .env
+```
+
+That's it — `ltx_video_modal` flips from UNAVAILABLE to AVAILABLE and joins the video menu.
+
+## Smoke test
+
+```bash
+curl -s -X POST "$MODAL_LTX2_ENDPOINT_URL" \
+  -H 'content-type: application/json' \
+  -d '{"prompt":"a red fox trotting through snow, cinematic","width":1024,"height":576,"num_frames":121,"fps":24,"steps":30,"negative_prompt":""}' \
+  --output test.mp4 && open test.mp4
+```
+
+## Cost / GPU
+
+- Default GPU is **L40S** (~$1.95/hr serverless) — LTX is light, so this stretches
+  Starter credits further than A100. A 5s clip is ~$0.03–0.05 warm; the container
+  **scales to zero** when idle (`scaledown_window=120`).
+- First request is a cold start that downloads the model (~10GB) into a persistent
+  Modal Volume, so it happens only once.
+- Edit `GPU` at the top of `modal_ltx_endpoint.py` to change hardware (`"A10G"` cheaper
+  for short clips, `"A100"` for large batches).
+
+## Notes
+
+- `scaledown_window` is the current Modal parameter name; on older `modal` versions it
+  is `container_idle_timeout` — rename if deploy errors on it.
+- The endpoint returns raw MP4 bytes, matching `generate_ltx_modal_video`, so no
+  external storage/bucket is required.

--- a/deploy/modal_ltx_endpoint.py
+++ b/deploy/modal_ltx_endpoint.py
@@ -1,0 +1,147 @@
+"""Modal deploy: self-hosted LTX-Video endpoint for OpenMontage (cheap draft/bulk video).
+
+This is the GPU endpoint that `tools/video/ltx_video_modal.py` calls. It returns raw
+MP4 bytes, matching the contract in `tools/video/_shared.py::generate_ltx_modal_video`,
+which POSTs JSON:
+
+    {prompt, width, height, num_frames, fps, steps, negative_prompt,
+     seed?, input_image? (base64), input_image_url?}
+
+and accepts either video bytes (content-type video/*) or JSON {"video_url": ...}.
+This endpoint returns bytes, so no external storage is needed.
+
+── Deploy (run locally; needs `pip install modal` + `python3 -m modal setup`) ──
+    modal deploy deploy/modal_ltx_endpoint.py
+Copy the printed web URL (…--generate.modal.run) and point the app at it:
+    export MODAL_LTX2_ENDPOINT_URL="https://<your-workspace>--openmontage-ltx-ltx-generate.modal.run"
+
+Cost note: LTX is light. On an L40S (~$1.95/hr serverless) a 5s clip is ~$0.03-0.05
+warm; the container scales to zero when idle. Bump GPU to A100 only for big batches.
+"""
+
+import base64
+import io
+import os
+import tempfile
+
+import modal
+
+APP_NAME = "openmontage-ltx"
+MODEL_ID = "Lightricks/LTX-Video"  # diffusers-integrated LTX-Video (fast, ~24GB)
+# LTX fits comfortably on L40S (48GB) and stretches Starter credits further than A100.
+# A10G (24GB) also works for short clips with VAE tiling; A100 for large batches.
+GPU = "L40S"
+
+image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .apt_install("ffmpeg")
+    .pip_install(
+        "torch>=2.4",
+        "diffusers>=0.32.0",
+        "transformers>=4.44",
+        "accelerate",
+        "sentencepiece",
+        "imageio",
+        "imageio-ffmpeg",
+        "pillow",
+        "hf_transfer",
+        "requests",
+        "fastapi[standard]",
+    )
+    .env({"HF_HUB_ENABLE_HF_TRANSFER": "1", "HF_HOME": "/cache/hf"})
+)
+
+app = modal.App(APP_NAME)
+# Persist model weights across cold starts so they download only once.
+hf_cache = modal.Volume.from_name("openmontage-hf-cache", create_if_missing=True)
+
+
+@app.cls(
+    image=image,
+    gpu=GPU,
+    volumes={"/cache": hf_cache},
+    timeout=900,
+    # scaledown_window is the current Modal name (older versions: container_idle_timeout).
+    scaledown_window=120,
+)
+class LTX:
+    @modal.enter()
+    def load(self):
+        import torch
+        from diffusers import LTXPipeline
+
+        self.torch = torch
+        self.pipe = LTXPipeline.from_pretrained(MODEL_ID, torch_dtype=torch.bfloat16)
+        self.pipe.to("cuda")
+        self.pipe.vae.enable_tiling()  # memory safety on smaller GPUs
+        self._i2v = None
+
+    def _image_pipe(self):
+        # Lazily build the image-to-video pipeline sharing the loaded weights.
+        if self._i2v is None:
+            from diffusers import LTXImageToVideoPipeline
+
+            self._i2v = LTXImageToVideoPipeline.from_pipe(self.pipe)
+        return self._i2v
+
+    @modal.fastapi_endpoint(method="POST")
+    def generate(self, payload: dict):
+        from fastapi import Response
+        from diffusers.utils import export_to_video
+
+        prompt = payload["prompt"]
+        width = int(payload.get("width", 1024))
+        height = int(payload.get("height", 576))
+        num_frames = int(payload.get("num_frames", 121))
+        steps = int(payload.get("steps", 30))
+        fps = int(payload.get("fps", 24))
+        negative = payload.get("negative_prompt", "")
+
+        generator = None
+        if payload.get("seed") is not None:
+            generator = self.torch.Generator("cuda").manual_seed(int(payload["seed"]))
+
+        kwargs = dict(
+            prompt=prompt,
+            negative_prompt=negative,
+            width=width,
+            height=height,
+            num_frames=num_frames,
+            num_inference_steps=steps,
+            generator=generator,
+        )
+
+        pipe = self.pipe
+        ref = self._load_ref_image(payload)
+        if ref is not None:
+            pipe = self._image_pipe()
+            kwargs["image"] = ref.resize((width, height))
+
+        frames = pipe(**kwargs).frames[0]
+
+        tmp = tempfile.NamedTemporaryFile(suffix=".mp4", delete=False)
+        tmp.close()
+        try:
+            export_to_video(frames, tmp.name, fps=fps)
+            data = open(tmp.name, "rb").read()
+        finally:
+            os.remove(tmp.name)
+
+        return Response(content=data, media_type="video/mp4")
+
+    @staticmethod
+    def _load_ref_image(payload: dict):
+        """Decode the image_to_video reference (base64 or URL), or None for text_to_video."""
+        from PIL import Image
+
+        b64 = payload.get("input_image")
+        url = payload.get("input_image_url")
+        if b64:
+            return Image.open(io.BytesIO(base64.b64decode(b64))).convert("RGB")
+        if url:
+            import requests
+
+            resp = requests.get(url, timeout=60)
+            resp.raise_for_status()
+            return Image.open(io.BytesIO(resp.content)).convert("RGB")
+        return None

--- a/tests/tools/test_ltx_modal_contract.py
+++ b/tests/tools/test_ltx_modal_contract.py
@@ -1,0 +1,101 @@
+"""Contract tests for the LTX-on-Modal path.
+
+The Modal endpoint itself can't run here (GPU + weights), but the *contract* between
+the app-side client (tools/video/_shared.py::generate_ltx_modal_video) and the deploy
+script (deploy/modal_ltx_endpoint.py) is verifiable without Modal:
+
+- the client POSTs exactly the keys the endpoint reads, and
+- the deploy script is valid Python that reads those same keys.
+
+Also checks the realistic cost that makes the quality_tier 'draft' lane prefer LTX.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+import requests
+
+import tools.video._shared as shared
+from tools.video.ltx_video_modal import LTXVideoModal
+
+DEPLOY_SCRIPT = Path(__file__).resolve().parents[2] / "deploy" / "modal_ltx_endpoint.py"
+
+# Keys the endpoint's generate() reads from the JSON body.
+ENDPOINT_KEYS = {"prompt", "width", "height", "num_frames", "steps", "fps", "negative_prompt"}
+
+
+class _FakeResponse:
+    def __init__(self, content=b"", headers=None, json_body=None):
+        self.content = content
+        self.headers = headers or {"content-type": "video/mp4"}
+        self._json = json_body
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._json
+
+
+@pytest.fixture
+def captured_post(monkeypatch):
+    """Capture the JSON payload the client POSTs, returning fake MP4 bytes."""
+    captured = {}
+
+    def fake_post(url, json=None, timeout=None):
+        captured["url"] = url
+        captured["payload"] = json
+        return _FakeResponse(content=b"FAKEMP4")
+
+    monkeypatch.setenv("MODAL_LTX2_ENDPOINT_URL", "https://example--generate.modal.run")
+    # generate_ltx_modal_video does `import requests` internally, so patch the module.
+    monkeypatch.setattr(requests, "post", fake_post)
+    return captured
+
+
+def test_text_to_video_payload_matches_endpoint(tmp_path, captured_post):
+    out = tmp_path / "clip.mp4"
+    result = shared.generate_ltx_modal_video({
+        "prompt": "a fox in snow",
+        "aspect_ratio": "16:9",
+        "output_path": str(out),
+    })
+    assert result.success is True
+    payload = captured_post["payload"]
+    # Every key the endpoint reads must be present, and nothing the endpoint needs is missing.
+    assert ENDPOINT_KEYS.issubset(payload.keys())
+    # LTX frame constraint the endpoint relies on: (num_frames - 1) % 8 == 0.
+    assert (payload["num_frames"] - 1) % 8 == 0
+    assert out.read_bytes() == b"FAKEMP4"
+
+
+def test_image_to_video_sends_base64(tmp_path, captured_post):
+    img = tmp_path / "ref.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+    out = tmp_path / "clip.mp4"
+    result = shared.generate_ltx_modal_video({
+        "prompt": "animate this",
+        "operation": "image_to_video",
+        "reference_image_path": str(img),
+        "output_path": str(out),
+    })
+    assert result.success is True
+    # Endpoint reads input_image (base64) for image_to_video.
+    assert "input_image" in captured_post["payload"]
+
+
+def test_cost_is_realistic_and_beats_premium_video_api():
+    # Must be well under the ~$0.30 premium-clip baseline so draft routing prefers LTX,
+    # and specifically < $0.05 so the scorer's cost_efficiency lane scores it top-tier.
+    cost = LTXVideoModal().estimate_cost({"prompt": "x"})
+    assert 0 < cost < 0.05
+
+
+def test_deploy_script_is_valid_python_and_reads_contract_keys():
+    src = DEPLOY_SCRIPT.read_text()
+    ast.parse(src)  # raises SyntaxError if the deploy script is malformed
+    # The endpoint must actually reference the payload keys the client sends.
+    for key in ENDPOINT_KEYS | {"seed", "input_image", "input_image_url"}:
+        assert key in src, f"deploy script never reads payload key {key!r}"

--- a/tools/video/ltx_video_modal.py
+++ b/tools/video/ltx_video_modal.py
@@ -87,7 +87,11 @@ class LTXVideoModal(BaseTool):
         return ToolStatus.AVAILABLE if os.environ.get("MODAL_LTX2_ENDPOINT_URL") else ToolStatus.UNAVAILABLE
 
     def estimate_cost(self, inputs: dict[str, object]) -> float:
-        return 0.25
+        # Self-hosted on a Modal L40S (~$1.95/hr serverless): a ~75s warm render of a
+        # 5s LTX clip ≈ $0.04 — an order of magnitude under premium video APIs (~$0.30/clip),
+        # which is what lets the quality_tier 'draft' lane route bulk video here.
+        # ponytail: flat estimate; scale by frames/GPU if you need tighter budgeting.
+        return 0.04
 
     def estimate_runtime(self, inputs: dict[str, object]) -> float:
         return 180.0


### PR DESCRIPTION
## Why

The biggest dollar lever in the cost-tiering initiative (`COST_OPTIMIZATION_RESEARCH.md`): self-host LTX-Video on a serverless GPU so **draft/bulk video costs ~$0.04/clip vs ~$0.30** on premium APIs. The tool `ltx_video_modal` already existed but had no endpoint to call — this provides it.

## Purely additive

Premium video APIs (Kling/Seedance/Veo via fal.ai) are untouched and stay the `hero`-tier choice. This only lights up the cheap `draft` lane.

## What

- **`deploy/modal_ltx_endpoint.py`** — a Modal app running LTX-Video, matching your existing GPU-web-function pattern (`voxarena-covers`, `flashhead-pro`). Returns **raw MP4 bytes**, a drop-in for `generate_ltx_modal_video`'s contract; supports text→video and image→video. Weights persist in a Modal Volume (download once). Defaults to **L40S** and **scales to zero** — cost-friendly for Starter credits.
- **`deploy/README.md`** — `modal deploy`, the one env var to set, a curl smoke test, GPU/cost notes.
- **`tools/video/ltx_video_modal.py`** — `estimate_cost` 0.25 → **0.04** (realistic L40S serverless). This is what makes the `quality_tier` `draft` lane actually route bulk video to LTX (the scorer's cost-efficiency now ranks it top-tier vs premium APIs).

## Deploy (user-run — needs your Modal auth + GPU)

```bash
pip install modal && python3 -m modal setup
modal deploy deploy/modal_ltx_endpoint.py
export MODAL_LTX2_ENDPOINT_URL="https://<workspace>--openmontage-ltx-ltx-generate.modal.run"
```

Then `ltx_video_modal` flips AVAILABLE and joins the video menu.

## Tests / verification

- 4 new tests (`tests/tools/test_ltx_modal_contract.py`): client↔endpoint **key contract**, image_to_video base64, realistic cost < $0.05, and **deploy script is valid Python that reads every contract key**.
- Green: **586 passed, 6 skipped**, stable across random orderings.
- The GPU render path can't be unit-tested without Modal, so the contract + cost + script-validity are covered; the diffusion call is a documented `ponytail:` calibration knob (confirm on first real deploy).

## Depends on

Routing benefit lands once **#299** (`quality_tier`) merges; the endpoint + tool work independently before that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)