### PR TITLE
feat(tools): add Sonilo video-to-music provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,8 @@ DASHSCOPE_API_KEY=           # Qwen image gen (qwen-image-2.0-pro), TTS (qwen3-t
 
 # --- Music ---
 SUNO_API_KEY=                # Suno AI music generation (full songs, instrumentals, any genre)
+SONILO_API_KEY=              # Sonilo video-to-music (original track generated from the assembled cut)
+                             # Get one at https://platform.sonilo.com/dashboard/api-keys
 
 # --- Video Generation ---
 HEYGEN_API_KEY=              # HeyGen API (VEO, Sora, Runway, Kling, Seedance via single key)

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ UNSPLASH_ACCESS_KEY=your-key   # Free stock images
 
 # Music:
 SUNO_API_KEY=your-key          # Full songs, instrumentals, any genre
+SONILO_API_KEY=your-key        # Original track generated from the assembled cut (licensed)
 
 # Voice & images:
 ELEVENLABS_API_KEY=your-key    # Premium TTS, AI music, sound effects
@@ -435,7 +436,7 @@ Final video output -- only if self-review passes
 OpenMontage/
 ├── tools/              # 48 Python tools (the agent's hands)
 │   ├── video/          # 13 video gen tools + compose, stitch, trim
-│   ├── audio/          # 4 TTS providers + Suno/ElevenLabs music, mixing, enhancement
+│   ├── audio/          # 4 TTS providers + Suno/ElevenLabs/Sonilo music, mixing, enhancement
 │   ├── graphics/       # 9 image/graphics generation tools + diagrams, code snippets, math
 │   ├── enhancement/    # Upscale, bg remove, face enhance, color grade
 │   ├── analysis/       # Transcription, scene detect, frame sampling
@@ -537,6 +538,7 @@ Each tool declares which Layer 3 skills it relies on. The agent reads Layer 1 to
 | **Suno AI** | Cloud API | Full song generation with vocals, lyrics, any genre. Up to 8 minutes. |
 | **ElevenLabs Music** | Cloud API | AI music generation |
 | **ElevenLabs SFX** | Cloud API | Sound effect generation |
+| **Sonilo** | Cloud API | Original track generated from the assembled cut — duration matches the video natively. Licensed, safe for commercial use (terms apply). |
 
 **Post-Production (always available, always free):**
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -23,6 +23,7 @@ Everything you need to know about every provider in OpenMontage — setup instru
 | 11 | **pay-as-you-go** | Suno | Full song generation with vocals and lyrics |
 | 12 | **$0 + GPU** | Local video gen | WAN 2.1, Hunyuan, CogVideo, LTX — free, offline |
 | 13 | **$0 + GPU** | Local Diffusion | Stable Diffusion images — free, offline |
+| 14 | **credit plans** | Sonilo | Original track generated from the assembled cut — duration matches the video natively |
 
 ### Environment Variable Summary
 
@@ -59,6 +60,7 @@ KLING_API_BASE_URL=          # Optional; default https://api-singapore.klingai.c
 HEYGEN_API_KEY=              # HeyGen avatar video gateway
 RUNWAY_API_KEY=              # Runway Gen-4 video (direct)
 SUNO_API_KEY=                # Suno music generation
+SONILO_API_KEY=              # Sonilo video-to-music (track generated from the assembled cut)
 
 # LOCAL (no keys needed — just GPU + install)
 VIDEO_GEN_LOCAL_ENABLED=     # Set to "true" for local video gen
@@ -610,6 +612,34 @@ Google TTS offers 700+ voices across 50+ languages. Voice names follow the patte
 
 ---
 
+### Sonilo — Music From the Assembled Cut
+
+> **Original track generated from the video itself.** Hand the rendered cut to the API and get back
+> a track matched to it — the model sees the timeline, so duration matches natively.
+> Tracks are licensed and safe for commercial use (terms apply).
+
+**Tools unlocked:** `sonilo_music`
+**Env var:** `SONILO_API_KEY`
+
+#### Setup
+
+1. Go to [sonilo.com](https://sonilo.com) and create an account
+2. Create an API key at [platform.sonilo.com/dashboard/api-keys](https://platform.sonilo.com/dashboard/api-keys)
+3. Add to `.env`: `SONILO_API_KEY=your-key-here`
+
+#### Usage Notes
+
+- Input is the assembled cut — a local video file (multipart upload) or an HTTP(S) `video_url` the backend fetches directly. Render the visual timeline first (`video_compose`), generate the track from the render, then mix with `audio_mixer`.
+- `prompt` is an optional style hint (mood, genre, instruments); the video drives structure and duration.
+- The API accepts videos up to 6 minutes.
+- Output is `.m4a` (AAC).
+
+#### Pricing
+
+Credit-based plans with a free tier; Pro $14.99/mo, Premium $29.99/mo. See [sonilo.com/pricing](https://sonilo.com/pricing).
+
+---
+
 ### Pexels — Free Stock Media
 
 > **Completely free.** No cost, no attribution required, commercial use allowed.
@@ -889,6 +919,7 @@ These tools require only FFmpeg or Python packages — no GPU, no API key.
 | **Higgsfield** | `HIGGSFIELD_API_KEY` + `HIGGSFIELD_API_SECRET` | `higgsfield_video` | Subscription ($15-84/mo) |
 | **HeyGen** | `HEYGEN_API_KEY` | `heygen_video` | Pay-as-you-go |
 | **Suno** | `SUNO_API_KEY` | `suno_music` | Pay-as-you-go |
+| **Sonilo** | `SONILO_API_KEY` | `sonilo_music` | Free tier + paid |
 | **Local GPU** | `VIDEO_GEN_LOCAL_ENABLED` | `wan_video`, `hunyuan_video`, `cogvideo_video`, `ltx_video_local` | Free (GPU required) |
 | **Local Diffusion** | — (install only) | `local_diffusion` | Free (GPU required) |
 | **Modal** | `MODAL_LTX2_ENDPOINT_URL` | `ltx_video_modal` | Self-hosted cloud |
@@ -904,7 +935,7 @@ How many providers cover each capability:
 | **Image Generation** | FLUX, Kling Official, Grok, Google Imagen, GPT Image 2, Recraft | Local Diffusion | Pexels, Pixabay (stock) |
 | **Video Generation** | Grok, Kling Official, Kling via fal.ai, Runway, Veo, Gemini Omni, Higgsfield, MiniMax, HeyGen | WAN, Hunyuan, CogVideo, LTX | Pexels, Pixabay (stock) |
 | **Text-to-Speech** | ElevenLabs, Google TTS, Kling Official, OpenAI | Piper | Piper, Google free tier, ElevenLabs free tier |
-| **Music Generation** | ElevenLabs, Suno, Google Lyria | — | ElevenLabs free tier |
+| **Music Generation** | ElevenLabs, Suno, Google Lyria, Sonilo | — | ElevenLabs free tier |
 | **Post-Production** | — | FFmpeg (compose, stitch, trim, mix, enhance, grade) | All free |
 | **Analysis** | — | WhisperX, Scene Detect, Frame Sampler, CLIP/BLIP-2 | All free |
 | **Enhancement** | — | Upscale, BG Remove, Face Enhance, Face Restore | All free |

--- a/skills/INDEX.md
+++ b/skills/INDEX.md
@@ -60,7 +60,7 @@ Key capability families to look for in the output:
 | `analysis` | — | Mixed providers |
 | `character_animation` | — | Local character specs, SVG rigs, pose libraries, action timelines, previews, and QA |
 | `graphics` | — | Local rendering tools |
-| `music_generation` | — | Single-provider |
+| `music_generation` | — | ElevenLabs, Suno, Google Lyria, Sonilo |
 | `subtitle` | — | Pure Python |
 | `avatar` | — | Local GPU models |
 | `video_post` | — | FFmpeg-based local tools |

--- a/skills/creative/music-gen-usage.md
+++ b/skills/creative/music-gen-usage.md
@@ -120,6 +120,25 @@ For cleaner ducking control, generate isolated stems:
 - `"soft ambient pad in C major, 80 BPM"` — synth pad only
 - Layer stems in FFmpeg during composition for precise ducking control
 
+## Generating From the Assembled Cut (Sonilo)
+
+The prompt-first providers above describe the music in text, then fit the
+result to the edit. `sonilo_music` runs the other way around: it takes the
+rendered cut (local file or HTTP(S) URL) and returns an original track
+generated from the video itself.
+
+- **Duration matches the cut natively** — no `offsetSeconds` window selection
+  or trimming pass afterwards.
+- **Use at the compose stage**: render the visual timeline first
+  (`video_compose`), generate the track from the render, then mix with
+  `audio_mixer` (the 18-20 dB ducking and EQ rules above still apply).
+- **`prompt` is an optional style hint** (mood, genre, instruments) — the
+  BPM/key tables above help phrase it, but the video drives structure and
+  duration.
+- **Requires `SONILO_API_KEY`.** Tracks are licensed and safe for commercial
+  use (terms apply).
+- **Limits**: input videos up to 6 minutes; output is `.m4a` (AAC).
+
 ## Applying to OpenMontage
 
 When using the `music_gen` tool:

--- a/tests/tools/test_sonilo_music.py
+++ b/tests/tools/test_sonilo_music.py
@@ -1,0 +1,373 @@
+"""Tests for tools/audio/sonilo_music.py — SoniloMusic tool.
+
+Network calls are stubbed with a fake ``requests`` module (the tool imports
+``requests`` lazily inside ``_generate``), so the suite runs hermetically —
+no API key, no network, no ffprobe required.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+import types
+
+import pytest
+
+from tools.base_tool import (
+    BaseTool,
+    ExecutionMode,
+    ToolRuntime,
+    ToolStatus,
+    ToolTier,
+)
+from tools.audio.sonilo_music import SoniloMusic
+from tools.tool_registry import ToolRegistry
+
+
+API_KEY = "test-key"
+
+
+def _chunk(data: bytes, index: int = 0) -> str:
+    return json.dumps(
+        {
+            "type": "audio_chunk",
+            "stream_index": index,
+            "num_streams": 1,
+            "data": base64.b64encode(data).decode("ascii"),
+        }
+    )
+
+
+_HAPPY_LINES = [
+    '{"type": "stage_start", "stage": "analysis"}',
+    _chunk(b"abc"),
+    '{"type": "title", "title": "Rainy Commute"}',
+    _chunk(b"def"),
+    "not json at all",
+    '{"type": "complete"}',
+]
+
+
+class _FakeStreamResponse:
+    def __init__(self, lines=None, status_code: int = 200, text: str = "") -> None:
+        self._lines = list(lines or [])
+        self.status_code = status_code
+        self.text = text
+
+    def iter_lines(self, decode_unicode: bool = False):
+        yield from self._lines
+
+    def json(self):
+        return json.loads(self.text)
+
+
+def _install_fake_requests(
+    monkeypatch: pytest.MonkeyPatch,
+    captured: dict,
+    response: _FakeStreamResponse,
+) -> types.ModuleType:
+    """Install a stub ``requests`` module that records the outgoing call."""
+    fake = types.ModuleType("requests")
+
+    def fake_post(url, headers=None, data=None, files=None, stream=False, timeout=None):  # noqa: ANN001
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["data"] = data
+        captured["files"] = files
+        captured["stream"] = stream
+        captured["timeout"] = timeout
+        return response
+
+    fake.post = fake_post
+    monkeypatch.setitem(sys.modules, "requests", fake)
+    return fake
+
+
+@pytest.fixture
+def tool(monkeypatch) -> SoniloMusic:
+    monkeypatch.setenv("SONILO_API_KEY", API_KEY)
+    # Keep tests hermetic: never shell out to ffprobe.
+    monkeypatch.setattr(SoniloMusic, "_probe_duration", staticmethod(lambda path: None))
+    return SoniloMusic()
+
+
+class TestSoniloMusicDefinition:
+    """Verify the tool class metadata matches project conventions."""
+
+    def test_class_inherits_basetool(self):
+        assert issubclass(SoniloMusic, BaseTool)
+
+    def test_name(self):
+        assert SoniloMusic.name == "sonilo_music"
+
+    def test_tier(self):
+        assert SoniloMusic.tier == ToolTier.GENERATE
+
+    def test_capability(self):
+        assert SoniloMusic.capability == "music_generation"
+
+    def test_provider(self):
+        assert SoniloMusic.provider == "sonilo"
+
+    def test_runtime(self):
+        assert SoniloMusic.runtime == ToolRuntime.API
+
+    def test_execution_mode(self):
+        assert SoniloMusic.execution_mode == ExecutionMode.SYNC
+
+    def test_capabilities_list(self):
+        assert "generate_background_music" in SoniloMusic.capabilities
+        assert "generate_music_from_video" in SoniloMusic.capabilities
+
+    def test_fallback_tools(self):
+        assert "music_gen" in SoniloMusic.fallback_tools
+        assert "pixabay_music" in SoniloMusic.fallback_tools
+        assert "freesound_music" in SoniloMusic.fallback_tools
+
+    def test_supports(self):
+        assert SoniloMusic.supports["video_conditioning"] is True
+        assert SoniloMusic.supports["native_duration_match"] is True
+
+    def test_input_schema_fields(self):
+        props = SoniloMusic.input_schema["properties"]
+        assert "video_path" in props
+        assert "video_url" in props
+        assert "prompt" in props
+        assert "output_path" in props
+
+    def test_no_retries_on_generation(self):
+        # Generation is non-idempotent — retries could double-charge.
+        assert SoniloMusic.retry_policy.max_retries == 0
+
+    def test_no_env_dependency_declared(self):
+        # Availability is reported via get_status(), like music_gen/suno_music.
+        assert SoniloMusic.dependencies == []
+
+
+class TestSoniloMusicStatus:
+    def test_unavailable_without_key(self, monkeypatch):
+        monkeypatch.delenv("SONILO_API_KEY", raising=False)
+        assert SoniloMusic().get_status() == ToolStatus.UNAVAILABLE
+
+    def test_available_with_key(self, monkeypatch):
+        monkeypatch.setenv("SONILO_API_KEY", API_KEY)
+        assert SoniloMusic().get_status() == ToolStatus.AVAILABLE
+
+    def test_execute_inert_without_key(self, monkeypatch):
+        monkeypatch.delenv("SONILO_API_KEY", raising=False)
+        result = SoniloMusic().execute({"video_url": "https://example.com/cut.mp4"})
+        assert result.success is False
+        assert "SONILO_API_KEY" in result.error
+
+    def test_dry_run_returns_dict(self, tool):
+        result = tool.dry_run({"video_url": "https://example.com/cut.mp4"})
+        assert result["tool"] == "sonilo_music"
+        assert result["would_execute"] is True
+
+
+class TestSoniloMusicValidation:
+    def test_rejects_both_inputs(self, tool):
+        result = tool.execute(
+            {"video_path": "cut.mp4", "video_url": "https://example.com/cut.mp4"}
+        )
+        assert result.success is False
+        assert "exactly one" in result.error
+
+    def test_rejects_neither_input(self, tool):
+        result = tool.execute({})
+        assert result.success is False
+        assert "exactly one" in result.error
+
+    def test_rejects_non_http_url(self, tool):
+        result = tool.execute({"video_url": "file:///etc/passwd"})
+        assert result.success is False
+        assert "http" in result.error
+
+    def test_rejects_missing_local_file(self, tool, tmp_path):
+        result = tool.execute({"video_path": str(tmp_path / "missing.mp4")})
+        assert result.success is False
+        assert "not found" in result.error
+
+    def test_rejects_video_over_duration_limit(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("SONILO_API_KEY", API_KEY)
+        monkeypatch.setattr(
+            SoniloMusic, "_probe_duration", staticmethod(lambda path: 400.0)
+        )
+        video = tmp_path / "long.mp4"
+        video.write_bytes(b"fake video")
+        result = SoniloMusic().execute({"video_path": str(video)})
+        assert result.success is False
+        assert "6 minutes" in result.error
+
+
+class TestSoniloMusicGenerate:
+    def test_url_mode_request_shape(self, tool, monkeypatch, tmp_path):
+        captured: dict = {}
+        _install_fake_requests(monkeypatch, captured, _FakeStreamResponse(_HAPPY_LINES))
+        out = tmp_path / "track.m4a"
+        result = tool.execute(
+            {
+                "video_url": "https://example.com/cut.mp4",
+                "prompt": "warm analog synths",
+                "output_path": str(out),
+            }
+        )
+
+        assert result.success is True
+        assert captured["url"] == "https://api.sonilo.com/v1/video-to-music"
+        assert captured["headers"]["Authorization"] == f"Bearer {API_KEY}"
+        assert captured["data"]["video_url"] == "https://example.com/cut.mp4"
+        assert captured["data"]["prompt"] == "warm analog synths"
+        assert captured["files"] is None
+        assert captured["stream"] is True
+
+    def test_file_mode_uploads_multipart(self, tool, monkeypatch, tmp_path):
+        captured: dict = {}
+        _install_fake_requests(monkeypatch, captured, _FakeStreamResponse(_HAPPY_LINES))
+        video = tmp_path / "final_cut.mp4"
+        video.write_bytes(b"fake video bytes")
+        out = tmp_path / "track.m4a"
+        result = tool.execute({"video_path": str(video), "output_path": str(out)})
+
+        assert result.success is True
+        name, _fh, mime = captured["files"]["video"]
+        assert name == "final_cut.mp4"
+        assert mime == "video/mp4"
+        # No prompt given — no stray form fields.
+        assert captured["data"] is None
+
+    def test_audio_chunks_are_concatenated(self, tool, monkeypatch, tmp_path):
+        captured: dict = {}
+        _install_fake_requests(monkeypatch, captured, _FakeStreamResponse(_HAPPY_LINES))
+        out = tmp_path / "track.m4a"
+        result = tool.execute(
+            {"video_url": "https://example.com/cut.mp4", "output_path": str(out)}
+        )
+
+        assert result.success is True
+        assert out.read_bytes() == b"abcdef"
+        assert result.artifacts == [str(out)]
+        assert result.data["title"] == "Rainy Commute"
+        assert result.data["format"] == "m4a"
+        assert result.data["provider"] == "sonilo"
+
+    def test_lowest_stream_index_is_returned(self, tool, monkeypatch, tmp_path):
+        lines = [_chunk(b"second", 1), _chunk(b"first", 0), '{"type": "complete"}']
+        _install_fake_requests(monkeypatch, {}, _FakeStreamResponse(lines))
+        out = tmp_path / "track.m4a"
+        result = tool.execute(
+            {"video_url": "https://example.com/cut.mp4", "output_path": str(out)}
+        )
+        assert result.success is True
+        assert out.read_bytes() == b"first"
+
+    def test_error_event_fails(self, tool, monkeypatch, tmp_path):
+        lines = [_chunk(b"abc"), '{"type": "error", "message": "generation failed"}']
+        _install_fake_requests(monkeypatch, {}, _FakeStreamResponse(lines))
+        result = tool.execute(
+            {
+                "video_url": "https://example.com/cut.mp4",
+                "output_path": str(tmp_path / "track.m4a"),
+            }
+        )
+        assert result.success is False
+        assert "generation failed" in result.error
+
+    def test_stream_without_complete_fails(self, tool, monkeypatch, tmp_path):
+        lines = [_chunk(b"abc")]
+        _install_fake_requests(monkeypatch, {}, _FakeStreamResponse(lines))
+        result = tool.execute(
+            {
+                "video_url": "https://example.com/cut.mp4",
+                "output_path": str(tmp_path / "track.m4a"),
+            }
+        )
+        assert result.success is False
+        assert "before completing" in result.error
+
+    def test_http_401_reports_rejected_key(self, tool, monkeypatch, tmp_path):
+        response = _FakeStreamResponse(
+            status_code=401, text='{"detail": "invalid key"}'
+        )
+        _install_fake_requests(monkeypatch, {}, response)
+        result = tool.execute(
+            {
+                "video_url": "https://example.com/cut.mp4",
+                "output_path": str(tmp_path / "track.m4a"),
+            }
+        )
+        assert result.success is False
+        assert "rejected" in result.error
+
+    def test_http_402_reports_credits(self, tool, monkeypatch, tmp_path):
+        response = _FakeStreamResponse(
+            status_code=402, text='{"detail": "no credits left"}'
+        )
+        _install_fake_requests(monkeypatch, {}, response)
+        result = tool.execute(
+            {
+                "video_url": "https://example.com/cut.mp4",
+                "output_path": str(tmp_path / "track.m4a"),
+            }
+        )
+        assert result.success is False
+        assert "no credits left" in result.error
+
+    def test_api_key_never_leaks_into_result(self, tool, monkeypatch, tmp_path):
+        response = _FakeStreamResponse(status_code=401, text='{"detail": "bad"}')
+        _install_fake_requests(monkeypatch, {}, response)
+        result = tool.execute(
+            {
+                "video_url": "https://example.com/cut.mp4",
+                "output_path": str(tmp_path / "track.m4a"),
+            }
+        )
+        assert API_KEY not in (result.error or "")
+        assert API_KEY not in json.dumps(result.data)
+
+    def test_cost_and_model_are_reported(self, tool, monkeypatch, tmp_path):
+        _install_fake_requests(monkeypatch, {}, _FakeStreamResponse(_HAPPY_LINES))
+        result = tool.execute(
+            {
+                "video_url": "https://example.com/cut.mp4",
+                "output_path": str(tmp_path / "track.m4a"),
+            }
+        )
+        assert result.success is True
+        assert result.cost_usd == tool.estimate_cost({})
+        assert result.model == "video-to-music"
+
+    def test_base_url_override(self, tool, monkeypatch, tmp_path):
+        monkeypatch.setenv("SONILO_API_URL", "https://staging.sonilo.test/")
+        captured: dict = {}
+        _install_fake_requests(monkeypatch, captured, _FakeStreamResponse(_HAPPY_LINES))
+        tool.execute(
+            {
+                "video_url": "https://example.com/cut.mp4",
+                "output_path": str(tmp_path / "track.m4a"),
+            }
+        )
+        assert captured["url"] == "https://staging.sonilo.test/v1/video-to-music"
+
+
+class TestSoniloMusicRegistry:
+    """Verify the tool is discoverable via the registry."""
+
+    def test_registry_registers_tool(self):
+        reg = ToolRegistry()
+        reg.register(SoniloMusic())
+        found = reg.get("sonilo_music")
+        assert found is not None
+        assert found.name == "sonilo_music"
+
+    def test_registry_finds_by_capability(self):
+        reg = ToolRegistry()
+        reg.register(SoniloMusic())
+        matches = reg.get_by_capability("music_generation")
+        assert any(t.name == "sonilo_music" for t in matches)
+
+    def test_registry_discovers_tool(self):
+        reg = ToolRegistry()
+        reg.discover("tools")
+        assert reg.get("sonilo_music") is not None

--- a/tools/audio/sonilo_music.py
+++ b/tools/audio/sonilo_music.py
@@ -1,0 +1,392 @@
+"""Sonilo music generation from an assembled video cut.
+
+Generates an original track matched to a rendered cut via the Sonilo
+video-to-music API. The model receives the video itself, so the returned
+track natively matches the cut's duration — no window selection or offset
+trimming pass afterwards. Tracks are licensed and safe for commercial use
+(terms apply). Reports unavailable when no API key is configured.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import mimetypes
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Optional
+from urllib.parse import urlparse
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+
+class SoniloMusic(BaseTool):
+    name = "sonilo_music"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "music_generation"
+    provider = "sonilo"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = []  # checked dynamically via API key
+    install_instructions = (
+        "Set the SONILO_API_KEY environment variable:\n"
+        "  export SONILO_API_KEY=your_key_here\n"
+        "Get a key at https://platform.sonilo.com/dashboard/api-keys"
+    )
+
+    agent_skills = ["music"]
+
+    capabilities = [
+        "generate_background_music",
+        "generate_music_from_video",
+        "duration_matched_music",
+    ]
+    supports = {
+        "video_conditioning": True,
+        "native_duration_match": True,
+        "style_prompt": True,
+        "licensed_output": True,
+    }
+    best_for = [
+        "background music generated from the assembled cut itself",
+        "exact-duration tracks for shorts and social cuts",
+        "client deliverables needing licensed music, safe for commercial use (terms apply)",
+    ]
+    not_good_for = [
+        "music before a cut exists (needs a rendered video input — use a prompt-based provider)",
+        "videos longer than 6 minutes (API limit)",
+        "sound effects (use a dedicated SFX tool)",
+    ]
+
+    fallback_tools = ["music_gen", "pixabay_music", "freesound_music"]
+
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "video_path": {
+                "type": "string",
+                "description": (
+                    "Local path to the assembled cut (the rendered video the "
+                    "track should match). Exactly one of video_path or "
+                    "video_url is required. The API accepts videos up to "
+                    "6 minutes."
+                ),
+            },
+            "video_url": {
+                "type": "string",
+                "description": (
+                    "HTTP(S) URL of the assembled cut; the backend fetches it "
+                    "directly. Exactly one of video_path or video_url is "
+                    "required."
+                ),
+            },
+            "prompt": {
+                "type": "string",
+                "description": (
+                    "Optional style hint for the track (mood, genre, "
+                    "instruments). The video itself drives structure and "
+                    "duration."
+                ),
+            },
+            "output_path": {
+                "type": "string",
+                "default": "sonilo_music_output.m4a",
+                "description": "Path where the generated .m4a file should be written",
+            },
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=100, network_required=True
+    )
+    # No automatic retries: the generation endpoint is non-idempotent, so a
+    # retry on a transient failure could double-charge the account.
+    retry_policy = RetryPolicy(max_retries=0)
+    idempotency_key_fields = ["video_path", "video_url", "prompt"]
+    side_effects = [
+        "writes audio file to output_path",
+        "uploads the input video to the Sonilo API (or passes video_url for the backend to fetch)",
+    ]
+    user_visible_verification = [
+        "Listen to the track against the cut for pacing and mood",
+    ]
+
+    _BASE_URL = "https://api.sonilo.com"
+    _ENDPOINT = "/v1/video-to-music"
+    _MODEL = "video-to-music"
+    # Matches the backend's generation read timeout. A long generation keeps
+    # running (and charging) server-side, so timing out sooner would orphan
+    # a paid request.
+    _TIMEOUT = 600
+    # The backend rejects videos longer than 6 minutes. Pre-checked locally
+    # (best-effort, via ffprobe) to fail fast before uploading a large render.
+    # Keep in sync with the backend's limit.
+    _MAX_VIDEO_DURATION_SECONDS = 360
+
+    def _get_api_key(self) -> Optional[str]:
+        return os.environ.get("SONILO_API_KEY")
+
+    def _get_base_url(self) -> str:
+        return os.environ.get("SONILO_API_URL", self._BASE_URL).rstrip("/")
+
+    def get_status(self) -> ToolStatus:
+        if self._get_api_key():
+            return ToolStatus.AVAILABLE
+        return ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        # Sonilo bills in plan credits rather than a flat USD rate.
+        # Approximation from the public Pro plan ($14.99/mo, up to 30 video
+        # generations): ~$0.50 per generation.
+        return 0.5
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        return 120.0
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        api_key = self._get_api_key()
+        if not api_key:
+            return ToolResult(
+                success=False,
+                error="No Sonilo API key. " + self.install_instructions,
+            )
+
+        video_path = inputs.get("video_path")
+        video_url = inputs.get("video_url")
+        if bool(video_path) == bool(video_url):
+            return ToolResult(
+                success=False,
+                error="Provide either video_path or video_url (exactly one, not both).",
+            )
+        if video_url:
+            scheme = urlparse(video_url).scheme.lower()
+            if scheme not in ("http", "https"):
+                return ToolResult(
+                    success=False,
+                    error="video_url must be an http:// or https:// URL.",
+                )
+
+        start = time.time()
+
+        try:
+            result = self._generate(inputs, api_key)
+        except Exception as e:
+            return ToolResult(success=False, error=f"Sonilo generation failed: {e}")
+
+        result.duration_seconds = round(time.time() - start, 2)
+        if result.success:
+            result.cost_usd = self.estimate_cost(inputs)
+            result.model = self._MODEL
+        return result
+
+    def _generate(self, inputs: dict[str, Any], api_key: str) -> ToolResult:
+        import requests
+
+        url = self._get_base_url() + self._ENDPOINT
+        headers = {"Authorization": f"Bearer {api_key}"}
+
+        form: dict[str, str] = {}
+        prompt = (inputs.get("prompt") or "").strip()
+        if prompt:
+            form["prompt"] = prompt
+
+        video_path = inputs.get("video_path")
+        if video_path:
+            resolved = Path(video_path)
+            if not resolved.is_file():
+                return ToolResult(
+                    success=False,
+                    error=f"Input video not found: {resolved}",
+                )
+            probed = self._probe_duration(str(resolved))
+            if probed is not None and probed > self._MAX_VIDEO_DURATION_SECONDS:
+                return ToolResult(
+                    success=False,
+                    error=(
+                        f"Input video is {probed:.0f}s; the Sonilo API accepts "
+                        f"videos up to {self._MAX_VIDEO_DURATION_SECONDS}s "
+                        "(6 minutes). Trim the cut or generate per segment."
+                    ),
+                )
+            mime, _ = mimetypes.guess_type(resolved.name)
+            with open(resolved, "rb") as fh:
+                files = {
+                    "video": (resolved.name, fh, mime or "application/octet-stream")
+                }
+                response = requests.post(
+                    url,
+                    headers=headers,
+                    data=form or None,
+                    files=files,
+                    stream=True,
+                    timeout=self._TIMEOUT,
+                )
+        else:
+            # URL mode — the backend fetches the video itself; send form fields only.
+            form["video_url"] = inputs["video_url"]
+            response = requests.post(
+                url,
+                headers=headers,
+                data=form,
+                stream=True,
+                timeout=self._TIMEOUT,
+            )
+
+        if response.status_code >= 400:
+            return ToolResult(
+                success=False,
+                error=self._http_error(response.status_code, self._read_error_detail(response)),
+            )
+
+        audio_bytes, title = self._consume_stream(response)
+
+        output_path = Path(inputs.get("output_path", "sonilo_music_output.m4a"))
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(audio_bytes)
+
+        data: dict[str, Any] = {
+            "provider": "sonilo",
+            "model": self._MODEL,
+            "prompt": prompt or None,
+            "title": title,
+            "output": str(output_path),
+            "format": "m4a",
+        }
+        track_duration = self._probe_duration(str(output_path))
+        if track_duration is not None:
+            data["duration_seconds"] = round(track_duration, 2)
+
+        return ToolResult(
+            success=True,
+            data=data,
+            artifacts=[str(output_path)],
+        )
+
+    def _consume_stream(self, response: Any) -> tuple[bytes, Optional[str]]:
+        """Consume the NDJSON event stream returned by the generation endpoint.
+
+        Event types: ``audio_chunk`` (base64 audio bytes, keyed by
+        ``stream_index``), ``title``, ``complete`` (terminal success), and
+        ``error`` (terminal failure). Progress events such as ``stage_start``
+        / ``stage_complete`` and malformed lines are ignored.
+        """
+        streams: dict[int, bytearray] = {}
+        title: Optional[str] = None
+        completed = False
+
+        for line in response.iter_lines(decode_unicode=True):
+            if not line or not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except ValueError:
+                continue
+            if not isinstance(event, dict):
+                continue
+            event_type = event.get("type")
+            if event_type == "audio_chunk":
+                data = event.get("data")
+                if not isinstance(data, str):
+                    continue
+                try:
+                    index = int(event.get("stream_index", 0))
+                except (TypeError, ValueError):
+                    continue
+                if index < 0:
+                    continue
+                try:
+                    decoded = base64.b64decode(data, validate=True)
+                except (binascii.Error, ValueError):
+                    continue
+                streams.setdefault(index, bytearray()).extend(decoded)
+            elif event_type == "title":
+                value = event.get("title")
+                if isinstance(value, str) and value.strip():
+                    title = value.strip()
+            elif event_type == "complete":
+                completed = True
+            elif event_type == "error":
+                raise RuntimeError(
+                    event.get("message") or event.get("code") or "Sonilo stream error"
+                )
+
+        if not completed:
+            raise RuntimeError("Sonilo stream ended before completing.")
+        if not streams:
+            raise RuntimeError("Sonilo stream completed without returning audio data.")
+
+        first_index = min(streams)
+        return bytes(streams[first_index]), title
+
+    @staticmethod
+    def _read_error_detail(response: Any) -> str:
+        try:
+            body = response.json()
+            if isinstance(body, dict):
+                detail = body.get("detail") or body.get("error") or body.get("message")
+                if isinstance(detail, str) and detail.strip():
+                    return detail.strip()
+        except Exception:
+            pass
+        text = getattr(response, "text", "") or ""
+        return text.strip()[:300] or "no error detail"
+
+    @staticmethod
+    def _http_error(status: int, detail: str) -> str:
+        if status == 401:
+            return (
+                "Sonilo API key was rejected. Check SONILO_API_KEY "
+                "(keys: https://platform.sonilo.com/dashboard/api-keys)."
+            )
+        if status == 402:
+            return detail or "Sonilo account has no remaining credits."
+        if status == 413:
+            return f"Sonilo upload is too large: {detail}"
+        if status == 429:
+            return f"Sonilo rate limit exceeded: {detail}"
+        return f"Sonilo API error ({status}): {detail}"
+
+    @staticmethod
+    def _probe_duration(path: str) -> Optional[float]:
+        """Best-effort ffprobe duration lookup; returns None when unavailable."""
+        if shutil.which("ffprobe") is None:
+            return None
+        try:
+            proc = subprocess.run(
+                [
+                    "ffprobe",
+                    "-v",
+                    "error",
+                    "-show_entries",
+                    "format=duration",
+                    "-of",
+                    "default=noprint_wrappers=1:nokey=1",
+                    path,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=True,
+            )
+            return float(proc.stdout.strip())
+        except Exception:
+            return None


### PR DESCRIPTION
## Summary

Adds a `sonilo_music` tool: a music provider that takes the assembled cut (the rendered timeline) and returns an original track generated from the video itself. Because the model receives the cut, the track's duration matches the video natively. Registers alongside `music_gen` (ElevenLabs), `suno_music`, and `google_music` under the `music_generation` capability. Proposed in #351.

Disclosure: I work on Sonilo.

## Why

#218 documents the friction in the short-form music-video workflow: picking the useful window of a longer generated track, and exact-duration control. This provider removes that glue work when a cut already exists — the track is generated from the cut, so there is no window selection or `offsetSeconds` pass, and duration matches the timeline natively. (The audio review-label item in #218 is orthogonal and untouched here.)

## Changes

### New files
- **`tools/audio/sonilo_music.py`** — tool implementation. Streaming POST to `https://api.sonilo.com/v1/video-to-music` (Bearer auth; multipart upload for a local `video_path`, or a `video_url` form field the backend fetches directly), consumes the NDJSON event stream (`audio_chunk` / `title` / `complete` / `error`), writes `.m4a`. Optional `prompt` style hint. Best-effort ffprobe pre-check fails fast when the cut exceeds the API's 6-minute limit. No automatic retries — the generation endpoint is non-idempotent, so a retry on a transient failure could double-charge.
- **`tests/tools/test_sonilo_music.py`** — 36 tests: class metadata, availability gating, input validation, request shape for both upload modes, NDJSON stream handling (chunk assembly, multi-stream index selection, title, error/incomplete streams), HTTP error mapping (401/402), a key-never-leaks-into-results check, and registry integration. `requests` is stubbed, so the suite runs hermetically — no key, no network, no ffprobe.

### Updated files
- **`.env.example`** — `SONILO_API_KEY` entry under the Music section
- **`docs/PROVIDERS.md`** — provider section (setup, usage notes, pricing), quick-start table, env var summary, key/tool table, capability coverage
- **`README.md`** — music env key block, audio tools listing, Music & Sound provider table
- **`skills/INDEX.md`** — `music_generation` capability row now lists the available providers
- **`skills/creative/music-gen-usage.md`** — when/how to use the cut-conditioned flow at the compose stage (render the timeline with `video_compose`, generate the track from the render, mix with `audio_mixer`)

## Integration

Follows the provider pattern of the existing music integrations (`music_gen`, `suno_music`, `google_music`): auto-discovers via the registry, no manual registration. Key setup works exactly like the ElevenLabs key — add `SONILO_API_KEY` to `.env`. With no key set, the tool reports `unavailable` and `execute()` returns a clear setup message instead of attempting a call. The key is only ever sent as the Authorization header; it is never logged and never appears in results or errors (pinned by a test). Fallback chain: `sonilo_music` → `music_gen` → `pixabay_music` → `freesound_music`.

Generated tracks are licensed and safe for commercial use (terms apply).

## Testing

```
tests/tools/test_sonilo_music.py    36 passed
tests/ (full suite)                 779 passed, 9 skipped — no regressions
make lint                           clean
```

One honest caveat: no live API call was made from this environment — no `SONILO_API_KEY` was present on the machine used to build this PR, and no key is bundled anywhere. The request/stream handling is ported from a working client of the same endpoint and pinned by the stubbed-stream tests. Happy to attach a live-run artifact if useful.

Closes #351. Addresses the window-selection and exact-duration friction in #218.
