### PR TITLE
fix(grok_video): set quality_score=0.9 to stop under-ranking (§8 #6)

### DIFF
--- a/tests/tools/test_grok_video_quality_score.py
+++ b/tests/tools/test_grok_video_quality_score.py
@@ -1,0 +1,23 @@
+"""Regression for grok_video quality_score (REVIEW §8 #6).
+
+Every premium video provider sets a quality_score (seedance 0.95, runway /
+higgsfield 0.9) so the scorer ranks them above stock/local options. grok_video
+— which ships native synchronized audio (lip-sync + dialogue + SFX in a single
+pass) — had none, so it was ranked only on supports/stability flags and
+under-ranked. This pins the field and confirms it surfaces in get_info().
+"""
+
+from __future__ import annotations
+
+from tools.video.grok_video import GrokVideo
+
+
+def test_grok_video_has_quality_score():
+    assert GrokVideo.quality_score is not None
+    # On par with the other native-audio/premium providers (0.9–0.95).
+    assert GrokVideo.quality_score >= 0.9
+
+
+def test_quality_score_surfaces_in_tool_info():
+    info = GrokVideo().get_info()
+    assert info["quality_score"] == GrokVideo.quality_score

--- a/tools/video/grok_video.py
+++ b/tools/video/grok_video.py
@@ -83,6 +83,11 @@ class GrokVideo(BaseTool):
     ]
     not_good_for = ["offline generation"]
     fallback_tools = ["veo_video", "runway_video", "kling_video", "minimax_video"]
+    # Native synchronized audio (lip-sync + dialogue + SFX in one pass) puts
+    # Grok on par with the other premium providers; without a quality_score the
+    # scorer only counted supports/stability flags, under-ranking it relative to
+    # seedance (0.95) / runway / higgsfield (0.9). See lib/scoring.py.
+    quality_score = 0.9
 
     input_schema = {
         "type": "object",


### PR DESCRIPTION
## Summary

Every premium video provider sets a `quality_score` (`seedance` 0.95, `runway` / `higgsfield` 0.9) so the scorer ranks them above stock/local options. `grok_video` — which ships **native synchronized audio** (lip-sync + dialogue + SFX in a single generation pass) — had none, so it was ranked only on `supports`/stability flags and was likely under-ranked.

Set `quality_score = 0.9`, on par with the other native-audio premium providers.

## Tests

`tests/tools/test_grok_video_quality_score.py` (2 tests):
- field is set and `>= 0.9`
- it surfaces in `get_info()` (the scorer reads it there)

## Refs

`docs/REVIEW-image-to-video-voice.md` §8 #6.

---
Review-gated — happy to take feedback.
