### PR TITLE
Add Atlas Cloud integration skill

### DIFF
--- a/.agents/skills/atlas-cloud/SKILL.md
+++ b/.agents/skills/atlas-cloud/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: atlas-cloud
+description: Atlas Cloud integration guide for OpenMontage workflows covering text-to-video, text-to-image, OpenAI-compatible chat completions, media upload, async polling, and live model/schema discovery.
+metadata:
+  author: OpenMontage
+  version: "1.0.0"
+  tags: atlascloud, video-generation, image-generation, llm, api, polling
+  openclaw:
+    requires:
+      env:
+        - ATLASCLOUD_API_KEY
+    primaryEnv: ATLASCLOUD_API_KEY
+---
+
+# Atlas Cloud
+
+Use this skill when an OpenMontage workflow needs Atlas Cloud for AI media generation or OpenAI-compatible LLM calls.
+
+## Authentication
+
+Set `ATLASCLOUD_API_KEY` before making requests.
+
+```bash
+export ATLASCLOUD_API_KEY="your-api-key"
+```
+
+Do not print, log, or commit the API key. Request failures should redact the token from errors.
+
+## Base URLs
+
+| API | Base URL | Purpose |
+| --- | --- | --- |
+| Media Generation | `https://api.atlascloud.ai/api/v1` | Image/video generation, prediction polling, media upload |
+| LLM Chat | `https://api.atlascloud.ai/v1` | OpenAI-compatible chat completions |
+
+All authenticated calls use:
+
+```text
+Authorization: Bearer $ATLASCLOUD_API_KEY
+Content-Type: application/json
+```
+
+## Required Discovery Step
+
+Before using a model in a production workflow, fetch the live model list and then fetch the target model schema.
+
+```bash
+curl -s "https://api.atlascloud.ai/api/v1/models"
+```
+
+Use only entries with `display_console: true`. For media requests, read the model's `schema` URL and only send fields listed in `components.schemas.Input.properties`.
+
+## Verified Example Models
+
+These model IDs and parameters were checked against the live Atlas Cloud model list and schemas on 2026-07-08.
+
+| Task | Model | Endpoint |
+| --- | --- | --- |
+| Text-to-video | `bytedance/seedance-2.0-mini/text-to-video` | `POST /model/generateVideo` |
+| Text-to-image | `google/nano-banana-2-lite/text-to-image` | `POST /model/generateImage` |
+| Chat completions | `deepseek-ai/deepseek-v4-pro` | `POST /chat/completions` |
+
+## OpenMontage Fit
+
+Atlas Cloud is useful when a pipeline needs:
+
+- short text-to-video generation with optional native audio
+- image generation for storyboards, thumbnails, B-roll cards, or visual concepts
+- OpenAI-compatible chat calls without adding a provider-specific SDK
+- temporary media upload for image-to-video or image-editing workflows
+
+## Workflow
+
+1. Fetch `/models` and confirm the selected model is visible.
+2. Fetch the selected model schema before building the request body.
+3. Submit a generation request.
+4. Poll `/model/prediction/{prediction_id}` until a terminal status.
+5. Download output URLs promptly and store them as project assets.
+
+## Quick Reference
+
+- [references/api.md](references/api.md) - endpoints, schema-verified fields, polling rules, and error handling
+- [references/examples.md](references/examples.md) - minimal cURL and Python snippets for image, video, chat, and media upload

--- a/.agents/skills/atlas-cloud/references/api.md
+++ b/.agents/skills/atlas-cloud/references/api.md
@@ -1,0 +1,147 @@
+# Atlas Cloud API Reference
+
+## Live Model Discovery
+
+Atlas Cloud models and schemas change over time. Always fetch the current model list first:
+
+```bash
+curl -s "https://api.atlascloud.ai/api/v1/models"
+```
+
+Use only models with `display_console: true`. For media generation, fetch the model entry's `schema` URL and build request bodies from `components.schemas.Input.properties`.
+
+## Media Endpoints
+
+Base URL:
+
+```text
+https://api.atlascloud.ai/api/v1
+```
+
+### Text-to-video
+
+Endpoint:
+
+```text
+POST /model/generateVideo
+```
+
+Schema-verified model:
+
+```text
+bytedance/seedance-2.0-mini/text-to-video
+```
+
+Required fields:
+
+- `model`
+- `prompt`
+
+Optional fields from the live schema checked on 2026-07-08:
+
+- `duration`: `-1`, or `4` through `15`; default `5`
+- `resolution`: `480p`, `720p`, `720p-SR`, `1080p-SR`, `1440p-SR`; default `720p`
+- `ratio`: `16:9`, `4:3`, `1:1`, `3:4`, `9:16`, `21:9`, `adaptive`; default `adaptive`
+- `bitrate_mode`: `standard` or `high`; default `standard`
+- `generate_audio`: boolean; default `true`
+- `seed`: integer; default `-1`
+- `watermark`: boolean; default `false`
+- `return_last_frame`: boolean; default `false`
+
+### Text-to-image
+
+Endpoint:
+
+```text
+POST /model/generateImage
+```
+
+Schema-verified model:
+
+```text
+google/nano-banana-2-lite/text-to-image
+```
+
+Required fields:
+
+- `model`
+- `prompt`
+
+Optional fields from the live schema checked on 2026-07-08:
+
+- `aspect_ratio`: `auto`, `1:1`, `3:2`, `2:3`, `3:4`, `4:3`, `4:5`, `5:4`, `9:16`, `16:9`, `21:9`, `4:1`, `1:4`, `8:1`, `1:8`; default `auto`
+- `enable_base64_output`: boolean; default `false`
+- `enable_sync_mode`: boolean; default `false`
+- `resolution`: `1k`; default `1k`
+- `thinking_level`: `default`, `high`, `minimal`; default `default`
+
+## Polling
+
+Submit responses include a prediction id. Poll:
+
+```text
+GET /model/prediction/{prediction_id}
+```
+
+Treat these statuses as in-progress:
+
+- `starting`
+- `processing`
+- `running`
+- `queued`
+
+Treat these as successful terminal statuses:
+
+- `completed`
+- `succeeded`
+
+Treat these as failed terminal statuses:
+
+- `failed`
+- `canceled`
+- `cancelled`
+- `error`
+
+Poll every 3 seconds for image generation and every 5 to 10 seconds for video generation. Do not retry generation POST requests automatically because a retry can create duplicate billable tasks.
+
+## Media Upload
+
+Use upload only when a model needs a public URL but the source file is local.
+
+```text
+POST /model/uploadMedia
+Content-Type: multipart/form-data
+```
+
+The form field is `file`. The response includes a temporary `download_url`. Use uploaded media URLs only for Atlas Cloud generation tasks.
+
+## OpenAI-Compatible Chat
+
+Base URL:
+
+```text
+https://api.atlascloud.ai/v1
+```
+
+Endpoint:
+
+```text
+POST /chat/completions
+```
+
+Example model confirmed visible in the live model list on 2026-07-08:
+
+```text
+deepseek-ai/deepseek-v4-pro
+```
+
+Use the standard OpenAI chat-completions request format with `model`, `messages`, `temperature`, `max_tokens`, and `stream` as needed.
+
+## Error Handling
+
+- `401`: missing or invalid API key
+- `402`: insufficient account balance
+- `429`: rate limited; retry GET polling with backoff
+- `5xx`: provider or gateway error; retry GET polling, but do not blindly retry POST generation submissions
+
+Always include the provider endpoint, model id, prediction id, and terminal status in error messages. Never include the API key.

--- a/.agents/skills/atlas-cloud/references/examples.md
+++ b/.agents/skills/atlas-cloud/references/examples.md
@@ -1,0 +1,132 @@
+# Atlas Cloud Examples
+
+All examples expect:
+
+```bash
+export ATLASCLOUD_API_KEY="your-api-key"
+```
+
+## Text-to-video
+
+```bash
+curl -s -X POST "https://api.atlascloud.ai/api/v1/model/generateVideo" \
+  -H "Authorization: Bearer $ATLASCLOUD_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "bytedance/seedance-2.0-mini/text-to-video",
+    "prompt": "A locked-off product shot of a matte black camera rotating on a glass table, soft studio lighting",
+    "duration": 5,
+    "resolution": "720p",
+    "ratio": "16:9",
+    "generate_audio": true,
+    "watermark": false
+  }'
+```
+
+## Text-to-image
+
+```bash
+curl -s -X POST "https://api.atlascloud.ai/api/v1/model/generateImage" \
+  -H "Authorization: Bearer $ATLASCLOUD_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "google/nano-banana-2-lite/text-to-image",
+    "prompt": "A clean storyboard frame for a cinematic SaaS product demo, realistic studio lighting",
+    "aspect_ratio": "16:9",
+    "resolution": "1k",
+    "thinking_level": "default"
+  }'
+```
+
+## Poll a prediction
+
+```bash
+curl -s \
+  -H "Authorization: Bearer $ATLASCLOUD_API_KEY" \
+  "https://api.atlascloud.ai/api/v1/model/prediction/$PREDICTION_ID"
+```
+
+## Python polling helper
+
+```python
+import os
+import time
+import requests
+
+
+API_KEY = os.environ["ATLASCLOUD_API_KEY"]
+MEDIA_BASE_URL = "https://api.atlascloud.ai/api/v1"
+
+
+def poll_prediction(prediction_id: str, interval_seconds: float = 5.0, timeout_seconds: float = 300.0):
+    headers = {"Authorization": f"Bearer {API_KEY}"}
+    deadline = time.time() + timeout_seconds
+
+    while time.time() < deadline:
+        response = requests.get(
+            f"{MEDIA_BASE_URL}/model/prediction/{prediction_id}",
+            headers=headers,
+            timeout=30,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        data = payload.get("data", payload)
+        status = str(data.get("status", "")).lower()
+
+        if status in {"completed", "succeeded"}:
+            return data
+        if status in {"failed", "canceled", "cancelled", "error"}:
+            raise RuntimeError(f"Atlas Cloud generation failed: {data}")
+
+        time.sleep(interval_seconds)
+
+    raise TimeoutError(f"Timed out waiting for Atlas Cloud prediction {prediction_id}")
+```
+
+## Upload local media
+
+```python
+import os
+import requests
+
+
+API_KEY = os.environ["ATLASCLOUD_API_KEY"]
+
+
+def upload_media(path: str) -> str:
+    with open(path, "rb") as file_obj:
+        response = requests.post(
+            "https://api.atlascloud.ai/api/v1/model/uploadMedia",
+            headers={"Authorization": f"Bearer {API_KEY}"},
+            files={"file": file_obj},
+            timeout=120,
+        )
+    response.raise_for_status()
+    payload = response.json()
+    data = payload.get("data", payload)
+    return data["download_url"]
+```
+
+## OpenAI-compatible chat
+
+```python
+from openai import OpenAI
+import os
+
+
+client = OpenAI(
+    api_key=os.environ["ATLASCLOUD_API_KEY"],
+    base_url="https://api.atlascloud.ai/v1",
+)
+
+response = client.chat.completions.create(
+    model="deepseek-ai/deepseek-v4-pro",
+    messages=[
+        {"role": "system", "content": "You help plan concise video production steps."},
+        {"role": "user", "content": "Draft three shot ideas for a 15-second launch video."},
+    ],
+    max_tokens=512,
+)
+
+print(response.choices[0].message.content)
+```


### PR DESCRIPTION
## Summary
- add an Atlas Cloud skill for OpenMontage media and LLM workflows
- document live model discovery, schema-first request construction, async polling, media upload, and OpenAI-compatible chat usage
- include schema-verified examples for text-to-video and text-to-image without changing README files

## Verification
- fetched the live Atlas Cloud model list and confirmed the example model IDs are visible with display_console=true
- fetched and checked schemas for bytedance/seedance-2.0-mini/text-to-video and google/nano-banana-2-lite/text-to-image
- validated the new skill frontmatter and confirmed the diff only adds .agents/skills/atlas-cloud files

No README changes.