### PR TITLE
fix(style_bridge): read playbook typography/pace from their real schema keys

### DIFF
--- a/lib/hyperframes_style_bridge.py
+++ b/lib/hyperframes_style_bridge.py
@@ -107,6 +107,7 @@ def style_bridge(
         palette = vl.get("color_palette", {}) or {}
         typo = playbook.get("typography", {}) or {}
         identity = playbook.get("identity", {}) or {}
+        motion = playbook.get("motion", {}) or {}
 
         bg = _first(palette.get("background"), css["--color-bg"])
         fg = _first(palette.get("text"), css["--color-fg"])
@@ -116,7 +117,10 @@ def style_bridge(
         surface = _first(palette.get("surface"), css["--color-surface"])
         muted = _first(palette.get("muted_text"), css["--color-muted"])
 
-        duration, ease = _motion_easing(identity.get("pace"))
+        # Pace lives under `identity` in the current schema; older/custom
+        # playbooks placed it under `motion`. Prefer the schema key, fall back
+        # to the legacy location so existing callers keep working.
+        duration, ease = _motion_easing(identity.get("pace") or motion.get("pace"))
 
         css.update(
             {
@@ -127,7 +131,11 @@ def style_bridge(
                 "--color-secondary": secondary,
                 "--color-surface": surface,
                 "--color-muted": muted,
-                "--font-heading": _font(typo, "headings", css["--font-heading"]),
+                # Schema key is `headings` (plural); legacy/custom playbooks used
+                # `heading` (singular). Prefer the schema key, fall back to legacy.
+                "--font-heading": _font(
+                    typo, "headings", _font(typo, "heading", css["--font-heading"])
+                ),
                 "--font-body": _font(typo, "body", css["--font-body"]),
                 "--font-mono": _font(typo, "code", css["--font-mono"]),
                 "--ease-primary": ease,

--- a/lib/hyperframes_style_bridge.py
+++ b/lib/hyperframes_style_bridge.py
@@ -57,14 +57,26 @@ def _font(typo: dict[str, Any], key: str, default: str) -> str:
     return default
 
 
-def _motion_easing(motion: dict[str, Any]) -> tuple[str, str]:
-    """Derive (duration, ease) from the playbook motion block."""
-    pace = (motion.get("pace") or "moderate").lower()
-    if pace == "fast":
-        return "0.4s", "cubic-bezier(0.33, 1, 0.68, 1)"
-    if pace == "slow":
-        return "0.9s", "cubic-bezier(0.65, 0, 0.35, 1)"
-    return "0.6s", "cubic-bezier(0.5, 0, 0.5, 1)"
+_FAST_EASE = "cubic-bezier(0.33, 1, 0.68, 1)"
+_SLOW_EASE = "cubic-bezier(0.65, 0, 0.35, 1)"
+_MODERATE_EASE = "cubic-bezier(0.5, 0, 0.5, 1)"
+
+# Keyed by the `identity.pace` enum (schema: slow/deliberate/moderate/fast/rapid).
+# Every enum value must be covered here — an unmapped-but-valid pace would
+# silently collapse to the moderate default.
+_PACE_MOTION = {
+    "rapid": ("0.3s", _FAST_EASE),
+    "fast": ("0.4s", _FAST_EASE),
+    "moderate": ("0.6s", _MODERATE_EASE),
+    "deliberate": ("0.8s", _SLOW_EASE),
+    "slow": ("0.9s", _SLOW_EASE),
+}
+
+
+def _motion_easing(pace: Any) -> tuple[str, str]:
+    """Derive (duration, ease) from the playbook's `identity.pace` value."""
+    key = pace.lower() if isinstance(pace, str) else "moderate"
+    return _PACE_MOTION.get(key, _PACE_MOTION["moderate"])
 
 
 def style_bridge(
@@ -94,7 +106,7 @@ def style_bridge(
         vl = playbook.get("visual_language", {}) or {}
         palette = vl.get("color_palette", {}) or {}
         typo = playbook.get("typography", {}) or {}
-        motion = playbook.get("motion", {}) or {}
+        identity = playbook.get("identity", {}) or {}
 
         bg = _first(palette.get("background"), css["--color-bg"])
         fg = _first(palette.get("text"), css["--color-fg"])
@@ -104,7 +116,7 @@ def style_bridge(
         surface = _first(palette.get("surface"), css["--color-surface"])
         muted = _first(palette.get("muted_text"), css["--color-muted"])
 
-        duration, ease = _motion_easing(motion)
+        duration, ease = _motion_easing(identity.get("pace"))
 
         css.update(
             {
@@ -115,7 +127,7 @@ def style_bridge(
                 "--color-secondary": secondary,
                 "--color-surface": surface,
                 "--color-muted": muted,
-                "--font-heading": _font(typo, "heading", css["--font-heading"]),
+                "--font-heading": _font(typo, "headings", css["--font-heading"]),
                 "--font-body": _font(typo, "body", css["--font-body"]),
                 "--font-mono": _font(typo, "code", css["--font-mono"]),
                 "--ease-primary": ease,

--- a/tests/lib/test_style_bridge_playbook_keys.py
+++ b/tests/lib/test_style_bridge_playbook_keys.py
@@ -83,3 +83,31 @@ def test_empty_playbook_still_renders_fallback():
     assert css["--font-heading"] == "Inter"
     assert css["--duration-entrance"] == "0.6s"
     assert "# DESIGN" in design_md
+
+
+def test_legacy_playbook_keys_still_work():
+    # Older/custom playbooks placed heading under `typography.heading` (singular)
+    # and pace under `motion.pace`. These must keep working as a fallback.
+    legacy = {
+        "name": "legacy",
+        "typography": {"heading": {"font": "Space Grotesk"}, "body": {"font": "Inter"}},
+        "motion": {"pace": "fast"},
+    }
+    css, _ = style_bridge(legacy)
+    assert css["--font-heading"] == "Space Grotesk"
+    assert css["--duration-entrance"] == "0.4s"
+
+
+def test_schema_keys_win_over_legacy_keys():
+    # When both shapes are present, the current schema keys take precedence.
+    both = {
+        "typography": {
+            "headings": {"font": "Montserrat"},
+            "heading": {"font": "Space Grotesk"},
+        },
+        "identity": {"pace": "slow"},
+        "motion": {"pace": "fast"},
+    }
+    css, _ = style_bridge(both)
+    assert css["--font-heading"] == "Montserrat"
+    assert css["--duration-entrance"] == "0.9s"  # identity.pace=slow wins

--- a/tests/lib/test_style_bridge_playbook_keys.py
+++ b/tests/lib/test_style_bridge_playbook_keys.py
@@ -1,0 +1,85 @@
+"""Regression tests: HyperFrames style bridge reads the playbook's real keys.
+
+Two defects, both silently dropping a schema-valid style choice back to the
+built-in fallback:
+
+  1. Heading font was read from ``typography.heading`` (singular). The playbook
+     schema defines ``typography.headings`` (plural, ``additionalProperties:
+     false``), so the singular key never existed and every composition fell back
+     to the default "Inter" heading font. ``body`` / ``code`` used the correct
+     keys, which isolates this to a key typo rather than a general failure.
+
+  2. Motion pace was read from ``motion.pace``. The schema puts ``pace`` under
+     ``identity`` (enum: slow/deliberate/moderate/fast/rapid); ``motion`` has
+     ``additionalProperties: false`` and no ``pace``. So the fast/slow branches
+     were dead and every playbook rendered the moderate default. The fix also
+     covers every enum value — previously even a correctly-placed
+     ``deliberate`` / ``rapid`` would have collapsed to moderate.
+"""
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from lib.hyperframes_style_bridge import style_bridge  # noqa: E402
+
+
+def _playbook(pace: str) -> dict:
+    return {
+        "name": "test-playbook",
+        "identity": {"pace": pace},
+        "typography": {
+            "headings": {"font": "Montserrat", "weight": 700},
+            "body": {"font": "Lora", "weight": 400},
+            "code": {"font": "Fira Code"},
+        },
+        "motion": {"animation_style": "smooth"},
+    }
+
+
+def test_heading_font_read_from_plural_key():
+    css, _ = style_bridge(_playbook("moderate"))
+    assert css["--font-heading"] == "Montserrat"
+    # body/code use their real keys and must keep working.
+    assert css["--font-body"] == "Lora"
+    assert css["--font-mono"] == "Fira Code"
+
+
+def test_pace_read_from_identity_block():
+    fast, _ = style_bridge(_playbook("fast"))
+    slow, _ = style_bridge(_playbook("slow"))
+    assert fast["--duration-entrance"] == "0.4s"
+    assert slow["--duration-entrance"] == "0.9s"
+    assert fast["--duration-entrance"] != slow["--duration-entrance"]
+
+
+def test_all_enum_paces_are_distinct_and_covered():
+    # Every schema enum value must map to its own motion profile — none may
+    # silently collapse to the moderate default.
+    durations = {
+        pace: style_bridge(_playbook(pace))[0]["--duration-entrance"]
+        for pace in ("slow", "deliberate", "moderate", "fast", "rapid")
+    }
+    assert durations["rapid"] == "0.3s"
+    assert durations["fast"] == "0.4s"
+    assert durations["moderate"] == "0.6s"
+    assert durations["deliberate"] == "0.8s"
+    assert durations["slow"] == "0.9s"
+    # deliberate and rapid must not be the moderate default.
+    assert durations["deliberate"] != durations["moderate"]
+    assert durations["rapid"] != durations["moderate"]
+
+
+def test_missing_or_unknown_pace_falls_back_to_moderate():
+    for playbook in ({"identity": {}}, {"identity": {"pace": "bogus"}}, {}):
+        css, _ = style_bridge(playbook)
+        assert css["--duration-entrance"] == "0.6s"
+
+
+def test_empty_playbook_still_renders_fallback():
+    css, design_md = style_bridge(None)
+    assert css["--font-heading"] == "Inter"
+    assert css["--duration-entrance"] == "0.6s"
+    assert "# DESIGN" in design_md


### PR DESCRIPTION
## What

`lib/hyperframes_style_bridge.py` read two playbook style tokens from keys that do not exist in the playbook schema, so both silently fell back to the built-in defaults:

- **Heading font** read `typography.heading` (singular). The schema defines `typography.headings` (plural, `additionalProperties: false`), and `playbook_generator` writes `headings`. Every HyperFrames composition rendered the fallback `Inter` heading font regardless of the playbook. `body`/`code` used the correct keys, isolating this to a key typo.
- **Motion pace** read `motion.pace`. The schema places `pace` under `identity` (enum `slow|deliberate|moderate|fast|rapid`); `motion` is `additionalProperties: false` with no `pace`, so the fast/slow branches were dead and every render used the moderate default. Pace is now sourced from `identity.pace`, and the mapping covers every enum value so a valid `deliberate`/`rapid` no longer collapses to moderate.

## Why

Playbook style choices (heading font, motion pace) were dropped for HyperFrames renders — the output silently used fallback defaults, diverging from both the playbook and the equivalent Remotion `themeConfig` path.

## Tests

New `tests/lib/test_style_bridge_playbook_keys.py`:
- plural heading key resolves; body/mono keep working
- pace sourced from `identity`; fast vs slow differ
- all five enum paces map to distinct motion profiles
- missing/unknown pace + empty-playbook path fall back safely

```
pytest tests/lib/test_style_bridge_playbook_keys.py -q -> 5 passed
```
Confirmed the three behavioral tests fail on `main` before the fix.

Closes #306