### PR TITLE
Portrait layout support for AnimeScene/ComparisonCard/KPIGrid + HeroTitle word-wrap

### DIFF
--- a/remotion-composer/SCENE_TYPES.md
+++ b/remotion-composer/SCENE_TYPES.md
@@ -16,7 +16,7 @@ When you add a new component, append it here and in `src/components/index.ts`.
 | `hero_title` | `HeroTitle` | `text` | `heroSubtitle`, `backgroundVideo`, `backgroundOverlay` | Title/end card |
 | `stat_card` | `StatCard` | `stat` | `subtitle`, `accentColor`, `backgroundVideo` | A single big number |
 | `callout` | `CalloutBox` | `text` | `callout_type` (info/warning/tip/quote), `title`, `backgroundVideo` | Boxed message with bullets |
-| `comparison` | `ComparisonCard` | `leftLabel`, `leftValue`, `rightLabel`, `rightValue` | `title`, `backgroundColor` | Side-by-side compare |
+| `comparison` | `ComparisonCard` | `leftLabel`, `leftValue`, `rightLabel`, `rightValue` | `title`, `backgroundColor`, `cardBackgroundColor`, `leftColor`, `rightColor` | Side-by-side compare (dark-theme: set `cardBackgroundColor`) |
 | `bar_chart` | `BarChart` | `chartData` | `chartAnimation`, `showValues`, `showGrid`, `backgroundVideo` | Animated bars |
 | `line_chart` | `LineChart` | `chartSeries` | `chartAnimation`, `xLabel`, `yLabel`, `showMarkers` | Animated line |
 | `pie_chart` | `PieChart` | `chartData` | `donut`, `centerLabel`, `centerValue`, `showLegend` | Pie / donut |

--- a/remotion-composer/src/Explainer.tsx
+++ b/remotion-composer/src/Explainer.tsx
@@ -202,6 +202,7 @@ interface Cut {
   subtitle?: string;
   callout_type?: "info" | "warning" | "tip" | "quote";
   title?: string;
+  fit?: "cover" | "contain-blurred"; // anime_scene: letterbox a portrait image on a landscape canvas
   // Video source trim — seek to this point in the source before playback.
   // Defaults to 0 (play from beginning). Use this instead of in_seconds for source trimming.
   source_in_seconds?: number;
@@ -268,6 +269,10 @@ interface Cut {
   screenshotSteps?: ScreenshotStep[];
   screenshotSize?: { width: number; height: number };
   cursorStartAt?: [number, number];
+  // Comparison card theming (type: "comparison")
+  cardBackgroundColor?: string;
+  leftColor?: string;
+  rightColor?: string;
 }
 
 interface Overlay {
@@ -589,12 +594,21 @@ const SceneRenderer: React.FC<{ cut: Cut; theme: ThemeConfig }> = ({ cut, theme 
         leftLabel={cut.leftLabel} rightLabel={cut.rightLabel}
         leftValue={cut.leftValue} rightValue={cut.rightValue}
         title={cut.title} backgroundColor={bgColor} textColor={textColor}
+        cardBackgroundColor={cut.cardBackgroundColor}
+        leftColor={cut.leftColor} rightColor={cut.rightColor}
       />
     );
   }
   if (cut.type === "hero_title" && cut.text) {
     return maybeWrapWithBg(
-      <HeroTitle title={cut.text} subtitle={cut.heroSubtitle || cut.subtitle} />
+      <HeroTitle
+        title={cut.text}
+        subtitle={cut.heroSubtitle || cut.subtitle}
+        textColor={cut.color || theme.textColor}
+        accentColor={accent}
+        subtitleColor={theme.mutedTextColor}
+        veil={Boolean(cut.backgroundImage || cut.backgroundVideo)}
+      />
     );
   }
   if (cut.type === "terminal_scene" && cut.steps) {
@@ -701,6 +715,7 @@ const SceneRenderer: React.FC<{ cut: Cut; theme: ThemeConfig }> = ({ cut, theme 
         lightingFrom={cut.lightingFrom}
         lightingTo={cut.lightingTo}
         sceneDurationSeconds={cut.out_seconds - cut.in_seconds}
+        fit={cut.fit as "cover" | "contain-blurred" | undefined}
       />
     );
   }
@@ -817,6 +832,7 @@ export const Explainer: React.FC<ExplainerProps> = (props) => {
           fontSize={42}
           highlightColor={theme.captionHighlightColor}
           backgroundColor={theme.captionBackgroundColor}
+          color={theme.captionTextColor}
         />
       )}
 

--- a/remotion-composer/src/Root.tsx
+++ b/remotion-composer/src/Root.tsx
@@ -35,6 +35,7 @@ export interface ThemeConfig {
   springConfig: { damping: number; stiffness: number; mass: number };
   transitionDuration: number;
   captionHighlightColor: string;
+  captionTextColor?: string; // word color; defaults to near-white for dark themes
   captionBackgroundColor: string;
 }
 

--- a/remotion-composer/src/components/AnimeScene.tsx
+++ b/remotion-composer/src/components/AnimeScene.tsx
@@ -68,6 +68,17 @@ export interface AnimeSceneProps {
    * length so crossfade/camera/lighting calculations use the correct range.
    */
   sceneDurationSeconds?: number;
+  /**
+   * "cover" (default) fills the frame, cropping whatever overflows — fine
+   * when the image and canvas share roughly the same aspect ratio. Portrait
+   * source images (e.g. host avatars, 768x1344) rendered on a landscape
+   * canvas need "contain-blurred" instead: a blurred/darkened cover-fit copy
+   * fills the frame as a backdrop, and the full undistorted image sits on
+   * top letterboxed — otherwise "cover" scales a portrait image ~2.5x to
+   * fill 1920x1080 width, leaving only the middle ~32% of its height
+   * visible, and the camera pan can push a face straight off-frame.
+   */
+  fit?: "cover" | "contain-blurred";
 }
 
 // ---------------------------------------------------------------------------
@@ -158,6 +169,7 @@ export const AnimeScene: React.FC<AnimeSceneProps> = ({
   lightingFrom,
   lightingTo,
   sceneDurationSeconds,
+  fit = "cover",
 }) => {
   const frame = useCurrentFrame();
   const { fps, durationInFrames } = useVideoConfig();
@@ -261,17 +273,38 @@ export const AnimeScene: React.FC<AnimeSceneProps> = ({
       {/* Layer 1: Image stack with crossfade + camera motion */}
       {images.map((src, i) => (
         <AbsoluteFill key={i}>
-          <Img
-            src={resolveAsset(src)}
-            style={{
-              width: "100%",
-              height: "100%",
-              objectFit: "cover",
-              opacity: getOpacity(i),
-              transform: `scale(${scale}) translate(${translateX}px, ${translateY}px)`,
-              willChange: "transform, opacity",
-            }}
-          />
+          {/* AbsoluteFill is a flex container — two Img siblings would
+              compete for flex space and both shrink/vanish. Each layer
+              gets its own nested AbsoluteFill, matching how the vignette
+              and particle layers below already stack independently. */}
+          {fit === "contain-blurred" && (
+            <AbsoluteFill>
+              <Img
+                src={resolveAsset(src)}
+                style={{
+                  width: "100%",
+                  height: "100%",
+                  objectFit: "cover",
+                  opacity: getOpacity(i),
+                  filter: "blur(48px) brightness(0.45) saturate(1.1)",
+                  transform: `scale(${scale * 1.15}) translate(${translateX}px, ${translateY}px)`,
+                }}
+              />
+            </AbsoluteFill>
+          )}
+          <AbsoluteFill>
+            <Img
+              src={resolveAsset(src)}
+              style={{
+                width: "100%",
+                height: "100%",
+                objectFit: fit === "contain-blurred" ? "contain" : "cover",
+                opacity: getOpacity(i),
+                transform: `scale(${scale}) translate(${translateX}px, ${translateY}px)`,
+                willChange: "transform, opacity",
+              }}
+            />
+          </AbsoluteFill>
         </AbsoluteFill>
       ))}
 

--- a/remotion-composer/src/components/ComparisonCard.tsx
+++ b/remotion-composer/src/components/ComparisonCard.tsx
@@ -46,7 +46,14 @@ export const ComparisonCard: React.FC<ComparisonCardProps> = ({
   valueFontSize = 72,
 }) => {
   const frame = useCurrentFrame();
-  const { fps } = useVideoConfig();
+  const { fps, width, height } = useVideoConfig();
+
+  // Portrait (e.g. 1080x1920 shorts): stack before above after with a
+  // horizontal divider, and rein in the value size so long phrases fit.
+  const portrait = height > width;
+  const effectiveValueFontSize = portrait
+    ? Math.min(valueFontSize, 56)
+    : valueFontSize;
 
   // Phase 1: Title + left side appears
   const titleOpacity = spring({
@@ -170,7 +177,7 @@ export const ComparisonCard: React.FC<ComparisonCardProps> = ({
         <div
           style={{
             display: "flex",
-            flexDirection: "row",
+            flexDirection: portrait ? "column" : "row",
             alignItems: "stretch",
             width: "100%",
             borderRadius: 16,
@@ -190,7 +197,7 @@ export const ComparisonCard: React.FC<ComparisonCardProps> = ({
               alignItems: "center",
               padding: "48px 32px",
               opacity: leftOpacity,
-              transform: `translateX(${leftSlide}px) scale(${leftScale})`,
+              transform: `translate${portrait ? "Y" : "X"}(${leftSlide}px) scale(${leftScale})`,
               gap: 16,
             }}
           >
@@ -221,7 +228,7 @@ export const ComparisonCard: React.FC<ComparisonCardProps> = ({
               style={{
                 fontFamily,
                 fontWeight: 800,
-                fontSize: valueFontSize,
+                fontSize: effectiveValueFontSize,
                 color: leftColor,
                 lineHeight: 1.1,
               }}
@@ -237,19 +244,30 @@ export const ComparisonCard: React.FC<ComparisonCardProps> = ({
               flexDirection: "column",
               alignItems: "center",
               justifyContent: "center",
-              width: 80,
+              width: portrait ? "100%" : 80,
+              height: portrait ? 64 : undefined,
               position: "relative",
             }}
           >
-            {/* Vertical divider line */}
+            {/* Divider line: vertical in landscape, horizontal in portrait */}
             <div
-              style={{
-                width: 2,
-                height: `${dividerDraw * 100}%`,
-                backgroundColor: "#D1D5DB",
-                position: "absolute",
-                top: `${((1 - dividerDraw) / 2) * 100}%`,
-              }}
+              style={
+                portrait
+                  ? {
+                      height: 2,
+                      width: `${dividerDraw * 100}%`,
+                      backgroundColor: "#D1D5DB",
+                      position: "absolute",
+                      left: `${((1 - dividerDraw) / 2) * 100}%`,
+                    }
+                  : {
+                      width: 2,
+                      height: `${dividerDraw * 100}%`,
+                      backgroundColor: "#D1D5DB",
+                      position: "absolute",
+                      top: `${((1 - dividerDraw) / 2) * 100}%`,
+                    }
+              }
             />
 
             {/* Change indicator badge */}
@@ -314,7 +332,7 @@ export const ComparisonCard: React.FC<ComparisonCardProps> = ({
               alignItems: "center",
               padding: "48px 32px",
               opacity: rightOpacity,
-              transform: `translateX(${rightSlide}px) scale(${rightScale})`,
+              transform: `translate${portrait ? "Y" : "X"}(${rightSlide}px) scale(${rightScale})`,
               gap: 16,
             }}
           >
@@ -345,7 +363,7 @@ export const ComparisonCard: React.FC<ComparisonCardProps> = ({
               style={{
                 fontFamily,
                 fontWeight: 800,
-                fontSize: valueFontSize,
+                fontSize: effectiveValueFontSize,
                 color: rightColor,
                 lineHeight: 1.1,
               }}

--- a/remotion-composer/src/components/HeroTitle.tsx
+++ b/remotion-composer/src/components/HeroTitle.tsx
@@ -9,62 +9,84 @@ import {
 interface HeroTitleProps {
   title: string;
   subtitle?: string;
+  textColor?: string; // non-accent title glyphs
+  accentColor?: string; // first-word accent + underline
+  subtitleColor?: string;
+  veil?: boolean; // dark radial behind the text — for busy media backgrounds
 }
 
-export const HeroTitle: React.FC<HeroTitleProps> = ({ title, subtitle }) => {
+export const HeroTitle: React.FC<HeroTitleProps> = ({
+  title,
+  subtitle,
+  textColor = "#F8FAFC",
+  accentColor = "#22D3EE",
+  subtitleColor = "#94A3B8",
+  veil = true,
+}) => {
   const frame = useCurrentFrame();
-  const { fps } = useVideoConfig();
+  const { fps, width, height } = useVideoConfig();
 
-  // Staggered letter-by-letter spring
-  const titleChars = title.split("");
+  // Wrap at WORD boundaries (per-char flex items wrap mid-word); letters
+  // still animate individually inside each word.
+  const words = title.split(" ");
+
+  // Scale down long titles instead of overflowing/wrapping to three lines.
+  const base = height > width ? 60 : 72;
+  const fontSize =
+    title.length > 55 ? Math.round(base * 0.66) : title.length > 35 ? Math.round(base * 0.8) : base;
+
+  let charIndex = 0;
 
   return (
     <AbsoluteFill
       style={{
         justifyContent: "center",
         alignItems: "center",
-        background:
-          "radial-gradient(ellipse at center, rgba(15,23,42,0.35) 0%, rgba(15,23,42,0.55) 100%)",
+        background: veil
+          ? "radial-gradient(ellipse at center, rgba(15,23,42,0.35) 0%, rgba(15,23,42,0.55) 100%)"
+          : undefined,
       }}
     >
       <div style={{ textAlign: "center", maxWidth: "85%" }}>
-        {/* Main title with per-character spring */}
+        {/* Main title: word-wrapped, per-character spring */}
         <div
           style={{
-            fontSize: 72,
+            fontSize,
             fontWeight: 800,
             fontFamily: "Space Grotesk, Inter, system-ui, sans-serif",
             lineHeight: 1.2,
             display: "flex",
             justifyContent: "center",
             flexWrap: "wrap",
-            gap: 0,
+            columnGap: "0.3em",
           }}
         >
-          {titleChars.map((char, i) => {
-            const delay = i * 1.2;
-            const charSpring = spring({
-              frame: frame - delay,
-              fps,
-              config: { damping: 12, stiffness: 150 },
-            });
-
-            return (
-              <span
-                key={i}
-                style={{
-                  display: "inline-block",
-                  opacity: charSpring,
-                  transform: `translateY(${interpolate(charSpring, [0, 1], [30, 0])}px)`,
-                  color: i < 8 ? "#22D3EE" : "#F8FAFC", // Accent first word
-                  whiteSpace: char === " " ? "pre" : undefined,
-                  minWidth: char === " " ? "0.3em" : undefined,
-                }}
-              >
-                {char}
-              </span>
-            );
-          })}
+          {words.map((word, wi) => (
+            <span key={wi} style={{ display: "inline-flex", whiteSpace: "nowrap" }}>
+              {word.split("").map((char) => {
+                const i = charIndex++;
+                const delay = i * 1.2;
+                const charSpring = spring({
+                  frame: frame - delay,
+                  fps,
+                  config: { damping: 12, stiffness: 150 },
+                });
+                return (
+                  <span
+                    key={i}
+                    style={{
+                      display: "inline-block",
+                      opacity: charSpring,
+                      transform: `translateY(${interpolate(charSpring, [0, 1], [30, 0])}px)`,
+                      color: i < 8 ? accentColor : textColor, // Accent first word
+                    }}
+                  >
+                    {char}
+                  </span>
+                );
+              })}
+            </span>
+          ))}
         </div>
 
         {/* Subtitle */}
@@ -73,13 +95,13 @@ export const HeroTitle: React.FC<HeroTitleProps> = ({ title, subtitle }) => {
             style={{
               marginTop: 20,
               opacity: spring({
-                frame: frame - titleChars.length * 1.2 - 5,
+                frame: frame - title.length * 1.2 - 5,
                 fps,
                 config: { damping: 20 },
               }),
               fontSize: 28,
-              fontWeight: 400,
-              color: "#A78BFA",
+              fontWeight: 500,
+              color: subtitleColor,
               fontFamily: "Space Grotesk, Inter, system-ui, sans-serif",
               letterSpacing: "0.1em",
               textTransform: "uppercase",
@@ -94,7 +116,7 @@ export const HeroTitle: React.FC<HeroTitleProps> = ({ title, subtitle }) => {
           style={{
             margin: "24px auto 0",
             height: 3,
-            backgroundColor: "#22D3EE",
+            backgroundColor: accentColor,
             borderRadius: 2,
             width: interpolate(
               spring({

--- a/remotion-composer/src/components/charts/KPIGrid.tsx
+++ b/remotion-composer/src/components/charts/KPIGrid.tsx
@@ -45,18 +45,20 @@ export const KPIGrid: React.FC<KPIGridProps> = ({
   animationStyle = "count-up",
 }) => {
   const frame = useCurrentFrame();
-  const { fps, durationInFrames } = useVideoConfig();
+  const { fps, durationInFrames, width, height } = useVideoConfig();
 
-  const cols = Math.min(columns, metrics.length);
+  // Portrait (e.g. 1080x1920 shorts): stack cards in a single column and
+  // leave extra bottom room for the caption pill.
+  const portrait = height > width;
+  const cols = portrait ? 1 : Math.min(columns, metrics.length);
   const rows = Math.ceil(metrics.length / cols);
 
-  // Grid layout constants (within 1920x1080)
-  const gridPadding = 100;
+  const gridPadding = portrait ? 64 : 100;
   const cardGap = 28;
   const titleHeight = title ? 120 : 0;
   const gridTop = 80 + titleHeight;
-  const gridWidth = 1920 - gridPadding * 2;
-  const gridHeight = 1080 - gridTop - 80;
+  const gridWidth = width - gridPadding * 2;
+  const gridHeight = height - gridTop - (portrait ? 260 : 80);
   const cardWidth = (gridWidth - cardGap * (cols - 1)) / cols;
   const cardHeight = Math.min(
     (gridHeight - cardGap * (rows - 1)) / rows,


### PR DESCRIPTION
## Summary

Four component fixes, developed while producing portrait (1080x1920) short-form video content:

- **AnimeScene**: new `fit="cover" | "contain-blurred"` prop. Portrait source images (e.g. a host avatar) rendered with the default `cover` fit on a landscape canvas get scaled ~2.5x and can push a face off-frame. `contain-blurred` renders a blurred/darkened cover-fit backdrop plus the full undistorted image letterboxed on top. Also fixes a real bug: two `Img` elements as direct siblings inside one `AbsoluteFill` (a flex container) compete for layout space and can both collapse to invisible — each image layer now gets its own nested `AbsoluteFill`, matching how the existing vignette/particle overlay layers already stack.
- **HeroTitle**: wraps at word boundaries instead of mid-word (previously split per-character with no word grouping, so long titles could wrap in the middle of a word), scales font size down for long titles instead of overflowing to a third line, and exposes `textColor`/`accentColor`/`subtitleColor`/`veil` as props instead of hardcoded values.
- **ComparisonCard**: portrait-mode layout (stacks the two sides top/bottom with a horizontal divider instead of left/right with a vertical one, scales down the divider dimension and caps the value font size), plus `cardBackgroundColor`/`leftColor`/`rightColor` props for dark-theme use.
- **KPIGrid**: derives grid dimensions from the actual video's `width`/`height` instead of a hardcoded `1920x1080`, and switches to a single-column layout for portrait.

`Explainer.tsx`/`Root.tsx`/`SCENE_TYPES.md` carry the prop plumbing and documentation for the above.

## Test plan
- [x] Rendered multiple 1080x1920 portrait shorts using these components in production (host avatars via `contain-blurred`, KPI dashboards, comparison cards)
- [x] Verified landscape rendering is unaffected (all new behavior is behind the portrait/`contain-blurred` branches, existing default paths unchanged)