### PR TITLE
fix(comfyui): T2V workflow pairs 14B models with the 5B VAE, breaking every run at VAEDecode

### DIFF
--- a/tools/_comfyui/workflows/wan22-t2v-4step.json
+++ b/tools/_comfyui/workflows/wan22-t2v-4step.json
@@ -24,7 +24,7 @@
   "4": {
     "class_type": "VAELoader",
     "inputs": {
-      "vae_name": "wan2.2_vae.safetensors"
+      "vae_name": "wan_2.1_vae.safetensors"
     }
   },
   "5": {

--- a/tools/video/comfyui_video.py
+++ b/tools/video/comfyui_video.py
@@ -57,7 +57,7 @@ _REQUIRED_MODELS_T2V = [
     *_REQUIRED_MODELS_COMMON,
     "wan2.2_t2v_high_noise_14B_fp8_scaled.safetensors",
     "wan2.2_t2v_low_noise_14B_fp8_scaled.safetensors",
-    "wan2.2_vae.safetensors",
+    "wan_2.1_vae.safetensors",
     "wan2.2_t2v_lightx2v_4steps_lora_v1.1_high_noise.safetensors",
     "wan2.2_t2v_lightx2v_4steps_lora_v1.1_low_noise.safetensors",
 ]


### PR DESCRIPTION
## Problem

The bundled T2V workflow `tools/_comfyui/workflows/wan22-t2v-4step.json` pairs the **WAN 2.2 14B FP8** diffusion models (`wan2.2_t2v_high_noise_14B_fp8_scaled.safetensors` / `wan2.2_t2v_low_noise_14B_fp8_scaled.safetensors`) with the wrong VAE: its `VAELoader` references `wan2.2_vae.safetensors`, which is the **WAN 2.2 5B** model's VAE and expects 48-channel latents. The 14B models produce 16-channel latents, so every text-to-video run through this workflow fails at the `VAEDecode` node.

## Repro

1. Install the models listed in `_REQUIRED_MODELS_T2V` (`tools/video/comfyui_video.py`).
2. Run any T2V generation through `comfyui_video` (or queue `wan22-t2v-4step.json` directly in ComfyUI).
3. Sampling completes, then `VAEDecode` fails with:

```
Expected tensor to have size 48 at dimension 1, but got size 16
```

## Fix

- `wan22-t2v-4step.json`: `vae_name` → `wan_2.1_vae.safetensors`, the VAE the WAN 2.2 14B models require. This matches the sibling `wan22-i2v-4step.json`, which already uses it with the same 14B FP8 model family.
- `tools/video/comfyui_video.py`: update `_REQUIRED_MODELS_T2V` to list `wan_2.1_vae.safetensors` so the preflight/required-models check matches the VAE the workflow actually loads (previously it would demand a model the workflow no longer uses, and not check for the one it does).

Verified locally: with the corrected VAE, the same workflow decodes and renders T2V output successfully on a RTX 4090.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
