### PR TITLE
docs(env): add missing FAL_AI_API_KEY alias, REPLICATE_API_TOKEN, HIGGSFIELD credentials (§8 #11)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,17 @@
 # --- Image + video gateway ---
 FAL_KEY=                     # FLUX images, Google Veo video, Kling video, MiniMax video, Recraft images
                              # Get one at https://fal.ai/dashboard/keys
+FAL_AI_API_KEY=              # Alias for FAL_KEY (some SDKs/docs use this name); either one is read.
+
+# --- Replicate ---
+REPLICATE_API_TOKEN=         # Replicate-hosted video gen (seedance_replicate). Needed to make the
+                             # Replicate-backed Seedance path selectable alongside the fal.ai one.
+                             # Get one at https://replicate.com/account/api-tokens
+
+# --- Higgsfield ---
+HIGGSFIELD_API_KEY=          # Higgsfield Cloud key (higgsfield_video). Pair with the secret below,
+HIGGSFIELD_API_SECRET=       # or use the combined HIGGSFIELD_KEY="<key>:<secret>" form instead.
+# HIGGSFIELD_KEY=            # Combined key:secret — set this INSTEAD of the _KEY/_SECRET pair if you prefer.
 
 # --- Google (one key unlocks image gen + TTS) ---
 GOOGLE_API_KEY=              # Google Imagen images, Google Cloud TTS (700+ voices, 50+ languages)


### PR DESCRIPTION
## Summary

`.env.example` drift — provider tools read these env vars but the example file never listed them, so a fresh setup silently misses them.

- **`FAL_AI_API_KEY`** — read by `kling`/`minimax`/`veo`/`seedance`/`recraft`/`flux` as an alias for `FAL_KEY` (`os.environ.get("FAL_KEY") or os.environ.get("FAL_AI_API_KEY")`), but only `FAL_KEY` was documented.
- **`REPLICATE_API_TOKEN`** — required by `seedance_replicate`; without it the Replicate-backed Seedance path stays unselectable.
- **`HIGGSFIELD_API_KEY` / `_API_SECRET` / `HIGGSFIELD_KEY`** — the three forms `higgsfield_video.py` accepts (combined `key:secret` vs split pair).

Doc-only, zero runtime change.

## Verification

Manual diff against `grep -rn` of env-var reads in `tools/` — every referenced var now appears in `.env.example`.

## Refs

`docs/REVIEW-image-to-video-voice.md` §8 #11.

---
Review-gated — happy to take feedback. Not blocking on anything downstream.
