### PR TITLE
[codex] Fix CI requests module isolation

### DIFF
--- a/tests/contracts/test_dashscope_tools.py
+++ b/tests/contracts/test_dashscope_tools.py
@@ -147,15 +147,14 @@ class TestContract:
         tool = cls()
         assert len(tool.user_visible_verification) > 0
 
-    def test_lazy_imports_requests(self, cls):
+    def test_lazy_imports_requests(self, cls, monkeypatch):
         """Tool module must not import requests at top level (registry
         discovery must stay fast)."""
         import importlib
         import sys
         # Remove requests from cache to simulate fresh import
         mod_name = cls.__module__
-        if "requests" in sys.modules:
-            del sys.modules["requests"]
+        monkeypatch.delitem(sys.modules, "requests", raising=False)
         # Re-import the tool module — should not pull in requests
         # (requests is imported inside execute(), not at module level)
         importlib.reload(sys.modules[mod_name])

--- a/tests/tools/test_music_gen_force_instrumental.py
+++ b/tests/tools/test_music_gen_force_instrumental.py
@@ -25,7 +25,10 @@ class _FakeResponse:
         return None
 
 
-def _install_fake_requests(captured: dict) -> types.ModuleType:
+def _install_fake_requests(
+    monkeypatch: pytest.MonkeyPatch,
+    captured: dict,
+) -> types.ModuleType:
     """Install a stub ``requests`` module that records the JSON payload."""
     fake = types.ModuleType("requests")
 
@@ -36,24 +39,25 @@ def _install_fake_requests(captured: dict) -> types.ModuleType:
         return _FakeResponse()
 
     fake.post = fake_post
-    sys.modules["requests"] = fake
+    monkeypatch.setitem(sys.modules, "requests", fake)
     return fake
 
 
 def test_force_instrumental_is_sent_true_by_default(monkeypatch, tmp_path):
     monkeypatch.setenv("ELEVENLABS_API_KEY", "test-key")
     captured: dict = {}
-    _install_fake_requests(captured)
+    _install_fake_requests(monkeypatch, captured)
     # Route the output to tmp_path so the test never writes music_output.mp3
     # into the repo root (the default output_path).
     out = tmp_path / "bg.mp3"
-    try:
-        MusicGen()._generate(
-            {"prompt": "gentle ambient", "duration_seconds": 10, "output_path": str(out)},
-            "test-key",
-        )
-    finally:
-        sys.modules.pop("requests", None)
+    MusicGen()._generate(
+        {
+            "prompt": "gentle ambient",
+            "duration_seconds": 10,
+            "output_path": str(out),
+        },
+        "test-key",
+    )
 
     assert "force_instrumental" in captured["payload"], "force_instrumental kwarg was never sent"
     assert captured["payload"]["force_instrumental"] is True
@@ -63,20 +67,17 @@ def test_force_instrumental_is_sent_true_by_default(monkeypatch, tmp_path):
 def test_explicit_vocal_opt_out_is_respected(monkeypatch, tmp_path):
     monkeypatch.setenv("ELEVENLABS_API_KEY", "test-key")
     captured: dict = {}
-    _install_fake_requests(captured)
+    _install_fake_requests(monkeypatch, captured)
     out = tmp_path / "vocals.mp3"
-    try:
-        MusicGen()._generate(
-            {
-                "prompt": "lead vocal pop",
-                "duration_seconds": 10,
-                "force_instrumental": False,
-                "output_path": str(out),
-            },
-            "test-key",
-        )
-    finally:
-        sys.modules.pop("requests", None)
+    MusicGen()._generate(
+        {
+            "prompt": "lead vocal pop",
+            "duration_seconds": 10,
+            "force_instrumental": False,
+            "output_path": str(out),
+        },
+        "test-key",
+    )
 
     assert captured["payload"]["force_instrumental"] is False
 

--- a/tests/tools/test_pixabay_per_page_clamp.py
+++ b/tests/tools/test_pixabay_per_page_clamp.py
@@ -1,8 +1,6 @@
 """Pixabay rejects per_page outside 3-200 with HTTP 400, so every
 Pixabay caller must clamp before building the request."""
 
-import requests
-
 from tools.graphics.pixabay_image import PixabayImage
 from tools.video.pixabay_video import PixabayVideo
 from tools.video.stock_sources.base import SearchFilters
@@ -25,10 +23,16 @@ def _capture_get(captured):
     return fake_get
 
 
+def _patch_requests_get(monkeypatch, captured):
+    import requests
+
+    monkeypatch.setattr(requests, "get", _capture_get(captured))
+
+
 def test_pixabay_video_tool_clamps_per_page(monkeypatch):
     monkeypatch.setenv("PIXABAY_API_KEY", "test-key")
     captured = {}
-    monkeypatch.setattr(requests, "get", _capture_get(captured))
+    _patch_requests_get(monkeypatch, captured)
 
     PixabayVideo().execute({"query": "sky", "per_page": 1})
     assert captured["params"]["per_page"] == 3
@@ -40,7 +44,7 @@ def test_pixabay_video_tool_clamps_per_page(monkeypatch):
 def test_pixabay_image_tool_clamps_per_page(monkeypatch):
     monkeypatch.setenv("PIXABAY_API_KEY", "test-key")
     captured = {}
-    monkeypatch.setattr(requests, "get", _capture_get(captured))
+    _patch_requests_get(monkeypatch, captured)
 
     PixabayImage().execute({"query": "sky", "per_page": 1})
     assert captured["params"]["per_page"] == 3
@@ -52,7 +56,7 @@ def test_pixabay_image_tool_clamps_per_page(monkeypatch):
 def test_pixabay_stock_source_clamps_per_page(monkeypatch):
     monkeypatch.setenv("PIXABAY_API_KEY", "test-key")
     captured = {}
-    monkeypatch.setattr(requests, "get", _capture_get(captured))
+    _patch_requests_get(monkeypatch, captured)
 
     source = PixabayVideoSource()
     source.search("sky", SearchFilters(per_page=1))


### PR DESCRIPTION
﻿## Summary
- restore requests import state in DashScope lazy-import tests using pytest monkeypatch
- install the music-gen fake requests module through monkeypatch so it is reverted after each test
- make Pixabay clamp tests patch requests at test execution time, matching the tools' lazy imports

## Root cause
Main CI was red because earlier tests deleted or replaced `sys.modules["requests"]` without restoring it. Later Pixabay clamp tests patched a stale requests module object while the tools imported a different one, causing real Pixabay calls with the test key.

## Validation
- `python -m pytest tests/contracts/test_dashscope_tools.py tests/tools/test_pixabay_per_page_clamp.py -q`
- `python -m pytest tests/tools/test_music_gen_force_instrumental.py tests/tools/test_pixabay_per_page_clamp.py -q`
- `python -m pytest tests/tools -q`
- `python -m py_compile tools/base_tool.py tools/tool_registry.py tools/cost_tracker.py tools/analysis/composition_validator.py`
- `python -m pytest -q` (requests/Pixabay failure fixed; one unrelated local Windows timing-budget failure in `tests/backlot/test_server.py`)
