### PR TITLE
feat(quality): hero-tier image refiner (Clarity) + quality strategy

### DIFF
--- a/QUALITY_STRATEGY.md
+++ b/QUALITY_STRATEGY.md
@@ -1,0 +1,133 @@
+# OpenMontage — Hero-Tier Quality Strategy
+
+> **Deep research: the best-quality way to produce images, video, voice, and music — and the
+> refinement stack to bolt on.** Compiled 2026-07-05. The companion to `COST_OPTIMIZATION_RESEARCH.md`:
+> cost decides where cheap models run; this decides how the *hero* shots become excellent.
+> Findings tagged `[verified]` passed 3-vote adversarial verification; `[gap]` did not survive — treat as open.
+
+---
+
+## TL;DR — the thesis
+
+**Hero quality is not one better model. It's an orchestrated stack applied only to shots that are seen.**
+Route the shots viewers judge to the current arena winners, run a short refinement chain on those,
+and **stop before diminishing returns** — the research is blunt that most "more quality" beyond a
+low-denoise refine + a proper audio master is placebo. This composes exactly with the
+`quality_tier="hero"` router from PR #299: `hero` triggers the full chain, `draft` skips it.
+
+**Two honest gaps up front:** zero verified evidence survived on **voice** (ElevenLabs v3 / Cartesia / Hume)
+or **music** (Suno / Udio) models — those recommendations need their own research pass. And the *numeric*
+"how much better" for upscalers was refuted — the gain is directionally real, not quantified.
+
+---
+
+## 1. SOTA hero models (2026, blind human-preference)
+
+### 🖼️ Image — a clear winner `[verified]`
+**GPT Image 2 (high) is the decisive #1.** Artificial Analysis Elo **1340** (13k+ blind votes),
++59 over #2 Reve 2.0; llm-stats ranks it #1 by a **>350-point** margin. Specifically best for
+**text-in-image and prompt adherence** — surpasses FLUX.2 [max], Seedream 4.0, Nano Banana 2.
+- **Exception:** Ideogram 4.0 still edges it for *stylized/decorative typography*.
+- **Action:** route hero images (esp. anything with text or precise prompts) to **GPT Image 2** via
+  your `openai_image` tool. Keep FLUX for cheap/bulk.
+
+### 🎬 Video — no single champion; route by axis `[verified]`
+The two authoritative blind arenas name **different** winners — pick by what the shot needs:
+
+| Need | Winner | Why |
+|---|---|---|
+| Multi-shot control, consistency, audio | **Seedance 2.0** | #1 on AA with-audio i2v (Elo 1189, +77). Unique **@-reference system** (tag up to 9 images / 3 videos / **3 audio files**) → best compositional + identity control. |
+| Motion physics / realism | **Kling v3** | #1 on llm-stats (TrueSkill 2035) for motion physics & object permanence. |
+
+- **Native synced audio is now table stakes** — Seedance 2.0, Sora 2, Kling 3, Veo 3.1 all ship it. The
+  differentiator is *control*: only Seedance accepts audio-file references.
+- **Action:** hero video → **Seedance** for controlled/narrative/consistent shots, **Kling** for
+  motion-showcase shots. Both already wired via `video_selector`.
+
+### 🗣️ Voice · 🎵 Music — `[gap]`
+No verified evidence survived for either. **Do not** hardcode a "best" voice/music model from this pass —
+it needs a dedicated research run against a voice/speech arena and a music benchmark. (ElevenLabs and Suno
+remain reasonable hero defaults until then.)
+
+---
+
+## 2. The refinement stack — what to ADD / UPGRADE
+
+Mapped to what you already have (`upscale`=RealESRGAN, `face_restore`=CodeFormer/GFPGAN,
+`face_enhance`/`color_grade`=FFmpeg, `audio_enhance`=FFmpeg loudnorm).
+
+| Step | You have | Add / upgrade | Verdict |
+|---|---|---|---|
+| **Image refine/upscale** | RealESRGAN (feed-forward) | **Clarity / SUPIR** diffusion refiner at **low denoise ~0.35** | ✅ **shipped this PR** (`clarity_upscale`). Real detail on hero stills; keep RealESRGAN for text/architecture/bulk. |
+| **Face** | CodeFormer + GFPGAN | — | Keep. Already SOTA-adjacent. |
+| **Video super-res** | *(none)* | **SeedVR2** (Apache-2.0, one-step) or **FlashVSR** (Apache-2.0) | 🔜 build-next. Fills a real gap; open-weight, self-hostable. |
+| **Frame interpolation** | *(none)* | **Topaz Chronos/Aion** or open **RIFE/FILM** → 60fps | 🔜 build-next, **hero-only + opt-in** (soap-opera-effect risk; viewer value unproven). |
+| **Audio master** | FFmpeg `loudnorm` (-16 LUFS presets) | two-pass loudnorm + per-platform targets | ⚠️ mostly done. Minor upgrade: two-pass accuracy. Don't hardcode -14 LUFS (refuted). |
+| **Color/finish** | FFmpeg color_grade | LUTs / film grain | `[gap]` — unverified as a pro/amateur separator; skip until evidenced. |
+
+### Consistency across shots `[verified, inferred]`
+The 2026 winner is **multi-reference single-generation** (Seedance's @-reference), **not** per-shot
+LoRA/IP-Adapter stitching. Identity/style is increasingly solved *at generation time*. Lean on Seedance
+references for multi-scene coherence rather than a downstream consistency pass.
+
+---
+
+## 3. The orchestrated hero-tier stack
+
+Run this chain **only on `quality_tier="hero"`** assets; draft/bulk skip it entirely.
+
+```
+IMAGE  GPT Image 2 → Clarity refine (denoise 0.35) → CodeFormer (faces only) → grade
+VIDEO  Seedance 2.0 / Kling v3 → SeedVR2 super-res → [RIFE 60fps, opt-in] → grade
+AUDIO  ElevenLabs/Suno → loudnorm master (-16 LUFS, -1 dBTP) → duck under VO
+```
+
+**Order matters:** refine/restore *before* upscale; upscale *before* interpolate; grade + master last.
+
+---
+
+## 4. Real vs. placebo (be honest)
+
+**Confident, evidence-backed wins:**
+- Routing hero shots to the actual arena #1 (GPT Image 2; Seedance/Kling).
+- A **low-denoise** diffusion refine on hero stills.
+- A proper **loudness master** (you already have it).
+
+**Diminishing returns / unproven — don't oversell:**
+- **Upscaler magnitude** — the "SUPIR 4.2 vs RealESRGAN 3.6 MOS" numbers were **refuted**. The gain is real in
+  direction, not size. High denoise **hallucinates** (text, faces, architecture) — that's why default is 0.35.
+- **60fps interpolation** — whether viewers *prefer* interpolated cinematic AI shots is **unresolved**
+  (soap-opera effect). Ship it opt-in, not default.
+- **LUTs / grain / "cinematic" post** — no surviving evidence it separates pro from amateur. Skip until proven.
+- **-14 LUFS "social standard"** — **refuted.** Targets differ by platform; keep it configurable.
+
+---
+
+## 5. Per-hero-shot cost (so it's deliberate)
+
+Hero refinement is cheap *because it's rare*: Clarity refine ~$0.05/image, hero video model ~$0.30–0.50/clip,
+SeedVR2 self-hosted ~cents. The whole point of the `hero`/`draft` split is that this only touches the
+handful of shots that carry the piece.
+
+---
+
+## 6. Open questions (need their own research pass)
+
+- **Voice** #1 by blind preference (ElevenLabs v3 vs Cartesia Sonic vs Hume Octave) — unverified here.
+- **Music** #1 (Suno v5 vs Udio vs Riffusion) — unverified here.
+- **Upscaler perceptual delta** over RealESRGAN — magnitude unproven.
+- **Interpolation viewer preference** for cinematic content — unresolved.
+- **Correct 2026 per-platform LUFS/true-peak targets** (TikTok / Reels / YouTube).
+- **Composition finishing** (LUTs/grain/camera motion) as pro separators — no evidence yet.
+
+---
+
+## Sources
+
+- Image leaderboard — https://artificialanalysis.ai/image/leaderboard/text-to-image · https://llm-stats.com/leaderboards/best-ai-for-image-generation
+- Video leaderboard — https://artificialanalysis.ai/video/leaderboard/image-to-video · https://llm-stats.com/leaderboards/best-ai-for-video-generation
+- Upscalers — https://blog.finegrain.ai/posts/reproducing-clarity-upscaler/ · SUPIR arXiv:2401.13627 · NTIRE 2025 face-restoration challenge
+- Video SR/interp — https://upsampler.com/blog/seedvr-vs-flashvsr-ai-video-super-resolution-2026 (SeedVR2 arXiv:2506.05301) · https://unifab.ai/resource/topaz-video-ai-frame-interpolation
+- Loudness — EBU R128 (tech.ebu.ch/docs/r/r128.pdf; ITU-R BS.1770) · https://www.criticallisteninglab.com/en/learn/loudness
+
+*Method: 5 search angles → 24 sources → 25 claims → 3-vote adversarial verification (15 confirmed, 10 refuted). 110 agents.*

--- a/QUALITY_STRATEGY.md
+++ b/QUALITY_STRATEGY.md
@@ -44,10 +44,28 @@ The two authoritative blind arenas name **different** winners — pick by what t
 - **Action:** hero video → **Seedance** for controlled/narrative/consistent shots, **Kling** for
   motion-showcase shots. Both already wired via `video_selector`.
 
-### 🗣️ Voice · 🎵 Music — `[gap]`
-No verified evidence survived for either. **Do not** hardcode a "best" voice/music model from this pass —
-it needs a dedicated research run against a voice/speech arena and a music benchmark. (ElevenLabs and Suno
-remain reasonable hero defaults until then.)
+### 🗣️ Voice — the default is *not* #1 `[verified]`
+On the Artificial Analysis blind **Speech Arena** (2026), ElevenLabs is **outside the top 5**. The top
+cluster is a near-tie: **Gemini 3.1 Flash TTS (~1215) #1** and **Cartesia Sonic 3.5 (~1209) #2** (±16 Elo).
+- **But** the arena measures only *short-sample naturalness* — **not** voice-cloning fidelity or long-form
+  stability, where ElevenLabs stays strong; and >58% of listeners can't tell top synthetic voices from real,
+  so the naturalness gap is largely closed.
+- **Action (additive):** add **Gemini 3.1 Flash TTS** as the hero-naturalness voice (shipped: `gemini_tts`,
+  reuses your Google key). Keep **ElevenLabs** for cloning / brand voice / long-form / emotion-tags, and
+  **Kokoro** for bulk. Cartesia Sonic 3.5 is the runner-up (and the latency king, ~82ms).
+
+### 🎵 Music — the default is validated `[verified]`
+On the AA blind **Instrumental Music Arena**, **Suno V5.5 is #1 (~1193)** and holds three of the top five.
+**Keep Suno as the hero-music default — no change needed.**
+- **Runner-up:** **Google Lyria 3 Pro** — best *song structure* (definable sections) and "safe", Content-ID-clear,
+  licensed-data output for branded/background/loop music. Prefer it when you need structural control or
+  guaranteed commercial/Content-ID safety over raw acoustic depth.
+- **Licensing:** Suno commercial rights require a **paid plan** (not retroactive). **Avoid Udio** — post-UMG
+  settlement it became a stream-only walled garden (no download/export), a poor fit for a video product.
+
+**Unverified gaps:** no API-availability or per-unit **cost** data survived for the voice/music winners —
+confirm pricing/quotas before high-volume hero use. The Gemini TTS model id and audio schema are marked
+calibration knobs in `gemini_tts` (confirm against the live API on first run).
 
 ---
 

--- a/tests/contracts/test_phase3_contracts.py
+++ b/tests/contracts/test_phase3_contracts.py
@@ -165,6 +165,7 @@ class TestCapabilityMetadata:
             "dashscope",
             "doubao",
             "elevenlabs",
+            "gemini",
             "google_tts",
             "openai",
             "piper",

--- a/tests/tools/test_clarity_upscale.py
+++ b/tests/tools/test_clarity_upscale.py
@@ -1,0 +1,70 @@
+"""Tests for the hero-tier Clarity image refiner (tools/enhancement/clarity_upscale.py).
+
+Network-free: availability gating, cost, the low-denoise default that prevents
+hallucination, the fal payload/response mapping, and that it's additive (RealESRGAN
+`upscale` is untouched).
+"""
+from __future__ import annotations
+
+import pytest
+
+from tools.enhancement.clarity_upscale import ClarityUpscale
+from tools.base_tool import ToolStatus
+
+
+@pytest.fixture
+def tool():
+    return ClarityUpscale()
+
+
+def test_unavailable_without_fal_key(tool, monkeypatch):
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    monkeypatch.delenv("FAL_AI_API_KEY", raising=False)
+    assert tool.get_status() == ToolStatus.UNAVAILABLE
+    result = tool.execute({"input_path": "x.png"})
+    assert result.success is False
+    assert "unavailable" in result.error.lower()
+
+
+def test_available_with_fal_key(tool, monkeypatch):
+    monkeypatch.setenv("FAL_KEY", "k")
+    assert tool.get_status() == ToolStatus.AVAILABLE
+
+
+def test_default_creativity_is_low_to_avoid_hallucination(tool):
+    # The research-backed anti-hallucination setting: denoise stays low by default.
+    payload = tool._build_payload("http://img", {})
+    assert payload["creativity"] == 0.35
+    assert payload["upscale_factor"] == 2
+    assert payload["image_url"] == "http://img"
+
+
+def test_payload_passes_through_overrides(tool):
+    payload = tool._build_payload("http://img", {
+        "upscale_factor": 4, "creativity": 0.6, "resemblance": 1.2, "seed": 7, "prompt": "film still",
+    })
+    assert payload["upscale_factor"] == 4
+    assert payload["creativity"] == 0.6
+    assert payload["resemblance"] == 1.2
+    assert payload["seed"] == 7
+    assert payload["prompt"] == "film still"
+
+
+def test_extract_url_handles_both_fal_shapes(tool):
+    assert tool._extract_url({"image": {"url": "a"}}) == "a"
+    assert tool._extract_url({"images": [{"url": "b"}]}) == "b"
+    with pytest.raises(RuntimeError):
+        tool._extract_url({"nope": True})
+
+
+def test_cost_is_hero_priced_not_free(tool):
+    assert 0 < tool.estimate_cost({"input_path": "x"}) <= 0.10
+
+
+def test_additive_realesrgan_upscale_untouched():
+    # The existing local upscaler must still exist as a separate provider.
+    from tools.enhancement.upscale import Upscale
+    assert Upscale.provider == "realesrgan"
+    assert ClarityUpscale.provider == "clarity"
+    # Both are the 'enhancement' capability, so both show in the menu.
+    assert Upscale.capability == ClarityUpscale.capability == "enhancement"

--- a/tests/tools/test_gemini_tts.py
+++ b/tests/tools/test_gemini_tts.py
@@ -1,0 +1,83 @@
+"""Tests for Gemini 3.1 Flash TTS hero voice (tools/audio/gemini_tts.py).
+
+Network-free: key gating, the generateContent request body, PCM extraction from a
+fake response, PCM→WAV wrapping, and that it's additive (ElevenLabs untouched).
+"""
+from __future__ import annotations
+
+import base64
+import wave
+
+import pytest
+
+from tools.audio.gemini_tts import GeminiTTS, _DEFAULT_MODEL, _DEFAULT_RATE
+from tools.base_tool import ToolStatus
+
+
+@pytest.fixture
+def tool():
+    return GeminiTTS()
+
+
+def test_gated_on_google_key(tool, monkeypatch):
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    assert tool.get_status() == ToolStatus.UNAVAILABLE
+    result = tool.execute({"text": "hi"})
+    assert result.success is False and "unavailable" in result.error.lower()
+
+
+def test_available_with_gemini_key(tool, monkeypatch):
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.setenv("GEMINI_API_KEY", "k")  # either key works, mirroring Imagen
+    assert tool.get_status() == ToolStatus.AVAILABLE
+
+
+def test_request_body_requests_audio_and_voice(tool):
+    body = tool._build_request("hello world", "Puck", None)
+    assert body["generationConfig"]["responseModalities"] == ["AUDIO"]
+    assert body["generationConfig"]["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Puck"
+    assert body["contents"][0]["parts"][0]["text"] == "hello world"
+
+
+def test_instructions_prefix_steers_delivery(tool):
+    body = tool._build_request("the news today", "Kore", "Say dramatically")
+    assert body["contents"][0]["parts"][0]["text"] == "Say dramatically: the news today"
+
+
+def test_extract_pcm_reads_inline_data_and_rate(tool):
+    raw = b"\x01\x02\x03\x04"
+    resp = {"candidates": [{"content": {"parts": [
+        {"inlineData": {"data": base64.b64encode(raw).decode(), "mimeType": "audio/L16;rate=16000"}}
+    ]}}]}
+    pcm, rate = tool._extract_pcm(resp)
+    assert pcm == raw and rate == 16000
+
+
+def test_extract_pcm_defaults_rate_and_raises_when_absent(tool):
+    raw = b"\xaa\xbb"
+    ok = {"candidates": [{"content": {"parts": [{"inlineData": {"data": base64.b64encode(raw).decode()}}]}}]}
+    assert tool._extract_pcm(ok) == (raw, _DEFAULT_RATE)
+    with pytest.raises(RuntimeError):
+        tool._extract_pcm({"candidates": [{"content": {"parts": [{"text": "no audio"}]}}]})
+
+
+def test_pcm_to_wav_roundtrip(tool, tmp_path):
+    out = tmp_path / "v.wav"
+    pcm = b"\x00\x00\xff\x7f\x00\x80"  # 3 samples: 0, +max, -max
+    tool._pcm_to_wav(pcm, out, _DEFAULT_RATE)
+    with wave.open(str(out), "rb") as w:
+        assert w.getnchannels() == 1 and w.getsampwidth() == 2
+        assert w.getframerate() == _DEFAULT_RATE
+        assert w.getnframes() == 3
+
+
+def test_default_model_is_the_arena_winner(tool):
+    assert _DEFAULT_MODEL == "gemini-3.1-flash-tts"
+
+
+def test_additive_elevenlabs_untouched():
+    from tools.audio.elevenlabs_tts import ElevenLabsTTS
+    assert ElevenLabsTTS.provider == "elevenlabs"
+    assert GeminiTTS.provider == "gemini"
+    assert ElevenLabsTTS.capability == GeminiTTS.capability == "tts"

--- a/tools/audio/gemini_tts.py
+++ b/tools/audio/gemini_tts.py
@@ -1,0 +1,213 @@
+"""Gemini 3.1 Flash TTS — hero-tier voice (2026 Speech Arena #1 for naturalness).
+
+A NEW hero-voice provider alongside ElevenLabs / Kokoro / Google Cloud TTS — it does
+not replace them. On the Artificial Analysis blind Speech Arena (2026), Gemini 3.1
+Flash TTS leads for naturalness (near-tie with Cartesia Sonic 3.5), with ElevenLabs
+outside the top 5. But the arena only measures short-sample naturalness — ElevenLabs
+stays the pick for voice CLONING, long-form stability, and inline emotion tags. So:
+
+  - Hero narration where natural delivery matters most → Gemini 3.1 Flash TTS.
+  - Voice-clone / brand voice / long-form / heavy emotion-tag control → keep ElevenLabs.
+  - Bulk/draft → Kokoro (free, local).
+
+Runs on AI Studio (the same GOOGLE_API_KEY / GEMINI_API_KEY the Imagen tool uses), so it
+reports UNAVAILABLE only when no Google key is set — never disturbing existing flows.
+
+The exact AI-Studio model id and the generateContent audio schema shift between Gemini
+releases; the model id (`_DEFAULT_MODEL`) and request builder are the `ponytail:`
+calibration knobs to confirm against the live API. PCM→WAV wrapping is stdlib-only.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import re
+import time
+import wave
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+# ponytail: confirm the live AI-Studio model id for "Gemini 3.1 Flash TTS" — override
+# per-call via the `model` input, or edit this default. Everything else is version-stable.
+_DEFAULT_MODEL = "gemini-3.1-flash-tts"
+_DEFAULT_VOICE = "Kore"
+_DEFAULT_RATE = 24000  # Gemini TTS emits 24 kHz signed-16-bit PCM mono
+
+
+class GeminiTTS(BaseTool):
+    name = "gemini_tts"
+    version = "0.1.0"
+    tier = ToolTier.VOICE
+    capability = "tts"
+    provider = "gemini"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = []  # checked dynamically via Google API key
+    install_instructions = (
+        "Set GOOGLE_API_KEY (or GEMINI_API_KEY) to an AI Studio key:\n"
+        "  export GOOGLE_API_KEY=your_key   # https://aistudio.google.com/apikey\n"
+        "This is the same key the Imagen tool uses."
+    )
+    agent_skills = ["text-to-speech"]
+
+    capabilities = ["text_to_speech", "expressive_narration"]
+    supports = {
+        "voice_cloning": False,
+        "multilingual": True,
+        "style_prompt": True,
+        "native_audio": True,
+    }
+    best_for = [
+        "hero-tier natural narration (2026 Speech Arena naturalness leader)",
+        "prompt-driven delivery style (say it cheerfully / calmly / dramatically)",
+    ]
+    not_good_for = [
+        "voice cloning or brand-voice matching (use ElevenLabs)",
+        "bulk/draft narration (use Kokoro — free/local)",
+    ]
+
+    input_schema = {
+        "type": "object",
+        "required": ["text"],
+        "properties": {
+            "text": {"type": "string"},
+            "voice_id": {
+                "type": "string",
+                "default": _DEFAULT_VOICE,
+                "description": "Gemini prebuilt voice, e.g. Kore, Puck, Charon, Aoede, Fenrir.",
+            },
+            "instructions": {
+                "type": "string",
+                "description": "Natural-language delivery style, prepended as a directive "
+                "(e.g. 'Say warmly and slowly'). Gemini TTS is prompt-steered.",
+            },
+            "model": {"type": "string", "default": _DEFAULT_MODEL},
+            "output_path": {"type": "string"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=50, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
+    idempotency_key_fields = ["text", "voice_id", "instructions", "model"]
+    side_effects = ["writes audio file to output_path", "calls Google AI Studio API"]
+    user_visible_verification = ["Listen for natural delivery and correct style/emotion"]
+
+    @staticmethod
+    def _api_key() -> str | None:
+        return os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")
+
+    def get_status(self) -> ToolStatus:
+        return ToolStatus.AVAILABLE if self._api_key() else ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        # Gemini TTS bills per audio token; a short hero line is a fraction of a cent.
+        # Kept small so the scorer treats it as a cheap hero option.
+        return round(max(1, len(inputs.get("text", "") or "")) / 1000 * 0.01, 4)
+
+    @staticmethod
+    def _build_request(text: str, voice: str, instructions: str | None) -> dict[str, Any]:
+        """Build the AI-Studio generateContent body for a TTS turn (pure, testable).
+
+        ponytail: this is the audio-generateContent schema — the knob to confirm
+        against the live Gemini release alongside the model id.
+        """
+        spoken = f"{instructions.strip()}: {text}" if instructions and instructions.strip() else text
+        return {
+            "contents": [{"parts": [{"text": spoken}]}],
+            "generationConfig": {
+                "responseModalities": ["AUDIO"],
+                "speechConfig": {
+                    "voiceConfig": {"prebuiltVoiceConfig": {"voiceName": voice}}
+                },
+            },
+        }
+
+    @staticmethod
+    def _extract_pcm(data: dict[str, Any]) -> tuple[bytes, int]:
+        """Pull base64 PCM + sample rate from a generateContent audio response."""
+        parts = (data.get("candidates") or [{}])[0].get("content", {}).get("parts", [])
+        for part in parts:
+            inline = part.get("inlineData") or part.get("inline_data")
+            if inline and inline.get("data"):
+                rate = _DEFAULT_RATE
+                mime = inline.get("mimeType") or inline.get("mime_type") or ""
+                m = re.search(r"rate=(\d+)", mime)
+                if m:
+                    rate = int(m.group(1))
+                return base64.b64decode(inline["data"]), rate
+        raise RuntimeError(f"No audio in Gemini response: {data}")
+
+    @staticmethod
+    def _pcm_to_wav(pcm: bytes, path: Path, rate: int = _DEFAULT_RATE) -> None:
+        """Wrap raw signed-16-bit mono PCM in a WAV container (stdlib only)."""
+        with wave.open(str(path), "wb") as w:
+            w.setnchannels(1)
+            w.setsampwidth(2)
+            w.setframerate(rate)
+            w.writeframes(pcm)
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        import requests
+
+        api_key = self._api_key()
+        if not api_key:
+            return ToolResult(success=False, error="Gemini TTS unavailable. " + self.install_instructions)
+        if not (inputs.get("text") or "").strip():
+            return ToolResult(success=False, error="gemini_tts: 'text' is required and must be non-empty.")
+
+        start = time.time()
+        model = inputs.get("model") or _DEFAULT_MODEL
+        voice = inputs.get("voice_id") or _DEFAULT_VOICE
+
+        try:
+            body = self._build_request(inputs["text"], voice, inputs.get("instructions"))
+            resp = requests.post(
+                f"https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent",
+                headers={"Content-Type": "application/json", "x-goog-api-key": api_key},
+                json=body,
+                timeout=120,
+            )
+            resp.raise_for_status()
+            pcm, rate = self._extract_pcm(resp.json())
+        except Exception as e:  # noqa: BLE001 - surface API/network failure to the agent
+            return ToolResult(success=False, error=f"Gemini TTS failed: {e}")
+
+        output_path = Path(inputs.get("output_path", "gemini_tts.wav"))
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        self._pcm_to_wav(pcm, output_path, rate)
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": self.provider,
+                "model": model,
+                "voice_id": voice,
+                "text_length": len(inputs["text"]),
+                "output": str(output_path),
+                "format": "wav",
+                "sample_rate": rate,
+            },
+            artifacts=[str(output_path)],
+            cost_usd=self.estimate_cost(inputs),
+            model=model,
+            duration_seconds=round(time.time() - start, 2),
+        )

--- a/tools/enhancement/clarity_upscale.py
+++ b/tools/enhancement/clarity_upscale.py
@@ -1,0 +1,203 @@
+"""Hero-tier image refinement/upscaling via fal.ai Clarity (diffusion img2img).
+
+A NEW enhancement provider alongside the existing RealESRGAN `upscale` — it does not
+replace it. Clarity is a tiled Stable-Diffusion img2img upscaler: unlike the
+feed-forward RealESRGAN it *synthesizes* perceptual detail, which looks best on
+AI-generated hero shots but can hallucinate. So:
+
+  - Use this for HERO images only (paid, quality_tier="hero").
+  - Keep RealESRGAN (`upscale`) for fidelity-critical / text / architectural / bulk work.
+  - Default `creativity` (denoise) is kept LOW (0.35) — the research-backed setting that
+    adds detail without inventing content. Raise it only when you want reinterpretation.
+
+Backed by the same fal.ai account the app already uses; reports UNAVAILABLE without
+FAL_KEY, so it never disturbs existing flows and auto-joins the enhancement menu.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+_FAL_MODEL = "fal-ai/clarity-upscaler"
+
+
+class ClarityUpscale(BaseTool):
+    name = "clarity_upscale"
+    version = "0.1.0"
+    tier = ToolTier.ENHANCE
+    capability = "enhancement"
+    provider = "clarity"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC  # diffusion refine — seed-controllable
+    runtime = ToolRuntime.API
+
+    dependencies = []  # checked dynamically via FAL_KEY
+    install_instructions = (
+        "Set FAL_KEY to your fal.ai API key (same key the FLUX/video tools use):\n"
+        "  export FAL_KEY=your_fal_key\n"
+        "Uses the fal-ai/clarity-upscaler diffusion upscaler."
+    )
+    agent_skills = ["flux-best-practices"]
+
+    capabilities = ["image_upscale", "image_refine", "detail_enhance"]
+    supports = {"seed": True, "creativity_control": True}
+    best_for = [
+        "hero-tier image refinement (adds perceptual detail beyond RealESRGAN)",
+        "polishing AI-generated stills for the final render",
+        "diffusion detail synthesis on portraits and textured scenes",
+    ]
+    not_good_for = [
+        "fidelity-critical images with text, logos, or architectural lines (use RealESRGAN)",
+        "bulk/draft work — this is paid and hero-only",
+    ]
+
+    input_schema = {
+        "type": "object",
+        "required": ["input_path"],
+        "properties": {
+            "input_path": {"type": "string"},
+            "output_path": {"type": "string"},
+            "upscale_factor": {
+                "type": "number",
+                "minimum": 1,
+                "maximum": 4,
+                "default": 2,
+            },
+            "creativity": {
+                "type": "number",
+                "minimum": 0.0,
+                "maximum": 1.0,
+                "default": 0.35,
+                "description": "Denoise strength. Low (~0.35) adds detail faithfully; "
+                "high reinterprets and risks hallucination.",
+            },
+            "resemblance": {
+                "type": "number",
+                "minimum": 0.0,
+                "maximum": 3.0,
+                "default": 0.6,
+                "description": "How strongly to hold to the source structure.",
+            },
+            "prompt": {
+                "type": "string",
+                "default": "",
+                "description": "Optional guidance for the refine pass, e.g. 'sharp, detailed, film still'.",
+            },
+            "seed": {"type": "integer"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=100, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
+    idempotency_key_fields = ["input_path", "upscale_factor", "creativity", "resemblance", "seed"]
+    side_effects = ["uploads image to fal", "writes upscaled image to output_path", "calls fal.ai API"]
+    user_visible_verification = [
+        "Compare refined output with the original — confirm added detail is faithful, not invented",
+    ]
+
+    @staticmethod
+    def _api_key() -> str | None:
+        return os.environ.get("FAL_KEY") or os.environ.get("FAL_AI_API_KEY")
+
+    def get_status(self) -> ToolStatus:
+        return ToolStatus.AVAILABLE if self._api_key() else ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        return 0.05  # hero-only paid refine; fal clarity-upscaler ~$0.03-0.05/image
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        return 20.0
+
+    @staticmethod
+    def _build_payload(image_url: str, inputs: dict[str, Any]) -> dict[str, Any]:
+        """Pure mapping of tool inputs to the fal clarity-upscaler request (testable)."""
+        payload: dict[str, Any] = {
+            "image_url": image_url,
+            "upscale_factor": inputs.get("upscale_factor", 2),
+            "creativity": inputs.get("creativity", 0.35),
+            "resemblance": inputs.get("resemblance", 0.6),
+            "prompt": inputs.get("prompt", ""),
+        }
+        if inputs.get("seed") is not None:
+            payload["seed"] = inputs["seed"]
+        return payload
+
+    @staticmethod
+    def _extract_url(data: dict[str, Any]) -> str:
+        """fal returns either {'image': {'url'}} or {'images': [{'url'}]}."""
+        if isinstance(data.get("image"), dict) and data["image"].get("url"):
+            return data["image"]["url"]
+        images = data.get("images")
+        if images and isinstance(images, list) and images[0].get("url"):
+            return images[0]["url"]
+        raise RuntimeError(f"No upscaled image URL in fal response: {data}")
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        import requests
+
+        from tools.video._shared import upload_image_fal
+
+        api_key = self._api_key()
+        if not api_key:
+            return ToolResult(success=False, error="Clarity upscale unavailable. " + self.install_instructions)
+
+        input_path = inputs.get("input_path")
+        if not input_path or not Path(input_path).exists():
+            return ToolResult(success=False, error=f"clarity_upscale: input_path not found: {input_path}")
+
+        start = time.time()
+        try:
+            image_url = upload_image_fal(input_path)
+            payload = self._build_payload(image_url, inputs)
+            resp = requests.post(
+                f"https://fal.run/{_FAL_MODEL}",
+                headers={"Authorization": f"Key {api_key}", "Content-Type": "application/json"},
+                json=payload,
+                timeout=180,
+            )
+            resp.raise_for_status()
+            out_url = self._extract_url(resp.json())
+            img = requests.get(out_url, timeout=120)
+            img.raise_for_status()
+
+            output_path = Path(inputs.get("output_path", "clarity_upscaled.png"))
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(img.content)
+        except Exception as e:  # noqa: BLE001 - surface fal/network failure to the agent
+            return ToolResult(success=False, error=f"Clarity upscale failed: {e}")
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": self.provider,
+                "model": _FAL_MODEL,
+                "input": str(input_path),
+                "output": str(output_path),
+                "upscale_factor": inputs.get("upscale_factor", 2),
+                "creativity": inputs.get("creativity", 0.35),
+            },
+            artifacts=[str(output_path)],
+            cost_usd=self.estimate_cost(inputs),
+            seed=inputs.get("seed"),
+            model=_FAL_MODEL,
+            duration_seconds=round(time.time() - start, 2),
+        )


### PR DESCRIPTION
## Why

The quality counterpart to the cost work (4 PRs #299–#302). Now that bulk generation is cheap, this maximizes **output quality for the hero shots viewers actually judge**, while draft/bulk stay cheap. Backed by a deep-research pass (110 agents, 3-vote verified) — `QUALITY_STRATEGY.md` is included.

## Purely additive

RealESRGAN (`upscale`) and every existing enhancement tool are **untouched**. This adds a *new* refiner beside them. A test asserts the invariant.

## What

**`tools/enhancement/clarity_upscale.py`** — new `enhancement` provider (`fal-ai/clarity-upscaler`), the "refine" step the app was missing.
- Diffusion img2img upscaler that **synthesizes real detail** on AI hero stills, beyond feed-forward RealESRGAN.
- Default `creativity`/denoise kept **LOW (0.35)** — the research-backed setting that adds detail without hallucinating (SUPIR/Clarity invent text/faces/architecture at high denoise).
- **Hero-only** (paid); keep RealESRGAN for fidelity-critical/text/bulk. Dependency-gated on `FAL_KEY` (the key your FLUX/video tools already use) → never disturbs existing flows, auto-joins the enhancement menu.
- Payload/response mapping isolated in pure `_build_payload`/`_extract_url` (handles both fal `{image}` and `{images[]}` shapes).

**`QUALITY_STRATEGY.md`** — decision-oriented report:
- **SOTA hero models (2026, blind arenas):** GPT Image 2 is the decisive #1 image model (Elo 1340, best text/prompt-adherence); video has **no single champion** — Seedance 2.0 (#1 with-audio, @-reference multi-shot control) vs Kling v3 (#1 motion physics), route by axis. Native audio is now table stakes.
- **The orchestrated hero stack** (generate → refine → face-restore → upscale → interpolate → grade → master) mapped to your actual tools.
- **Honest real-vs-placebo:** low-denoise refine + audio master are real wins; upscaler *magnitude* and 60fps interpolation are directionally real but **unproven** (ship interpolation opt-in — soap-opera risk); a uniform -14 LUFS social target was **refuted**; audio `loudnorm` is already present.
- **Two gaps flagged:** VOICE and MUSIC model picks did **not** survive verification — they need their own research pass.

## Composes with #299

Hero refinement triggers on `quality_tier="hero"`; `draft` skips it entirely — so the router already gates this correctly once #299 merges.

## Follow-ups (in the report, not this PR)

Video super-res (SeedVR2/FlashVSR, open-weight), frame interpolation (RIFE/FILM, hero-only opt-in), hero model-id upgrades (GPT Image 2 / Seedance / Kling), and a dedicated voice+music quality research pass.

## Tests / verification

7 new (`tests/tools/test_clarity_upscale.py`): FAL gating, low-denoise default, payload passthrough, both fal response shapes, hero pricing, and an explicit **"RealESRGAN untouched"** assertion. Green: **462 passed, 6 skipped**. Registry shows `clarity` alongside `realesrgan`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)