### PR TITLE
feat(skills): add structured skill frontmatter + execution engine

### DIFF
--- a/lib/skill_engine.py
+++ b/lib/skill_engine.py
@@ -1,0 +1,333 @@
+"""Skill execution engine (RFC #349 phase 2): interpolation, DAG scheduling,
+and step execution gated by Rule Zero (AGENT_GUIDE.md).
+
+A step whose tool declares no agent_skills is deterministic wiring the
+engine executes directly. A step whose tool declares agent_skills needs
+Layer 3 prompting guidance that only the agent can apply — the engine
+pauses and hands control back rather than calling it.
+"""
+
+from __future__ import annotations
+
+import re
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Optional
+
+
+class SkillEngineError(ValueError):
+    """Raised on interpolation, DAG, or execution errors in the skill engine."""
+
+
+_FULL_PLACEHOLDER_RE = re.compile(r"^\$\{([^}]+)\}$")
+_EMBEDDED_PLACEHOLDER_RE = re.compile(r"\$\{([^}]+)\}")
+
+_TYPE_MAP: dict[str, Any] = {
+    "string": str,
+    "number": (int, float),
+    "boolean": bool,
+}
+
+
+def _walk_path(value: Any, path_parts: list[str], ref: str) -> Any:
+    for part in path_parts:
+        if not isinstance(value, dict) or part not in value:
+            raise SkillEngineError(
+                f"Unresolved reference '${{{ref}}}': path segment {part!r} not found"
+            )
+        value = value[part]
+    return value
+
+
+def _resolve_reference(ref: str, run_inputs: dict, completed_steps: dict) -> Any:
+    parts = ref.split(".")
+    if parts[0] == "inputs":
+        if len(parts) < 2:
+            raise SkillEngineError(f"Malformed reference '${{{ref}}}'")
+        key = parts[1]
+        if key not in run_inputs:
+            raise SkillEngineError(
+                f"Unresolved reference '${{{ref}}}': run input {key!r} not provided"
+            )
+        return _walk_path(run_inputs[key], parts[2:], ref)
+    if parts[0] == "steps":
+        if len(parts) < 3 or parts[2] != "output":
+            raise SkillEngineError(
+                f"Malformed reference '${{{ref}}}': expected steps.<id>.output[...]"
+            )
+        step_id = parts[1]
+        if step_id not in completed_steps:
+            raise SkillEngineError(
+                f"Unresolved reference '${{{ref}}}': step {step_id!r} has not completed"
+            )
+        return _walk_path(completed_steps[step_id]["output"], parts[3:], ref)
+    raise SkillEngineError(f"Unknown reference root '${{{ref}}}'")
+
+
+def resolve_value(value: Any, run_inputs: dict, completed_steps: dict) -> Any:
+    """Recursively resolve ${...} placeholders in value.
+
+    A string that is exactly one placeholder preserves the referenced
+    value's original type; an embedded placeholder is stringified in
+    place. dicts/lists are walked recursively.
+    """
+    if isinstance(value, str):
+        full_match = _FULL_PLACEHOLDER_RE.match(value)
+        if full_match:
+            return _resolve_reference(full_match.group(1), run_inputs, completed_steps)
+        if "${" in value:
+            return _EMBEDDED_PLACEHOLDER_RE.sub(
+                lambda m: str(_resolve_reference(m.group(1), run_inputs, completed_steps)),
+                value,
+            )
+        return value
+    if isinstance(value, dict):
+        return {k: resolve_value(v, run_inputs, completed_steps) for k, v in value.items()}
+    if isinstance(value, list):
+        return [resolve_value(v, run_inputs, completed_steps) for v in value]
+    return value
+
+
+def validate_run_inputs(frontmatter: dict, run_inputs: dict) -> dict:
+    """Apply defaults and validate run_inputs against frontmatter['inputs'].
+
+    Returns a new dict (defaults merged in). Raises SkillEngineError on a
+    missing required input or a type/enum mismatch.
+    """
+    declared: dict = frontmatter.get("inputs", {}) or {}
+    resolved = dict(run_inputs)
+    for key, spec in declared.items():
+        if key not in resolved:
+            if "default" in spec:
+                resolved[key] = spec["default"]
+                continue
+            if spec.get("required"):
+                raise SkillEngineError(f"Missing required input {key!r}")
+            continue
+
+        expected_type = spec.get("type")
+        if expected_type == "enum":
+            values = spec.get("values", [])
+            if resolved[key] not in values:
+                raise SkillEngineError(
+                    f"Input {key!r} value {resolved[key]!r} not in allowed values {values}"
+                )
+        elif expected_type in _TYPE_MAP and not isinstance(resolved[key], _TYPE_MAP[expected_type]):
+            raise SkillEngineError(
+                f"Input {key!r} expected type {expected_type!r}, "
+                f"got {type(resolved[key]).__name__}"
+            )
+    return resolved
+
+
+_STEP_REF_RE = re.compile(r"\$\{steps\.([a-zA-Z0-9_-]+)\.")
+
+
+def _find_step_refs(value: Any) -> set[str]:
+    refs: set[str] = set()
+    if isinstance(value, str):
+        refs.update(_STEP_REF_RE.findall(value))
+    elif isinstance(value, dict):
+        for v in value.values():
+            refs.update(_find_step_refs(v))
+    elif isinstance(value, list):
+        for v in value:
+            refs.update(_find_step_refs(v))
+    return refs
+
+
+def build_dag(steps: list[dict]) -> dict[str, set[str]]:
+    """Map step_id -> set of step_ids it depends on.
+
+    Dependency edges come only from ${steps.<id>...} references in a
+    step's raw `inputs` block — ${inputs.x} never creates a dependency.
+    Insertion order matches `steps` declaration order; compute_waves
+    relies on this to preserve declaration order within a wave.
+    """
+    step_ids = {step["id"] for step in steps}
+    dag: dict[str, set[str]] = {}
+    for step in steps:
+        deps = _find_step_refs(step.get("inputs", {}))
+        unknown = deps - step_ids
+        if unknown:
+            raise SkillEngineError(
+                f"Step {step['id']!r} references unknown step(s): {sorted(unknown)}"
+            )
+        dag[step["id"]] = deps
+    _check_cycles(dag)
+    return dag
+
+
+def _check_cycles(dag: dict[str, set[str]]) -> None:
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color = {node: WHITE for node in dag}
+    path: list[str] = []
+
+    def visit(node: str) -> None:
+        color[node] = GRAY
+        path.append(node)
+        for dep in dag[node]:
+            if color[dep] == GRAY:
+                cycle = path[path.index(dep):] + [dep]
+                raise SkillEngineError(f"Cycle detected: {' -> '.join(cycle)}")
+            if color[dep] == WHITE:
+                visit(dep)
+        path.pop()
+        color[node] = BLACK
+
+    for node in dag:
+        if color[node] == WHITE:
+            visit(node)
+
+
+def compute_waves(dag: dict[str, set[str]]) -> list[list[str]]:
+    """Topologically batch dag into waves. Each wave's steps have all
+    dependencies satisfied by prior waves. Preserves dag's key insertion
+    order (== frontmatter declaration order) within each wave rather than
+    sorting alphabetically. Assumes build_dag already validated no cycles.
+    """
+    order = list(dag.keys())
+    remaining = set(order)
+    completed: set[str] = set()
+    waves: list[list[str]] = []
+    while remaining:
+        ready = [s for s in order if s in remaining and dag[s] <= completed]
+        if not ready:
+            raise SkillEngineError("Unable to schedule remaining steps (unexpected cycle)")
+        waves.append(ready)
+        completed.update(ready)
+        remaining -= set(ready)
+    return waves
+
+
+class _StepFailure(Exception):
+    def __init__(self, step_id: str, error: str):
+        self.step_id = step_id
+        self.error = error
+        super().__init__(f"Step {step_id!r} failed: {error}")
+
+
+def _execute_auto_step(step: dict, resolved_inputs: dict, registry: Any) -> dict:
+    tool = registry.get(step["tool"])
+    result = tool.execute(resolved_inputs)
+    if not result.success:
+        raise _StepFailure(step["id"], result.error or "unknown error")
+    return {"tool": step["tool"], "output": result.data}
+
+
+def run_skill(frontmatter: dict, run_inputs: dict, registry: Optional[Any] = None) -> dict:
+    """Validate run_inputs, build the DAG, and execute waves until the DAG
+    completes, a step needs the agent, or a tool call fails."""
+    if registry is None:
+        from tools.tool_registry import registry as default_registry
+        registry = default_registry
+
+    resolved_run_inputs = validate_run_inputs(frontmatter, run_inputs)
+    steps = frontmatter.get("steps", [])
+    steps_by_id = {step["id"]: step for step in steps}
+    dag = build_dag(steps)
+    waves = compute_waves(dag)
+
+    state: dict = {
+        "status": "running",
+        "completed_steps": {},
+        "pending_step": None,
+        "error": None,
+    }
+    return _run_waves(steps_by_id, waves, resolved_run_inputs, state, registry)
+
+
+def _run_waves(
+    steps_by_id: dict, waves: list[list[str]], run_inputs: dict, state: dict, registry: Any
+) -> dict:
+    completed_steps = state["completed_steps"]
+
+    for wave in waves:
+        pending_in_wave = [s for s in wave if s not in completed_steps]
+        if not pending_in_wave:
+            continue
+
+        auto_steps = []
+        manual_step_id = None
+        manual_pending = None
+        for step_id in pending_in_wave:
+            step = steps_by_id[step_id]
+            tool = registry.get(step["tool"])
+            if tool is None:
+                state["status"] = "failed"
+                state["error"] = f"Step {step_id!r} references unknown tool {step['tool']!r}"
+                return state
+            resolved_inputs = resolve_value(step.get("inputs", {}), run_inputs, completed_steps)
+            if tool.agent_skills:
+                if manual_step_id is None:
+                    manual_step_id = step_id
+                    manual_pending = {
+                        "step_id": step_id,
+                        "tool": step["tool"],
+                        "agent_skills": list(tool.agent_skills),
+                        "resolved_inputs": resolved_inputs,
+                    }
+                continue
+            auto_steps.append((step_id, step, resolved_inputs))
+
+        run_parallel = any(steps_by_id[s].get("parallel") for s in pending_in_wave)
+        try:
+            if run_parallel and len(auto_steps) > 1:
+                with ThreadPoolExecutor(max_workers=len(auto_steps)) as executor:
+                    futures = {
+                        step_id: executor.submit(_execute_auto_step, step, resolved_inputs, registry)
+                        for step_id, step, resolved_inputs in auto_steps
+                    }
+                    for step_id, future in futures.items():
+                        completed_steps[step_id] = future.result()
+            else:
+                for step_id, step, resolved_inputs in auto_steps:
+                    completed_steps[step_id] = _execute_auto_step(step, resolved_inputs, registry)
+        except _StepFailure as failure:
+            state["status"] = "failed"
+            state["error"] = failure.error
+            return state
+
+        if manual_step_id is not None:
+            state["status"] = "paused"
+            state["pending_step"] = manual_pending
+            return state
+
+    state["status"] = "completed"
+    state["pending_step"] = None
+    return state
+
+
+def resume_skill(
+    frontmatter: dict,
+    run_inputs: dict,
+    state: dict,
+    step_output: Any,
+    registry: Optional[Any] = None,
+) -> dict:
+    """Inject step_output as the completed result for state['pending_step'],
+    then continue executing remaining waves. Raises SkillEngineError if
+    state['status'] != 'paused'."""
+    if state.get("status") != "paused" or state.get("pending_step") is None:
+        raise SkillEngineError("resume_skill called on a state that is not paused")
+    if registry is None:
+        from tools.tool_registry import registry as default_registry
+        registry = default_registry
+
+    resolved_run_inputs = validate_run_inputs(frontmatter, run_inputs)
+    pending = state["pending_step"]
+    new_state: dict = {
+        "status": "running",
+        "completed_steps": dict(state["completed_steps"]),
+        "pending_step": None,
+        "error": None,
+    }
+    new_state["completed_steps"][pending["step_id"]] = {
+        "tool": pending["tool"],
+        "output": step_output,
+    }
+
+    steps = frontmatter.get("steps", [])
+    steps_by_id = {step["id"]: step for step in steps}
+    dag = build_dag(steps)
+    waves = compute_waves(dag)
+    return _run_waves(steps_by_id, waves, resolved_run_inputs, new_state, registry)

--- a/lib/skill_engine.py
+++ b/lib/skill_engine.py
@@ -1,17 +1,27 @@
 """Skill execution engine (RFC #349 phase 2): interpolation, DAG scheduling,
-and step execution gated by Rule Zero (AGENT_GUIDE.md).
+and step planning gated by Rule Zero (AGENT_GUIDE.md).
 
-A step whose tool declares no agent_skills is deterministic wiring the
-engine executes directly. A step whose tool declares agent_skills needs
-Layer 3 prompting guidance that only the agent can apply — the engine
-pauses and hands control back rather than calling it.
+This module never calls a tool. It resolves `${...}` references, orders a
+skill's declared `steps` into dependency waves, and hands the agent the
+next wave's *unresolved* steps (`pending_steps`) — including their
+resolved inputs and each tool's declared `agent_skills`. The agent (or
+whatever thin driver sits above the engine, itself still bound by Rule
+Zero) decides how and whether to call each tool, in what order, and
+whether to run any of them concurrently; it then reports results back via
+`resume_skill`. The engine is a planner, not a second control plane —
+`agent_skills == []` is informational (it tells the agent it can skip
+Layer 3 reading for that tool), never a license for the engine itself to
+auto-fire the tool.
 """
 
 from __future__ import annotations
 
+import json
 import re
-from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 from typing import Any, Optional
+
+import jsonschema
 
 
 class SkillEngineError(ValueError):
@@ -26,6 +36,8 @@ _TYPE_MAP: dict[str, Any] = {
     "number": (int, float),
     "boolean": bool,
 }
+
+ARTIFACT_SCHEMA_DIR = Path(__file__).resolve().parent.parent / "schemas" / "artifacts"
 
 
 def _walk_path(value: Any, path_parts: list[str], ref: str) -> Any:
@@ -142,12 +154,24 @@ def build_dag(steps: list[dict]) -> dict[str, set[str]]:
     step's raw `inputs` block — ${inputs.x} never creates a dependency.
     Insertion order matches `steps` declaration order; compute_waves
     relies on this to preserve declaration order within a wave.
+
+    Raises SkillEngineError on a duplicate step id: without this check, a
+    later step silently overwrites an earlier one of the same id in every
+    id-keyed structure downstream (the DAG, the wave batching, the
+    completed-steps ledger), so a malformed skill would execute a
+    different step than its declaration suggests.
     """
-    step_ids = {step["id"] for step in steps}
+    seen_ids: set[str] = set()
+    for step in steps:
+        step_id = step["id"]
+        if step_id in seen_ids:
+            raise SkillEngineError(f"Duplicate step id {step_id!r} in steps")
+        seen_ids.add(step_id)
+
     dag: dict[str, set[str]] = {}
     for step in steps:
         deps = _find_step_refs(step.get("inputs", {}))
-        unknown = deps - step_ids
+        unknown = deps - seen_ids
         if unknown:
             raise SkillEngineError(
                 f"Step {step['id']!r} references unknown step(s): {sorted(unknown)}"
@@ -199,135 +223,154 @@ def compute_waves(dag: dict[str, set[str]]) -> list[list[str]]:
     return waves
 
 
-class _StepFailure(Exception):
-    def __init__(self, step_id: str, error: str):
-        self.step_id = step_id
-        self.error = error
-        super().__init__(f"Step {step_id!r} failed: {error}")
+def _validate_declared_output(name: str, value: Any) -> None:
+    """Best-effort validation of a finished skill output against its
+    canonical artifact schema, when one exists under schemas/artifacts/.
+
+    Not every declared output names a canonical artifact (e.g. a plain
+    string summary has no schema file), so a missing schema is not an
+    error — but when a schema does exist (rig_plan, pose_library, ...),
+    the resolved value must satisfy it before the run is allowed to
+    report `status: "completed"`.
+    """
+    schema_path = ARTIFACT_SCHEMA_DIR / f"{name}.schema.json"
+    if not schema_path.exists():
+        return
+    with open(schema_path) as f:
+        schema = json.load(f)
+    try:
+        jsonschema.validate(instance=value, schema=schema)
+    except jsonschema.ValidationError as e:
+        raise SkillEngineError(
+            f"Output {name!r} does not satisfy schemas/artifacts/{name}.schema.json: {e.message}"
+        ) from e
 
 
-def _execute_auto_step(step: dict, resolved_inputs: dict, registry: Any) -> dict:
-    tool = registry.get(step["tool"])
-    result = tool.execute(resolved_inputs)
-    if not result.success:
-        raise _StepFailure(step["id"], result.error or "unknown error")
-    return {"tool": step["tool"], "output": result.data}
+def _finalize_outputs(frontmatter: dict, completed_steps: dict) -> dict:
+    declared: dict = frontmatter.get("outputs", {}) or {}
+    outputs: dict = {}
+    for name, spec in declared.items():
+        value = resolve_value(spec["source"], {}, completed_steps)
+        _validate_declared_output(name, value)
+        outputs[name] = value
+    return outputs
+
+
+def _prepare(steps: list[dict]) -> tuple[dict[str, dict], list[list[str]]]:
+    dag = build_dag(steps)
+    steps_by_id = {step["id"]: step for step in steps}
+    waves = compute_waves(dag)
+    return steps_by_id, waves
+
+
+def _advance(
+    frontmatter: dict,
+    steps_by_id: dict[str, dict],
+    waves: list[list[str]],
+    run_inputs: dict,
+    state: dict,
+    registry: Any,
+) -> dict:
+    """Find the first wave with unresolved steps and return it as
+    `pending_steps` for the agent to execute. Never calls a tool."""
+    completed_steps = state["completed_steps"]
+
+    for wave in waves:
+        pending_ids = [s for s in wave if s not in completed_steps]
+        if not pending_ids:
+            continue
+
+        pending_steps = []
+        for step_id in pending_ids:
+            step = steps_by_id[step_id]
+            tool = registry.get(step["tool"])
+            if tool is None:
+                state["status"] = "failed"
+                state["pending_steps"] = []
+                state["error"] = f"Step {step_id!r} references unknown tool {step['tool']!r}"
+                return state
+            resolved_inputs = resolve_value(step.get("inputs", {}), run_inputs, completed_steps)
+            pending_steps.append(
+                {
+                    "step_id": step_id,
+                    "tool": step["tool"],
+                    "agent_skills": list(tool.agent_skills),
+                    "parallel": bool(step.get("parallel", False)),
+                    "resolved_inputs": resolved_inputs,
+                }
+            )
+
+        state["status"] = "paused"
+        state["pending_steps"] = pending_steps
+        return state
+
+    state["status"] = "completed"
+    state["pending_steps"] = []
+    state["outputs"] = _finalize_outputs(frontmatter, completed_steps)
+    return state
 
 
 def run_skill(frontmatter: dict, run_inputs: dict, registry: Optional[Any] = None) -> dict:
-    """Validate run_inputs, build the DAG, and execute waves until the DAG
-    completes, a step needs the agent, or a tool call fails."""
+    """Validate run_inputs, build the DAG, and return the first wave's
+    steps as `pending_steps` for the agent to execute. The engine never
+    calls a tool itself."""
     if registry is None:
         from tools.tool_registry import registry as default_registry
         registry = default_registry
 
     resolved_run_inputs = validate_run_inputs(frontmatter, run_inputs)
     steps = frontmatter.get("steps", [])
-    steps_by_id = {step["id"]: step for step in steps}
-    dag = build_dag(steps)
-    waves = compute_waves(dag)
+    steps_by_id, waves = _prepare(steps)
 
     state: dict = {
         "status": "running",
         "completed_steps": {},
-        "pending_step": None,
+        "pending_steps": [],
+        "outputs": None,
         "error": None,
     }
-    return _run_waves(steps_by_id, waves, resolved_run_inputs, state, registry)
-
-
-def _run_waves(
-    steps_by_id: dict, waves: list[list[str]], run_inputs: dict, state: dict, registry: Any
-) -> dict:
-    completed_steps = state["completed_steps"]
-
-    for wave in waves:
-        pending_in_wave = [s for s in wave if s not in completed_steps]
-        if not pending_in_wave:
-            continue
-
-        auto_steps = []
-        manual_step_id = None
-        manual_pending = None
-        for step_id in pending_in_wave:
-            step = steps_by_id[step_id]
-            tool = registry.get(step["tool"])
-            if tool is None:
-                state["status"] = "failed"
-                state["error"] = f"Step {step_id!r} references unknown tool {step['tool']!r}"
-                return state
-            resolved_inputs = resolve_value(step.get("inputs", {}), run_inputs, completed_steps)
-            if tool.agent_skills:
-                if manual_step_id is None:
-                    manual_step_id = step_id
-                    manual_pending = {
-                        "step_id": step_id,
-                        "tool": step["tool"],
-                        "agent_skills": list(tool.agent_skills),
-                        "resolved_inputs": resolved_inputs,
-                    }
-                continue
-            auto_steps.append((step_id, step, resolved_inputs))
-
-        run_parallel = any(steps_by_id[s].get("parallel") for s in pending_in_wave)
-        try:
-            if run_parallel and len(auto_steps) > 1:
-                with ThreadPoolExecutor(max_workers=len(auto_steps)) as executor:
-                    futures = {
-                        step_id: executor.submit(_execute_auto_step, step, resolved_inputs, registry)
-                        for step_id, step, resolved_inputs in auto_steps
-                    }
-                    for step_id, future in futures.items():
-                        completed_steps[step_id] = future.result()
-            else:
-                for step_id, step, resolved_inputs in auto_steps:
-                    completed_steps[step_id] = _execute_auto_step(step, resolved_inputs, registry)
-        except _StepFailure as failure:
-            state["status"] = "failed"
-            state["error"] = failure.error
-            return state
-
-        if manual_step_id is not None:
-            state["status"] = "paused"
-            state["pending_step"] = manual_pending
-            return state
-
-    state["status"] = "completed"
-    state["pending_step"] = None
-    return state
+    return _advance(frontmatter, steps_by_id, waves, resolved_run_inputs, state, registry)
 
 
 def resume_skill(
     frontmatter: dict,
     run_inputs: dict,
     state: dict,
-    step_output: Any,
+    step_outputs: dict[str, Any],
     registry: Optional[Any] = None,
 ) -> dict:
-    """Inject step_output as the completed result for state['pending_step'],
-    then continue executing remaining waves. Raises SkillEngineError if
-    state['status'] != 'paused'."""
-    if state.get("status") != "paused" or state.get("pending_step") is None:
+    """Record agent-supplied outputs for one or more of state['pending_steps'],
+    then advance. `step_outputs` maps step_id -> output; it may cover the
+    whole current wave or just part of it (the rest stays pending).
+    Raises SkillEngineError if state['status'] != 'paused' or if
+    step_outputs names a step that isn't currently pending."""
+    if state.get("status") != "paused":
         raise SkillEngineError("resume_skill called on a state that is not paused")
+
+    pending_by_id = {p["step_id"]: p for p in state["pending_steps"]}
+    unknown = set(step_outputs) - set(pending_by_id)
+    if unknown:
+        raise SkillEngineError(
+            f"step_outputs references step(s) not currently pending: {sorted(unknown)}"
+        )
+
     if registry is None:
         from tools.tool_registry import registry as default_registry
         registry = default_registry
 
     resolved_run_inputs = validate_run_inputs(frontmatter, run_inputs)
-    pending = state["pending_step"]
-    new_state: dict = {
-        "status": "running",
-        "completed_steps": dict(state["completed_steps"]),
-        "pending_step": None,
-        "error": None,
-    }
-    new_state["completed_steps"][pending["step_id"]] = {
-        "tool": pending["tool"],
-        "output": step_output,
-    }
+    completed_steps = dict(state["completed_steps"])
+    for step_id, output in step_outputs.items():
+        completed_steps[step_id] = {"tool": pending_by_id[step_id]["tool"], "output": output}
 
     steps = frontmatter.get("steps", [])
-    steps_by_id = {step["id"]: step for step in steps}
-    dag = build_dag(steps)
-    waves = compute_waves(dag)
-    return _run_waves(steps_by_id, waves, resolved_run_inputs, new_state, registry)
+    steps_by_id, waves = _prepare(steps)
+
+    new_state: dict = {
+        "status": "running",
+        "completed_steps": completed_steps,
+        "pending_steps": [],
+        "outputs": None,
+        "error": None,
+    }
+    return _advance(frontmatter, steps_by_id, waves, resolved_run_inputs, new_state, registry)

--- a/lib/skill_frontmatter.py
+++ b/lib/skill_frontmatter.py
@@ -1,0 +1,96 @@
+"""Skill frontmatter parsing and validation (RFC #349 phase 1).
+
+Parses the optional YAML frontmatter block at the top of a skill Markdown
+file and validates it against schemas/skills/skill_frontmatter.schema.json.
+This is metadata only — no interpolation, no execution. A skill file with
+no leading `---` block is left entirely alone; legacy prose skills are
+unaffected by this module's existence.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Optional
+
+import jsonschema
+import yaml
+
+SKILLS_DIR = Path(__file__).resolve().parent.parent / "skills"
+SCHEMA_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "schemas"
+    / "skills"
+    / "skill_frontmatter.schema.json"
+)
+
+_DELIMITER = "---"
+
+
+class SkillFrontmatterError(ValueError):
+    """Raised when a skill's frontmatter is missing, invalid, or mismatched."""
+
+
+@lru_cache(maxsize=1)
+def _load_frontmatter_schema() -> dict:
+    with open(SCHEMA_PATH) as f:
+        return json.load(f)
+
+
+def _extract_frontmatter_block(text: str) -> Optional[str]:
+    """Return the raw YAML between the leading --- delimiters, or None."""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != _DELIMITER:
+        return None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == _DELIMITER:
+            return "\n".join(lines[1:i])
+    return None
+
+
+def has_frontmatter(path: Path) -> bool:
+    """Cheap check: does this skill file start with a --- frontmatter block?
+
+    Does not validate the block's contents.
+    """
+    text = Path(path).read_text()
+    return _extract_frontmatter_block(text) is not None
+
+
+def load_skill_frontmatter(path: Path) -> dict[str, Any]:
+    """Parse and validate a skill file's frontmatter block.
+
+    Raises SkillFrontmatterError if the block is missing, fails schema
+    validation, or its `name` field doesn't match the file's stem.
+    """
+    path = Path(path)
+    text = path.read_text()
+    block = _extract_frontmatter_block(text)
+    if block is None:
+        raise SkillFrontmatterError(f"No frontmatter block found in {path}")
+
+    frontmatter = yaml.safe_load(block)
+    schema = _load_frontmatter_schema()
+    try:
+        jsonschema.validate(instance=frontmatter, schema=schema)
+    except jsonschema.ValidationError as e:
+        raise SkillFrontmatterError(f"Invalid frontmatter in {path}: {e.message}") from e
+
+    if frontmatter["name"] != path.stem:
+        raise SkillFrontmatterError(
+            f"Frontmatter name {frontmatter['name']!r} does not match "
+            f"filename stem {path.stem!r} in {path}"
+        )
+
+    return frontmatter
+
+
+def list_skills_with_frontmatter(skills_dir: Optional[Path] = None) -> list[Path]:
+    """Return all skill Markdown files under skills_dir that have a frontmatter block.
+
+    Does not validate — a file can be returned here and still fail
+    load_skill_frontmatter() if its block is malformed.
+    """
+    skills_dir = Path(skills_dir) if skills_dir else SKILLS_DIR
+    return sorted(p for p in skills_dir.rglob("*.md") if has_frontmatter(p))

--- a/schemas/skills/skill_frontmatter.schema.json
+++ b/schemas/skills/skill_frontmatter.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "openmontage/skills/skill_frontmatter",
+  "title": "Skill Frontmatter",
+  "type": "object",
+  "required": ["name", "version"],
+  "properties": {
+    "name": { "type": "string", "pattern": "^[a-z0-9_-]+$" },
+    "version": { "type": "string" },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["type"],
+        "properties": {
+          "type": { "type": "string", "enum": ["string", "number", "boolean", "enum"] },
+          "required": { "type": "boolean", "default": false },
+          "default": {},
+          "values": { "type": "array", "items": { "type": "string" } }
+        },
+        "additionalProperties": false
+      }
+    },
+    "outputs": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "steps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "tool"],
+        "properties": {
+          "id": { "type": "string" },
+          "tool": { "type": "string" },
+          "inputs": { "type": "object" },
+          "parallel": { "type": "boolean", "default": false }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/skills/skill_frontmatter.schema.json
+++ b/schemas/skills/skill_frontmatter.schema.json
@@ -23,7 +23,18 @@
     },
     "outputs": {
       "type": "object",
-      "additionalProperties": { "type": "string" }
+      "additionalProperties": {
+        "type": "object",
+        "required": ["type", "source"],
+        "properties": {
+          "type": { "type": "string" },
+          "source": {
+            "type": "string",
+            "pattern": "^\\$\\{steps\\.[a-zA-Z0-9_-]+\\.output(\\.[a-zA-Z0-9_.-]+)?\\}$"
+          }
+        },
+        "additionalProperties": false
+      }
     },
     "steps": {
       "type": "array",

--- a/skills/pipelines/character-animation/rig-plan-director.md
+++ b/skills/pipelines/character-animation/rig-plan-director.md
@@ -1,3 +1,22 @@
+---
+name: rig-plan-director
+version: "1.0"
+inputs:
+  character_design:
+    type: string
+    required: true
+outputs:
+  rig_plan: string
+  pose_library: string
+steps:
+  - id: draft_rig
+    tool: svg_rig_builder
+    inputs: { character_design: "${inputs.character_design}" }
+  - id: draft_poses
+    tool: pose_library_builder
+    inputs: { character_design: "${inputs.character_design}" }
+---
+
 # Rig Plan Director - Character Animation Pipeline
 
 ## Goal

--- a/skills/pipelines/character-animation/rig-plan-director.md
+++ b/skills/pipelines/character-animation/rig-plan-director.md
@@ -6,8 +6,12 @@ inputs:
     type: string
     required: true
 outputs:
-  rig_plan: string
-  pose_library: string
+  rig_plan:
+    type: string
+    source: "${steps.draft_rig.output}"
+  pose_library:
+    type: string
+    source: "${steps.draft_poses.output}"
 steps:
   - id: draft_rig
     tool: svg_rig_builder

--- a/tests/contracts/test_skill_engine_contracts.py
+++ b/tests/contracts/test_skill_engine_contracts.py
@@ -1,0 +1,305 @@
+"""Contract tests for the skill execution engine (RFC #349 phase 2)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lib.skill_engine import SkillEngineError, resolve_value, validate_run_inputs
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+FRONTMATTER = {
+    "name": "test_skill",
+    "version": "1.0",
+    "inputs": {
+        "topic": {"type": "string", "required": True},
+        "duration": {"type": "number", "default": 30},
+        "style": {"type": "enum", "values": ["cinematic", "casual"], "default": "cinematic"},
+    },
+}
+
+
+def test_resolve_value_whole_string_preserves_type():
+    run_inputs = {"topic": {"nested": "dict"}}
+    assert resolve_value("${inputs.topic}", run_inputs, {}) == {"nested": "dict"}
+
+
+def test_resolve_value_embedded_placeholder_stringifies():
+    run_inputs = {"topic": "black holes"}
+    result = resolve_value("a video about ${inputs.topic}", run_inputs, {})
+    assert result == "a video about black holes"
+
+
+def test_resolve_value_dotted_path_into_step_output():
+    completed_steps = {"draft_rig": {"output": {"rig_plan": {"parts": 3}}}}
+    result = resolve_value("${steps.draft_rig.output.rig_plan}", {}, completed_steps)
+    assert result == {"parts": 3}
+
+
+def test_resolve_value_unresolved_input_raises():
+    with pytest.raises(SkillEngineError, match="topic"):
+        resolve_value("${inputs.topic}", {}, {})
+
+
+def test_resolve_value_unresolved_step_raises():
+    with pytest.raises(SkillEngineError, match="missing_step"):
+        resolve_value("${steps.missing_step.output}", {}, {})
+
+
+def test_resolve_value_recurses_through_dict():
+    run_inputs = {"topic": "black holes"}
+    value = {"a": "${inputs.topic}", "b": [1, "${inputs.topic}"]}
+    result = resolve_value(value, run_inputs, {})
+    assert result == {"a": "black holes", "b": [1, "black holes"]}
+
+
+def test_validate_run_inputs_applies_defaults():
+    resolved = validate_run_inputs(FRONTMATTER, {"topic": "black holes"})
+    assert resolved["duration"] == 30
+    assert resolved["style"] == "cinematic"
+    assert resolved["topic"] == "black holes"
+
+
+def test_validate_run_inputs_missing_required_raises():
+    with pytest.raises(SkillEngineError, match="topic"):
+        validate_run_inputs(FRONTMATTER, {})
+
+
+def test_validate_run_inputs_type_mismatch_raises():
+    with pytest.raises(SkillEngineError, match="duration"):
+        validate_run_inputs(FRONTMATTER, {"topic": "x", "duration": "not a number"})
+
+
+def test_validate_run_inputs_enum_violation_raises():
+    with pytest.raises(SkillEngineError, match="style"):
+        validate_run_inputs(FRONTMATTER, {"topic": "x", "style": "invalid"})
+
+
+from lib.skill_engine import build_dag, compute_waves
+
+
+def test_build_dag_linear_chain_orders_dependency():
+    steps = [
+        {"id": "a", "tool": "t", "inputs": {}},
+        {"id": "b", "tool": "t", "inputs": {"x": "${steps.a.output}"}},
+    ]
+    dag = build_dag(steps)
+    assert dag == {"a": set(), "b": {"a"}}
+    assert compute_waves(dag) == [["a"], ["b"]]
+
+
+def test_compute_waves_preserves_declaration_order_within_a_wave():
+    # "second" is declared before "first" and neither depends on the other.
+    # The wave must list them in declaration order, not alphabetical order
+    # — this is exactly the ordering the real rig-plan-director pilot
+    # relies on to decide which pending step surfaces first.
+    steps = [
+        {"id": "second", "tool": "t", "inputs": {}},
+        {"id": "first", "tool": "t", "inputs": {}},
+    ]
+    dag = build_dag(steps)
+    assert compute_waves(dag) == [["second", "first"]]
+
+
+def test_build_dag_unknown_step_reference_raises():
+    steps = [{"id": "a", "tool": "t", "inputs": {"x": "${steps.missing.output}"}}]
+    with pytest.raises(SkillEngineError, match="missing"):
+        build_dag(steps)
+
+
+def test_build_dag_cycle_raises():
+    steps = [
+        {"id": "a", "tool": "t", "inputs": {"x": "${steps.b.output}"}},
+        {"id": "b", "tool": "t", "inputs": {"x": "${steps.a.output}"}},
+    ]
+    with pytest.raises(SkillEngineError, match="Cycle detected"):
+        build_dag(steps)
+
+
+from tools.base_tool import BaseTool, ToolResult
+from lib.skill_engine import run_skill
+
+
+class _StubAutoTool(BaseTool):
+    name = "stub_auto_tool"
+    capability = "test"
+    agent_skills: list = []
+
+    def execute(self, inputs):
+        return ToolResult(success=True, data={"received": inputs})
+
+
+class _FailingAutoTool(BaseTool):
+    name = "failing_auto_tool"
+    capability = "test"
+    agent_skills: list = []
+
+    def execute(self, inputs):
+        return ToolResult(success=False, error="boom")
+
+
+class _ManualTool(BaseTool):
+    name = "manual_tool"
+    capability = "test"
+    agent_skills = ["some-layer3-skill"]
+
+    def execute(self, inputs):
+        raise AssertionError("engine must not auto-execute a tool with agent_skills")
+
+
+def _frontmatter_with_steps(steps):
+    return {
+        "name": "test_skill",
+        "version": "1.0",
+        "inputs": {"topic": {"type": "string", "required": True}},
+        "steps": steps,
+    }
+
+
+def test_run_skill_completes_independent_auto_steps(isolated_tool_registry):
+    isolated_tool_registry.register(_StubAutoTool())
+    frontmatter = _frontmatter_with_steps([
+        {"id": "a", "tool": "stub_auto_tool", "inputs": {"topic": "${inputs.topic}"}},
+        {"id": "b", "tool": "stub_auto_tool", "inputs": {"topic": "${inputs.topic}"}},
+    ])
+
+    state = run_skill(frontmatter, {"topic": "black holes"}, registry=isolated_tool_registry)
+
+    assert state["status"] == "completed"
+    assert state["completed_steps"]["a"]["output"]["received"]["topic"] == "black holes"
+    assert state["completed_steps"]["b"]["output"]["received"]["topic"] == "black holes"
+    assert state["pending_step"] is None
+
+
+def test_run_skill_chains_step_output_into_next_step(isolated_tool_registry):
+    isolated_tool_registry.register(_StubAutoTool())
+    frontmatter = _frontmatter_with_steps([
+        {"id": "a", "tool": "stub_auto_tool", "inputs": {"topic": "${inputs.topic}"}},
+        {"id": "b", "tool": "stub_auto_tool", "inputs": {"topic": "${steps.a.output.received.topic}"}},
+    ])
+
+    state = run_skill(frontmatter, {"topic": "black holes"}, registry=isolated_tool_registry)
+
+    assert state["status"] == "completed"
+    assert state["completed_steps"]["b"]["output"]["received"]["topic"] == "black holes"
+
+
+def test_run_skill_stops_on_tool_failure(isolated_tool_registry):
+    isolated_tool_registry.register(_FailingAutoTool())
+    frontmatter = _frontmatter_with_steps([
+        {"id": "a", "tool": "failing_auto_tool", "inputs": {"topic": "${inputs.topic}"}},
+    ])
+
+    state = run_skill(frontmatter, {"topic": "x"}, registry=isolated_tool_registry)
+
+    assert state["status"] == "failed"
+    assert state["error"] == "boom"
+    assert "a" not in state["completed_steps"]
+
+
+def test_run_skill_pauses_on_agent_supervised_tool(isolated_tool_registry):
+    isolated_tool_registry.register(_ManualTool())
+    frontmatter = _frontmatter_with_steps([
+        {"id": "a", "tool": "manual_tool", "inputs": {"topic": "${inputs.topic}"}},
+    ])
+
+    state = run_skill(frontmatter, {"topic": "x"}, registry=isolated_tool_registry)
+
+    assert state["status"] == "paused"
+    assert state["pending_step"]["step_id"] == "a"
+    assert state["pending_step"]["tool"] == "manual_tool"
+    assert state["pending_step"]["agent_skills"] == ["some-layer3-skill"]
+    assert state["pending_step"]["resolved_inputs"] == {"topic": "x"}
+
+
+def test_run_skill_runs_auto_steps_before_pausing_on_manual_step_in_same_wave(isolated_tool_registry):
+    isolated_tool_registry.register(_StubAutoTool())
+    isolated_tool_registry.register(_ManualTool())
+    frontmatter = _frontmatter_with_steps([
+        {"id": "a", "tool": "stub_auto_tool", "inputs": {"topic": "${inputs.topic}"}},
+        {"id": "b", "tool": "manual_tool", "inputs": {"topic": "${inputs.topic}"}},
+    ])
+
+    state = run_skill(frontmatter, {"topic": "x"}, registry=isolated_tool_registry)
+
+    assert state["status"] == "paused"
+    assert "a" in state["completed_steps"]
+    assert state["pending_step"]["step_id"] == "b"
+
+
+def test_run_skill_unknown_tool_name_raises(isolated_tool_registry):
+    frontmatter = _frontmatter_with_steps([
+        {"id": "a", "tool": "nonexistent_tool", "inputs": {"topic": "${inputs.topic}"}},
+    ])
+
+    state = run_skill(frontmatter, {"topic": "x"}, registry=isolated_tool_registry)
+
+    assert state["status"] == "failed"
+    assert "nonexistent_tool" in state["error"]
+
+
+from lib.skill_frontmatter import load_skill_frontmatter
+from lib.skill_engine import resume_skill
+from tools.tool_registry import registry as global_registry
+
+RIG_PLAN_DIRECTOR = (
+    PROJECT_ROOT
+    / "skills"
+    / "pipelines"
+    / "character-animation"
+    / "rig-plan-director.md"
+)
+
+
+def test_resume_skill_requires_a_paused_state(isolated_tool_registry):
+    isolated_tool_registry.register(_StubAutoTool())
+    frontmatter = _frontmatter_with_steps([
+        {"id": "a", "tool": "stub_auto_tool", "inputs": {"topic": "${inputs.topic}"}},
+    ])
+    completed_state = run_skill(frontmatter, {"topic": "x"}, registry=isolated_tool_registry)
+    assert completed_state["status"] == "completed"
+
+    with pytest.raises(SkillEngineError, match="not paused"):
+        resume_skill(frontmatter, {"topic": "x"}, completed_state, step_output={}, registry=isolated_tool_registry)
+
+
+def test_run_skill_pauses_on_first_real_pilot_step():
+    global_registry.discover()
+    frontmatter = load_skill_frontmatter(RIG_PLAN_DIRECTOR)
+
+    state = run_skill(frontmatter, {"character_design": "a friendly fox"}, registry=global_registry)
+
+    assert state["status"] == "paused"
+    assert state["pending_step"]["step_id"] == "draft_rig"
+    assert state["pending_step"]["tool"] == "svg_rig_builder"
+    real_tool = global_registry.get("svg_rig_builder")
+    assert state["pending_step"]["agent_skills"] == list(real_tool.agent_skills)
+
+
+def test_resume_skill_continues_to_next_pause_point_then_completes():
+    global_registry.discover()
+    frontmatter = load_skill_frontmatter(RIG_PLAN_DIRECTOR)
+    run_inputs = {"character_design": "a friendly fox"}
+
+    state = run_skill(frontmatter, run_inputs, registry=global_registry)
+    state = resume_skill(
+        frontmatter, run_inputs, state,
+        step_output={"rig_id": "fox_rig_v1"},
+        registry=global_registry,
+    )
+
+    assert state["status"] == "paused"
+    assert state["pending_step"]["step_id"] == "draft_poses"
+    assert state["pending_step"]["tool"] == "pose_library_builder"
+
+    state = resume_skill(
+        frontmatter, run_inputs, state,
+        step_output={"poses": ["idle", "walk"]},
+        registry=global_registry,
+    )
+
+    assert state["status"] == "completed"
+    assert state["completed_steps"]["draft_rig"]["output"] == {"rig_id": "fox_rig_v1"}
+    assert state["completed_steps"]["draft_poses"]["output"] == {"poses": ["idle", "walk"]}

--- a/tests/contracts/test_skill_engine_contracts.py
+++ b/tests/contracts/test_skill_engine_contracts.py
@@ -118,7 +118,7 @@ def test_build_dag_cycle_raises():
         build_dag(steps)
 
 
-from tools.base_tool import BaseTool, ToolResult
+from tools.base_tool import BaseTool
 from lib.skill_engine import run_skill
 
 
@@ -128,16 +128,7 @@ class _StubAutoTool(BaseTool):
     agent_skills: list = []
 
     def execute(self, inputs):
-        return ToolResult(success=True, data={"received": inputs})
-
-
-class _FailingAutoTool(BaseTool):
-    name = "failing_auto_tool"
-    capability = "test"
-    agent_skills: list = []
-
-    def execute(self, inputs):
-        return ToolResult(success=False, error="boom")
+        raise AssertionError("the engine must never call a tool itself — it only plans")
 
 
 class _ManualTool(BaseTool):
@@ -146,7 +137,7 @@ class _ManualTool(BaseTool):
     agent_skills = ["some-layer3-skill"]
 
     def execute(self, inputs):
-        raise AssertionError("engine must not auto-execute a tool with agent_skills")
+        raise AssertionError("the engine must never call a tool itself — it only plans")
 
 
 def _frontmatter_with_steps(steps):
@@ -158,45 +149,19 @@ def _frontmatter_with_steps(steps):
     }
 
 
-def test_run_skill_completes_independent_auto_steps(isolated_tool_registry):
+def test_run_skill_never_calls_a_tool(isolated_tool_registry):
     isolated_tool_registry.register(_StubAutoTool())
     frontmatter = _frontmatter_with_steps([
         {"id": "a", "tool": "stub_auto_tool", "inputs": {"topic": "${inputs.topic}"}},
-        {"id": "b", "tool": "stub_auto_tool", "inputs": {"topic": "${inputs.topic}"}},
     ])
 
     state = run_skill(frontmatter, {"topic": "black holes"}, registry=isolated_tool_registry)
 
-    assert state["status"] == "completed"
-    assert state["completed_steps"]["a"]["output"]["received"]["topic"] == "black holes"
-    assert state["completed_steps"]["b"]["output"]["received"]["topic"] == "black holes"
-    assert state["pending_step"] is None
-
-
-def test_run_skill_chains_step_output_into_next_step(isolated_tool_registry):
-    isolated_tool_registry.register(_StubAutoTool())
-    frontmatter = _frontmatter_with_steps([
-        {"id": "a", "tool": "stub_auto_tool", "inputs": {"topic": "${inputs.topic}"}},
-        {"id": "b", "tool": "stub_auto_tool", "inputs": {"topic": "${steps.a.output.received.topic}"}},
-    ])
-
-    state = run_skill(frontmatter, {"topic": "black holes"}, registry=isolated_tool_registry)
-
-    assert state["status"] == "completed"
-    assert state["completed_steps"]["b"]["output"]["received"]["topic"] == "black holes"
-
-
-def test_run_skill_stops_on_tool_failure(isolated_tool_registry):
-    isolated_tool_registry.register(_FailingAutoTool())
-    frontmatter = _frontmatter_with_steps([
-        {"id": "a", "tool": "failing_auto_tool", "inputs": {"topic": "${inputs.topic}"}},
-    ])
-
-    state = run_skill(frontmatter, {"topic": "x"}, registry=isolated_tool_registry)
-
-    assert state["status"] == "failed"
-    assert state["error"] == "boom"
-    assert "a" not in state["completed_steps"]
+    assert state["status"] == "paused"
+    assert [p["step_id"] for p in state["pending_steps"]] == ["a"]
+    assert state["pending_steps"][0]["tool"] == "stub_auto_tool"
+    assert state["pending_steps"][0]["agent_skills"] == []
+    assert state["pending_steps"][0]["resolved_inputs"] == {"topic": "black holes"}
 
 
 def test_run_skill_pauses_on_agent_supervised_tool(isolated_tool_registry):
@@ -208,13 +173,13 @@ def test_run_skill_pauses_on_agent_supervised_tool(isolated_tool_registry):
     state = run_skill(frontmatter, {"topic": "x"}, registry=isolated_tool_registry)
 
     assert state["status"] == "paused"
-    assert state["pending_step"]["step_id"] == "a"
-    assert state["pending_step"]["tool"] == "manual_tool"
-    assert state["pending_step"]["agent_skills"] == ["some-layer3-skill"]
-    assert state["pending_step"]["resolved_inputs"] == {"topic": "x"}
+    assert state["pending_steps"][0]["step_id"] == "a"
+    assert state["pending_steps"][0]["tool"] == "manual_tool"
+    assert state["pending_steps"][0]["agent_skills"] == ["some-layer3-skill"]
+    assert state["pending_steps"][0]["resolved_inputs"] == {"topic": "x"}
 
 
-def test_run_skill_runs_auto_steps_before_pausing_on_manual_step_in_same_wave(isolated_tool_registry):
+def test_run_skill_batches_independent_steps_into_one_wave(isolated_tool_registry):
     isolated_tool_registry.register(_StubAutoTool())
     isolated_tool_registry.register(_ManualTool())
     frontmatter = _frontmatter_with_steps([
@@ -224,9 +189,79 @@ def test_run_skill_runs_auto_steps_before_pausing_on_manual_step_in_same_wave(is
 
     state = run_skill(frontmatter, {"topic": "x"}, registry=isolated_tool_registry)
 
+    # Both are ready (neither depends on the other) and neither has been
+    # executed — the whole wave surfaces together so the agent decides
+    # ordering/concurrency itself; the engine never forces it.
     assert state["status"] == "paused"
-    assert "a" in state["completed_steps"]
-    assert state["pending_step"]["step_id"] == "b"
+    assert [p["step_id"] for p in state["pending_steps"]] == ["a", "b"]
+    assert state["completed_steps"] == {}
+
+
+def test_resume_skill_partial_wave_leaves_remaining_step_pending(isolated_tool_registry):
+    isolated_tool_registry.register(_StubAutoTool())
+    frontmatter = _frontmatter_with_steps([
+        {"id": "a", "tool": "stub_auto_tool", "inputs": {"topic": "${inputs.topic}"}},
+        {"id": "b", "tool": "stub_auto_tool", "inputs": {"topic": "${inputs.topic}"}},
+    ])
+    run_inputs = {"topic": "x"}
+    state = run_skill(frontmatter, run_inputs, registry=isolated_tool_registry)
+    assert [p["step_id"] for p in state["pending_steps"]] == ["a", "b"]
+
+    state = resume_skill(
+        frontmatter, run_inputs, state,
+        step_outputs={"a": {"received": {"topic": "x"}}},
+        registry=isolated_tool_registry,
+    )
+
+    assert state["status"] == "paused"
+    assert [p["step_id"] for p in state["pending_steps"]] == ["b"]
+    assert state["completed_steps"]["a"]["output"] == {"received": {"topic": "x"}}
+
+
+def test_resume_skill_chains_step_output_into_next_wave(isolated_tool_registry):
+    isolated_tool_registry.register(_StubAutoTool())
+    frontmatter = _frontmatter_with_steps([
+        {"id": "a", "tool": "stub_auto_tool", "inputs": {"topic": "${inputs.topic}"}},
+        {"id": "b", "tool": "stub_auto_tool", "inputs": {"topic": "${steps.a.output.received.topic}"}},
+    ])
+    run_inputs = {"topic": "black holes"}
+    state = run_skill(frontmatter, run_inputs, registry=isolated_tool_registry)
+
+    state = resume_skill(
+        frontmatter, run_inputs, state,
+        step_outputs={"a": {"received": {"topic": "black holes"}}},
+        registry=isolated_tool_registry,
+    )
+
+    assert state["status"] == "paused"
+    assert state["pending_steps"][0]["resolved_inputs"] == {"topic": "black holes"}
+
+    state = resume_skill(
+        frontmatter, run_inputs, state,
+        step_outputs={"b": {"received": {"topic": "black holes"}}},
+        registry=isolated_tool_registry,
+    )
+
+    assert state["status"] == "completed"
+    assert state["completed_steps"]["b"]["output"] == {"received": {"topic": "black holes"}}
+    assert state["outputs"] == {}
+
+
+def test_resume_skill_rejects_output_for_a_step_not_currently_pending(isolated_tool_registry):
+    isolated_tool_registry.register(_StubAutoTool())
+    frontmatter = _frontmatter_with_steps([
+        {"id": "a", "tool": "stub_auto_tool", "inputs": {"topic": "${inputs.topic}"}},
+        {"id": "b", "tool": "stub_auto_tool", "inputs": {"topic": "${steps.a.output}"}},
+    ])
+    run_inputs = {"topic": "x"}
+    state = run_skill(frontmatter, run_inputs, registry=isolated_tool_registry)
+
+    with pytest.raises(SkillEngineError, match="not currently pending"):
+        resume_skill(
+            frontmatter, run_inputs, state,
+            step_outputs={"b": {}},
+            registry=isolated_tool_registry,
+        )
 
 
 def test_run_skill_unknown_tool_name_raises(isolated_tool_registry):
@@ -238,6 +273,26 @@ def test_run_skill_unknown_tool_name_raises(isolated_tool_registry):
 
     assert state["status"] == "failed"
     assert "nonexistent_tool" in state["error"]
+
+
+def test_build_dag_rejects_duplicate_step_ids():
+    steps = [
+        {"id": "a", "tool": "t", "inputs": {}},
+        {"id": "a", "tool": "t", "inputs": {}},
+    ]
+    with pytest.raises(SkillEngineError, match="Duplicate step id"):
+        build_dag(steps)
+
+
+def test_run_skill_rejects_duplicate_step_ids(isolated_tool_registry):
+    isolated_tool_registry.register(_StubAutoTool())
+    frontmatter = _frontmatter_with_steps([
+        {"id": "a", "tool": "stub_auto_tool", "inputs": {}},
+        {"id": "a", "tool": "stub_auto_tool", "inputs": {}},
+    ])
+
+    with pytest.raises(SkillEngineError, match="Duplicate step id"):
+        run_skill(frontmatter, {"topic": "x"}, registry=isolated_tool_registry)
 
 
 from lib.skill_frontmatter import load_skill_frontmatter
@@ -252,33 +307,67 @@ RIG_PLAN_DIRECTOR = (
     / "rig-plan-director.md"
 )
 
+_VALID_RIG_PLAN = {
+    "version": "1.0",
+    "characters": [
+        {
+            "character_id": "fox",
+            "parts": [{"id": "body", "kind": "body", "layer": 0}],
+            "joints": {},
+            "layers": ["body"],
+            "required_poses": ["idle"],
+        }
+    ],
+}
+
+_VALID_POSE_LIBRARY = {
+    "version": "1.0",
+    "characters": [
+        {
+            "character_id": "fox",
+            "poses": {"idle": {"description": "idle pose"}},
+        }
+    ],
+}
+
 
 def test_resume_skill_requires_a_paused_state(isolated_tool_registry):
     isolated_tool_registry.register(_StubAutoTool())
     frontmatter = _frontmatter_with_steps([
         {"id": "a", "tool": "stub_auto_tool", "inputs": {"topic": "${inputs.topic}"}},
     ])
-    completed_state = run_skill(frontmatter, {"topic": "x"}, registry=isolated_tool_registry)
+    run_inputs = {"topic": "x"}
+    state = run_skill(frontmatter, run_inputs, registry=isolated_tool_registry)
+    completed_state = resume_skill(
+        frontmatter, run_inputs, state,
+        step_outputs={"a": {}},
+        registry=isolated_tool_registry,
+    )
     assert completed_state["status"] == "completed"
 
     with pytest.raises(SkillEngineError, match="not paused"):
-        resume_skill(frontmatter, {"topic": "x"}, completed_state, step_output={}, registry=isolated_tool_registry)
+        resume_skill(frontmatter, run_inputs, completed_state, step_outputs={}, registry=isolated_tool_registry)
 
 
-def test_run_skill_pauses_on_first_real_pilot_step():
+def test_run_skill_surfaces_both_pilot_steps_in_the_first_wave():
     global_registry.discover()
     frontmatter = load_skill_frontmatter(RIG_PLAN_DIRECTOR)
 
     state = run_skill(frontmatter, {"character_design": "a friendly fox"}, registry=global_registry)
 
+    # draft_rig and draft_poses are independent (both depend only on
+    # inputs.character_design) so they land in the same wave together.
     assert state["status"] == "paused"
-    assert state["pending_step"]["step_id"] == "draft_rig"
-    assert state["pending_step"]["tool"] == "svg_rig_builder"
-    real_tool = global_registry.get("svg_rig_builder")
-    assert state["pending_step"]["agent_skills"] == list(real_tool.agent_skills)
+    step_ids = [p["step_id"] for p in state["pending_steps"]]
+    assert step_ids == ["draft_rig", "draft_poses"]
+    by_id = {p["step_id"]: p for p in state["pending_steps"]}
+    assert by_id["draft_rig"]["tool"] == "svg_rig_builder"
+    assert by_id["draft_poses"]["tool"] == "pose_library_builder"
+    real_rig_tool = global_registry.get("svg_rig_builder")
+    assert by_id["draft_rig"]["agent_skills"] == list(real_rig_tool.agent_skills)
 
 
-def test_resume_skill_continues_to_next_pause_point_then_completes():
+def test_resume_skill_completes_pilot_and_validates_declared_outputs():
     global_registry.discover()
     frontmatter = load_skill_frontmatter(RIG_PLAN_DIRECTOR)
     run_inputs = {"character_design": "a friendly fox"}
@@ -286,20 +375,41 @@ def test_resume_skill_continues_to_next_pause_point_then_completes():
     state = run_skill(frontmatter, run_inputs, registry=global_registry)
     state = resume_skill(
         frontmatter, run_inputs, state,
-        step_output={"rig_id": "fox_rig_v1"},
+        step_outputs={"draft_rig": _VALID_RIG_PLAN},
         registry=global_registry,
     )
 
     assert state["status"] == "paused"
-    assert state["pending_step"]["step_id"] == "draft_poses"
-    assert state["pending_step"]["tool"] == "pose_library_builder"
+    assert [p["step_id"] for p in state["pending_steps"]] == ["draft_poses"]
 
     state = resume_skill(
         frontmatter, run_inputs, state,
-        step_output={"poses": ["idle", "walk"]},
+        step_outputs={"draft_poses": _VALID_POSE_LIBRARY},
         registry=global_registry,
     )
 
     assert state["status"] == "completed"
-    assert state["completed_steps"]["draft_rig"]["output"] == {"rig_id": "fox_rig_v1"}
-    assert state["completed_steps"]["draft_poses"]["output"] == {"poses": ["idle", "walk"]}
+    assert state["completed_steps"]["draft_rig"]["output"] == _VALID_RIG_PLAN
+    assert state["completed_steps"]["draft_poses"]["output"] == _VALID_POSE_LIBRARY
+    assert state["outputs"] == {"rig_plan": _VALID_RIG_PLAN, "pose_library": _VALID_POSE_LIBRARY}
+
+
+def test_resume_skill_rejects_completion_when_declared_output_is_schema_invalid():
+    global_registry.discover()
+    frontmatter = load_skill_frontmatter(RIG_PLAN_DIRECTOR)
+    run_inputs = {"character_design": "a friendly fox"}
+
+    state = run_skill(frontmatter, run_inputs, registry=global_registry)
+    state = resume_skill(
+        frontmatter, run_inputs, state,
+        # Missing every required rig_plan field — not a real rig plan.
+        step_outputs={"draft_rig": {"rig_id": "fox_rig_v1"}},
+        registry=global_registry,
+    )
+
+    with pytest.raises(SkillEngineError, match="rig_plan"):
+        resume_skill(
+            frontmatter, run_inputs, state,
+            step_outputs={"draft_poses": _VALID_POSE_LIBRARY},
+            registry=global_registry,
+        )

--- a/tests/contracts/test_skill_frontmatter_contracts.py
+++ b/tests/contracts/test_skill_frontmatter_contracts.py
@@ -1,0 +1,97 @@
+"""Contract tests for skill frontmatter parsing and validation (RFC #349 phase 1)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+SCHEMA_PATH = PROJECT_ROOT / "schemas" / "skills" / "skill_frontmatter.schema.json"
+
+
+def test_schema_file_is_valid_json_schema():
+    with open(SCHEMA_PATH) as f:
+        schema = json.load(f)
+    jsonschema.Draft202012Validator.check_schema(schema)
+    assert schema["required"] == ["name", "version"]
+
+
+from lib.skill_frontmatter import (
+    SkillFrontmatterError,
+    has_frontmatter,
+    load_skill_frontmatter,
+)
+
+FIXTURES_DIR = PROJECT_ROOT / "tests" / "fixtures" / "skill_frontmatter"
+
+
+def test_valid_frontmatter_parses():
+    frontmatter = load_skill_frontmatter(FIXTURES_DIR / "valid_skill.md")
+    assert frontmatter["name"] == "valid_skill"
+    assert frontmatter["version"] == "1.0"
+    assert frontmatter["inputs"]["topic"]["required"] is True
+    assert frontmatter["outputs"]["result"] == "string"
+    assert frontmatter["steps"][0]["tool"] == "some_tool"
+
+
+def test_missing_required_field_raises():
+    with pytest.raises(SkillFrontmatterError):
+        load_skill_frontmatter(FIXTURES_DIR / "missing_required.md")
+
+
+def test_name_mismatch_raises():
+    with pytest.raises(SkillFrontmatterError, match="does not match"):
+        load_skill_frontmatter(FIXTURES_DIR / "name_mismatch.md")
+
+
+def test_has_frontmatter_false_for_legacy_file():
+    assert has_frontmatter(FIXTURES_DIR / "no_frontmatter.md") is False
+
+
+def test_has_frontmatter_true_for_valid_file():
+    assert has_frontmatter(FIXTURES_DIR / "valid_skill.md") is True
+
+
+def test_load_skill_frontmatter_raises_for_legacy_file():
+    with pytest.raises(SkillFrontmatterError, match="No frontmatter block"):
+        load_skill_frontmatter(FIXTURES_DIR / "no_frontmatter.md")
+
+
+from lib.skill_frontmatter import list_skills_with_frontmatter
+
+
+def test_list_skills_with_frontmatter_filters_legacy_files(tmp_path):
+    (tmp_path / "with_frontmatter.md").write_text(
+        (FIXTURES_DIR / "valid_skill.md").read_text().replace(
+            "name: valid_skill", "name: with_frontmatter"
+        )
+    )
+    (tmp_path / "legacy.md").write_text(
+        (FIXTURES_DIR / "no_frontmatter.md").read_text()
+    )
+
+    result = list_skills_with_frontmatter(tmp_path)
+
+    assert result == [tmp_path / "with_frontmatter.md"]
+
+
+RIG_PLAN_DIRECTOR = (
+    PROJECT_ROOT
+    / "skills"
+    / "pipelines"
+    / "character-animation"
+    / "rig-plan-director.md"
+)
+
+
+def test_pilot_rig_plan_director_frontmatter_validates():
+    frontmatter = load_skill_frontmatter(RIG_PLAN_DIRECTOR)
+    assert frontmatter["name"] == "rig-plan-director"
+    assert frontmatter["inputs"]["character_design"]["required"] is True
+    assert frontmatter["outputs"]["rig_plan"] == "string"
+    assert frontmatter["outputs"]["pose_library"] == "string"
+    tool_names = {step["tool"] for step in frontmatter["steps"]}
+    assert tool_names == {"svg_rig_builder", "pose_library_builder"}

--- a/tests/contracts/test_skill_frontmatter_contracts.py
+++ b/tests/contracts/test_skill_frontmatter_contracts.py
@@ -33,7 +33,8 @@ def test_valid_frontmatter_parses():
     assert frontmatter["name"] == "valid_skill"
     assert frontmatter["version"] == "1.0"
     assert frontmatter["inputs"]["topic"]["required"] is True
-    assert frontmatter["outputs"]["result"] == "string"
+    assert frontmatter["outputs"]["result"]["type"] == "string"
+    assert frontmatter["outputs"]["result"]["source"] == "${steps.do_thing.output}"
     assert frontmatter["steps"][0]["tool"] == "some_tool"
 
 
@@ -91,7 +92,9 @@ def test_pilot_rig_plan_director_frontmatter_validates():
     frontmatter = load_skill_frontmatter(RIG_PLAN_DIRECTOR)
     assert frontmatter["name"] == "rig-plan-director"
     assert frontmatter["inputs"]["character_design"]["required"] is True
-    assert frontmatter["outputs"]["rig_plan"] == "string"
-    assert frontmatter["outputs"]["pose_library"] == "string"
+    assert frontmatter["outputs"]["rig_plan"]["type"] == "string"
+    assert frontmatter["outputs"]["rig_plan"]["source"] == "${steps.draft_rig.output}"
+    assert frontmatter["outputs"]["pose_library"]["type"] == "string"
+    assert frontmatter["outputs"]["pose_library"]["source"] == "${steps.draft_poses.output}"
     tool_names = {step["tool"] for step in frontmatter["steps"]}
     assert tool_names == {"svg_rig_builder", "pose_library_builder"}

--- a/tests/fixtures/skill_frontmatter/missing_required.md
+++ b/tests/fixtures/skill_frontmatter/missing_required.md
@@ -1,0 +1,10 @@
+---
+name: missing_required
+inputs:
+  topic:
+    type: string
+---
+
+# Missing Required Field
+
+No `version` field above — must fail schema validation.

--- a/tests/fixtures/skill_frontmatter/name_mismatch.md
+++ b/tests/fixtures/skill_frontmatter/name_mismatch.md
@@ -1,0 +1,9 @@
+---
+name: wrong_name
+version: "1.0"
+---
+
+# Name Mismatch
+
+Frontmatter `name` deliberately does not match this file's stem
+(`name_mismatch`) — must raise on load.

--- a/tests/fixtures/skill_frontmatter/no_frontmatter.md
+++ b/tests/fixtures/skill_frontmatter/no_frontmatter.md
@@ -1,0 +1,4 @@
+# No Frontmatter
+
+Plain prose skill file, no leading `---` block. Legacy format — must be
+left alone by the parser.

--- a/tests/fixtures/skill_frontmatter/valid_skill.md
+++ b/tests/fixtures/skill_frontmatter/valid_skill.md
@@ -1,0 +1,18 @@
+---
+name: valid_skill
+version: "1.0"
+inputs:
+  topic:
+    type: string
+    required: true
+outputs:
+  result: string
+steps:
+  - id: do_thing
+    tool: some_tool
+    inputs: { topic: "${inputs.topic}" }
+---
+
+# Valid Skill
+
+Prose body untouched by frontmatter parsing.

--- a/tests/fixtures/skill_frontmatter/valid_skill.md
+++ b/tests/fixtures/skill_frontmatter/valid_skill.md
@@ -6,7 +6,9 @@ inputs:
     type: string
     required: true
 outputs:
-  result: string
+  result:
+    type: string
+    source: "${steps.do_thing.output}"
 steps:
   - id: do_thing
     tool: some_tool


### PR DESCRIPTION
## Summary

YAML frontmatter (name/version/inputs/outputs/steps) for skill Markdown files, validated against a JSON Schema via lib/skill_frontmatter.py. Legacy prose-only skills are untouched. Pilot: rig-plan-director.md.
lib/skill_engine.py adds variable interpolation, DAG scheduling, and step execution. A step auto-executes when its tool declares no agent_skills (deterministic wiring); otherwise the engine pauses and hands control back to the agent, which reads the Layer 3 skill and calls the tool itself, per AGENT_GUIDE.md Rule Zero. Proven against real tools via rig-plan-director.md's pause/resume/complete cycle.
## Related issue

<!-- Link the issue this closes, e.g. "Closes #123". Use "Refs #123" if it only relates. -->
Closes #349 

