### PR TITLE
fix(remotion): correct file:// URI slash count for POSIX absolute paths

### DIFF
--- a/remotion-composer/src/CinematicRenderer.tsx
+++ b/remotion-composer/src/CinematicRenderer.tsx
@@ -19,7 +19,15 @@ function resolveAsset(src: string): string {
   }
   const clean = src.replace(/^file:\/\/\/?/, "");
   if (clean.startsWith("/") || /^[A-Za-z]:[/\\]/.test(clean)) {
-    return `file:///${clean.replace(/\\/g, "/")}`;
+    const posix = clean.replace(/\\/g, "/");
+    // POSIX absolute paths already have a leading "/" — file:// + posix
+    // gives exactly three slashes. Windows drive paths (C:/...) need the
+    // extra slash added explicitly. Do not merge these branches — adding
+    // "file:///" unconditionally double-slashes POSIX paths (file:////...).
+    if (posix.startsWith("/")) {
+      return `file://${posix}`;
+    }
+    return `file:///${posix}`;
   }
   return staticFile(clean);
 }

--- a/remotion-composer/src/CollageBurst.tsx
+++ b/remotion-composer/src/CollageBurst.tsx
@@ -26,7 +26,15 @@ function resolveAsset(src: string): string {
   if (src.startsWith("http://") || src.startsWith("https://") || src.startsWith("data:")) return src;
   const clean = src.replace(/^file:\/\/\/?/, "");
   if (clean.startsWith("/") || /^[A-Za-z]:[\\/]/.test(clean)) {
-    return `file:///${clean.replace(/\\/g, "/")}`;
+    const posix = clean.replace(/\\/g, "/");
+    // POSIX absolute paths already have a leading "/" — file:// + posix
+    // gives exactly three slashes. Windows drive paths (C:/...) need the
+    // extra slash added explicitly. Do not merge these branches — adding
+    // "file:///" unconditionally double-slashes POSIX paths (file:////...).
+    if (posix.startsWith("/")) {
+      return `file://${posix}`;
+    }
+    return `file:///${posix}`;
   }
   return staticFile(clean);
 }

--- a/remotion-composer/src/Explainer.tsx
+++ b/remotion-composer/src/Explainer.tsx
@@ -22,7 +22,15 @@ function resolveAsset(src: string): string {
   // Absolute paths (Unix: /foo, Windows: C:\foo or C:/foo) — convert to file:// URI
   // staticFile() only accepts relative paths within public/, so absolute paths must bypass it
   if (clean.startsWith("/") || /^[A-Za-z]:[\\/]/.test(clean)) {
-    return `file:///${clean.replace(/\\/g, "/")}`;
+    const posix = clean.replace(/\\/g, "/");
+    // POSIX absolute paths already have a leading "/" — file:// + posix
+    // gives exactly three slashes. Windows drive paths (C:/...) need the
+    // extra slash added explicitly. Do not merge these branches — adding
+    // "file:///" unconditionally double-slashes POSIX paths (file:////...).
+    if (posix.startsWith("/")) {
+      return `file://${posix}`;
+    }
+    return `file:///${posix}`;
   }
   return staticFile(clean);
 }

--- a/remotion-composer/src/LyricOverlay.tsx
+++ b/remotion-composer/src/LyricOverlay.tsx
@@ -19,7 +19,15 @@ function resolveAsset(src: string): string {
   if (src.startsWith("http://") || src.startsWith("https://") || src.startsWith("data:")) return src;
   const clean = src.replace(/^file:\/\/\/?/, "");
   if (clean.startsWith("/") || /^[A-Za-z]:[\\/]/.test(clean)) {
-    return `file:///${clean.replace(/\\/g, "/")}`;
+    const posix = clean.replace(/\\/g, "/");
+    // POSIX absolute paths already have a leading "/" — file:// + posix
+    // gives exactly three slashes. Windows drive paths (C:/...) need the
+    // extra slash added explicitly. Do not merge these branches — adding
+    // "file:///" unconditionally double-slashes POSIX paths (file:////...).
+    if (posix.startsWith("/")) {
+      return `file://${posix}`;
+    }
+    return `file:///${posix}`;
   }
   return staticFile(clean);
 }

--- a/remotion-composer/src/TitledVideo.tsx
+++ b/remotion-composer/src/TitledVideo.tsx
@@ -46,7 +46,15 @@ function resolveAsset(src: string): string {
   }
   const clean = src.replace(/^file:\/\/\/?/, "");
   if (clean.startsWith("/") || /^[A-Za-z]:[\\/]/.test(clean)) {
-    return `file:///${clean.replace(/\\/g, "/")}`;
+    const posix = clean.replace(/\\/g, "/");
+    // POSIX absolute paths already have a leading "/" — file:// + posix
+    // gives exactly three slashes. Windows drive paths (C:/...) need the
+    // extra slash added explicitly. Do not merge these branches — adding
+    // "file:///" unconditionally double-slashes POSIX paths (file:////...).
+    if (posix.startsWith("/")) {
+      return `file://${posix}`;
+    }
+    return `file:///${posix}`;
   }
   return staticFile(clean);
 }

--- a/remotion-composer/src/components/ScreenshotScene.tsx
+++ b/remotion-composer/src/components/ScreenshotScene.tsx
@@ -90,7 +90,15 @@ function resolveAsset(src: string): string {
   }
   const clean = src.replace(/^file:\/\/\/?/, "");
   if (clean.startsWith("/") || /^[A-Za-z]:[\\/]/.test(clean)) {
-    return `file:///${clean.replace(/\\/g, "/")}`;
+    const posix = clean.replace(/\\/g, "/");
+    // POSIX absolute paths already have a leading "/" — file:// + posix
+    // gives exactly three slashes. Windows drive paths (C:/...) need the
+    // extra slash added explicitly. Do not merge these branches — adding
+    // "file:///" unconditionally double-slashes POSIX paths (file:////...).
+    if (posix.startsWith("/")) {
+      return `file://${posix}`;
+    }
+    return `file:///${posix}`;
   }
   return staticFile(clean);
 }


### PR DESCRIPTION
## Problem

`resolveAsset()` (copied across the Remotion compositions) builds a `file://` URI for absolute source paths like this:

```ts
return `file:///${clean.replace(/\\/g, "/")}`;
```

For a **POSIX** absolute path `clean` already starts with `/` (e.g. `/Users/me/clip.mp4`), so this produces **four** leading slashes — `file:////Users/me/clip.mp4`. That's a malformed file URI (empty authority followed by an extra leading `/` in the path). Chromium tolerates it in some contexts, but it's incorrect and can fail depending on the consumer.

## Fix

Split the two cases instead of prefixing `file:///` unconditionally:

- **POSIX** absolute paths (already have a leading `/`) → `file://` + path → `file:///Users/...` (correct three slashes).
- **Windows** drive paths (`C:/...`, no leading slash) → keep the explicit extra slash → `file:///C:/...`.

Applied identically to all six compositions that each carry a copy of `resolveAsset()`: `CinematicRenderer`, `CollageBurst`, `Explainer`, `LyricOverlay`, `TitledVideo`, and `ScreenshotScene`.

No behavior change for Windows drive paths, or for `http(s)` / `data:` / relative (`staticFile`) sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
