### PR TITLE
feat(pipeline): add product-motion — repo-grounded product UI animations

### DIFF
--- a/.agents/skills/glass-ui-motion/SKILL.md
+++ b/.agents/skills/glass-ui-motion/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: glass-ui-motion
+description: Author polished-SaaS product UI animations in Remotion — faithful replicas of a product's real components assembling on glassmorphic surfaces with spring motion and frame-accurate sound effects. Use in the product-motion pipeline's assets/edit stages, or for any atelier composition that animates a real product's UI. Knowledge only — ships no reusable components (atelier doctrine).
+license: MIT
+compatibility: Remotion via remotion-composer/ (atelier path). SFX generation needs sfx_gen (ELEVENLABS_API_KEY).
+metadata: {"openclaw": {"requires": {"env": []}}}
+---
+
+# Glass UI Motion
+
+The craft knowledge for **product-motion** atelier compositions: rebuild a
+product's real UI as Remotion React components, stage it on glass surfaces,
+assemble it element-by-element with spring choreography, and land sound
+effects on the exact settle frames.
+
+This skill carries **knowledge, never components** — per atelier doctrine
+("reuse engine knowledge, never creative components"), every run hand-authors
+its own scene components under `projects/<slug>/`. Read
+`skills/meta/bespoke-composition.md` first for the atelier construction
+sequence; this skill is the product-UI specialization of its step 2–4.
+
+## 1. The truthful-replica method
+
+The replica's authority is the repo, flowing through the `design_system` and
+`ui_inventory` artifacts from the repo_analysis stage:
+
+1. **Read the actual component source before authoring each replica.** The
+   `ui_inventory` entry lists `source_files` — open them. Port the real
+   structure: field order, label text, button copy, icon placement. If the
+   source says `Create workspace`, the replica says `Create workspace`.
+2. **Style exclusively from `design_system` tokens.** Define the tokens once
+   as a `tokens.ts` module in the project generated from the artifact, and
+   import from it everywhere. **No hex/size literal in a scene file that is
+   not in the artifact** — this is grep-auditable and reviewed at the compose
+   stage.
+3. **Record provenance per asset.** Every scene snapshot registered in the
+   asset_manifest carries `provenance.source_files` (the repo files it
+   replicates) and `provenance.design_tokens` (the token names it draws
+   from). Deviations go in `provenance.notes` with the reason.
+4. **Simplify by omission, never by substitution.** A replica may drop a
+   toolbar the scene doesn't need; it may not restyle one it keeps.
+
+## 2. Glass surface recipes
+
+The staging language: the product's UI sits on (or is framed by) frosted
+panels themed from its own palette (`design_system.tokens.glass`).
+
+```tsx
+// Composed from the design_system glass spec — values from the artifact.
+const glassPanel: React.CSSProperties = {
+  background: glass.background,            // primary/surface at 6–12% alpha
+  backdropFilter: `blur(${glass.backdrop_blur})`,
+  WebkitBackdropFilter: `blur(${glass.backdrop_blur})`,
+  border: glass.border,                    // 1px, white/text at 10–16% alpha
+  borderRadius: tokens.radii.card,         // the PRODUCT's radius, not a generic 24px
+  boxShadow: "0 24px 64px rgba(0,0,0,0.35)",
+};
+```
+
+- Layer order back-to-front: ambient background (subtle gradient from the
+  product's background token, optional slow drift) → glass panel(s) → the UI
+  replica → highlight strokes.
+- Top-edge highlight: a 1px inset gradient stroke at ~2x border alpha sells
+  the glass without skeuomorphism.
+- `backdropFilter` only blurs what is *behind* the panel — give it something
+  to blur (gradient blobs, oversized blurred type) or it reads as flat tint.
+  In-repo precedent for a working backdropFilter treatment:
+  `remotion-composer/src/components/ProviderChip.tsx` (read as mechanics, do
+  not import — stock imports fail the atelier guardrail).
+- **Respect the product's own register.** Glass intensity is a dial, not a
+  default: a dense, bordered, light-mode product wants restrained glass (low
+  blur, near-opaque panels); a dark gradient-heavy product can carry more.
+  When `design_system.summary` and glassmorphism disagree, the product wins.
+
+## 3. Assembly choreography
+
+Read `references/assembly-choreography.md` for build order, spring presets,
+stagger math, and settle-frame calculation. The one-line rules:
+
+- Build order is semantic: **container → chrome → fields → content → focus**.
+- One spring vocabulary per video (2–3 presets max), stagger 4–7 frames.
+- Every element's **settle frame** is computed, not eyeballed — it is where
+  the SFX cue lands.
+- Restraint: one thing assembling at a time is a story; twelve is noise.
+
+## 4. SFX cueing
+
+Read `references/sfx-cues.md` for the cue taxonomy, derivation rules, and
+generation prompts. Summary:
+
+- Generate short effects with the `sfx_gen` tool (ElevenLabs
+  sound-generation); register them in the asset_manifest as `type: "sfx"`.
+- Cues live **in-composition** as `<Audio>` sequences at exact settle frames
+  (atelier compositions may use `<Audio>` freely — narration/music stay on
+  the `audio_mixer` post-mix path).
+- The cue sheet (scene → element → frame → sfx asset) lives in the atelier
+  `props.json`, derived by the edit director from the scene plan's assembly
+  beats.
+- Density cap ≈ 1 cue per 0.7s; conservative gain (`volume={0.35}`-ish) since
+  post-mix loudnorm applies to the whole mix.
+
+## 5. Remotion mechanics that bite here
+
+- Frame-accurate audio: `<Sequence from={settleFrame}><Audio src={staticFile("sfx/tick.mp3")} volume={0.35}/></Sequence>`.
+  `<Audio>` rejects `file://` URLs — route SFX through the project's
+  `public_dir` and `staticFile()`.
+- Determinism: any randomness (gradient blob positions, particle drift) uses
+  Remotion's `random(seed)`, never `Math.random()`.
+- Fonts: load the product's real fonts (from the repo's font files or
+  next/font equivalents) at module scope via `@remotion/fonts`; a replica in
+  the wrong typeface fails the fidelity gate.
+- Per-scene `durationInFrames` must cover the last settle + a 12–18 frame
+  hold; nothing should still be moving at the cut.
+- Snapshot stills for the assets gate: `scripts/atelier_snapshots.py` renders
+  one PNG per scene at its most-assembled frame.
+
+## Distinctness check (before compose)
+
+Atelier's closing question, product-flavored: *could this composition be any
+other product's video?* If the palette, radii, type, and the UI itself don't
+answer "no" on sight, the replica isn't grounded enough — go back to the
+design_system.

--- a/.agents/skills/glass-ui-motion/references/assembly-choreography.md
+++ b/.agents/skills/glass-ui-motion/references/assembly-choreography.md
@@ -1,0 +1,80 @@
+# Assembly choreography
+
+How UI elements assemble on screen. The goal is the "product coming together"
+feeling of polished SaaS launch films: deliberate, weighted, never busy.
+
+## Build order — semantic, not spatial
+
+Assemble in the order a user *understands* the surface:
+
+1. **Container** — the glass panel / window chrome scales-fades in first and
+   establishes the stage.
+2. **Chrome** — nav, header, sidebar: the frame of reference.
+3. **Fields / structure** — form fields, table headers, card grids, in
+   reading order (top-left → bottom-right for LTR products).
+4. **Content** — values, rows, chart data populating the structure. Numbers
+   may count up; charts draw in.
+5. **Focus** — the one interaction the scene is about: cursor arrives, field
+   focuses, button presses, toggle flips. At most one focus beat per scene.
+
+Never assemble in random or purely aesthetic order — the build order IS the
+narration's visual argument.
+
+## Spring vocabulary
+
+Pick **2–3 presets for the whole video** and reuse them; per-element bespoke
+springs read as jitter. Solid starting set (Remotion `spring()`):
+
+```tsx
+// containers / panels — weighty, no overshoot
+const settle  = { damping: 200, stiffness: 120, mass: 1 };
+// fields / cards — light pop with a hint of overshoot
+const pop     = { damping: 18,  stiffness: 160, mass: 0.9 };
+// focus accents (button press, toggle) — snappy
+const snap    = { damping: 14,  stiffness: 260, mass: 0.6 };
+```
+
+Element entrances combine 2 of: translateY (12–24px), scale (0.96→1),
+opacity (0→1), blur (4px→0). Pick one combination per element *class* (all
+fields enter the same way).
+
+## Stagger math
+
+- Sibling elements (fields in a form, cards in a grid): stagger start frames
+  by **4–7 frames** (@30fps). Under 3 reads as simultaneous; over 10 reads as
+  a slideshow.
+- Grids: stagger by `row * cols + col` order (reading order), or radially
+  from the focus element for emphasis.
+- Between build-order groups (chrome → fields), leave a **6–10 frame breath**.
+
+## Settle frames — computed, not eyeballed
+
+The settle frame is where the element visually stops; it is also the SFX cue
+frame. For a spring started at `from` with config `c`:
+
+```tsx
+import {measureSpring} from "remotion";
+const settleFrame = from + measureSpring({fps, config: c}); // frames until rest
+```
+
+Compute settle frames in the props-generation step and write them into the cue
+sheet — do not hand-tune numbers scattered through scene files.
+
+## Camera and parallax restraint
+
+- The "camera" (a wrapper transform) may do ONE slow move per scene: a 2–4%
+  scale drift or a gentle pan. Never both, never fast.
+- Parallax between background blobs and the glass panel: ≤ 8px of relative
+  drift. It sells depth; more sells seasickness.
+- No 3D card flips, no rotations beyond ±2°, no bounce loops. Polished SaaS
+  is weighted and calm.
+
+## Timing against narration
+
+- Scene assembly should complete within the narration beat that introduces it
+  (from the scene plan's assembly beats). If narration for the form runs 6s,
+  the form finishes assembling by ~5s and holds.
+- Hold every completed scene 12–18 frames before the cut — nothing may still
+  be moving at a scene boundary.
+- Count-up numbers and chart draws end 0.5–1s before the cut so the viewer
+  reads the final value.

--- a/.agents/skills/glass-ui-motion/references/sfx-cues.md
+++ b/.agents/skills/glass-ui-motion/references/sfx-cues.md
@@ -1,0 +1,85 @@
+# SFX cues for UI assembly
+
+Deriving, generating, and placing sound effects for product-motion scenes.
+Primary path is **in-composition `<Audio>`** — cues are frame-accurate to the
+computed settle frames, which post-mix `start_seconds` can never guarantee.
+
+## Cue taxonomy — element class → sound
+
+| Element class | Cue | sfx_gen prompt sketch | Length |
+|---|---|---|---|
+| Glass panel / container | low soft whoosh + settle | "soft airy whoosh into a gentle low thump, smooth, subtle" | 0.8–1.2s |
+| Form field / card / row | glass tick | "single soft glass tick, short, clean, high and quiet" | 0.5s |
+| Button press (focus beat) | tactile click | "satisfying soft tactile click, plastic-glass, single" | 0.5s |
+| Toggle / checkbox | snap | "tiny crisp snap, single, bright but quiet" | 0.5s |
+| Chart draw / count-up | rising shimmer | "soft rising shimmer sweep, airy, 1 second, gentle" | 0.8–1.5s |
+| Success / completion | warm pop | "warm rounded pop with a faint bell tail, single, pleasant" | 0.6–1s |
+
+Rules of thumb: generate **one sound per element class and reuse it** across
+the video (consistency reads as design; variety reads as chaos). 4–6 distinct
+SFX assets covers a whole video.
+
+## Derivation rules (edit stage)
+
+From each scene's assembly beats (scene_plan) and computed settle frames:
+
+1. Container settle → whoosh cue.
+2. Each staggered sibling group: cue the **first and last** sibling's settle,
+   not every one — a tick per field in an 8-field form is a typewriter, not a
+   product film. Exception: ≤3 siblings may each cue.
+3. The focus beat always cues (click/snap).
+4. **Density cap: ~1 cue per 0.7s** per scene. Over cap, drop cues in this
+   order: middle siblings → chart shimmer → container whoosh. Never drop the
+   focus beat.
+5. No cue in the first 12 frames of the video (it lands before the viewer is
+   oriented) and none inside the final hold.
+
+## Generation (assets stage)
+
+```python
+registry._tools["sfx_gen"].execute({
+    "prompt": "single soft glass tick, short, clean, high and quiet",
+    "duration_seconds": 0.5,
+    "prompt_influence": 0.6,   # cue sounds want adherence; textures can go lower
+    "output_path": "projects/<id>/assets/audio/sfx_tick.mp3",
+})
+```
+
+Register each in the asset_manifest as `type: "sfx"` with the generation
+prompt. Listen to each effect once before wiring cues — a harsh or long SFX
+poisons every cue that reuses it.
+
+## Cue sheet → composition
+
+The edit director writes the cue sheet into the atelier `props.json`:
+
+```json
+{
+  "sfx_cues": [
+    {"scene_id": "form-assembly", "element": "panel", "frame": 18, "asset_id": "sfx_whoosh", "volume": 0.4},
+    {"scene_id": "form-assembly", "element": "field-email", "frame": 42, "asset_id": "sfx_tick", "volume": 0.3},
+    {"scene_id": "form-assembly", "element": "submit-press", "frame": 96, "asset_id": "sfx_click", "volume": 0.45}
+  ]
+}
+```
+
+Scene components render cues generically:
+
+```tsx
+{cues.filter(c => c.scene_id === id).map(c => (
+  <Sequence key={`${c.element}-${c.frame}`} from={c.frame} durationInFrames={60}>
+    <Audio src={staticFile(`audio/${c.asset_id}.mp3`)} volume={c.volume} />
+  </Sequence>
+))}
+```
+
+## Gain discipline
+
+- Cue volumes 0.3–0.45; the container whoosh may reach 0.5. SFX support the
+  narration, they never compete with it.
+- Narration + music are mixed in post by `audio_mixer` with loudnorm over the
+  **whole** mix — hot in-composition SFX will pump the normalization. When in
+  doubt, quieter.
+- Fallback: if a run post-mixes SFX instead (no atelier composition), the same
+  cue sheet maps to `edit_decisions.audio.sfx[]` (`asset_id`, `start_seconds =
+  frame/fps`, `volume`) and `audio_mixer`'s `sfx` track role handles it.

--- a/.agents/skills/repo-design-extraction/SKILL.md
+++ b/.agents/skills/repo-design-extraction/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: repo-design-extraction
+description: Extract a design system and UI inventory from a product's source-code repository (React/Next/Vue/Tailwind web frontends). Use in the product-motion pipeline's repo_analysis stage, or whenever a video must be grounded in a repo's real design tokens rather than a live URL. Produces the schema-validated design_system and ui_inventory artifacts with per-token provenance.
+license: MIT
+compatibility: No API keys. Optional `node` on PATH improves tailwind config evaluation.
+metadata: {"openclaw": {"requires": {"env": []}}}
+---
+
+# Repo Design Extraction
+
+Turn a product's **source repository** into two grounded artifacts:
+
+1. **`design_system`** (`schemas/artifacts/design_system.schema.json`) — tokens
+   (colors, typography, spacing, radii, shadows, glass) where **every value
+   cites the repo file it was read from**.
+2. **`ui_inventory`** (`schemas/artifacts/ui_inventory.schema.json`) — the
+   screens and components that exist, each with `source_files` and
+   `reviewed: true` (the inspected-not-assumed contract).
+
+This is the source-code sibling of `website-to-video`'s URL capture
+(`step-1-design.md`): same brand-truth goal, but grounded in the repo's own
+configs and component source instead of computed CSS from a live page.
+
+## The governing rule — read, don't invent
+
+A value goes in `tokens` only if you **read it in the repo**. Anything you
+derive (a glass spec composed from the palette, a spacing scale inferred from
+usage) is marked honestly: glass gets `derived: true` + `rationale`; everything
+else goes in `gaps[]` with `how_inferred`. A design_system whose tokens can't
+be spot-checked against their cited files is a defect, not a draft.
+
+## Process
+
+### Step 1 — Run the scanner first
+
+```python
+from tools.tool_registry import registry
+registry.discover()
+scan = registry._tools["repo_design_extractor"].execute({
+    "repo_path": "/path/to/product-repo",
+    "output_path": "projects/<project-id>/artifacts/repo_scan_report.json",
+})
+```
+
+The scan report gives you: `framework`, `styling_systems`, `candidate_files`
+(tailwind configs, `:root`/`@theme` CSS, theme modules, app shells),
+`css_custom_properties` (name/value/**file/line**), `tailwind_theme` (JS
+configs evaluated via node; `null` for TS configs — read those yourself),
+`fonts`, `screen_candidates` (with routes), and `components_index`.
+
+If `truncated: true`, say so — a partial scan silently presented as complete
+violates the no-silent-caps rule.
+
+### Step 2 — Read the flagged files
+
+The scanner locates; you interpret. Read every `candidate_files` entry plus the
+top screen candidates. Framework-specific guides:
+**`references/design-system-authoring.md`** (tokens) and
+**`references/ui-inventory-authoring.md`** (screens/components).
+
+### Step 3 — Author `design_system`
+
+- Assign **semantic roles** (primary / surface / text-muted / card-radius…)
+  from how tokens are *used* in components, not from name guessing.
+- Copy hex/size values **verbatim** — no rounding, no "close enough".
+- Provenance: prefer the scanner's file+line for CSS vars; for tailwind config
+  values use `key` (e.g. `theme.extend.colors.brand`).
+- Record the repo's `git_commit` (`git -C <repo> rev-parse HEAD`) when available.
+- Derive the glass spec last (see the authoring reference) — it is almost
+  always `derived: true`.
+
+### Step 4 — Author `ui_inventory`
+
+Walk `screen_candidates`, read each screen's source, list its real
+`ui_elements` **with their actual label text from the JSX/template**. Score
+flagship candidates (see reference) and write `flagship_recommendations` —
+these are what the user approves at the repo_analysis gate.
+
+### Step 5 — Validate and checkpoint
+
+```python
+from schemas.artifacts import validate_artifact
+validate_artifact("design_system", design_system)
+validate_artifact("ui_inventory", ui_inventory)
+```
+
+Write both into the `repo_analysis` checkpoint (`design_system` is canonical,
+`ui_inventory` supplementary) and present: the design read in one paragraph,
+the token table with provenance, the flagship screen recommendations, and the
+`gaps[]` ledger — then wait for approval.
+
+## Anti-patterns
+
+- Filling a palette from the product's marketing site instead of the repo
+  (that's `website-to-video` — a different grounding; never mix silently).
+- Inventing tokens "every design system has" (a warning color the repo lacks).
+- `ui_elements` labels like "Submit button" when the source says `Create
+  workspace` — labels are evidence, copy them exactly.
+- Listing a screen without having opened its source file (`reviewed: true` is
+  a contract, not a formality).
+- Hiding a thin design system. If the repo has 4 CSS vars and default Tailwind,
+  the design_system is *small* — say so and lean on `component_styles` +
+  `gaps[]`, don't pad it.

--- a/.agents/skills/repo-design-extraction/SKILL.md
+++ b/.agents/skills/repo-design-extraction/SKILL.md
@@ -2,7 +2,7 @@
 name: repo-design-extraction
 description: Extract a design system and UI inventory from a product's source-code repository (React/Next/Vue/Tailwind web frontends). Use in the product-motion pipeline's repo_analysis stage, or whenever a video must be grounded in a repo's real design tokens rather than a live URL. Produces the schema-validated design_system and ui_inventory artifacts with per-token provenance.
 license: MIT
-compatibility: No API keys. Optional `node` on PATH improves tailwind config evaluation.
+compatibility: No API keys. Reads the target repo only; never executes its code by default.
 metadata: {"openclaw": {"requires": {"env": []}}}
 ---
 
@@ -44,12 +44,28 @@ scan = registry._tools["repo_design_extractor"].execute({
 
 The scan report gives you: `framework`, `styling_systems`, `candidate_files`
 (tailwind configs, `:root`/`@theme` CSS, theme modules, app shells),
-`css_custom_properties` (name/value/**file/line**), `tailwind_theme` (JS
-configs evaluated via node; `null` for TS configs — read those yourself),
-`fonts`, `screen_candidates` (with routes), and `components_index`.
+`css_custom_properties` (name/value/**file/line**), `tailwind_theme` +
+`tailwind_theme_source`, `fonts`, `screen_candidates` (each with `route` and
+`route_source`), `components_index`, and `warnings`.
+
+Repo-relative paths are POSIX (`app/globals.css`) on every platform — quote
+them verbatim into artifact provenance.
 
 If `truncated: true`, say so — a partial scan silently presented as complete
-violates the no-silent-caps rule.
+violates the no-silent-caps rule. Read `warnings[]` and surface anything in it.
+
+**The scanner never runs the product's code.** A `tailwind.config.*` is
+executable JavaScript: requiring it would let an untrusted repo read secrets,
+write files, or make network calls. So the `theme` literal is parsed
+*statically* (works for `.ts` configs too). A config that computes its theme at
+runtime returns `tailwind_theme: null` with a warning — **read the config file
+yourself**, that is the intended path, not the `allow_config_execution` opt-in.
+Only reach for that opt-in on a repo you personally trust, tell the user you
+are doing it and why, and expect `tailwind_theme_source: "executed"` plus a
+warning in the run record.
+
+`output_path` must live under `projects/<project-id>/artifacts/`; the scanner
+rejects a path inside `repo_path` — the analyzed repo is never written to.
 
 ### Step 2 — Read the flagged files
 

--- a/.agents/skills/repo-design-extraction/references/design-system-authoring.md
+++ b/.agents/skills/repo-design-extraction/references/design-system-authoring.md
@@ -1,0 +1,96 @@
+# Authoring `design_system` from repo sources
+
+Framework-specific reading guides and token-distillation rules. The scanner
+(`repo_design_extractor`) has already located the files; this is how to read
+them.
+
+## Where tokens live, by styling system
+
+### Tailwind v3 (`tailwind.config.{js,ts,cjs,mjs}`)
+
+- Scanner evaluates JS configs into `tailwind_theme`; **TS configs come back
+  `null` — read the file yourself** and extract `theme` / `theme.extend`.
+- `theme.extend.*` **extends** defaults; a color under `extend.colors` is a
+  brand token. A full `theme.colors` (no extend) **replaces** defaults — then
+  the listed palette is the entire palette.
+- Values referencing CSS vars (`"hsl(var(--primary))"`, common in shadcn/ui)
+  mean the *real* value lives in the CSS `:root` block — resolve through and
+  cite the CSS file+line as provenance, noting the tailwind key in `role`.
+- Provenance for config values: `{file: "tailwind.config.ts", key: "theme.extend.colors.brand"}`.
+
+### Tailwind v4 (CSS-first `@theme`)
+
+- No JS config. Tokens are CSS custom properties inside `@theme { ... }`
+  blocks (scanner flags these files as `theme_css` and parses the vars).
+- Namespaced conventions: `--color-*`, `--font-*`, `--radius-*`, `--shadow-*`,
+  `--spacing-*` — the namespace gives you the token category for free.
+
+### Plain CSS custom properties (`:root`)
+
+- The scanner's `css_custom_properties` list is authoritative (file+line).
+- Watch for **dark-mode duplicates** (`.dark { --background: ... }`,
+  `@media (prefers-color-scheme: dark)`): record both values when present —
+  the video should match the mode the product actually ships as default.
+
+### styled-components / Emotion
+
+- Look for a `ThemeProvider` theme object (scanner flags `theme_source` files
+  by name; also grep for `createGlobalStyle` and `ThemeProvider`).
+- The theme object's keys are your token names; provenance `key` is the object
+  path (e.g. `theme.colors.primary`).
+
+### Vue / Nuxt SFCs
+
+- Global tokens usually live in `assets/css/*.css` or a `styles/` dir
+  (`:root` vars — scanner catches these).
+- Component-scoped `<style scoped>` blocks hold per-component styling — use
+  them for `component_styles`, not global tokens.
+
+## Typography
+
+- **next/font imports** (scanner's `fonts` with `source: "next/font"`) are the
+  ground truth for Next apps — include weights from the import options if
+  specified in the source.
+- `@font-face` families: cite the CSS file; note the font *files* exist in the
+  repo (the replica build can reference them via `public_dir`).
+- Type scale: read the heading/body styles actually used on flagship screens
+  (Tailwind classes like `text-4xl font-semibold tracking-tight` are scale
+  evidence — resolve them to concrete values via the Tailwind defaults or the
+  config overrides, and cite the component file that uses them).
+
+## Component styles
+
+For each button/input/card variant on a flagship screen, record a
+`css_summary` condensed from the actual classes/styles, e.g.:
+
+```json
+{
+  "variant": "primary button",
+  "css_summary": "bg --primary, text white, radius 8px (rounded-lg), px-4 py-2, shadow-sm, hover:bg-primary/90, text-sm font-medium",
+  "provenance": {"file": "components/ui/button.tsx", "line": 12}
+}
+```
+
+Copy class lists faithfully — they are what the replica must reproduce.
+
+## Deriving the glass spec (`tokens.glass`)
+
+Most products have no frosted surfaces; the glass panels are the *video's*
+staging device, themed by the product's palette. Standard derivation:
+
+- `background`: the primary or surface color at 6–12% alpha
+  (`rgba(99,102,241,0.08)`)
+- `backdrop_blur`: 16–28px
+- `border`: `1px solid` white (dark video bg) or the text color (light bg) at
+  10–16% alpha
+- `highlight`: optional 1px top-edge stroke at ~2x the border alpha
+- Set `derived: true` and write the `rationale` ("composed from --primary and
+  --background; product has no glass surfaces").
+- If the product *does* use `backdrop-filter` anywhere, that's real
+  provenance — cite it and set `derived: false`.
+
+Every derived value that isn't the glass spec goes in `gaps[]`:
+
+```json
+{"token": "spacing scale", "how_inferred": "no explicit scale; inferred 4/8/12/16/24 from usage frequency in app/page.tsx"}
+```

--- a/.agents/skills/repo-design-extraction/references/design-system-authoring.md
+++ b/.agents/skills/repo-design-extraction/references/design-system-authoring.md
@@ -8,8 +8,13 @@ them.
 
 ### Tailwind v3 (`tailwind.config.{js,ts,cjs,mjs}`)
 
-- Scanner evaluates JS configs into `tailwind_theme`; **TS configs come back
-  `null` — read the file yourself** and extract `theme` / `theme.extend`.
+- The scanner parses the `theme` literal **statically** (JS and TS alike) into
+  `tailwind_theme`, with `tailwind_theme_source: "static"`. It never executes
+  the config — that would run arbitrary repo JavaScript.
+- A config that builds its theme at runtime (spreads a preset, calls a
+  function, `require`s another module) comes back `null` with a warning:
+  **read the file yourself** and extract `theme` / `theme.extend`. That is the
+  normal path, not a failure.
 - `theme.extend.*` **extends** defaults; a color under `extend.colors` is a
   brand token. A full `theme.colors` (no extend) **replaces** defaults — then
   the listed palette is the entire palette.

--- a/.agents/skills/repo-design-extraction/references/ui-inventory-authoring.md
+++ b/.agents/skills/repo-design-extraction/references/ui-inventory-authoring.md
@@ -1,0 +1,70 @@
+# Authoring `ui_inventory` from repo sources
+
+How to turn the scanner's `screen_candidates` / `components_index` into the
+`ui_inventory` artifact. The contract: **every screen listed was actually
+read** (`reviewed: true`), and every `ui_elements[].label` is the element's
+real text from the source.
+
+## Walking screens
+
+- **Next app router** (`app/**/page.tsx`): the scanner derived the route from
+  the directory. Read the page *and* the components it imports — the page file
+  is often just a shell; the real UI lives one import away. Add those files to
+  `source_files` too.
+- **Next pages router / Vue pages**: same, route from file path.
+- **Non-routed roots** (`src/views`, `src/screens`, `src/features`): treat
+  each top-level view as a screen; leave `route` unset unless a router config
+  says otherwise.
+- Skip auth walls, error pages, and legal pages unless the brief asks for
+  them — they are rarely flagship surfaces.
+
+## Recording ui_elements
+
+For each screen list the elements that would *assemble* in an animation —
+forms, inputs, buttons, cards, tables, charts, navs, badges, avatars, toggles,
+tabs, modals. Rules:
+
+- `label` is the **visible text in the source**: the button's children, the
+  input's label/placeholder, the card's title. Copy exactly (`"Create
+  workspace"`, not "CTA button").
+- `source_file` is where the element's markup lives (the component file, not
+  the page that imports it, when they differ).
+- Dynamic content (`{user.name}`, mapped rows): describe the shape —
+  `label: "invoice rows (date, amount, status badge)"`.
+- 5–12 elements per screen is the useful range. The elements you list become
+  the build-order beats in scene planning — inventory what would animate, not
+  every div.
+
+## Shared components (`components`)
+
+Promote a component out of a screen into `components[]` when it appears on
+multiple screens or is individually animation-worthy (a stat card, a nav item,
+a form field group). `used_by_screens` links it back.
+
+## Flagship scoring
+
+Score each screen for `flagship_recommendations` on:
+
+1. **Visual richness** — number and variety of animatable elements.
+2. **Story value** — does it show the product's core promise (the dashboard,
+   the editor), or is it plumbing (settings)?
+3. **Form presence** — the brief wants forms/UI assembling; a screen with a
+   real form (labels, fields, a submit) is a strong candidate.
+4. **Replica feasibility** — a screen of custom canvas/WebGL is hard to
+   replicate truthfully; prefer DOM-built surfaces.
+
+Recommend 3–5 screens with one-line `why` each. The user picks at the
+repo_analysis gate — recommendations are input, not decisions.
+
+## planning_implications
+
+Concrete, actionable, ≥1. Good examples:
+
+- "Dashboard uses a 3-column card grid — the hero scene should assemble cards
+  into that grid, not invent a new layout."
+- "All CTAs are `--primary` filled buttons with 8px radius — replicas must not
+  use outline buttons."
+- "The onboarding form at /signup has 4 fields + OAuth buttons — natural
+  assembly sequence for the form scene."
+- "Product ships dark mode by default (`.dark` on html) — the video should be
+  dark-first."

--- a/.agents/skills/repo-design-extraction/references/ui-inventory-authoring.md
+++ b/.agents/skills/repo-design-extraction/references/ui-inventory-authoring.md
@@ -8,13 +8,17 @@ real text from the source.
 ## Walking screens
 
 - **Next app router** (`app/**/page.tsx`): the scanner derived the route from
-  the directory. Read the page *and* the components it imports — the page file
-  is often just a shell; the real UI lives one import away. Add those files to
-  `source_files` too.
-- **Next pages router / Vue pages**: same, route from file path.
-- **Non-routed roots** (`src/views`, `src/screens`, `src/features`): treat
-  each top-level view as a screen; leave `route` unset unless a router config
-  says otherwise.
+  the directory (`route_source: "next-app-router"`). Read the page *and* the
+  components it imports — the page file is often just a shell; the real UI
+  lives one import away. Add those files to `source_files` too.
+- **Next pages router** and **SvelteKit** (`src/routes/**/+page.svelte`): same,
+  route derived from the file path.
+- **Non-routed roots** (`src/views`, `src/screens`, `src/features`, and
+  `src/routes` outside SvelteKit): the scanner reports `route: null` /
+  `route_source: "not_derivable"` because the URL lives in a router config it
+  does not read. Treat each top-level view as a screen and leave `route` unset
+  unless you **read** the router config and can cite it. Do not reconstruct a
+  route from the filename — an invented route reads as fact in the artifact.
 - Skip auth walls, error pages, and legal pages unless the brief asks for
   them — they are rarely flagship surfaces.
 

--- a/.claude/skills/glass-ui-motion/SKILL.md
+++ b/.claude/skills/glass-ui-motion/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: glass-ui-motion
+description: Author polished-SaaS product UI animations in Remotion — faithful replicas of a product's real components assembling on glassmorphic surfaces with spring motion and frame-accurate sound effects. Use in the product-motion pipeline's assets/edit stages, or for any atelier composition that animates a real product's UI. Knowledge only — ships no reusable components (atelier doctrine).
+license: MIT
+compatibility: Remotion via remotion-composer/ (atelier path). SFX generation needs sfx_gen (ELEVENLABS_API_KEY).
+metadata: {"openclaw": {"requires": {"env": []}}}
+---
+
+# Glass UI Motion
+
+The craft knowledge for **product-motion** atelier compositions: rebuild a
+product's real UI as Remotion React components, stage it on glass surfaces,
+assemble it element-by-element with spring choreography, and land sound
+effects on the exact settle frames.
+
+This skill carries **knowledge, never components** — per atelier doctrine
+("reuse engine knowledge, never creative components"), every run hand-authors
+its own scene components under `projects/<slug>/`. Read
+`skills/meta/bespoke-composition.md` first for the atelier construction
+sequence; this skill is the product-UI specialization of its step 2–4.
+
+## 1. The truthful-replica method
+
+The replica's authority is the repo, flowing through the `design_system` and
+`ui_inventory` artifacts from the repo_analysis stage:
+
+1. **Read the actual component source before authoring each replica.** The
+   `ui_inventory` entry lists `source_files` — open them. Port the real
+   structure: field order, label text, button copy, icon placement. If the
+   source says `Create workspace`, the replica says `Create workspace`.
+2. **Style exclusively from `design_system` tokens.** Define the tokens once
+   as a `tokens.ts` module in the project generated from the artifact, and
+   import from it everywhere. **No hex/size literal in a scene file that is
+   not in the artifact** — this is grep-auditable and reviewed at the compose
+   stage.
+3. **Record provenance per asset.** Every scene snapshot registered in the
+   asset_manifest carries `provenance.source_files` (the repo files it
+   replicates) and `provenance.design_tokens` (the token names it draws
+   from). Deviations go in `provenance.notes` with the reason.
+4. **Simplify by omission, never by substitution.** A replica may drop a
+   toolbar the scene doesn't need; it may not restyle one it keeps.
+
+## 2. Glass surface recipes
+
+The staging language: the product's UI sits on (or is framed by) frosted
+panels themed from its own palette (`design_system.tokens.glass`).
+
+```tsx
+// Composed from the design_system glass spec — values from the artifact.
+const glassPanel: React.CSSProperties = {
+  background: glass.background,            // primary/surface at 6–12% alpha
+  backdropFilter: `blur(${glass.backdrop_blur})`,
+  WebkitBackdropFilter: `blur(${glass.backdrop_blur})`,
+  border: glass.border,                    // 1px, white/text at 10–16% alpha
+  borderRadius: tokens.radii.card,         // the PRODUCT's radius, not a generic 24px
+  boxShadow: "0 24px 64px rgba(0,0,0,0.35)",
+};
+```
+
+- Layer order back-to-front: ambient background (subtle gradient from the
+  product's background token, optional slow drift) → glass panel(s) → the UI
+  replica → highlight strokes.
+- Top-edge highlight: a 1px inset gradient stroke at ~2x border alpha sells
+  the glass without skeuomorphism.
+- `backdropFilter` only blurs what is *behind* the panel — give it something
+  to blur (gradient blobs, oversized blurred type) or it reads as flat tint.
+  In-repo precedent for a working backdropFilter treatment:
+  `remotion-composer/src/components/ProviderChip.tsx` (read as mechanics, do
+  not import — stock imports fail the atelier guardrail).
+- **Respect the product's own register.** Glass intensity is a dial, not a
+  default: a dense, bordered, light-mode product wants restrained glass (low
+  blur, near-opaque panels); a dark gradient-heavy product can carry more.
+  When `design_system.summary` and glassmorphism disagree, the product wins.
+
+## 3. Assembly choreography
+
+Read `references/assembly-choreography.md` for build order, spring presets,
+stagger math, and settle-frame calculation. The one-line rules:
+
+- Build order is semantic: **container → chrome → fields → content → focus**.
+- One spring vocabulary per video (2–3 presets max), stagger 4–7 frames.
+- Every element's **settle frame** is computed, not eyeballed — it is where
+  the SFX cue lands.
+- Restraint: one thing assembling at a time is a story; twelve is noise.
+
+## 4. SFX cueing
+
+Read `references/sfx-cues.md` for the cue taxonomy, derivation rules, and
+generation prompts. Summary:
+
+- Generate short effects with the `sfx_gen` tool (ElevenLabs
+  sound-generation); register them in the asset_manifest as `type: "sfx"`.
+- Cues live **in-composition** as `<Audio>` sequences at exact settle frames
+  (atelier compositions may use `<Audio>` freely — narration/music stay on
+  the `audio_mixer` post-mix path).
+- The cue sheet (scene → element → frame → sfx asset) lives in the atelier
+  `props.json`, derived by the edit director from the scene plan's assembly
+  beats.
+- Density cap ≈ 1 cue per 0.7s; conservative gain (`volume={0.35}`-ish) since
+  post-mix loudnorm applies to the whole mix.
+
+## 5. Remotion mechanics that bite here
+
+- Frame-accurate audio: `<Sequence from={settleFrame}><Audio src={staticFile("sfx/tick.mp3")} volume={0.35}/></Sequence>`.
+  `<Audio>` rejects `file://` URLs — route SFX through the project's
+  `public_dir` and `staticFile()`.
+- Determinism: any randomness (gradient blob positions, particle drift) uses
+  Remotion's `random(seed)`, never `Math.random()`.
+- Fonts: load the product's real fonts (from the repo's font files or
+  next/font equivalents) at module scope via `@remotion/fonts`; a replica in
+  the wrong typeface fails the fidelity gate.
+- Per-scene `durationInFrames` must cover the last settle + a 12–18 frame
+  hold; nothing should still be moving at the cut.
+- Snapshot stills for the assets gate: `scripts/atelier_snapshots.py` renders
+  one PNG per scene at its most-assembled frame.
+
+## Distinctness check (before compose)
+
+Atelier's closing question, product-flavored: *could this composition be any
+other product's video?* If the palette, radii, type, and the UI itself don't
+answer "no" on sight, the replica isn't grounded enough — go back to the
+design_system.

--- a/.claude/skills/glass-ui-motion/references/assembly-choreography.md
+++ b/.claude/skills/glass-ui-motion/references/assembly-choreography.md
@@ -1,0 +1,80 @@
+# Assembly choreography
+
+How UI elements assemble on screen. The goal is the "product coming together"
+feeling of polished SaaS launch films: deliberate, weighted, never busy.
+
+## Build order — semantic, not spatial
+
+Assemble in the order a user *understands* the surface:
+
+1. **Container** — the glass panel / window chrome scales-fades in first and
+   establishes the stage.
+2. **Chrome** — nav, header, sidebar: the frame of reference.
+3. **Fields / structure** — form fields, table headers, card grids, in
+   reading order (top-left → bottom-right for LTR products).
+4. **Content** — values, rows, chart data populating the structure. Numbers
+   may count up; charts draw in.
+5. **Focus** — the one interaction the scene is about: cursor arrives, field
+   focuses, button presses, toggle flips. At most one focus beat per scene.
+
+Never assemble in random or purely aesthetic order — the build order IS the
+narration's visual argument.
+
+## Spring vocabulary
+
+Pick **2–3 presets for the whole video** and reuse them; per-element bespoke
+springs read as jitter. Solid starting set (Remotion `spring()`):
+
+```tsx
+// containers / panels — weighty, no overshoot
+const settle  = { damping: 200, stiffness: 120, mass: 1 };
+// fields / cards — light pop with a hint of overshoot
+const pop     = { damping: 18,  stiffness: 160, mass: 0.9 };
+// focus accents (button press, toggle) — snappy
+const snap    = { damping: 14,  stiffness: 260, mass: 0.6 };
+```
+
+Element entrances combine 2 of: translateY (12–24px), scale (0.96→1),
+opacity (0→1), blur (4px→0). Pick one combination per element *class* (all
+fields enter the same way).
+
+## Stagger math
+
+- Sibling elements (fields in a form, cards in a grid): stagger start frames
+  by **4–7 frames** (@30fps). Under 3 reads as simultaneous; over 10 reads as
+  a slideshow.
+- Grids: stagger by `row * cols + col` order (reading order), or radially
+  from the focus element for emphasis.
+- Between build-order groups (chrome → fields), leave a **6–10 frame breath**.
+
+## Settle frames — computed, not eyeballed
+
+The settle frame is where the element visually stops; it is also the SFX cue
+frame. For a spring started at `from` with config `c`:
+
+```tsx
+import {measureSpring} from "remotion";
+const settleFrame = from + measureSpring({fps, config: c}); // frames until rest
+```
+
+Compute settle frames in the props-generation step and write them into the cue
+sheet — do not hand-tune numbers scattered through scene files.
+
+## Camera and parallax restraint
+
+- The "camera" (a wrapper transform) may do ONE slow move per scene: a 2–4%
+  scale drift or a gentle pan. Never both, never fast.
+- Parallax between background blobs and the glass panel: ≤ 8px of relative
+  drift. It sells depth; more sells seasickness.
+- No 3D card flips, no rotations beyond ±2°, no bounce loops. Polished SaaS
+  is weighted and calm.
+
+## Timing against narration
+
+- Scene assembly should complete within the narration beat that introduces it
+  (from the scene plan's assembly beats). If narration for the form runs 6s,
+  the form finishes assembling by ~5s and holds.
+- Hold every completed scene 12–18 frames before the cut — nothing may still
+  be moving at a scene boundary.
+- Count-up numbers and chart draws end 0.5–1s before the cut so the viewer
+  reads the final value.

--- a/.claude/skills/glass-ui-motion/references/sfx-cues.md
+++ b/.claude/skills/glass-ui-motion/references/sfx-cues.md
@@ -1,0 +1,85 @@
+# SFX cues for UI assembly
+
+Deriving, generating, and placing sound effects for product-motion scenes.
+Primary path is **in-composition `<Audio>`** — cues are frame-accurate to the
+computed settle frames, which post-mix `start_seconds` can never guarantee.
+
+## Cue taxonomy — element class → sound
+
+| Element class | Cue | sfx_gen prompt sketch | Length |
+|---|---|---|---|
+| Glass panel / container | low soft whoosh + settle | "soft airy whoosh into a gentle low thump, smooth, subtle" | 0.8–1.2s |
+| Form field / card / row | glass tick | "single soft glass tick, short, clean, high and quiet" | 0.5s |
+| Button press (focus beat) | tactile click | "satisfying soft tactile click, plastic-glass, single" | 0.5s |
+| Toggle / checkbox | snap | "tiny crisp snap, single, bright but quiet" | 0.5s |
+| Chart draw / count-up | rising shimmer | "soft rising shimmer sweep, airy, 1 second, gentle" | 0.8–1.5s |
+| Success / completion | warm pop | "warm rounded pop with a faint bell tail, single, pleasant" | 0.6–1s |
+
+Rules of thumb: generate **one sound per element class and reuse it** across
+the video (consistency reads as design; variety reads as chaos). 4–6 distinct
+SFX assets covers a whole video.
+
+## Derivation rules (edit stage)
+
+From each scene's assembly beats (scene_plan) and computed settle frames:
+
+1. Container settle → whoosh cue.
+2. Each staggered sibling group: cue the **first and last** sibling's settle,
+   not every one — a tick per field in an 8-field form is a typewriter, not a
+   product film. Exception: ≤3 siblings may each cue.
+3. The focus beat always cues (click/snap).
+4. **Density cap: ~1 cue per 0.7s** per scene. Over cap, drop cues in this
+   order: middle siblings → chart shimmer → container whoosh. Never drop the
+   focus beat.
+5. No cue in the first 12 frames of the video (it lands before the viewer is
+   oriented) and none inside the final hold.
+
+## Generation (assets stage)
+
+```python
+registry._tools["sfx_gen"].execute({
+    "prompt": "single soft glass tick, short, clean, high and quiet",
+    "duration_seconds": 0.5,
+    "prompt_influence": 0.6,   # cue sounds want adherence; textures can go lower
+    "output_path": "projects/<id>/assets/audio/sfx_tick.mp3",
+})
+```
+
+Register each in the asset_manifest as `type: "sfx"` with the generation
+prompt. Listen to each effect once before wiring cues — a harsh or long SFX
+poisons every cue that reuses it.
+
+## Cue sheet → composition
+
+The edit director writes the cue sheet into the atelier `props.json`:
+
+```json
+{
+  "sfx_cues": [
+    {"scene_id": "form-assembly", "element": "panel", "frame": 18, "asset_id": "sfx_whoosh", "volume": 0.4},
+    {"scene_id": "form-assembly", "element": "field-email", "frame": 42, "asset_id": "sfx_tick", "volume": 0.3},
+    {"scene_id": "form-assembly", "element": "submit-press", "frame": 96, "asset_id": "sfx_click", "volume": 0.45}
+  ]
+}
+```
+
+Scene components render cues generically:
+
+```tsx
+{cues.filter(c => c.scene_id === id).map(c => (
+  <Sequence key={`${c.element}-${c.frame}`} from={c.frame} durationInFrames={60}>
+    <Audio src={staticFile(`audio/${c.asset_id}.mp3`)} volume={c.volume} />
+  </Sequence>
+))}
+```
+
+## Gain discipline
+
+- Cue volumes 0.3–0.45; the container whoosh may reach 0.5. SFX support the
+  narration, they never compete with it.
+- Narration + music are mixed in post by `audio_mixer` with loudnorm over the
+  **whole** mix — hot in-composition SFX will pump the normalization. When in
+  doubt, quieter.
+- Fallback: if a run post-mixes SFX instead (no atelier composition), the same
+  cue sheet maps to `edit_decisions.audio.sfx[]` (`asset_id`, `start_seconds =
+  frame/fps`, `volume`) and `audio_mixer`'s `sfx` track role handles it.

--- a/.claude/skills/repo-design-extraction/SKILL.md
+++ b/.claude/skills/repo-design-extraction/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: repo-design-extraction
+description: Extract a design system and UI inventory from a product's source-code repository (React/Next/Vue/Tailwind web frontends). Use in the product-motion pipeline's repo_analysis stage, or whenever a video must be grounded in a repo's real design tokens rather than a live URL. Produces the schema-validated design_system and ui_inventory artifacts with per-token provenance.
+license: MIT
+compatibility: No API keys. Optional `node` on PATH improves tailwind config evaluation.
+metadata: {"openclaw": {"requires": {"env": []}}}
+---
+
+# Repo Design Extraction
+
+Turn a product's **source repository** into two grounded artifacts:
+
+1. **`design_system`** (`schemas/artifacts/design_system.schema.json`) — tokens
+   (colors, typography, spacing, radii, shadows, glass) where **every value
+   cites the repo file it was read from**.
+2. **`ui_inventory`** (`schemas/artifacts/ui_inventory.schema.json`) — the
+   screens and components that exist, each with `source_files` and
+   `reviewed: true` (the inspected-not-assumed contract).
+
+This is the source-code sibling of `website-to-video`'s URL capture
+(`step-1-design.md`): same brand-truth goal, but grounded in the repo's own
+configs and component source instead of computed CSS from a live page.
+
+## The governing rule — read, don't invent
+
+A value goes in `tokens` only if you **read it in the repo**. Anything you
+derive (a glass spec composed from the palette, a spacing scale inferred from
+usage) is marked honestly: glass gets `derived: true` + `rationale`; everything
+else goes in `gaps[]` with `how_inferred`. A design_system whose tokens can't
+be spot-checked against their cited files is a defect, not a draft.
+
+## Process
+
+### Step 1 — Run the scanner first
+
+```python
+from tools.tool_registry import registry
+registry.discover()
+scan = registry._tools["repo_design_extractor"].execute({
+    "repo_path": "/path/to/product-repo",
+    "output_path": "projects/<project-id>/artifacts/repo_scan_report.json",
+})
+```
+
+The scan report gives you: `framework`, `styling_systems`, `candidate_files`
+(tailwind configs, `:root`/`@theme` CSS, theme modules, app shells),
+`css_custom_properties` (name/value/**file/line**), `tailwind_theme` (JS
+configs evaluated via node; `null` for TS configs — read those yourself),
+`fonts`, `screen_candidates` (with routes), and `components_index`.
+
+If `truncated: true`, say so — a partial scan silently presented as complete
+violates the no-silent-caps rule.
+
+### Step 2 — Read the flagged files
+
+The scanner locates; you interpret. Read every `candidate_files` entry plus the
+top screen candidates. Framework-specific guides:
+**`references/design-system-authoring.md`** (tokens) and
+**`references/ui-inventory-authoring.md`** (screens/components).
+
+### Step 3 — Author `design_system`
+
+- Assign **semantic roles** (primary / surface / text-muted / card-radius…)
+  from how tokens are *used* in components, not from name guessing.
+- Copy hex/size values **verbatim** — no rounding, no "close enough".
+- Provenance: prefer the scanner's file+line for CSS vars; for tailwind config
+  values use `key` (e.g. `theme.extend.colors.brand`).
+- Record the repo's `git_commit` (`git -C <repo> rev-parse HEAD`) when available.
+- Derive the glass spec last (see the authoring reference) — it is almost
+  always `derived: true`.
+
+### Step 4 — Author `ui_inventory`
+
+Walk `screen_candidates`, read each screen's source, list its real
+`ui_elements` **with their actual label text from the JSX/template**. Score
+flagship candidates (see reference) and write `flagship_recommendations` —
+these are what the user approves at the repo_analysis gate.
+
+### Step 5 — Validate and checkpoint
+
+```python
+from schemas.artifacts import validate_artifact
+validate_artifact("design_system", design_system)
+validate_artifact("ui_inventory", ui_inventory)
+```
+
+Write both into the `repo_analysis` checkpoint (`design_system` is canonical,
+`ui_inventory` supplementary) and present: the design read in one paragraph,
+the token table with provenance, the flagship screen recommendations, and the
+`gaps[]` ledger — then wait for approval.
+
+## Anti-patterns
+
+- Filling a palette from the product's marketing site instead of the repo
+  (that's `website-to-video` — a different grounding; never mix silently).
+- Inventing tokens "every design system has" (a warning color the repo lacks).
+- `ui_elements` labels like "Submit button" when the source says `Create
+  workspace` — labels are evidence, copy them exactly.
+- Listing a screen without having opened its source file (`reviewed: true` is
+  a contract, not a formality).
+- Hiding a thin design system. If the repo has 4 CSS vars and default Tailwind,
+  the design_system is *small* — say so and lean on `component_styles` +
+  `gaps[]`, don't pad it.

--- a/.claude/skills/repo-design-extraction/SKILL.md
+++ b/.claude/skills/repo-design-extraction/SKILL.md
@@ -2,7 +2,7 @@
 name: repo-design-extraction
 description: Extract a design system and UI inventory from a product's source-code repository (React/Next/Vue/Tailwind web frontends). Use in the product-motion pipeline's repo_analysis stage, or whenever a video must be grounded in a repo's real design tokens rather than a live URL. Produces the schema-validated design_system and ui_inventory artifacts with per-token provenance.
 license: MIT
-compatibility: No API keys. Optional `node` on PATH improves tailwind config evaluation.
+compatibility: No API keys. Reads the target repo only; never executes its code by default.
 metadata: {"openclaw": {"requires": {"env": []}}}
 ---
 
@@ -44,12 +44,28 @@ scan = registry._tools["repo_design_extractor"].execute({
 
 The scan report gives you: `framework`, `styling_systems`, `candidate_files`
 (tailwind configs, `:root`/`@theme` CSS, theme modules, app shells),
-`css_custom_properties` (name/value/**file/line**), `tailwind_theme` (JS
-configs evaluated via node; `null` for TS configs — read those yourself),
-`fonts`, `screen_candidates` (with routes), and `components_index`.
+`css_custom_properties` (name/value/**file/line**), `tailwind_theme` +
+`tailwind_theme_source`, `fonts`, `screen_candidates` (each with `route` and
+`route_source`), `components_index`, and `warnings`.
+
+Repo-relative paths are POSIX (`app/globals.css`) on every platform — quote
+them verbatim into artifact provenance.
 
 If `truncated: true`, say so — a partial scan silently presented as complete
-violates the no-silent-caps rule.
+violates the no-silent-caps rule. Read `warnings[]` and surface anything in it.
+
+**The scanner never runs the product's code.** A `tailwind.config.*` is
+executable JavaScript: requiring it would let an untrusted repo read secrets,
+write files, or make network calls. So the `theme` literal is parsed
+*statically* (works for `.ts` configs too). A config that computes its theme at
+runtime returns `tailwind_theme: null` with a warning — **read the config file
+yourself**, that is the intended path, not the `allow_config_execution` opt-in.
+Only reach for that opt-in on a repo you personally trust, tell the user you
+are doing it and why, and expect `tailwind_theme_source: "executed"` plus a
+warning in the run record.
+
+`output_path` must live under `projects/<project-id>/artifacts/`; the scanner
+rejects a path inside `repo_path` — the analyzed repo is never written to.
 
 ### Step 2 — Read the flagged files
 

--- a/.claude/skills/repo-design-extraction/references/design-system-authoring.md
+++ b/.claude/skills/repo-design-extraction/references/design-system-authoring.md
@@ -1,0 +1,96 @@
+# Authoring `design_system` from repo sources
+
+Framework-specific reading guides and token-distillation rules. The scanner
+(`repo_design_extractor`) has already located the files; this is how to read
+them.
+
+## Where tokens live, by styling system
+
+### Tailwind v3 (`tailwind.config.{js,ts,cjs,mjs}`)
+
+- Scanner evaluates JS configs into `tailwind_theme`; **TS configs come back
+  `null` — read the file yourself** and extract `theme` / `theme.extend`.
+- `theme.extend.*` **extends** defaults; a color under `extend.colors` is a
+  brand token. A full `theme.colors` (no extend) **replaces** defaults — then
+  the listed palette is the entire palette.
+- Values referencing CSS vars (`"hsl(var(--primary))"`, common in shadcn/ui)
+  mean the *real* value lives in the CSS `:root` block — resolve through and
+  cite the CSS file+line as provenance, noting the tailwind key in `role`.
+- Provenance for config values: `{file: "tailwind.config.ts", key: "theme.extend.colors.brand"}`.
+
+### Tailwind v4 (CSS-first `@theme`)
+
+- No JS config. Tokens are CSS custom properties inside `@theme { ... }`
+  blocks (scanner flags these files as `theme_css` and parses the vars).
+- Namespaced conventions: `--color-*`, `--font-*`, `--radius-*`, `--shadow-*`,
+  `--spacing-*` — the namespace gives you the token category for free.
+
+### Plain CSS custom properties (`:root`)
+
+- The scanner's `css_custom_properties` list is authoritative (file+line).
+- Watch for **dark-mode duplicates** (`.dark { --background: ... }`,
+  `@media (prefers-color-scheme: dark)`): record both values when present —
+  the video should match the mode the product actually ships as default.
+
+### styled-components / Emotion
+
+- Look for a `ThemeProvider` theme object (scanner flags `theme_source` files
+  by name; also grep for `createGlobalStyle` and `ThemeProvider`).
+- The theme object's keys are your token names; provenance `key` is the object
+  path (e.g. `theme.colors.primary`).
+
+### Vue / Nuxt SFCs
+
+- Global tokens usually live in `assets/css/*.css` or a `styles/` dir
+  (`:root` vars — scanner catches these).
+- Component-scoped `<style scoped>` blocks hold per-component styling — use
+  them for `component_styles`, not global tokens.
+
+## Typography
+
+- **next/font imports** (scanner's `fonts` with `source: "next/font"`) are the
+  ground truth for Next apps — include weights from the import options if
+  specified in the source.
+- `@font-face` families: cite the CSS file; note the font *files* exist in the
+  repo (the replica build can reference them via `public_dir`).
+- Type scale: read the heading/body styles actually used on flagship screens
+  (Tailwind classes like `text-4xl font-semibold tracking-tight` are scale
+  evidence — resolve them to concrete values via the Tailwind defaults or the
+  config overrides, and cite the component file that uses them).
+
+## Component styles
+
+For each button/input/card variant on a flagship screen, record a
+`css_summary` condensed from the actual classes/styles, e.g.:
+
+```json
+{
+  "variant": "primary button",
+  "css_summary": "bg --primary, text white, radius 8px (rounded-lg), px-4 py-2, shadow-sm, hover:bg-primary/90, text-sm font-medium",
+  "provenance": {"file": "components/ui/button.tsx", "line": 12}
+}
+```
+
+Copy class lists faithfully — they are what the replica must reproduce.
+
+## Deriving the glass spec (`tokens.glass`)
+
+Most products have no frosted surfaces; the glass panels are the *video's*
+staging device, themed by the product's palette. Standard derivation:
+
+- `background`: the primary or surface color at 6–12% alpha
+  (`rgba(99,102,241,0.08)`)
+- `backdrop_blur`: 16–28px
+- `border`: `1px solid` white (dark video bg) or the text color (light bg) at
+  10–16% alpha
+- `highlight`: optional 1px top-edge stroke at ~2x the border alpha
+- Set `derived: true` and write the `rationale` ("composed from --primary and
+  --background; product has no glass surfaces").
+- If the product *does* use `backdrop-filter` anywhere, that's real
+  provenance — cite it and set `derived: false`.
+
+Every derived value that isn't the glass spec goes in `gaps[]`:
+
+```json
+{"token": "spacing scale", "how_inferred": "no explicit scale; inferred 4/8/12/16/24 from usage frequency in app/page.tsx"}
+```

--- a/.claude/skills/repo-design-extraction/references/design-system-authoring.md
+++ b/.claude/skills/repo-design-extraction/references/design-system-authoring.md
@@ -8,8 +8,13 @@ them.
 
 ### Tailwind v3 (`tailwind.config.{js,ts,cjs,mjs}`)
 
-- Scanner evaluates JS configs into `tailwind_theme`; **TS configs come back
-  `null` — read the file yourself** and extract `theme` / `theme.extend`.
+- The scanner parses the `theme` literal **statically** (JS and TS alike) into
+  `tailwind_theme`, with `tailwind_theme_source: "static"`. It never executes
+  the config — that would run arbitrary repo JavaScript.
+- A config that builds its theme at runtime (spreads a preset, calls a
+  function, `require`s another module) comes back `null` with a warning:
+  **read the file yourself** and extract `theme` / `theme.extend`. That is the
+  normal path, not a failure.
 - `theme.extend.*` **extends** defaults; a color under `extend.colors` is a
   brand token. A full `theme.colors` (no extend) **replaces** defaults — then
   the listed palette is the entire palette.

--- a/.claude/skills/repo-design-extraction/references/ui-inventory-authoring.md
+++ b/.claude/skills/repo-design-extraction/references/ui-inventory-authoring.md
@@ -1,0 +1,70 @@
+# Authoring `ui_inventory` from repo sources
+
+How to turn the scanner's `screen_candidates` / `components_index` into the
+`ui_inventory` artifact. The contract: **every screen listed was actually
+read** (`reviewed: true`), and every `ui_elements[].label` is the element's
+real text from the source.
+
+## Walking screens
+
+- **Next app router** (`app/**/page.tsx`): the scanner derived the route from
+  the directory. Read the page *and* the components it imports — the page file
+  is often just a shell; the real UI lives one import away. Add those files to
+  `source_files` too.
+- **Next pages router / Vue pages**: same, route from file path.
+- **Non-routed roots** (`src/views`, `src/screens`, `src/features`): treat
+  each top-level view as a screen; leave `route` unset unless a router config
+  says otherwise.
+- Skip auth walls, error pages, and legal pages unless the brief asks for
+  them — they are rarely flagship surfaces.
+
+## Recording ui_elements
+
+For each screen list the elements that would *assemble* in an animation —
+forms, inputs, buttons, cards, tables, charts, navs, badges, avatars, toggles,
+tabs, modals. Rules:
+
+- `label` is the **visible text in the source**: the button's children, the
+  input's label/placeholder, the card's title. Copy exactly (`"Create
+  workspace"`, not "CTA button").
+- `source_file` is where the element's markup lives (the component file, not
+  the page that imports it, when they differ).
+- Dynamic content (`{user.name}`, mapped rows): describe the shape —
+  `label: "invoice rows (date, amount, status badge)"`.
+- 5–12 elements per screen is the useful range. The elements you list become
+  the build-order beats in scene planning — inventory what would animate, not
+  every div.
+
+## Shared components (`components`)
+
+Promote a component out of a screen into `components[]` when it appears on
+multiple screens or is individually animation-worthy (a stat card, a nav item,
+a form field group). `used_by_screens` links it back.
+
+## Flagship scoring
+
+Score each screen for `flagship_recommendations` on:
+
+1. **Visual richness** — number and variety of animatable elements.
+2. **Story value** — does it show the product's core promise (the dashboard,
+   the editor), or is it plumbing (settings)?
+3. **Form presence** — the brief wants forms/UI assembling; a screen with a
+   real form (labels, fields, a submit) is a strong candidate.
+4. **Replica feasibility** — a screen of custom canvas/WebGL is hard to
+   replicate truthfully; prefer DOM-built surfaces.
+
+Recommend 3–5 screens with one-line `why` each. The user picks at the
+repo_analysis gate — recommendations are input, not decisions.
+
+## planning_implications
+
+Concrete, actionable, ≥1. Good examples:
+
+- "Dashboard uses a 3-column card grid — the hero scene should assemble cards
+  into that grid, not invent a new layout."
+- "All CTAs are `--primary` filled buttons with 8px radius — replicas must not
+  use outline buttons."
+- "The onboarding form at /signup has 4 fields + OAuth buttons — natural
+  assembly sequence for the form scene."
+- "Product ships dark mode by default (`.dark` on html) — the video should be
+  dark-first."

--- a/.claude/skills/repo-design-extraction/references/ui-inventory-authoring.md
+++ b/.claude/skills/repo-design-extraction/references/ui-inventory-authoring.md
@@ -8,13 +8,17 @@ real text from the source.
 ## Walking screens
 
 - **Next app router** (`app/**/page.tsx`): the scanner derived the route from
-  the directory. Read the page *and* the components it imports — the page file
-  is often just a shell; the real UI lives one import away. Add those files to
-  `source_files` too.
-- **Next pages router / Vue pages**: same, route from file path.
-- **Non-routed roots** (`src/views`, `src/screens`, `src/features`): treat
-  each top-level view as a screen; leave `route` unset unless a router config
-  says otherwise.
+  the directory (`route_source: "next-app-router"`). Read the page *and* the
+  components it imports — the page file is often just a shell; the real UI
+  lives one import away. Add those files to `source_files` too.
+- **Next pages router** and **SvelteKit** (`src/routes/**/+page.svelte`): same,
+  route derived from the file path.
+- **Non-routed roots** (`src/views`, `src/screens`, `src/features`, and
+  `src/routes` outside SvelteKit): the scanner reports `route: null` /
+  `route_source: "not_derivable"` because the URL lives in a router config it
+  does not read. Treat each top-level view as a screen and leave `route` unset
+  unless you **read** the router config and can cite it. Do not reconstruct a
+  route from the filename — an invented route reads as fact in the artifact.
 - Skip auth walls, error pages, and legal pages unless the brief asks for
   them — they are rarely flagship surfaces.
 

--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -248,6 +248,7 @@ If the folder has tracks, the proposal and asset stages should present them as o
 | `animated-explainer` | Topic to fully generated explainer | production |
 | `talking-head` | Footage-led speaker videos | beta |
 | `screen-demo` | Screen recordings and walkthroughs | production |
+| `product-motion` | Repo-grounded product UI animations — glass surfaces, real forms/elements assembling with SFX | beta |
 | `clip-factory` | Many clips from one long source | beta |
 | `podcast-repurpose` | Podcast highlights and derivatives | beta |
 | `cinematic` | Trailer, teaser, and mood-led edits | production |
@@ -681,6 +682,7 @@ The `.agents/skills/` directory is large. When you're not coming in through a to
 | **Speech-to-text** | `speech-to-text` (whisper `transcriber` — default, offline), `azure-speech-to-text` (optional cloud STT — tool `azure_stt`, preferred when `AZURE_SPEECH_KEY` is set) |
 | **Avatar / lip-sync** | `avatar-video`, `heygen`, `create-video`, `faceswap`, `video-translate`, `agents` |
 | **Capture** | `playwright-recording` (browser flows), `ffmpeg` (post) |
+| **Product/repo grounding** | `repo-design-extraction` (design_system + ui_inventory from a source repo — tool `repo_design_extractor`), `glass-ui-motion` (truthful UI replicas, glass staging, assembly choreography, SFX cues — tool `sfx_gen`) |
 | **Visualization** | `beautiful-mermaid`, `d3-viz`, `manim-composer`, `manimce-best-practices`, `manimgl-best-practices` |
 | **Media editing** | `video-edit`, `video-download`, `video-understand`, `video-toolkit`, `visual-style` |
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -226,7 +226,7 @@ No subscription — pure pay-as-you-go, no minimum spend.
 
 > **Premium voice quality.** Best TTS for narration-heavy videos. Also generates music and sound effects.
 
-**Tools unlocked:** `elevenlabs_tts`, `music_gen`
+**Tools unlocked:** `elevenlabs_tts`, `music_gen`, `sfx_gen`
 **Env var:** `ELEVENLABS_API_KEY`
 
 #### Setup
@@ -247,6 +247,23 @@ No subscription — pure pay-as-you-go, no minimum spend.
 | Scale | $330/mo | 2,000,000 | Priority support |
 
 **Free tier:** 10,000 characters/month (roughly 2-3 minutes of narration). API access included. Music generation and sound effects also available on free tier with limited credits.
+
+#### Sound effects (`sfx_gen`)
+
+Sound-effect generation is billed **per minute of generated audio**, not per effect, and each plan bundles a monthly generation allowance:
+
+| Plan | Included SFX generations |
+|------|--------------------------|
+| Free / pay-as-you-go | 8 |
+| Starter | 150 |
+| Creator | 605 |
+| Pro | 3,000 |
+| Scale | 9,000 |
+| Business | 30,000 |
+
+Pay-as-you-go list rate: **$0.12/minute** — so a 0.6s UI tick is ~$0.001 and a 20s ambient bed is ~$0.04. `sfx_gen.estimate_cost()` uses this list rate as an upper bound; check [elevenlabs.io/pricing/api](https://elevenlabs.io/pricing/api) for current numbers before quoting them to a user.
+
+A typical `product-motion` run generates 4-8 short cues (well under $0.05 total).
 
 ---
 
@@ -880,7 +897,7 @@ These tools require only FFmpeg or Python packages — no GPU, no API key.
 | **Pixabay** | `PIXABAY_API_KEY` | `pixabay_image`, `pixabay_video` | Free |
 | **Piper** | — (install only) | `piper_tts` | Free |
 | **Google** | `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) | `google_tts`, `google_imagen`, `google_music`, `gemini_omni_video`, `veo_video` | Free tier (TTS) + paid |
-| **ElevenLabs** | `ELEVENLABS_API_KEY` | `elevenlabs_tts`, `music_gen` | Free tier + paid |
+| **ElevenLabs** | `ELEVENLABS_API_KEY` | `elevenlabs_tts`, `music_gen`, `sfx_gen` | Free tier + paid |
 | **fal.ai** | `FAL_KEY` | `flux_image`, `recraft_image`, `kling_video`, `veo_video`, `minimax_video` | Pay-as-you-go |
 | **Kling Official** | `KLING_API_KEY` | `kling_official_video`, `kling_official_image`, `kling_tts`, `kling_avatar`, `kling_lip_sync` | Pay-as-you-go |
 | **OpenAI** | `OPENAI_API_KEY` | `openai_tts`, `openai_image` | Paid only |
@@ -905,6 +922,7 @@ How many providers cover each capability:
 | **Video Generation** | Grok, Kling Official, Kling via fal.ai, Runway, Veo, Gemini Omni, Higgsfield, MiniMax, HeyGen | WAN, Hunyuan, CogVideo, LTX | Pexels, Pixabay (stock) |
 | **Text-to-Speech** | ElevenLabs, Google TTS, Kling Official, OpenAI | Piper | Piper, Google free tier, ElevenLabs free tier |
 | **Music Generation** | ElevenLabs, Suno, Google Lyria | — | ElevenLabs free tier |
+| **Sound Effects** | ElevenLabs | — | ElevenLabs free tier (8 generations) |
 | **Post-Production** | — | FFmpeg (compose, stitch, trim, mix, enhance, grade) | All free |
 | **Analysis** | — | WhisperX, Scene Detect, Frame Sampler, CLIP/BLIP-2 | All free |
 | **Enhancement** | — | Upscale, BG Remove, Face Enhance, Face Restore | All free |

--- a/lib/checkpoint.py
+++ b/lib/checkpoint.py
@@ -18,17 +18,21 @@ from schemas.artifacts import ARTIFACT_NAMES, validate_artifact
 
 # All known stages across all pipelines (used only for artifact name lookup).
 ALL_KNOWN_STAGES = frozenset([
-    "research", "proposal", "idea", "script", "scene_plan",
+    "research", "repo_analysis", "proposal", "idea", "script", "scene_plan",
     "assets", "edit", "compose", "publish",
 ])
 
 # Backward-compatible alias — existing code / tests that import STAGES still work.
 # New code should use get_pipeline_stages(pipeline_type) instead.
+# NOTE: repo_analysis (product-motion) is intentionally NOT in this legacy
+# fallback order — manifest-driven pipelines get their order from
+# get_pipeline_stages(pipeline_type); the fallback keeps the canonical 9.
 STAGES = ["research", "proposal", "idea", "script", "scene_plan",
           "assets", "edit", "compose", "publish"]
 
 CANONICAL_STAGE_ARTIFACTS = {
     "research": "research_brief",
+    "repo_analysis": "design_system",
     "proposal": "proposal_packet",
     "idea": "brief",
     "script": "script",
@@ -45,6 +49,7 @@ SUPPLEMENTARY_ARTIFACTS = {
     "source_media_review",  # Required before first planning stage when user media exists
     "final_review",         # Required by compose stage before presenting to user
     "video_analysis_brief", # Reference-video grounding artifact carried alongside stages
+    "ui_inventory",         # Screens/components catalog produced alongside design_system (repo_analysis)
 }
 
 

--- a/lib/checkpoint.py
+++ b/lib/checkpoint.py
@@ -49,7 +49,11 @@ SUPPLEMENTARY_ARTIFACTS = {
     "source_media_review",  # Required before first planning stage when user media exists
     "final_review",         # Required by compose stage before presenting to user
     "video_analysis_brief", # Reference-video grounding artifact carried alongside stages
-    "ui_inventory",         # Screens/components catalog produced alongside design_system (repo_analysis)
+    # Screens/components catalog authored alongside design_system in
+    # repo_analysis. Supplementary only in the sense that it is not the stage's
+    # *canonical* artifact — product-motion declares it in the stage's
+    # `required_outputs`, so a repo_analysis checkpoint cannot close without it.
+    "ui_inventory",
 }
 
 
@@ -106,10 +110,29 @@ def _load_checkpoint_schema() -> dict[str, Any]:
         return json.load(f)
 
 
+def _stage_required_outputs(pipeline_type: Optional[str], stage: str) -> list[str]:
+    """Manifest-declared artifacts a stage must produce, beyond the canonical one.
+
+    A manifest that cannot be loaded yields [] — the canonical-artifact check
+    still applies, and _stage_requires_approval already fails closed on an
+    unknown pipeline_type, so a typo cannot reach here and quietly disable the
+    requirement.
+    """
+    if not pipeline_type or pipeline_type == "unknown":
+        return []
+    from lib.pipeline_loader import get_stage_required_outputs, load_pipeline_readonly
+    try:
+        manifest = load_pipeline_readonly(pipeline_type)
+    except Exception:
+        return []
+    return get_stage_required_outputs(manifest, stage)
+
+
 def _validate_artifacts_for_stage(
     stage: str,
     status: str,
     artifacts: dict[str, Any],
+    pipeline_type: Optional[str] = None,
 ) -> None:
     # Valid stages come from the pipeline manifest (get_pipeline_stages), which
     # can declare stages beyond the 9 canonical ones (e.g. character-animation's
@@ -126,6 +149,25 @@ def _validate_artifacts_for_stage(
             f"Stage {stage!r} with status {status!r} must include "
             f"canonical artifact {required_artifact!r}"
         )
+
+    # Manifest-declared required_outputs. Some stages produce more than one
+    # load-bearing artifact (product-motion's repo_analysis authors both
+    # design_system and ui_inventory, and every downstream truthfulness check
+    # reads the second one). Declaring only a canonical artifact would let such
+    # a stage close half-done.
+    if status in {"completed", "awaiting_human"}:
+        missing = [
+            name
+            for name in _stage_required_outputs(pipeline_type, stage)
+            if name not in artifacts
+        ]
+        if missing:
+            raise CheckpointValidationError(
+                f"Stage {stage!r} with status {status!r} is missing "
+                f"required output(s) {missing!r} declared by the "
+                f"{pipeline_type!r} manifest. Produce them before closing the "
+                f"stage — downstream stages read them."
+            )
 
     for artifact_name, artifact_data in artifacts.items():
         if artifact_name not in ARTIFACT_NAMES:
@@ -168,7 +210,7 @@ def validate_checkpoint(checkpoint: dict[str, Any]) -> None:
     if not isinstance(artifacts, dict):
         raise CheckpointValidationError("Checkpoint artifacts must be a dictionary")
 
-    _validate_artifacts_for_stage(stage, status, artifacts)
+    _validate_artifacts_for_stage(stage, status, artifacts, pipeline_type)
 
     try:
         jsonschema.validate(instance=checkpoint, schema=_load_checkpoint_schema())

--- a/lib/pipeline_loader.py
+++ b/lib/pipeline_loader.py
@@ -182,6 +182,23 @@ def get_stage_human_approval_default(manifest: dict, stage_name: str) -> Optiona
     return None
 
 
+def get_stage_required_outputs(manifest: dict, stage_name: str) -> list[str]:
+    """Artifacts a completed/awaiting_human checkpoint for this stage must carry.
+
+    Declared per-stage as `required_outputs`. The canonical artifact
+    (CANONICAL_STAGE_ARTIFACTS) is always required on top of this — the field
+    exists for stages whose contract needs *more* than one artifact, e.g.
+    product-motion's repo_analysis, where downstream fidelity checks read
+    ui_inventory as well as design_system.
+
+    Returns [] for stages that declare nothing (the common case).
+    """
+    for stage in manifest["stages"]:
+        if stage["name"] == stage_name:
+            return list(stage.get("required_outputs", []))
+    return []
+
+
 def get_stage_review_focus(manifest: dict, stage_name: str) -> list[str]:
     """Get the review focus items for a stage."""
     for stage in manifest["stages"]:

--- a/pipeline_defs/product-motion.yaml
+++ b/pipeline_defs/product-motion.yaml
@@ -1,0 +1,251 @@
+name: product-motion
+version: "1.0"
+description: >
+  Repo-grounded product screen animations. Point the pipeline at a product's
+  source repository (web frontends: React/Next/Vue/Tailwind); it extracts the
+  real design system and UI inventory with per-token provenance
+  (repo_design_extractor + the repo-design-extraction skill), then re-authors
+  faithful replicas of the product's actual screens as a hand-authored
+  (atelier) composition — glassmorphic staging, forms and UI elements
+  assembling piece-by-piece with spring motion, and frame-accurate sound
+  effects (glass-ui-motion skill + sfx_gen). Truthfulness is enforced by a
+  provenance chain: design_system tokens cite repo file+line, ui_inventory
+  screens cite source files, replica assets carry provenance.source_files,
+  and the assets gate reviews per-scene snapshot stills against the sources.
+  Composition mode is atelier by default (per-product replicas are inherently
+  bespoke); runtime is chosen at proposal — Remotion for React/Next repos
+  (replicas are near-1:1 JSX ports), HyperFrames as the genuine alternative
+  for Vue/Nuxt or Tailwind-heavy markup.
+category: custom
+stability: beta
+default_checkpoint_policy: guided
+
+orchestration:
+  mode: executive-producer
+  skill: pipelines/product-motion/executive-producer
+  budget_default_usd: 2.00
+  max_revisions_per_stage: 3
+  max_send_backs: 3
+  max_wall_time_minutes: 30
+
+extensions:
+  custom_scripts: true
+  custom_playbooks: true
+  custom_skills: true
+  custom_tools: false
+
+required_skills:
+  - pipelines/product-motion/executive-producer
+  - pipelines/product-motion/repo-director
+  - pipelines/product-motion/proposal-director
+  - pipelines/product-motion/script-director
+  - pipelines/product-motion/scene-director
+  - pipelines/product-motion/asset-director
+  - pipelines/product-motion/edit-director
+  - pipelines/product-motion/compose-director
+  - pipelines/product-motion/publish-director
+  - meta/reviewer
+  - meta/checkpoint-protocol
+  - meta/bespoke-composition
+  - meta/taste-direction
+
+compatible_playbooks:
+  recommended: []
+  also_works: []
+  custom_allowed: true
+
+stages:
+  - name: repo_analysis
+    skill: pipelines/product-motion/repo-director
+    produces:
+      - design_system
+      - ui_inventory
+      - decision_log
+    required_tools:
+      - repo_design_extractor
+    tools_available:
+      - repo_design_extractor
+    checkpoint_required: true
+    human_approval_default: true
+    review_focus:
+      - Every design_system token carries provenance (file, and line/key where possible)
+      - Spot-check 3 tokens against their cited repo files — values must match verbatim
+      - gaps[] honestly lists every derived/inferred value (glass spec, missing scales)
+      - Every ui_inventory screen has reviewed=true and source_files that exist in the repo
+      - ui_elements labels are the actual visible text from the source, not paraphrases
+      - flagship_recommendations give the user a real choice with reasoning
+    success_criteria:
+      - Schema-valid design_system artifact
+      - Schema-valid ui_inventory artifact
+      - User approved the flagship screens and the design read
+
+  - name: proposal
+    skill: pipelines/product-motion/proposal-director
+    required_artifacts_in:
+      - design_system
+      - ui_inventory
+    produces:
+      - proposal_packet
+      - decision_log
+    tools_available: []
+    checkpoint_required: true
+    human_approval_default: true
+    review_focus:
+      - Concepts feature the approved flagship screens, not invented surfaces
+      - Both composition runtimes presented with per-runtime tradeoffs (HARD RULE)
+      - composition_mode decision logged (atelier default, with cost/effort disclosure)
+      - Music and SFX plan surfaced with provider status and costs
+      - Itemized cost estimate covers TTS, music, SFX, and render
+    success_criteria:
+      - Schema-valid proposal_packet artifact
+      - decision_log has render_runtime_selection and composition_mode entries with options_considered
+
+  - name: script
+    skill: pipelines/product-motion/script-director
+    required_artifacts_in:
+      - proposal_packet
+    optional_artifacts_in:
+      - design_system
+      - ui_inventory
+    produces:
+      - script
+    tools_available: []
+    checkpoint_required: true
+    human_approval_default: true
+    review_focus:
+      - Narration beats map 1:1 to screens/moments from the approved concept
+      - Assembly moments (form building, cards arriving) are explicit script beats
+      - Claims about the product are supported by what the repo actually shows
+    success_criteria:
+      - Schema-valid script artifact
+      - Every section names the screen_id it narrates over
+
+  - name: scene_plan
+    skill: pipelines/product-motion/scene-director
+    required_artifacts_in:
+      - script
+    optional_artifacts_in:
+      - design_system
+      - ui_inventory
+    produces:
+      - scene_plan
+    tools_available: []
+    checkpoint_required: true
+    human_approval_default: true
+    review_focus:
+      - One scene per flagship surface; every scene references a ui_inventory screen_id
+      - Element build order is semantic (container -> chrome -> fields -> content -> focus)
+      - Assembly beats fit inside their narration beat with a hold before each cut
+      - SFX intents follow the cue taxonomy and density cap
+    success_criteria:
+      - Schema-valid scene_plan artifact
+      - Every scene's required assets list the repo source files to replicate
+
+  - name: assets
+    skill: pipelines/product-motion/asset-director
+    required_artifacts_in:
+      - scene_plan
+      - design_system
+      - ui_inventory
+    optional_artifacts_in:
+      - script
+    produces:
+      - asset_manifest
+    required_tools:
+      - tts_selector
+    optional_tools:
+      - music_gen
+      - sfx_gen
+      - image_selector
+      - subtitle_gen
+    tools_available:
+      - tts_selector
+      - music_gen
+      - sfx_gen
+      - image_selector
+      - subtitle_gen
+    checkpoint_required: true
+    human_approval_default: true
+    review_focus:
+      - This is the FIDELITY GATE — per-scene snapshot stills reviewed against the repo sources
+      - Every replica snapshot asset carries provenance.source_files and provenance.design_tokens
+      - No hex/size literal in authored scenes that is not a design_system token (grep-audit)
+      - Replica structure matches the source (field order, labels, button copy)
+      - Narration sample approved before batch; SFX auditioned before cue wiring
+    success_criteria:
+      - Schema-valid asset_manifest artifact
+      - All referenced asset files exist on disk
+      - User approved the replica snapshots scene-by-scene
+
+  - name: edit
+    skill: pipelines/product-motion/edit-director
+    required_artifacts_in:
+      - scene_plan
+      - asset_manifest
+    optional_artifacts_in:
+      - script
+    produces:
+      - edit_decisions
+    tools_available: []
+    checkpoint_required: true
+    human_approval_default: false
+    review_focus:
+      - Scene order and timings match narration segment durations
+      - SFX cue sheet lands on computed settle frames and respects the density cap
+      - edit_decisions.bespoke block is complete (entry, composition_id, props_path, art_direction)
+      - render_runtime carried unchanged from proposal_packet
+    success_criteria:
+      - Schema-valid edit_decisions artifact
+      - Cue sheet references only asset_manifest sfx asset ids
+
+  - name: compose
+    skill: pipelines/product-motion/compose-director
+    required_artifacts_in:
+      - edit_decisions
+      - asset_manifest
+    optional_artifacts_in:
+      - scene_plan
+      - design_system
+    produces:
+      - render_report
+      - final_review
+    required_tools:
+      - video_compose
+      - audio_mixer
+    optional_tools:
+      - hyperframes_compose
+    tools_available:
+      - video_compose
+      - hyperframes_compose
+      - audio_mixer
+    checkpoint_required: true
+    human_approval_default: false
+    review_focus:
+      - Output video is playable and crisp at target resolution (ffprobe verified)
+      - "render_runtime in edit_decisions matches proposal_packet — silent swap is a CRITICAL governance violation"
+      - Provenance spot-check — one token per scene verified against its cited repo file in the final frames
+      - SFX land on element-settle frames; narration/music mix is ducked and normalized
+      - Nothing is still moving at any scene cut
+    success_criteria:
+      - Schema-valid render_report artifact
+      - Output file exists and passes ffprobe validation
+      - final_review recorded before presenting to the user
+
+  - name: publish
+    skill: pipelines/product-motion/publish-director
+    required_artifacts_in:
+      - render_report
+      - final_review
+    optional_artifacts_in:
+      - proposal_packet
+    produces:
+      - publish_log
+    tools_available: []
+    checkpoint_required: true
+    human_approval_default: true
+    review_focus:
+      - Metadata names the product and its core promise accurately
+      - Export package is complete (video, metadata, thumbnail concept)
+    success_criteria:
+      - Schema-valid publish_log artifact
+      - Export directory contains video, metadata, and thumbnail concept

--- a/pipeline_defs/product-motion.yaml
+++ b/pipeline_defs/product-motion.yaml
@@ -61,6 +61,12 @@ stages:
       - design_system
       - ui_inventory
       - decision_log
+    # Both grounding artifacts are load-bearing: every downstream truthfulness
+    # claim and the assets fidelity gate read ui_inventory, so a repo_analysis
+    # checkpoint carrying only design_system is not a completed stage.
+    required_outputs:
+      - design_system
+      - ui_inventory
     required_tools:
       - repo_design_extractor
     tools_available:

--- a/schemas/artifacts/__init__.py
+++ b/schemas/artifacts/__init__.py
@@ -31,6 +31,8 @@ ARTIFACT_NAMES = [
     "final_review",
     "character_qa_report",
     "video_analysis_brief",
+    "design_system",
+    "ui_inventory",
 ]
 
 

--- a/schemas/artifacts/asset_manifest.schema.json
+++ b/schemas/artifacts/asset_manifest.schema.json
@@ -34,6 +34,24 @@
           "provider": { "type": "string", "description": "Provider name (e.g. pixabay, google_imagen)" },
           "license": { "type": "string", "description": "License type (e.g. Pixabay License, CC0)" },
           "original_url": { "type": "string", "description": "Source URL if downloaded from a stock service" },
+          "provenance": {
+            "type": "object",
+            "description": "For assets that replicate a real product's UI (product-motion pipeline): the repo sources this asset is grounded in. Enables truthfulness spot-checks at review gates.",
+            "properties": {
+              "source_files": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Repo-relative paths of the component/screen files this asset replicates"
+              },
+              "design_tokens": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Names of design_system tokens the asset's styling draws from"
+              },
+              "notes": { "type": "string", "description": "Deviations from the source and why" }
+            },
+            "additionalProperties": false
+          },
           "voice_performance": {
             "type": "object",
             "description": "Applied voice-performance contract for narration assets.",

--- a/schemas/artifacts/design_system.schema.json
+++ b/schemas/artifacts/design_system.schema.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "openmontage/artifacts/design_system",
+  "title": "Design System",
+  "description": "Design system extracted from a product's source-code repository. Canonical artifact of the repo_analysis stage. Every token carries provenance (the repo file it was read from) — this is the enforceable core of staying truthful to the actual product. Anything inferred rather than read goes in gaps[].",
+  "type": "object",
+  "required": ["version", "source", "tokens", "summary"],
+  "$defs": {
+    "provenance": {
+      "type": "object",
+      "description": "Where in the analyzed repo this value was read from",
+      "required": ["file"],
+      "properties": {
+        "file": { "type": "string", "description": "Repo-relative path of the source file" },
+        "line": { "type": "integer", "description": "1-indexed line number, when known" },
+        "key": { "type": "string", "description": "Config key or CSS custom property name (e.g. '--color-primary', 'theme.extend.colors.brand')" }
+      },
+      "additionalProperties": false
+    },
+    "token": {
+      "type": "object",
+      "required": ["name", "value", "provenance"],
+      "properties": {
+        "name": { "type": "string" },
+        "value": { "type": "string" },
+        "role": { "type": "string", "description": "Semantic role (e.g. 'primary', 'surface', 'text-muted', 'card-radius')" },
+        "provenance": { "$ref": "#/$defs/provenance" }
+      },
+      "additionalProperties": false
+    },
+    "component_style": {
+      "type": "object",
+      "required": ["variant", "css_summary", "provenance"],
+      "properties": {
+        "variant": { "type": "string", "description": "e.g. 'primary button', 'ghost button', 'text input focused'" },
+        "css_summary": { "type": "string", "description": "The styling that defines this variant, condensed (colors, radius, border, shadow, padding, type)" },
+        "provenance": { "$ref": "#/$defs/provenance" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "version": { "type": "string", "const": "1.0" },
+    "source": {
+      "type": "object",
+      "required": ["repo_path", "framework"],
+      "properties": {
+        "repo_path": { "type": "string", "description": "Absolute or user-supplied path of the analyzed repository" },
+        "framework": {
+          "type": "string",
+          "enum": ["react", "next", "vue", "nuxt", "svelte", "other"],
+          "description": "Primary frontend framework detected from package.json"
+        },
+        "styling_systems": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["tailwind", "css-variables", "styled-components", "css-modules", "sass", "emotion", "inline", "other"]
+          },
+          "description": "Styling approaches actually found in the repo"
+        },
+        "git_commit": { "type": "string", "description": "Commit SHA the analysis was run against, for reproducibility" }
+      },
+      "additionalProperties": false
+    },
+    "tokens": {
+      "type": "object",
+      "description": "The extracted design tokens. Values must be read from the repo, not invented — inferred values belong in gaps[] with the glass spec's derived flag as the model.",
+      "properties": {
+        "colors": { "type": "array", "items": { "$ref": "#/$defs/token" } },
+        "typography": {
+          "type": "object",
+          "properties": {
+            "fonts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["family", "provenance"],
+                "properties": {
+                  "family": { "type": "string" },
+                  "role": { "type": "string", "description": "display | body | mono | caption" },
+                  "weights": { "type": "array", "items": { "type": "integer" } },
+                  "provenance": { "$ref": "#/$defs/provenance" }
+                },
+                "additionalProperties": false
+              }
+            },
+            "scale": {
+              "type": "array",
+              "description": "Type scale entries (size/weight/line-height per role)",
+              "items": {
+                "type": "object",
+                "required": ["name", "provenance"],
+                "properties": {
+                  "name": { "type": "string" },
+                  "size": { "type": "string" },
+                  "weight": { "type": "string" },
+                  "line_height": { "type": "string" },
+                  "letter_spacing": { "type": "string" },
+                  "provenance": { "$ref": "#/$defs/provenance" }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "spacing": { "type": "array", "items": { "$ref": "#/$defs/token" } },
+        "radii": { "type": "array", "items": { "$ref": "#/$defs/token" } },
+        "shadows": { "type": "array", "items": { "$ref": "#/$defs/token" } },
+        "glass": {
+          "type": "object",
+          "description": "Glass/frosted surface spec for the video's panels. Usually DERIVED from the product's palette rather than read verbatim — set derived: true and explain in rationale.",
+          "required": ["derived"],
+          "properties": {
+            "background": { "type": "string" },
+            "backdrop_blur": { "type": "string" },
+            "border": { "type": "string" },
+            "highlight": { "type": "string", "description": "Top-edge highlight stroke, if any" },
+            "derived": { "type": "boolean", "description": "true when composed from palette tokens rather than read from repo CSS" },
+            "rationale": { "type": "string", "description": "How the spec was derived, or provenance note when read directly" },
+            "provenance": { "$ref": "#/$defs/provenance" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "component_styles": {
+      "type": "object",
+      "description": "Exact per-component CSS summaries read from the repo's real components",
+      "properties": {
+        "buttons": { "type": "array", "items": { "$ref": "#/$defs/component_style" } },
+        "inputs": { "type": "array", "items": { "$ref": "#/$defs/component_style" } },
+        "cards": { "type": "array", "items": { "$ref": "#/$defs/component_style" } },
+        "other": { "type": "array", "items": { "$ref": "#/$defs/component_style" } }
+      },
+      "additionalProperties": false
+    },
+    "gaps": {
+      "type": "array",
+      "description": "Honesty ledger: every value that was inferred or derived rather than read from the repo, and how",
+      "items": {
+        "type": "object",
+        "required": ["token", "how_inferred"],
+        "properties": {
+          "token": { "type": "string" },
+          "how_inferred": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "summary": {
+      "type": "string",
+      "description": "The design read in prose — what this product's visual language actually is, stated from evidence"
+    },
+    "metadata": { "type": "object" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/artifacts/ui_inventory.schema.json
+++ b/schemas/artifacts/ui_inventory.schema.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "openmontage/artifacts/ui_inventory",
+  "title": "UI Inventory",
+  "description": "Catalog of the screens and components found in a product's source-code repository. Supplementary artifact of the repo_analysis stage (alongside design_system). Ensures the agent inspects the actual UI code instead of planning around assumptions — the same inspected-not-assumed contract as source_media_review.",
+  "type": "object",
+  "required": ["version", "repo_path", "screens", "summary", "planning_implications"],
+  "properties": {
+    "version": { "type": "string", "const": "1.0" },
+    "repo_path": { "type": "string", "description": "Path of the analyzed repository" },
+    "screens": {
+      "type": "array",
+      "description": "Screens/pages found in the repo. Each must have been actually read, not guessed from file names.",
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "source_files", "purpose", "reviewed"],
+        "properties": {
+          "id": { "type": "string", "description": "Stable slug used by scene_plan scenes to reference this screen (e.g. 'dashboard', 'signup-form')" },
+          "name": { "type": "string" },
+          "route": { "type": "string", "description": "URL route when derivable (e.g. '/settings/billing')" },
+          "source_files": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1,
+            "description": "Repo-relative paths of the files that implement this screen"
+          },
+          "purpose": { "type": "string", "description": "What the screen does for the user, stated from the code that was read" },
+          "ui_elements": {
+            "type": "array",
+            "description": "Notable elements on the screen — these become the assembling pieces in the animation",
+            "items": {
+              "type": "object",
+              "required": ["type", "label"],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["form", "input", "button", "table", "card", "nav", "chart", "modal", "list", "badge", "avatar", "toggle", "tabs", "other"]
+                },
+                "label": { "type": "string", "description": "The element's actual visible text/label from the source, when present" },
+                "source_file": { "type": "string" }
+              },
+              "additionalProperties": false
+            }
+          },
+          "flagship_notes": { "type": "string", "description": "Why this screen is (or isn't) a hero surface for the video" },
+          "reviewed": {
+            "type": "boolean",
+            "const": true,
+            "description": "Must be true — the source was actually read, not assumed"
+          }
+        },
+        "additionalProperties": false
+      },
+      "minItems": 1
+    },
+    "components": {
+      "type": "array",
+      "description": "Shared/reusable components worth replicating individually",
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "source_file"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "source_file": { "type": "string" },
+          "kind": { "type": "string", "description": "e.g. 'form field', 'stat card', 'nav item'" },
+          "used_by_screens": { "type": "array", "items": { "type": "string" } }
+        },
+        "additionalProperties": false
+      }
+    },
+    "flagship_recommendations": {
+      "type": "array",
+      "description": "Which screens the video should feature, with reasoning — presented to the user at the repo_analysis gate",
+      "items": {
+        "type": "object",
+        "required": ["screen_id", "why"],
+        "properties": {
+          "screen_id": { "type": "string" },
+          "why": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "summary": {
+      "type": "string",
+      "description": "What the product's UI actually consists of — specific, from observation ('a 3-panel dashboard with a usage chart, an invoices table, and a team settings form'), not generic"
+    },
+    "planning_implications": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Concrete constraints or opportunities that must affect proposal/script/scene planning. Each item should be actionable.",
+      "minItems": 1
+    },
+    "metadata": { "type": "object" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/pipelines/pipeline_manifest.schema.json
+++ b/schemas/pipelines/pipeline_manifest.schema.json
@@ -61,6 +61,11 @@
             "items": { "type": "string" },
             "description": "Artifact names this stage produces"
           },
+          "required_outputs": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Subset of `produces` that a completed or awaiting_human checkpoint for this stage MUST contain. Use when downstream stages depend on more than the stage's canonical artifact; lib/checkpoint.py enforces it at write time."
+          },
           "preferred_tools": {
             "type": "array",
             "items": { "type": "string" },

--- a/skills/INDEX.md
+++ b/skills/INDEX.md
@@ -177,6 +177,20 @@ Stage director skills teach the agent HOW to execute each pipeline stage. Each s
 | Compose Director | `pipelines/screen-demo/compose-director.md` | `compose` | Legibility-first render, crisp screen output, verification |
 | Publish Director | `pipelines/screen-demo/publish-director.md` | `publish` | Searchable metadata, chapter packaging, thumbnail concepts |
 
+### Product Motion Pipeline (`pipelines/product-motion/`) — v1.0
+
+| Skill | File | Stage | Key Capabilities |
+|-------|------|-------|-----------------|
+| **Executive Producer** | `pipelines/product-motion/executive-producer.md` | `all` | **8-stage orchestration, fidelity-first quality bar, provenance-chain enforcement** |
+| Repo Director | `pipelines/product-motion/repo-director.md` | `repo_analysis` | Repo scan, design_system + ui_inventory authoring, flagship recommendations |
+| Proposal Director | `pipelines/product-motion/proposal-director.md` | `proposal` | Concepts from real screens, both-runtimes presentation, atelier mode, music/SFX plan |
+| Script Director | `pipelines/product-motion/script-director.md` | `script` | Screen-mapped narration, assembly moments as beats, truthful claims |
+| Scene Director | `pipelines/product-motion/scene-director.md` | `scene_plan` | Element build order, assembly beats, SFX intents, glass staging plan |
+| Asset Director | `pipelines/product-motion/asset-director.md` | `assets` | Truthful replicas from source, tokens.ts, snapshot fidelity gate, SFX generation |
+| Edit Director | `pipelines/product-motion/edit-director.md` | `edit` | Timing map, settle-frame SFX cue sheet, bespoke render block |
+| Compose Director | `pipelines/product-motion/compose-director.md` | `compose` | Runtime-routed atelier render, provenance spot-check, post-mix |
+| Publish Director | `pipelines/product-motion/publish-director.md` | `publish` | Accurate product metadata, chapters, license trail |
+
 ### Clip Factory Pipeline (`pipelines/clip-factory/`) — v2.0
 
 | Skill | File | Stage | Key Capabilities |
@@ -314,6 +328,7 @@ Claude Code accesses them via symlinks in `.claude/skills/`.
 | **Diagrams** | `beautiful-mermaid`, `d3-viz` | `intellectronica/agent-skills`, `davila7/claude-code-templates` |
 | **Animation** | `framer-motion`, `lottie-bodymovin` | `pproenca/dot-skills`, `dylantarre/animation-principles` |
 | **Design** | `tailwind-design-system`, `web-design-guidelines`, `vercel-react-best-practices`, `vercel-composition-patterns` | `wshobson/agents`, `vercel-labs/agent-skills` |
+| **Product/Repo Grounding** | `repo-design-extraction` (design_system + ui_inventory from a source repo; tool `repo_design_extractor`), `glass-ui-motion` (truthful UI replicas, glass staging, assembly choreography, SFX cues; tool `sfx_gen`) | Local OpenMontage skills |
 | **AI Video (HeyGen)** | `heygen`, `avatar-video`, `create-video`, `faceswap`, `ai-video-gen`, `video-download`, `video-edit`, `video-translate`, `video-understand`, `visual-style` | `heygen-com/skills` |
 | **AI Video/Image/TTS/Avatar (Kling Official)** | `kling-official` - official direct API auth, Classic/Turbo/Omni task protocols, multi-reference Omni syntax, internal Elements/Account Usage helpers, callback notes, TTS voice parameters, avatar/lip-sync face selection, error handling, and cost governance for `kling_official_video` / `kling_official_image` / `kling_tts` / `kling_avatar` / `kling_lip_sync` | Local OpenMontage skill |
 | **AI Video (Premium)** | `seedance-2-0` — preferred premium default (cinematic, trailer, multi-shot, lip-sync, synced audio); accessed via `seedance_video` (fal.ai) or `heygen_video` Avatar Shots | Local OpenMontage skill |

--- a/skills/pipelines/product-motion/asset-director.md
+++ b/skills/pipelines/product-motion/asset-director.md
@@ -1,0 +1,82 @@
+# Asset Director — Product-Motion Pipeline
+
+## When to Use
+
+Fifth stage — where the replicas get built. You produce every asset: the
+hand-authored replica scene components (with per-scene snapshot stills for
+the gate), narration audio, music, and SFX. This stage ends at the **fidelity
+gate**: the user reviews replica snapshots against the real product before
+any motion/render work is locked in.
+
+## Prerequisites
+
+| Layer | Resource | Purpose |
+|-------|----------|---------|
+| Layer 3 | `.agents/skills/glass-ui-motion/SKILL.md` (+ references) | The truthful-replica method, glass recipes, SFX generation |
+| Meta | `skills/meta/bespoke-composition.md` | Atelier construction sequence and engine gotchas |
+| Scripts | `scripts/scaffold_atelier_project.py`, `scripts/atelier_snapshots.py` | Project scaffold; per-scene stills |
+| Tools | `tts_selector`, `music_gen`, `sfx_gen`, `image_selector`, `subtitle_gen` | Audio + support assets |
+| Artifacts in | `scene_plan`, `design_system`, `ui_inventory` | What to build and the truth to build it from |
+
+## Process
+
+### 1. Scaffold the atelier project
+
+`scripts/scaffold_atelier_project.py` under `projects/<id>/`. Generate
+`tokens.ts` **from the design_system artifact** — every color/font/radius/
+shadow/glass value as a named export. This module is the only place style
+values may live; scene files import from it (the no-literal rule is
+grep-audited at review).
+
+### 2. Author replicas (the heart of the stage)
+
+Per scene, per the glass-ui-motion method:
+
+1. Open the repo `source_files` the scene plan cites. Read the real JSX/
+   template.
+2. Port the structure faithfully — field order, labels, button copy, icons —
+   into a scene component under `projects/<id>/scenes/`. Simplify by
+   omission, never substitution.
+3. Style only from `tokens.ts`. Load the product's real fonts.
+4. Wire the assembly choreography (build order, spring presets, staggers)
+   from the scene plan — motion can be refined at edit, but entrances exist
+   now so snapshots look real.
+5. Never import from `remotion-composer/src/components` or the stock
+   compositions — the atelier guardrail fails the render, and the doctrine
+   fails the review.
+
+### 3. Snapshot stills for the gate
+
+`scripts/atelier_snapshots.py` renders one PNG per scene at its
+most-assembled frame → `projects/<id>/assets/images/`. Register each in the
+asset_manifest as `type: "image"`, `subtype: "scene_snapshot"`, with
+**`provenance.source_files`** (the repo files replicated) and
+**`provenance.design_tokens`** (token names used). Deviations →
+`provenance.notes`.
+
+### 4. Narration, music, SFX
+
+- **Narration**: sample-first protocol (generate `sample_section_id`, play,
+  approve, then batch) via `tts_selector` with the proposal's provider.
+  Record `voice_performance` metadata per asset.
+- **Music**: per the proposal's music decision (library / generated via
+  `music_gen` with `force_instrumental: true` / none).
+- **SFX**: generate one effect per cue class used by the scene plan (4-6
+  total) via `sfx_gen`, prompts from `references/sfx-cues.md`. Listen to each
+  once. Register as `type: "sfx"` with the generation prompt.
+
+### 5. Validate, review, gate
+
+Validate `asset_manifest`; run the grep-audit (no non-token literals in
+`scenes/`); self-review against the manifest's review_focus. Checkpoint
+`awaiting_human` and present **scene-by-scene**: snapshot still + the repo
+source it replicates + provenance. Ask for corrections per scene. **End your
+turn.**
+
+## Failure modes
+
+- A replica styled from memory of the screenshot instead of the source file —
+  labels drift, spacing lies. Always re-open the source.
+- Snapshot taken mid-assembly (elements missing) — the user can't judge
+  fidelity. Snapshot at the most-assembled frame.
+- SFX generated per-element instead of per-class — 20 assets where 5 belong.

--- a/skills/pipelines/product-motion/compose-director.md
+++ b/skills/pipelines/product-motion/compose-director.md
@@ -1,0 +1,37 @@
+# Compose Director — Product-Motion Pipeline
+
+## When to Use
+
+Seventh stage (auto-proceeds). `edit_decisions` is locked. You render the
+final video, post-mix the audio, run the final review, and produce
+`render_report` + `final_review`.
+
+## Process
+
+1. **Route by `render_runtime`** — read it from `edit_decisions`; it must
+   match `proposal_packet.production_plan.render_runtime`. `video_compose`
+   dispatches automatically: `render_runtime="remotion"` +
+   `composition_mode="atelier"` → `_render_via_atelier`;
+   `render_runtime="hyperframes"` → `hyperframes_compose` /
+   `_render_via_hyperframes`. **A mismatch or silent swap is a CRITICAL
+   governance violation** — if the locked runtime is unavailable at compose
+   time (Node missing, HyperFrames doctor fails), STOP and escalate per the
+   blocker protocol; do not render on the other runtime without user approval
+   and a re-logged `render_runtime_selection` decision.
+2. **Render.** The atelier path stages sources, runs the stock-import
+   guardrail (a violation fails the render with `re_author` — fix the scene,
+   don't bypass), renders via `npx remotion render`, and runs the built-in
+   final review probes.
+3. **Post-mix** narration + music over the rendered video via `audio_mixer`
+   (ducking + loudnorm). SFX are already inside the composition — do not add
+   them again as post-mix tracks.
+4. **Final review** (`final_review` artifact), beyond the technical probes:
+   - **Provenance spot-check**: for each scene, pick one token visible in the
+     final frames and verify it against the design_system's cited repo
+     file+line. A drift here is a fidelity defect → send back to assets.
+   - SFX land on settle frames (scrub the cue frames); mix is narration-led.
+   - Nothing moving at any cut; fonts are the product's real fonts.
+   - Distinctness: could this be any other product's video? It must not be.
+5. **ffprobe** the output (resolution, duration, both audio characteristics),
+   write `render_report` with encoding profile + verification notes,
+   checkpoint, and present the deliverable with the final_review summary.

--- a/skills/pipelines/product-motion/edit-director.md
+++ b/skills/pipelines/product-motion/edit-director.md
@@ -1,0 +1,46 @@
+# Edit Director — Product-Motion Pipeline
+
+## When to Use
+
+Sixth stage (auto-proceeds). Replicas and audio approved. You lock the
+timing: scene sequence, narration alignment, the SFX cue sheet, and the
+`bespoke` block that routes the atelier render.
+
+## Process
+
+1. **Timing map**: order scenes per the scene plan; set each scene's
+   `durationInFrames` from its narration segment's real audio duration
+   (ffprobe the generated files — never the estimate) + the 12-18 frame hold.
+   Nothing may still be moving at a cut.
+2. **Compute settle frames** for every choreographed element
+   (`measureSpring` per `references/assembly-choreography.md`) and derive the
+   **SFX cue sheet** per `references/sfx-cues.md`: first/last-sibling rule,
+   density cap ~1 per 0.7s, focus beat always cues. Write the cue sheet into
+   the atelier `props.json` (`sfx_cues[]` with scene_id/element/frame/
+   asset_id/volume). Cues reference only asset_manifest sfx ids.
+3. **Audio plan**: narration + music stay on the post-mix path — build
+   `edit_decisions.audio` (narration segments with start times, music with
+   fade/loop and the playbook volume). SFX are in-composition and do NOT go
+   into `audio.sfx[]` (that field is the post-mix fallback only — using both
+   double-fires every cue).
+4. **The bespoke block** (routes `video_compose._render_via_atelier`):
+
+   ```json
+   "composition_mode": "atelier",
+   "render_runtime": "<carried from proposal_packet — unchanged>",
+   "bespoke": {
+     "entry": "projects/<id>/src/index.ts",
+     "composition_id": "<CompositionId>",
+     "props_path": "projects/<id>/artifacts/props.json",
+     "public_dir": "projects/<id>/assets",
+     "art_direction": "projects/<id>/artifacts/art-direction.md"
+   }
+   ```
+
+   `render_runtime` is carried from `proposal_packet` **unchanged** — if the
+   proposal locked `hyperframes`, the bespoke path is the HyperFrames
+   equivalent and this block adapts per `skills/core/hyperframes.md`; a
+   silent swap either direction is a CRITICAL violation.
+5. Validate `edit_decisions`, self-review (manifest review_focus), checkpoint
+   `completed` (no human gate) — but surface the timing map in your progress
+   note so the board shows it.

--- a/skills/pipelines/product-motion/executive-producer.md
+++ b/skills/pipelines/product-motion/executive-producer.md
@@ -1,0 +1,64 @@
+# Executive Producer — Product-Motion Pipeline
+
+## When to Use
+
+You are orchestrating a **product-motion** run: the user pointed OpenMontage at
+a product's source repository and wants polished-SaaS product screen
+animations — the product's real UI, rebuilt faithfully, assembling on glass
+surfaces with spring motion and sound effects.
+
+This pipeline is **beta** — say so when the user selects it.
+
+## The quality bar that rules this pipeline
+
+**Fidelity is a first-class deliverable.** A gorgeous animation of a UI the
+product doesn't have is a failed run. The provenance chain is the mechanism:
+
+```
+repo file+line → design_system token → replica scene component
+repo source_files → ui_inventory screen → scene_plan scene → asset provenance
+```
+
+Any stage that breaks a link in this chain gets sent back, budget permitting.
+
+## Stage flow
+
+`repo_analysis → proposal → script → scene_plan → assets → edit → compose → publish`
+
+Gates (from the manifest, binding): repo_analysis, proposal, script,
+scene_plan, assets (the fidelity gate), publish. edit and compose
+auto-proceed.
+
+## Orchestration duties
+
+1. **Init the workspace** (`init_project`) and open the Backlot board before
+   any stage. The repo under analysis is *input*, never workspace — nothing is
+   ever written into the user's product repo.
+2. **Preflight** per AGENT_GUIDE: `provider_menu_summary()`, present the
+   capability menu. This pipeline needs: a TTS provider (narration), Remotion
+   or HyperFrames (composition), and optionally `sfx_gen` + `music_gen`
+   (ELEVENLABS_API_KEY) for sound. `repo_design_extractor` is always
+   available (local). If no SFX provider is configured, surface it at
+   proposal — the "with sound effects" promise degrades and the user must
+   choose knowingly.
+3. **Read the director skill before each stage** — no exceptions.
+4. **Budget**: default $2.00. Narration (TTS) + music (1 track) + 4-6 SFX +
+   render is typically well under this; repo analysis and composition
+   authoring are token-cost, not API-cost.
+5. **Escalate blockers** per the Decision Communication Contract — especially
+   runtime unavailability at compose (never silently swap `render_runtime`).
+6. **Send-backs**: max 3 per stage. A fidelity failure at the assets gate
+   (replica doesn't match source) sends assets back, not scene_plan — unless
+   the scene plan referenced a screen the inventory never had, which is a
+   repo_analysis defect.
+
+## What NOT to do
+
+- Do not let the run proceed past repo_analysis if the design_system is
+  unvalidated or tokens lack provenance.
+- Do not substitute a live-URL capture (`website-to-video`) for repo
+  extraction without telling the user — different grounding, different truth.
+- Do not allow stock scene-type assembly (`cut.type` catalog) — this pipeline
+  composes via the atelier path; the `_ATELIER_STOCK_IMPORT_RE` guardrail in
+  `video_compose` will fail the render anyway.
+- Do not skip the per-scene snapshot review at the assets gate to save time.

--- a/skills/pipelines/product-motion/proposal-director.md
+++ b/skills/pipelines/product-motion/proposal-director.md
@@ -1,0 +1,85 @@
+# Proposal Director — Product-Motion Pipeline
+
+## When to Use
+
+Second stage. `design_system` + `ui_inventory` are approved. You produce the
+`proposal_packet` the user green-lights before any creative writing or
+spending: concepts, runtime, authoring mode, taste profile, music/SFX plan,
+and itemized cost.
+
+## Prerequisites
+
+Read first: `skills/meta/taste-direction.md` (the taste_profile travels from
+here), `skills/meta/bespoke-composition.md` (atelier contract),
+`skills/core/hyperframes.md` (runtime decision matrix).
+
+## Process
+
+### 1. Concepts (2-3, differentiated)
+
+Each concept picks 3-5 approved flagship screens and a narrative arc (e.g.
+"problem → the dashboard answers it → the form that gets you there → close").
+Concepts must feature screens from `ui_inventory` — a concept that needs a
+surface the product doesn't have is invalid. Tie each concept to
+`design_system.summary`: the product's own visual language leads; glass
+staging intensity is a dial set per the glass-ui-motion skill.
+
+### 2. Composition runtime — Present both (HARD RULE)
+
+Check availability (`video_compose.get_info()["render_engines"]`), then
+**present both runtimes** with per-brief tradeoffs before locking
+`render_runtime`. For this pipeline the honest framing is:
+
+- **Remotion** — recommended for **React/Next repos**: replicas are near-1:1
+  ports of the actual JSX; native `spring()` choreography; frame-accurate
+  in-composition SFX via `<Audio>`; atelier precedents exist. Tradeoff:
+  Vue/Svelte templates must be translated to React, one more fidelity risk.
+- **HyperFrames** — the genuine alternative for **Vue/Nuxt or Tailwind-heavy
+  markup**: HTML/CSS replicas can reuse the repo's template markup and
+  Tailwind classes nearly verbatim (arguably *more* truthful there); GSAP
+  timelines for assembly. Tradeoff: SFX cueing is post-mix territory and the
+  glass-ui-motion Remotion mechanics don't transfer 1:1.
+
+Let `design_system.source.framework` drive your recommendation, recommend one
+with rationale, and wait for the user's choice. If only one runtime is
+installed, say so explicitly and record the other as
+`rejected_because: "runtime not available on this machine"`.
+
+Log `decision_log` entry `category: "render_runtime_selection"`, subject
+"Composition runtime", with BOTH runtimes (plus ffmpeg where it applied) in
+`options_considered`. Lock the choice in
+`proposal_packet.production_plan.render_runtime` — compose must carry it
+unchanged; a silent swap (e.g. to `render_runtime="hyperframes"` or back) is
+a CRITICAL governance violation.
+
+### 3. Authoring mode — atelier by default
+
+This pipeline's replicas are inherently per-product, so **atelier** is the
+default `composition_mode`. Disclose the tradeoff (more tokens/iteration than
+templated; that's the price of a bespoke, truthful piece) and log
+`decision_log` `category: "composition_mode"`, subject "Composition authoring
+mode", with `templated` in `options_considered` and why it was rejected
+(stock scene types cannot be faithful to this product's UI).
+
+### 4. Taste profile
+
+Run `skills/meta/taste-direction.md`; carry the resulting `taste_profile`
+into `production_plan.taste_profile`. `design_read` comes straight from
+`design_system.summary`. Typical product-motion dials: motion_intensity 4-6
+(weighted, calm), information_density 3-5, palette_discipline strict (the
+product's tokens only).
+
+### 5. Music + SFX plan (mandatory)
+
+Per AGENT_GUIDE's Music Plan: check `music_library/`, then
+`registry.get_by_capability("music_generation")`, present the explicit
+choices (library track / user-supplied / generate / none). For SFX: check
+`sfx_gen` availability; if unavailable, the "with sound effects" promise
+degrades — present the 1-minute env-var fix (read `install_instructions`)
+and let the user choose. Record both in the proposal.
+
+### 6. Cost + production plan
+
+Itemize: narration TTS (chars × provider rate), music (1 track), SFX (4-6
+effects × ~$0.03), render (local, $0). State per-stage plan and gates. Then
+checkpoint `awaiting_human`, present, **end your turn**.

--- a/skills/pipelines/product-motion/proposal-director.md
+++ b/skills/pipelines/product-motion/proposal-director.md
@@ -80,6 +80,10 @@ and let the user choose. Record both in the proposal.
 
 ### 6. Cost + production plan
 
-Itemize: narration TTS (chars × provider rate), music (1 track), SFX (4-6
-effects × ~$0.03), render (local, $0). State per-stage plan and gates. Then
-checkpoint `awaiting_human`, present, **end your turn**.
+Itemize: narration TTS (chars × provider rate), music (1 track), SFX, render
+(local, $0). Do not hardcode provider rates — call `estimate_cost()` on the
+tool you actually plan to use. SFX in particular is billed per minute of
+generated audio, not per effect, so 4-6 short cues cost far less than a
+single ambient bed; `sfx_gen.estimate_cost()` returns a list-rate upper
+bound. State per-stage plan and gates. Then checkpoint `awaiting_human`,
+present, **end your turn**.

--- a/skills/pipelines/product-motion/publish-director.md
+++ b/skills/pipelines/product-motion/publish-director.md
@@ -1,0 +1,24 @@
+# Publish Director — Product-Motion Pipeline
+
+## When to Use
+
+Final stage (human-gated). The render is approved. You package the
+deliverable.
+
+## Process
+
+1. **Export package** under `projects/<id>/renders/export/`:
+   - the final MP4 (and a platform-cropped variant if the proposal promised
+     one),
+   - `metadata.json`: title, description, tags — name the product and its
+     core promise accurately; the description may cite the featured screens.
+     No claims the video doesn't show.
+   - thumbnail concept: the strongest snapshot still (usually the hero
+     screen's most-assembled frame) with a one-line framing note.
+2. **Chapter markers** from the scene timing map (one per featured screen)
+   when the target platform supports them.
+3. **Attribution/licensing**: music/SFX provenance from the asset_manifest
+   (provider, generation prompts) recorded in the publish log — SaaS launch
+   videos get reused; the license trail must travel with the file.
+4. Validate `publish_log`, checkpoint `awaiting_human`, present the package
+   contents, **end your turn**.

--- a/skills/pipelines/product-motion/repo-director.md
+++ b/skills/pipelines/product-motion/repo-director.md
@@ -1,0 +1,60 @@
+# Repo Director — Product-Motion Pipeline
+
+## When to Use
+
+First stage of a product-motion run. You have a path to the user's product
+repository. You produce the two artifacts everything downstream is grounded
+in: **`design_system`** (canonical) and **`ui_inventory`** (supplementary),
+plus `decision_log` entries.
+
+## Prerequisites
+
+| Layer | Resource | Purpose |
+|-------|----------|---------|
+| Tool | `repo_design_extractor` | Deterministic scan: framework, token sources, CSS vars with file+line, screens/components index |
+| Layer 3 skill | `.agents/skills/repo-design-extraction/SKILL.md` (+ its `references/`) | **Read before authoring** — reading guides per styling system, distillation rules, provenance discipline |
+| Schemas | `schemas/artifacts/design_system.schema.json`, `ui_inventory.schema.json` | Artifact validation |
+
+## Process
+
+1. **Confirm scope.** v1 targets web frontends (React/Next/Vue/Tailwind). If
+   the scan detects `framework: "other"` or no UI code, stop and tell the
+   user what was found — do not force a backend repo through this pipeline.
+2. **Run the scanner** with `output_path` under
+   `projects/<id>/artifacts/repo_scan_report.json`. Surface `truncated: true`
+   if reported.
+3. **Read the flagged sources** and author both artifacts per the
+   `repo-design-extraction` skill. Non-negotiables:
+   - every token value copied verbatim with provenance,
+   - `gaps[]` lists everything derived (the glass spec almost always),
+   - every screen actually opened (`reviewed: true` is a contract),
+   - `ui_elements` labels are the source's real strings.
+4. **Record the design read** — one paragraph in `design_system.summary`
+   stating what this product's visual language *is*, from evidence. This
+   seeds the taste work at proposal.
+5. **Log decisions**: `decision_log` entry `category: "grounding_source"`,
+   subject "Design-system grounding" — repo extraction chosen; note
+   live-URL capture (`website-to-video`) as the option considered when the
+   repo also has a deployed site.
+6. **Validate** both artifacts (`validate_artifact`), self-review against the
+   manifest's `review_focus`, then checkpoint `awaiting_human`.
+
+## Presenting at the gate
+
+Show the user, in plain language:
+
+1. The design read (2-3 sentences) + a token table (color swatches described,
+   fonts, radii) **with provenance columns**.
+2. The screens found, and 3-5 `flagship_recommendations` with one-line whys.
+3. The `gaps[]` ledger — what was derived and how.
+4. Ask: which screens should the video feature? Any token corrections?
+
+Then **end your turn** and wait.
+
+## Failure modes to catch
+
+- Thin design system (4 CSS vars, default Tailwind): present it honestly and
+  lean on `component_styles`; do not pad with invented tokens.
+- Monorepo: ask which package/app is the product before scanning everything.
+- Tokens behind CSS vars referenced by Tailwind (`hsl(var(--primary))`):
+  resolve through to the CSS file — the config key alone is not provenance.

--- a/skills/pipelines/product-motion/repo-director.md
+++ b/skills/pipelines/product-motion/repo-director.md
@@ -4,8 +4,15 @@
 
 First stage of a product-motion run. You have a path to the user's product
 repository. You produce the two artifacts everything downstream is grounded
-in: **`design_system`** (canonical) and **`ui_inventory`** (supplementary),
-plus `decision_log` entries.
+in: **`design_system`** (the stage's canonical artifact) and
+**`ui_inventory`**, plus `decision_log` entries.
+
+**Both are mandatory.** The manifest declares them as the stage's
+`required_outputs`, and `write_checkpoint` refuses a `completed` or
+`awaiting_human` repo_analysis checkpoint that is missing either — every
+downstream truthfulness claim and the assets fidelity gate read
+`ui_inventory`. Use an `in_progress` checkpoint while the stage is still
+being assembled.
 
 ## Prerequisites
 
@@ -21,8 +28,18 @@ plus `decision_log` entries.
    the scan detects `framework: "other"` or no UI code, stop and tell the
    user what was found — do not force a backend repo through this pipeline.
 2. **Run the scanner** with `output_path` under
-   `projects/<id>/artifacts/repo_scan_report.json`. Surface `truncated: true`
-   if reported.
+   `projects/<id>/artifacts/repo_scan_report.json` — a path inside the
+   product repo is rejected; the analyzed repo is never written to. Surface
+   `truncated: true` and everything in `warnings[]` if reported.
+
+   The scanner does **not** execute the product's code. If `tailwind_theme`
+   is `null`, open the config and read it — do not reach for the
+   `allow_config_execution` opt-in, which runs the repo's JavaScript. If you
+   ever think a run genuinely needs it, that is a user decision: say what it
+   does and get approval first.
+   Screens whose `route_source` is `not_derivable` have no route the scanner
+   can know; leave `route` unset in `ui_inventory` unless you read the router
+   config yourself.
 3. **Read the flagged sources** and author both artifacts per the
    `repo-design-extraction` skill. Non-negotiables:
    - every token value copied verbatim with provenance,

--- a/skills/pipelines/product-motion/scene-director.md
+++ b/skills/pipelines/product-motion/scene-director.md
@@ -1,0 +1,37 @@
+# Scene Director — Product-Motion Pipeline
+
+## When to Use
+
+Fourth stage. Script approved. You turn each script section into a concrete
+scene spec: which screen, which elements assemble in what order, on what
+beats, with what SFX intents.
+
+## Prerequisites
+
+Read `.agents/skills/glass-ui-motion/SKILL.md` and its
+`references/assembly-choreography.md` — build-order semantics, stagger math,
+and settle-frame rules live there. Bring `design_system` and `ui_inventory`
+into context; scenes reference them constantly.
+
+## Process
+
+1. **One scene per flagship surface** (plus open/close). Each scene carries:
+   - `screen_id` from `ui_inventory` (the manifest review checks this),
+   - the **element build order** — the scene's `ui_elements` in semantic
+     assembly order (container → chrome → fields → content → focus),
+   - **assembly beats**: which narration phrase each element group lands on,
+   - **SFX intents** per the cue taxonomy (whoosh/tick/click/shimmer/pop) —
+     intents only; frames are computed at edit,
+   - duration from the section's narration length + a 12-18 frame hold.
+2. **Required assets per scene** must list the repo `source_files` to
+   replicate (from the ui_inventory screen/components) — this is the link the
+   asset director builds from, and the manifest's success criterion.
+3. **Glass staging plan**: how many panels, what sits on glass vs. on the
+   ambient background, one camera move max per scene — per the
+   glass-ui-motion recipes, themed by `design_system.tokens.glass`.
+4. **Density discipline**: information_density and motion_intensity from the
+   proposal's `taste_profile` cap simultaneous motion and callouts. One focus
+   beat per scene, maximum.
+5. Validate (`scene_plan` schema), self-review, checkpoint `awaiting_human`,
+   present per-scene: screen, build order, beats, SFX intents. **End your
+   turn.**

--- a/skills/pipelines/product-motion/script-director.md
+++ b/skills/pipelines/product-motion/script-director.md
@@ -1,0 +1,33 @@
+# Script Director — Product-Motion Pipeline
+
+## When to Use
+
+Third stage. The proposal (concept, screens, runtime, taste) is approved. You
+write the narration script whose beats the screen animations will land on.
+
+## Process
+
+1. **Structure = the approved concept's screen order.** Each script section
+   narrates over exactly one screen (or the open/close). Put the screen's
+   `ui_inventory` id in the section's metadata — the manifest requires every
+   section to name the `screen_id` it narrates over.
+2. **Assembly moments are script beats.** Where the form assembles, where the
+   dashboard cards arrive, where the button gets pressed — write those as
+   explicit beats with intended timing, because scene_plan converts them into
+   element build orders and the SFX cue sheet hangs off them. A section that
+   says "the dashboard appears" is under-written; "the usage chart draws in
+   as we say 'see every request in real time'" is right.
+3. **Truthful claims only.** Narration may only claim what the repo evidences
+   (`ui_inventory` purposes, real labels, real flows). "Invite your team in
+   two clicks" is only sayable if the invite flow exists in the inventory.
+   Marketing superlatives about the product's internals are out; what the UI
+   visibly does is in.
+4. **Register**: polished-SaaS founder/product register — confident, calm,
+   concrete. Short sentences that leave air for the assembly beats. Target
+   duration from the proposal; ~140 words per minute of narration.
+5. **Voice performance**: set `voice_performance` per the TTS provider chosen
+   at proposal (see the provider's Layer 3 skill for parameter mapping) and
+   pick the `sample_section_id` for the assets-stage sample gate.
+6. Validate against `schemas/artifacts/script.schema.json`, self-review
+   (review_focus in the manifest), checkpoint `awaiting_human`, present the
+   script with per-section screen mapping, **end your turn**.

--- a/tests/contracts/test_product_motion_pipeline.py
+++ b/tests/contracts/test_product_motion_pipeline.py
@@ -1,0 +1,285 @@
+"""Contract tests for the product-motion pipeline.
+
+Covers: manifest validity against the pipeline schema, skill-file existence,
+produces/artifact-name integrity, checkpoint wiring for the new repo_analysis
+stage, golden + invalid fixtures for the design_system and ui_inventory
+artifacts, and the asset_manifest provenance extension.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(ROOT))
+
+from lib.checkpoint import (
+    ALL_KNOWN_STAGES,
+    CANONICAL_STAGE_ARTIFACTS,
+    SUPPLEMENTARY_ARTIFACTS,
+    CheckpointValidationError,
+    write_checkpoint,
+)
+from schemas.artifacts import ARTIFACT_NAMES, validate_artifact
+
+MANIFEST_PATH = ROOT / "pipeline_defs" / "product-motion.yaml"
+SCHEMA_PATH = ROOT / "schemas" / "pipelines" / "pipeline_manifest.schema.json"
+
+
+@pytest.fixture(scope="module")
+def manifest():
+    with open(MANIFEST_PATH, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+# ---- Golden fixtures ----
+
+GOLDEN_DESIGN_SYSTEM = {
+    "version": "1.0",
+    "source": {
+        "repo_path": "/work/acme-app",
+        "framework": "next",
+        "styling_systems": ["tailwind", "css-variables"],
+        "git_commit": "abc1234",
+    },
+    "tokens": {
+        "colors": [
+            {"name": "primary", "value": "#6366f1", "role": "primary",
+             "provenance": {"file": "app/globals.css", "line": 12, "key": "--primary"}},
+        ],
+        "typography": {
+            "fonts": [
+                {"family": "Inter", "role": "body", "weights": [400, 600],
+                 "provenance": {"file": "app/layout.tsx", "line": 3}},
+            ],
+            "scale": [
+                {"name": "h1", "size": "36px", "weight": "600", "line_height": "1.1",
+                 "provenance": {"file": "app/page.tsx", "line": 22}},
+            ],
+        },
+        "radii": [
+            {"name": "card", "value": "12px",
+             "provenance": {"file": "tailwind.config.ts", "key": "theme.extend.borderRadius.lg"}},
+        ],
+        "glass": {
+            "derived": True,
+            "background": "rgba(99,102,241,0.08)",
+            "backdrop_blur": "24px",
+            "border": "1px solid rgba(255,255,255,0.12)",
+            "rationale": "composed from --primary at low alpha; product has no frosted surfaces",
+        },
+    },
+    "component_styles": {
+        "buttons": [
+            {"variant": "primary button",
+             "css_summary": "bg --primary, white text, rounded-lg (8px), px-4 py-2, text-sm font-medium",
+             "provenance": {"file": "components/ui/button.tsx", "line": 20}},
+        ],
+    },
+    "gaps": [
+        {"token": "glass", "how_inferred": "derived from palette (no glass in product)"},
+    ],
+    "summary": "Indigo-primary minimal SaaS, Inter throughout, 8-12px radii, dark-first.",
+}
+
+GOLDEN_UI_INVENTORY = {
+    "version": "1.0",
+    "repo_path": "/work/acme-app",
+    "screens": [
+        {
+            "id": "dashboard",
+            "name": "Dashboard",
+            "route": "/",
+            "source_files": ["app/page.tsx", "components/stat-card.tsx"],
+            "purpose": "usage overview with stat cards and a request chart",
+            "ui_elements": [
+                {"type": "card", "label": "Monthly active users",
+                 "source_file": "components/stat-card.tsx"},
+                {"type": "chart", "label": "requests over time (area chart)",
+                 "source_file": "app/page.tsx"},
+            ],
+            "flagship_notes": "hero surface — richest animatable layout",
+            "reviewed": True,
+        }
+    ],
+    "components": [
+        {"id": "stat-card", "name": "StatCard", "source_file": "components/stat-card.tsx",
+         "kind": "stat card", "used_by_screens": ["dashboard"]},
+    ],
+    "flagship_recommendations": [
+        {"screen_id": "dashboard", "why": "shows the product's core promise at a glance"},
+    ],
+    "summary": "Single dashboard app: stat cards, one chart, settings form.",
+    "planning_implications": [
+        "Hero scene should assemble the stat-card grid, then draw the chart.",
+    ],
+}
+
+
+# ---- Manifest ----
+
+class TestManifest:
+    def test_validates_against_pipeline_schema(self, manifest):
+        with open(SCHEMA_PATH) as f:
+            schema = json.load(f)
+        jsonschema.validate(manifest, schema)
+
+    def test_stage_order(self, manifest):
+        names = [s["name"] for s in manifest["stages"]]
+        assert names == [
+            "repo_analysis", "proposal", "script", "scene_plan",
+            "assets", "edit", "compose", "publish",
+        ]
+
+    def test_all_required_skill_files_exist(self, manifest):
+        for ref in manifest["required_skills"]:
+            path = ROOT / "skills" / f"{ref}.md"
+            assert path.is_file(), f"required_skills references missing file: {path}"
+
+    def test_all_stage_skill_files_exist(self, manifest):
+        for stage in manifest["stages"]:
+            path = ROOT / "skills" / f"{stage['skill']}.md"
+            assert path.is_file(), f"stage {stage['name']} skill missing: {path}"
+
+    def test_produces_are_known_artifacts(self, manifest):
+        for stage in manifest["stages"]:
+            for produced in stage.get("produces", []):
+                assert produced in ARTIFACT_NAMES, (
+                    f"stage {stage['name']} produces unknown artifact {produced!r}"
+                )
+
+    def test_repo_analysis_and_assets_are_gated(self, manifest):
+        gates = {s["name"]: s["human_approval_default"] for s in manifest["stages"]}
+        assert gates["repo_analysis"] is True
+        assert gates["assets"] is True, "assets is the fidelity gate — must be gated"
+        assert gates["proposal"] is True
+
+    def test_layer3_skills_exist(self):
+        for name in ("repo-design-extraction", "glass-ui-motion"):
+            assert (ROOT / ".agents" / "skills" / name / "SKILL.md").is_file()
+            assert (ROOT / ".claude" / "skills" / name / "SKILL.md").is_file()
+
+
+# ---- Checkpoint wiring ----
+
+class TestCheckpointWiring:
+    def test_stage_registered(self):
+        assert "repo_analysis" in ALL_KNOWN_STAGES
+        assert CANONICAL_STAGE_ARTIFACTS["repo_analysis"] == "design_system"
+        assert "ui_inventory" in SUPPLEMENTARY_ARTIFACTS
+
+    def test_repo_analysis_checkpoint_roundtrip(self, tmp_path):
+        path = write_checkpoint(
+            tmp_path, "proj", "repo_analysis", "awaiting_human",
+            artifacts={
+                "design_system": GOLDEN_DESIGN_SYSTEM,
+                "ui_inventory": GOLDEN_UI_INVENTORY,
+            },
+            pipeline_type="product-motion",
+            human_approval_required=True,
+        )
+        assert path.exists()
+
+    def test_repo_analysis_requires_design_system(self, tmp_path):
+        with pytest.raises(CheckpointValidationError):
+            write_checkpoint(
+                tmp_path, "proj", "repo_analysis", "awaiting_human",
+                artifacts={"ui_inventory": GOLDEN_UI_INVENTORY},
+                pipeline_type="product-motion",
+                human_approval_required=True,
+            )
+
+    def test_repo_analysis_gate_enforced(self, tmp_path):
+        """Gated stage cannot be completed without human approval."""
+        with pytest.raises(CheckpointValidationError, match="GATE VIOLATION"):
+            write_checkpoint(
+                tmp_path, "proj", "repo_analysis", "completed",
+                artifacts={"design_system": GOLDEN_DESIGN_SYSTEM},
+                pipeline_type="product-motion",
+            )
+
+
+# ---- Artifact schemas ----
+
+class TestDesignSystemSchema:
+    def test_golden_validates(self):
+        validate_artifact("design_system", GOLDEN_DESIGN_SYSTEM)
+
+    def test_token_without_provenance_rejected(self):
+        bad = copy.deepcopy(GOLDEN_DESIGN_SYSTEM)
+        del bad["tokens"]["colors"][0]["provenance"]
+        with pytest.raises(jsonschema.ValidationError):
+            validate_artifact("design_system", bad)
+
+    def test_glass_requires_derived_flag(self):
+        bad = copy.deepcopy(GOLDEN_DESIGN_SYSTEM)
+        del bad["tokens"]["glass"]["derived"]
+        with pytest.raises(jsonschema.ValidationError):
+            validate_artifact("design_system", bad)
+
+    def test_unknown_framework_rejected(self):
+        bad = copy.deepcopy(GOLDEN_DESIGN_SYSTEM)
+        bad["source"]["framework"] = "flutter"
+        with pytest.raises(jsonschema.ValidationError):
+            validate_artifact("design_system", bad)
+
+
+class TestUiInventorySchema:
+    def test_golden_validates(self):
+        validate_artifact("ui_inventory", GOLDEN_UI_INVENTORY)
+
+    def test_unreviewed_screen_rejected(self):
+        bad = copy.deepcopy(GOLDEN_UI_INVENTORY)
+        bad["screens"][0]["reviewed"] = False
+        with pytest.raises(jsonschema.ValidationError):
+            validate_artifact("ui_inventory", bad)
+
+    def test_screen_without_sources_rejected(self):
+        bad = copy.deepcopy(GOLDEN_UI_INVENTORY)
+        bad["screens"][0]["source_files"] = []
+        with pytest.raises(jsonschema.ValidationError):
+            validate_artifact("ui_inventory", bad)
+
+    def test_planning_implications_required(self):
+        bad = copy.deepcopy(GOLDEN_UI_INVENTORY)
+        bad["planning_implications"] = []
+        with pytest.raises(jsonschema.ValidationError):
+            validate_artifact("ui_inventory", bad)
+
+
+class TestAssetManifestProvenance:
+    def test_snapshot_with_provenance_validates(self):
+        validate_artifact("asset_manifest", {
+            "version": "1.0",
+            "assets": [{
+                "id": "snap-dashboard",
+                "type": "image",
+                "subtype": "scene_snapshot",
+                "path": "assets/images/dashboard.png",
+                "source_tool": "atelier_snapshots",
+                "scene_id": "scene-dashboard",
+                "provenance": {
+                    "source_files": ["app/page.tsx", "components/stat-card.tsx"],
+                    "design_tokens": ["primary", "card"],
+                    "notes": "sidebar omitted (not in scene)",
+                },
+            }],
+        })
+
+    def test_provenance_rejects_unknown_fields(self):
+        with pytest.raises(jsonschema.ValidationError):
+            validate_artifact("asset_manifest", {
+                "version": "1.0",
+                "assets": [{
+                    "id": "a", "type": "image", "path": "x.png",
+                    "source_tool": "t", "scene_id": "s",
+                    "provenance": {"invented_field": True},
+                }],
+            })

--- a/tests/contracts/test_product_motion_pipeline.py
+++ b/tests/contracts/test_product_motion_pipeline.py
@@ -196,12 +196,62 @@ class TestCheckpointWiring:
                 human_approval_required=True,
             )
 
+    def test_repo_analysis_requires_ui_inventory(self, tmp_path):
+        """design_system alone does not close repo_analysis.
+
+        Every downstream truthfulness claim and the assets fidelity gate read
+        ui_inventory, so a checkpoint without it is a half-finished stage.
+        """
+        with pytest.raises(CheckpointValidationError, match="ui_inventory"):
+            write_checkpoint(
+                tmp_path, "proj", "repo_analysis", "awaiting_human",
+                artifacts={"design_system": GOLDEN_DESIGN_SYSTEM},
+                pipeline_type="product-motion",
+                human_approval_required=True,
+            )
+
+    def test_repo_analysis_completed_requires_ui_inventory(self, tmp_path):
+        with pytest.raises(CheckpointValidationError, match="ui_inventory"):
+            write_checkpoint(
+                tmp_path, "proj", "repo_analysis", "completed",
+                artifacts={"design_system": GOLDEN_DESIGN_SYSTEM},
+                pipeline_type="product-motion",
+                human_approval_required=True,
+                human_approved=True,
+            )
+
+    def test_in_progress_checkpoint_may_be_partial(self, tmp_path):
+        """The requirement is about closing the stage, not entering it —
+        the in_progress heartbeat must still be writable."""
+        path = write_checkpoint(
+            tmp_path, "proj", "repo_analysis", "in_progress",
+            artifacts={"design_system": GOLDEN_DESIGN_SYSTEM},
+            pipeline_type="product-motion",
+            human_approval_required=True,
+        )
+        assert path.exists()
+
+    def test_required_outputs_declared_in_manifest(self, manifest):
+        """The enforcement is manifest-driven — the declaration is the source
+        of truth, not a hardcoded stage list in lib/checkpoint.py."""
+        stage = next(s for s in manifest["stages"] if s["name"] == "repo_analysis")
+        assert set(stage["required_outputs"]) == {"design_system", "ui_inventory"}
+        assert set(stage["required_outputs"]) <= set(stage["produces"])
+
+    def test_required_outputs_are_known_artifacts(self, manifest):
+        for stage in manifest["stages"]:
+            for name in stage.get("required_outputs", []):
+                assert name in ARTIFACT_NAMES
+
     def test_repo_analysis_gate_enforced(self, tmp_path):
         """Gated stage cannot be completed without human approval."""
         with pytest.raises(CheckpointValidationError, match="GATE VIOLATION"):
             write_checkpoint(
                 tmp_path, "proj", "repo_analysis", "completed",
-                artifacts={"design_system": GOLDEN_DESIGN_SYSTEM},
+                artifacts={
+                    "design_system": GOLDEN_DESIGN_SYSTEM,
+                    "ui_inventory": GOLDEN_UI_INVENTORY,
+                },
                 pipeline_type="product-motion",
             )
 

--- a/tests/tools/test_repo_design_extractor.py
+++ b/tests/tools/test_repo_design_extractor.py
@@ -1,0 +1,200 @@
+"""Focused tests for the repo design-system scanner.
+
+Builds fixture mini-repos in tmp_path and asserts framework detection,
+CSS-custom-property parsing with file+line provenance, candidate-file
+classification, node degradation, caps, and determinism. No network.
+"""
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.base_tool import BaseTool, ToolStatus, ToolTier, ToolRuntime
+from tools.tool_registry import ToolRegistry
+from tools.analysis.repo_design_extractor import RepoDesignExtractor
+
+
+@pytest.fixture
+def next_repo(tmp_path):
+    """Minimal Next.js + Tailwind repo with tokens, fonts, screens, components."""
+    repo = tmp_path / "next-app"
+    (repo / "app" / "settings").mkdir(parents=True)
+    (repo / "components" / "ui").mkdir(parents=True)
+    (repo / "node_modules" / "junk").mkdir(parents=True)
+
+    (repo / "package.json").write_text(
+        '{"name":"mini","dependencies":{"next":"14.0.0","react":"18.2.0"},'
+        '"devDependencies":{"tailwindcss":"3.4.0"}}'
+    )
+    (repo / "tailwind.config.js").write_text(
+        'module.exports = { theme: { extend: { colors: { brand: "#6366f1" } } } };'
+    )
+    (repo / "app" / "globals.css").write_text(
+        ":root {\n"
+        "  --background: #0a0a0f;\n"
+        "  --primary: #6366f1;\n"
+        "}\n"
+        '@font-face { font-family: "Cal Sans"; src: url(/cal.woff2); }\n'
+    )
+    (repo / "app" / "layout.tsx").write_text(
+        'import { Inter } from "next/font/google"\n'
+        "export default function Layout({children}) { return <body>{children}</body> }\n"
+    )
+    (repo / "app" / "page.tsx").write_text("export default function Page(){return null}")
+    (repo / "app" / "settings" / "page.tsx").write_text(
+        "export default function Page(){return null}"
+    )
+    (repo / "components" / "ui" / "button.tsx").write_text("export function Button(){}")
+    (repo / "node_modules" / "junk" / "x.css").write_text(":root { --evil: red; }")
+    return repo
+
+
+@pytest.fixture
+def vue_repo(tmp_path):
+    repo = tmp_path / "vue-app"
+    (repo / "src" / "views").mkdir(parents=True)
+    (repo / "src" / "components").mkdir(parents=True)
+    (repo / "package.json").write_text('{"dependencies":{"vue":"3.4.0"}}')
+    (repo / "src" / "views" / "Dashboard.vue").write_text("<template><main/></template>")
+    (repo / "src" / "components" / "StatCard.vue").write_text("<template><div/></template>")
+    return repo
+
+
+# ---- Contract ----
+
+class TestContract:
+    def test_inherits_base_tool(self):
+        assert issubclass(RepoDesignExtractor, BaseTool)
+
+    def test_identity(self):
+        t = RepoDesignExtractor()
+        assert t.name == "repo_design_extractor"
+        assert t.capability == "analysis"
+        assert t.runtime == ToolRuntime.LOCAL
+        assert t.tier == ToolTier.ANALYZE
+        assert "repo-design-extraction" in t.agent_skills
+
+    def test_always_available_and_free(self):
+        t = RepoDesignExtractor()
+        assert t.get_status() == ToolStatus.AVAILABLE
+        assert t.estimate_cost({}) == 0.0
+
+
+# ---- Registry discovery ----
+
+class TestDiscovery:
+    def test_discoverable(self):
+        reg = ToolRegistry()
+        reg.discover("tools")
+        assert reg.get("repo_design_extractor") is not None
+
+    def test_capability_routing(self):
+        reg = ToolRegistry()
+        reg.discover("tools")
+        names = [t.name for t in reg.get_by_capability("analysis")]
+        assert "repo_design_extractor" in names
+
+
+# ---- Scan behavior ----
+
+class TestScan:
+    def test_framework_and_styling_detection(self, next_repo):
+        res = RepoDesignExtractor().execute({"repo_path": str(next_repo)})
+        assert res.success
+        assert res.data["framework"] == "next"
+        assert "tailwind" in res.data["styling_systems"]
+        assert "css-variables" in res.data["styling_systems"]
+
+    def test_vue_framework_detection(self, vue_repo):
+        res = RepoDesignExtractor().execute({"repo_path": str(vue_repo)})
+        assert res.success
+        assert res.data["framework"] == "vue"
+        # views become screen candidates; components indexed
+        assert any(s["path"].endswith("Dashboard.vue") for s in res.data["screen_candidates"])
+        assert any(c["name"] == "StatCard" for c in res.data["components_index"])
+
+    def test_css_vars_carry_file_and_line_provenance(self, next_repo):
+        res = RepoDesignExtractor().execute({"repo_path": str(next_repo)})
+        by_name = {v["name"]: v for v in res.data["css_custom_properties"]}
+        assert by_name["--primary"]["value"] == "#6366f1"
+        assert by_name["--primary"]["file"] == "app/globals.css"
+        assert by_name["--primary"]["line"] == 3
+        assert by_name["--background"]["line"] == 2
+
+    def test_node_modules_skipped(self, next_repo):
+        res = RepoDesignExtractor().execute({"repo_path": str(next_repo)})
+        assert not any(v["name"] == "--evil" for v in res.data["css_custom_properties"])
+        assert not any("node_modules" in c["path"] for c in res.data["candidate_files"])
+
+    def test_candidate_classification(self, next_repo):
+        res = RepoDesignExtractor().execute({"repo_path": str(next_repo)})
+        kinds = {c["path"]: c["kind"] for c in res.data["candidate_files"]}
+        assert kinds["tailwind.config.js"] == "tailwind_config"
+        assert kinds["app/globals.css"] == "css_variables"
+        assert kinds["app/layout.tsx"] == "app_shell"
+
+    def test_fonts_from_font_face_and_next_font(self, next_repo):
+        res = RepoDesignExtractor().execute({"repo_path": str(next_repo)})
+        families = {(f["family"], f["source"]) for f in res.data["fonts"]}
+        assert ("Cal Sans", "font-face") in families
+        assert ("Inter", "next/font") in families
+
+    def test_app_router_routes(self, next_repo):
+        res = RepoDesignExtractor().execute({"repo_path": str(next_repo)})
+        routes = {s["path"]: s["route"] for s in res.data["screen_candidates"]}
+        assert routes["app/page.tsx"] == "/"
+        assert routes["app/settings/page.tsx"] == "/settings"
+        # layout is not a screen
+        assert "app/layout.tsx" not in routes
+
+    def test_tailwind_theme_via_node_or_null(self, next_repo):
+        """With node present the JS config evaluates; without it, degrades to null."""
+        res = RepoDesignExtractor().execute({"repo_path": str(next_repo)})
+        theme = res.data["tailwind_theme"]
+        if shutil.which("node"):
+            assert theme["extend"]["colors"]["brand"] == "#6366f1"
+        else:
+            assert theme is None
+
+    def test_degrades_to_null_without_node(self, next_repo, monkeypatch):
+        monkeypatch.setattr(shutil, "which", lambda _: None)
+        res = RepoDesignExtractor().execute({"repo_path": str(next_repo)})
+        assert res.success
+        assert res.data["tailwind_theme"] is None
+
+    def test_max_files_reports_truncation(self, next_repo):
+        res = RepoDesignExtractor().execute({"repo_path": str(next_repo), "max_files": 2})
+        assert res.success
+        assert res.data["truncated"] is True
+        assert res.data["files_scanned"] == 2
+
+    def test_deterministic(self, next_repo):
+        t = RepoDesignExtractor()
+        a = t.execute({"repo_path": str(next_repo)}).data
+        b = t.execute({"repo_path": str(next_repo)}).data
+        assert a == b
+
+    def test_writes_scan_report_artifact(self, next_repo, tmp_path):
+        out = tmp_path / "artifacts" / "scan.json"
+        res = RepoDesignExtractor().execute(
+            {"repo_path": str(next_repo), "output_path": str(out)}
+        )
+        assert res.success
+        assert res.artifacts == [str(out)]
+        assert out.exists()
+
+    def test_missing_repo_errors(self, tmp_path):
+        res = RepoDesignExtractor().execute({"repo_path": str(tmp_path / "nope")})
+        assert not res.success
+        assert "not a directory" in res.error
+
+    def test_never_writes_into_target_repo(self, next_repo):
+        before = sorted(p.relative_to(next_repo) for p in next_repo.rglob("*"))
+        RepoDesignExtractor().execute({"repo_path": str(next_repo)})
+        after = sorted(p.relative_to(next_repo) for p in next_repo.rglob("*"))
+        assert before == after

--- a/tests/tools/test_repo_design_extractor.py
+++ b/tests/tools/test_repo_design_extractor.py
@@ -2,10 +2,13 @@
 
 Builds fixture mini-repos in tmp_path and asserts framework detection,
 CSS-custom-property parsing with file+line provenance, candidate-file
-classification, node degradation, caps, and determinism. No network.
+classification, POSIX path normalization (contract paths must not vary with
+the host separator), route derivability, the no-target-code-execution
+guarantee, caps, and determinism. No network.
 """
 
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -62,6 +65,19 @@ def vue_repo(tmp_path):
     (repo / "package.json").write_text('{"dependencies":{"vue":"3.4.0"}}')
     (repo / "src" / "views" / "Dashboard.vue").write_text("<template><main/></template>")
     (repo / "src" / "components" / "StatCard.vue").write_text("<template><div/></template>")
+    return repo
+
+
+@pytest.fixture
+def svelte_repo(tmp_path):
+    repo = tmp_path / "svelte-app"
+    (repo / "src" / "routes" / "settings").mkdir(parents=True)
+    (repo / "package.json").write_text(
+        '{"devDependencies":{"@sveltejs/kit":"2.0.0","svelte":"4.0.0"}}'
+    )
+    (repo / "src" / "routes" / "+page.svelte").write_text("<main/>")
+    (repo / "src" / "routes" / "+layout.svelte").write_text("<slot/>")
+    (repo / "src" / "routes" / "settings" / "+page.svelte").write_text("<main/>")
     return repo
 
 
@@ -144,29 +160,6 @@ class TestScan:
         assert ("Cal Sans", "font-face") in families
         assert ("Inter", "next/font") in families
 
-    def test_app_router_routes(self, next_repo):
-        res = RepoDesignExtractor().execute({"repo_path": str(next_repo)})
-        routes = {s["path"]: s["route"] for s in res.data["screen_candidates"]}
-        assert routes["app/page.tsx"] == "/"
-        assert routes["app/settings/page.tsx"] == "/settings"
-        # layout is not a screen
-        assert "app/layout.tsx" not in routes
-
-    def test_tailwind_theme_via_node_or_null(self, next_repo):
-        """With node present the JS config evaluates; without it, degrades to null."""
-        res = RepoDesignExtractor().execute({"repo_path": str(next_repo)})
-        theme = res.data["tailwind_theme"]
-        if shutil.which("node"):
-            assert theme["extend"]["colors"]["brand"] == "#6366f1"
-        else:
-            assert theme is None
-
-    def test_degrades_to_null_without_node(self, next_repo, monkeypatch):
-        monkeypatch.setattr(shutil, "which", lambda _: None)
-        res = RepoDesignExtractor().execute({"repo_path": str(next_repo)})
-        assert res.success
-        assert res.data["tailwind_theme"] is None
-
     def test_max_files_reports_truncation(self, next_repo):
         res = RepoDesignExtractor().execute({"repo_path": str(next_repo), "max_files": 2})
         assert res.success
@@ -198,3 +191,260 @@ class TestScan:
         RepoDesignExtractor().execute({"repo_path": str(next_repo)})
         after = sorted(p.relative_to(next_repo) for p in next_repo.rglob("*"))
         assert before == after
+
+
+# ---- Route derivation ----
+
+class TestRouteDerivation:
+    """A route is emitted only where a framework convention determines it.
+
+    Synthesizing `/` + filename for non-routed roots produced authoritative-
+    looking routes that the scanner cannot actually know.
+    """
+
+    def test_app_router_routes(self, next_repo):
+        res = RepoDesignExtractor().execute({"repo_path": str(next_repo)})
+        screens = {s["path"]: s for s in res.data["screen_candidates"]}
+        assert screens["app/page.tsx"]["route"] == "/"
+        assert screens["app/page.tsx"]["route_source"] == "next-app-router"
+        assert screens["app/settings/page.tsx"]["route"] == "/settings"
+        # layout is not a screen
+        assert "app/layout.tsx" not in screens
+
+    def test_pages_router_routes(self, tmp_path):
+        repo = tmp_path / "pages-app"
+        (repo / "pages" / "billing").mkdir(parents=True)
+        (repo / "pages" / "api").mkdir(parents=True)
+        (repo / "package.json").write_text('{"dependencies":{"next":"13.0.0"}}')
+        (repo / "pages" / "index.tsx").write_text("export default function P(){}")
+        (repo / "pages" / "billing" / "plans.tsx").write_text("export default function P(){}")
+        (repo / "pages" / "_app.tsx").write_text("export default function A(){}")
+        (repo / "pages" / "api" / "hook.ts").write_text("export default function H(){}")
+
+        res = RepoDesignExtractor().execute({"repo_path": str(repo)})
+        screens = {s["path"]: s for s in res.data["screen_candidates"]}
+        assert screens["pages/index.tsx"]["route"] == "/"
+        assert screens["pages/billing/plans.tsx"]["route"] == "/billing/plans"
+        assert screens["pages/billing/plans.tsx"]["route_source"] == "next-pages-router"
+        # underscore files and API handlers are not screens
+        assert "pages/_app.tsx" not in screens
+        assert "pages/api/hook.ts" not in screens
+
+    def test_sveltekit_routes(self, svelte_repo):
+        res = RepoDesignExtractor().execute({"repo_path": str(svelte_repo)})
+        assert res.data["framework"] == "svelte"
+        screens = {s["path"]: s for s in res.data["screen_candidates"]}
+        assert screens["src/routes/+page.svelte"]["route"] == "/"
+        assert screens["src/routes/settings/+page.svelte"]["route"] == "/settings"
+        assert screens["src/routes/settings/+page.svelte"]["route_source"] == "sveltekit"
+        # layouts are not screens
+        assert "src/routes/+layout.svelte" not in screens
+
+    def test_non_routed_root_reports_no_route(self, vue_repo):
+        """src/views has no path→URL convention; the route must not be invented."""
+        res = RepoDesignExtractor().execute({"repo_path": str(vue_repo)})
+        views = [s for s in res.data["screen_candidates"]
+                 if s["path"] == "src/views/Dashboard.vue"]
+        assert len(views) == 1
+        assert views[0]["route"] is None
+        assert views[0]["route_source"] == "not_derivable"
+
+    def test_src_routes_without_sveltekit_is_not_derivable(self, tmp_path):
+        repo = tmp_path / "solid-ish"
+        (repo / "src" / "routes").mkdir(parents=True)
+        (repo / "package.json").write_text('{"dependencies":{"react":"18.2.0"}}')
+        (repo / "src" / "routes" / "Home.tsx").write_text("export default function H(){}")
+
+        res = RepoDesignExtractor().execute({"repo_path": str(repo)})
+        screen = res.data["screen_candidates"][0]
+        assert screen["route"] is None
+        assert screen["route_source"] == "not_derivable"
+
+
+# ---- Path normalization (Windows contract) ----
+
+class TestPathNormalization:
+    """Repo-relative paths are contract values: they carry into artifact
+    provenance and drive classification and route derivation. They must be
+    POSIX on every host, and parsing must not assume the host separator.
+    """
+
+    def test_all_contract_paths_are_posix(self, next_repo):
+        res = RepoDesignExtractor().execute({"repo_path": str(next_repo)})
+        emitted = (
+            [c["path"] for c in res.data["candidate_files"]]
+            + [v["file"] for v in res.data["css_custom_properties"]]
+            + [f["file"] for f in res.data["fonts"]]
+            + [s["path"] for s in res.data["screen_candidates"]]
+            + [c["path"] for c in res.data["components_index"]]
+        )
+        assert emitted, "fixture should produce paths to check"
+        assert not [p for p in emitted if "\\" in p]
+        assert "app/globals.css" in emitted
+        assert "components/ui/button.tsx" in emitted
+
+    def test_walk_emits_posix_relative_paths(self, next_repo):
+        files, _ = RepoDesignExtractor()._walk(next_repo, 5000)
+        assert "app/globals.css" in files
+        assert "app/settings/page.tsx" in files
+        assert not [f for f in files if "\\" in f]
+
+    def test_screen_indexing_tolerates_native_separators(self):
+        """Windows-shaped input must still resolve routes, not fall through."""
+        screens = RepoDesignExtractor()._index_screens(
+            ["app\\page.tsx", "app\\settings\\page.tsx"], "next"
+        )
+        routes = {s["path"]: s["route"] for s in screens}
+        assert routes["app\\page.tsx"] == "/"
+        assert routes["app\\settings\\page.tsx"] == "/settings"
+
+    def test_component_indexing_tolerates_native_separators(self):
+        comps = RepoDesignExtractor()._index_components(["components\\ui\\button.tsx"])
+        assert [c["name"] for c in comps] == ["button"]
+
+    def test_route_groups_stripped_with_native_separators(self):
+        screens = RepoDesignExtractor()._index_screens(
+            ["app\\(marketing)\\pricing\\page.tsx"], "next"
+        )
+        assert screens[0]["route"] == "/pricing"
+
+
+# ---- Target-repo code execution ----
+
+class TestNoTargetCodeExecution:
+    """A tailwind config is executable JavaScript. Scanning an untrusted repo
+    must not run it: the theme is parsed statically, and execution is an
+    explicit opt-in that is recorded in the report.
+    """
+
+    def test_static_parse_resolves_js_theme_without_node(self, next_repo, monkeypatch):
+        def fail(*a, **k):  # pragma: no cover - must never be reached
+            raise AssertionError("node must not be invoked by default")
+
+        monkeypatch.setattr(subprocess, "run", fail)
+        res = RepoDesignExtractor().execute({"repo_path": str(next_repo)})
+        assert res.success
+        assert res.data["tailwind_theme"]["extend"]["colors"]["brand"] == "#6366f1"
+        assert res.data["tailwind_theme_source"] == "static"
+
+    def test_static_parse_handles_ts_config(self, tmp_path):
+        """TS configs used to be skipped entirely; static parsing reads them."""
+        repo = tmp_path / "ts-app"
+        repo.mkdir()
+        (repo / "package.json").write_text(
+            '{"devDependencies":{"tailwindcss":"3.4.0"}}'
+        )
+        (repo / "tailwind.config.ts").write_text(
+            "import type { Config } from 'tailwindcss'\n"
+            "export default {\n"
+            "  content: ['./app/**/*.tsx'],\n"
+            "  theme: {\n"
+            "    // brand scale\n"
+            "    extend: { borderRadius: { lg: '12px' } },\n"
+            "  },\n"
+            "} satisfies Config\n"
+        )
+        res = RepoDesignExtractor().execute({"repo_path": str(repo)})
+        assert res.data["tailwind_theme"]["extend"]["borderRadius"]["lg"] == "12px"
+        assert res.data["tailwind_theme_source"] == "static"
+
+    def test_dynamic_config_is_refused_not_executed(self, tmp_path, monkeypatch):
+        repo = tmp_path / "dyn-app"
+        repo.mkdir()
+        (repo / "package.json").write_text(
+            '{"devDependencies":{"tailwindcss":"3.4.0"}}'
+        )
+        (repo / "tailwind.config.js").write_text(
+            "const preset = require('./preset');\n"
+            "module.exports = { theme: { extend: preset.buildColors() } };\n"
+        )
+
+        def fail(*a, **k):  # pragma: no cover - must never be reached
+            raise AssertionError("node must not be invoked without opt-in")
+
+        monkeypatch.setattr(subprocess, "run", fail)
+        res = RepoDesignExtractor().execute({"repo_path": str(repo)})
+        assert res.success
+        assert res.data["tailwind_theme"] is None
+        assert res.data["tailwind_theme_source"] is None
+        assert any("allow_config_execution" in w for w in res.data["warnings"])
+
+    def test_opt_in_execution_is_surfaced_in_warnings(self, tmp_path):
+        if not shutil.which("node"):
+            pytest.skip("node not on PATH")
+        repo = tmp_path / "dyn-app"
+        repo.mkdir()
+        (repo / "package.json").write_text(
+            '{"devDependencies":{"tailwindcss":"3.4.0"}}'
+        )
+        (repo / "tailwind.config.js").write_text(
+            "function build() { return { colors: { brand: '#0ea5e9' } }; }\n"
+            "module.exports = { theme: { extend: build() } };\n"
+        )
+        res = RepoDesignExtractor().execute(
+            {"repo_path": str(repo), "allow_config_execution": True}
+        )
+        assert res.success
+        assert res.data["tailwind_theme"]["extend"]["colors"]["brand"] == "#0ea5e9"
+        assert res.data["tailwind_theme_source"] == "executed"
+        assert any("EXECUTED target-repo code" in w for w in res.data["warnings"])
+
+    def test_opt_in_without_node_degrades_to_null(self, next_repo, monkeypatch, tmp_path):
+        repo = tmp_path / "dyn-app"
+        repo.mkdir()
+        (repo / "tailwind.config.js").write_text(
+            "module.exports = { theme: { extend: build() } };\n"
+        )
+        monkeypatch.setattr(shutil, "which", lambda _: None)
+        res = RepoDesignExtractor().execute(
+            {"repo_path": str(repo), "allow_config_execution": True}
+        )
+        assert res.success
+        assert res.data["tailwind_theme"] is None
+        assert any("node" in w for w in res.data["warnings"])
+
+    def test_opt_in_is_part_of_the_idempotency_key(self):
+        t = RepoDesignExtractor()
+        safe = t.idempotency_key({"repo_path": "/x"})
+        unsafe = t.idempotency_key({"repo_path": "/x", "allow_config_execution": True})
+        assert safe != unsafe
+
+
+# ---- output_path guard ----
+
+class TestOutputPathGuard:
+    """"never writes to repo_path" is a guarantee, so it is enforced."""
+
+    def test_output_inside_repo_rejected(self, next_repo):
+        res = RepoDesignExtractor().execute({
+            "repo_path": str(next_repo),
+            "output_path": str(next_repo / "scan.json"),
+        })
+        assert not res.success
+        assert "inside repo_path" in res.error
+        assert not (next_repo / "scan.json").exists()
+
+    def test_nested_output_inside_repo_rejected(self, next_repo):
+        res = RepoDesignExtractor().execute({
+            "repo_path": str(next_repo),
+            "output_path": str(next_repo / "app" / "artifacts" / "scan.json"),
+        })
+        assert not res.success
+        assert "inside repo_path" in res.error
+
+    def test_traversal_into_repo_rejected(self, next_repo, tmp_path):
+        sneaky = tmp_path / "elsewhere" / ".." / "next-app" / "scan.json"
+        res = RepoDesignExtractor().execute({
+            "repo_path": str(next_repo),
+            "output_path": str(sneaky),
+        })
+        assert not res.success
+        assert "inside repo_path" in res.error
+
+    def test_output_outside_repo_allowed(self, next_repo, tmp_path):
+        out = tmp_path / "projects" / "p" / "artifacts" / "scan.json"
+        res = RepoDesignExtractor().execute(
+            {"repo_path": str(next_repo), "output_path": str(out)}
+        )
+        assert res.success
+        assert out.exists()

--- a/tests/tools/test_sfx_gen.py
+++ b/tests/tools/test_sfx_gen.py
@@ -1,0 +1,175 @@
+"""Focused tests for the ElevenLabs sound-effect generation tool.
+
+No live API calls: the network layer is monkeypatched. Covers the tool
+contract, registry discovery, status gating, payload construction, and
+execute() guardrails.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.base_tool import BaseTool, ToolStatus, ToolTier, ToolRuntime
+from tools.tool_registry import ToolRegistry
+from tools.audio.sfx_gen import SfxGen
+from tools.audio.music_gen import MusicGen
+
+
+FAKE_MP3 = b"\xff\xfb\x90\x00" + b"\x00" * 32
+
+
+class _FakeResponse:
+    def __init__(self, content=FAKE_MP3, status_code=200, text=""):
+        self.content = content
+        self.status_code = status_code
+        self.text = text
+
+
+@pytest.fixture
+def eleven_env(monkeypatch):
+    monkeypatch.setenv("ELEVENLABS_API_KEY", "fake-key")
+
+
+# ---- Contract ----
+
+class TestContract:
+    def test_inherits_base_tool(self):
+        assert issubclass(SfxGen, BaseTool)
+
+    def test_identity(self):
+        t = SfxGen()
+        assert t.name == "sfx_gen"
+        assert t.capability == "sfx_generation"
+        assert t.provider == "elevenlabs"
+        assert t.runtime == ToolRuntime.API
+        assert t.tier == ToolTier.GENERATE
+        assert "sound-effects" in t.agent_skills
+        assert "generate_sfx" in t.capabilities
+
+    def test_music_gen_no_longer_claims_sfx(self):
+        """generate_sfx moved here — music_gen must not double-claim it."""
+        assert "generate_sfx" not in MusicGen.capabilities
+
+    def test_cost_is_flat_per_effect(self):
+        assert SfxGen().estimate_cost({"prompt": "tick"}) == pytest.approx(0.03)
+
+
+# ---- Registry discovery ----
+
+class TestDiscovery:
+    def test_discoverable(self):
+        reg = ToolRegistry()
+        reg.discover("tools")
+        assert reg.get("sfx_gen") is not None
+
+    def test_capability_routing(self):
+        reg = ToolRegistry()
+        reg.discover("tools")
+        names = [t.name for t in reg.get_by_capability("sfx_generation")]
+        assert names == ["sfx_gen"]
+
+
+# ---- Status ----
+
+class TestStatus:
+    def test_unavailable_without_key(self, monkeypatch):
+        monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+        assert SfxGen().get_status() == ToolStatus.UNAVAILABLE
+
+    def test_available_with_key(self, eleven_env):
+        assert SfxGen().get_status() == ToolStatus.AVAILABLE
+
+
+# ---- execute() ----
+
+class TestExecute:
+    def test_missing_key(self, monkeypatch):
+        monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+        res = SfxGen().execute({"prompt": "soft glass tick"})
+        assert not res.success
+        assert "API key" in res.error
+
+    def test_success_path_mocked(self, eleven_env, tmp_path, monkeypatch):
+        import requests
+
+        captured = {}
+
+        def fake_post(url, headers=None, json=None, timeout=None):
+            captured["url"] = url
+            captured["headers"] = headers
+            captured["payload"] = json
+            return _FakeResponse()
+
+        monkeypatch.setattr(requests, "post", fake_post)
+
+        out = tmp_path / "sfx" / "tick.mp3"
+        res = SfxGen().execute({
+            "prompt": "single soft glass tick, short",
+            "duration_seconds": 0.5,
+            "prompt_influence": 0.6,
+            "output_path": str(out),
+        })
+
+        assert res.success
+        assert res.model == "elevenlabs-sound-generation"
+        assert res.cost_usd == pytest.approx(0.03)
+        assert out.read_bytes() == FAKE_MP3
+        assert res.artifacts == [str(out)]
+        assert captured["url"] == "https://api.elevenlabs.io/v1/sound-generation"
+        assert captured["headers"]["xi-api-key"] == "fake-key"
+        assert captured["payload"] == {
+            "text": "single soft glass tick, short",
+            "prompt_influence": 0.6,
+            "duration_seconds": 0.5,
+        }
+
+    def test_loop_and_auto_duration(self, eleven_env, tmp_path, monkeypatch):
+        import requests
+
+        captured = {}
+        monkeypatch.setattr(
+            requests, "post",
+            lambda url, headers=None, json=None, timeout=None: (
+                captured.update(payload=json), _FakeResponse())[1],
+        )
+        res = SfxGen().execute({
+            "prompt": "airy ambient hum",
+            "loop": True,
+            "output_path": str(tmp_path / "hum.mp3"),
+        })
+        assert res.success
+        # no duration key when omitted (API auto-calculates); loop passed through
+        assert "duration_seconds" not in captured["payload"]
+        assert captured["payload"]["loop"] is True
+
+    def test_http_error_surfaced(self, eleven_env, tmp_path, monkeypatch):
+        import requests
+
+        monkeypatch.setattr(
+            requests, "post",
+            lambda *a, **k: _FakeResponse(content=b"", status_code=422,
+                                          text="duration out of range"),
+        )
+        res = SfxGen().execute(
+            {"prompt": "tick", "output_path": str(tmp_path / "x.mp3")}
+        )
+        assert not res.success
+        assert "422" in res.error
+        assert "duration out of range" in res.error
+
+    def test_request_exception_surfaced(self, eleven_env, tmp_path, monkeypatch):
+        import requests
+
+        def boom(*a, **k):
+            raise requests.exceptions.ConnectionError("no route to host")
+
+        monkeypatch.setattr(requests, "post", boom)
+        res = SfxGen().execute(
+            {"prompt": "tick", "output_path": str(tmp_path / "x.mp3")}
+        )
+        assert not res.success
+        assert "no route to host" in res.error

--- a/tests/tools/test_sfx_gen.py
+++ b/tests/tools/test_sfx_gen.py
@@ -54,8 +54,65 @@ class TestContract:
         """generate_sfx moved here — music_gen must not double-claim it."""
         assert "generate_sfx" not in MusicGen.capabilities
 
-    def test_cost_is_flat_per_effect(self):
-        assert SfxGen().estimate_cost({"prompt": "tick"}) == pytest.approx(0.03)
+    def test_declares_its_env_dependency(self):
+        """Registry setup/dependency reporting groups providers by env var —
+        a tool that needs a key but declares none cannot be explained."""
+        assert SfxGen.dependencies == ["env:ELEVENLABS_API_KEY"]
+        assert "ELEVENLABS_API_KEY" in SfxGen.install_instructions
+
+
+# ---- Cost ----
+
+class TestCost:
+    """Billing is per minute of generated audio, so cost scales with duration
+    rather than being one flat figure presented as durable."""
+
+    def test_cost_scales_with_duration(self):
+        t = SfxGen()
+        short = t.estimate_cost({"prompt": "tick", "duration_seconds": 0.6})
+        long = t.estimate_cost({"prompt": "bed", "duration_seconds": 20})
+        assert short < long
+        # $0.12/min list rate
+        assert short == pytest.approx(0.6 / 60 * 0.12, abs=1e-4)
+        assert long == pytest.approx(20 / 60 * 0.12, abs=1e-4)
+
+    def test_auto_duration_uses_nominal_estimate(self):
+        cost = SfxGen().estimate_cost({"prompt": "tick"})
+        assert 0 < cost < 0.02
+
+    def test_reported_cost_matches_estimate(self, eleven_env, tmp_path, monkeypatch):
+        import requests
+
+        monkeypatch.setattr(
+            requests, "post",
+            lambda *a, **k: _FakeResponse(),
+        )
+        inputs = {
+            "prompt": "soft glass tick",
+            "duration_seconds": 1.0,
+            "output_path": str(tmp_path / "tick.mp3"),
+        }
+        res = SfxGen().execute(inputs)
+        assert res.cost_usd == pytest.approx(SfxGen().estimate_cost(inputs))
+
+
+# ---- Idempotency ----
+
+class TestIdempotency:
+    def test_omitted_defaults_hash_like_explicit_defaults(self):
+        """Omitting prompt_influence/loop and passing their declared defaults
+        describe the same request — they must not cause a duplicate paid call."""
+        t = SfxGen()
+        assert t.idempotency_key({"prompt": "tick"}) == t.idempotency_key(
+            {"prompt": "tick", "prompt_influence": 0.3, "loop": False}
+        )
+
+    def test_real_differences_still_change_the_key(self):
+        t = SfxGen()
+        base = t.idempotency_key({"prompt": "tick"})
+        assert base != t.idempotency_key({"prompt": "tick", "prompt_influence": 0.9})
+        assert base != t.idempotency_key({"prompt": "tick", "loop": True})
+        assert base != t.idempotency_key({"prompt": "whoosh"})
 
 
 # ---- Registry discovery ----
@@ -71,6 +128,41 @@ class TestDiscovery:
         reg.discover("tools")
         names = [t.name for t in reg.get_by_capability("sfx_generation")]
         assert names == ["sfx_gen"]
+
+    def test_appears_in_provider_menu(self):
+        reg = ToolRegistry()
+        reg.discover("tools")
+        menu = reg.provider_menu()
+        assert "sfx_generation" in menu
+        entries = menu["sfx_generation"]["available"] + menu["sfx_generation"]["unavailable"]
+        entry = next(e for e in entries if e["name"] == "sfx_gen")
+        assert entry["provider"] == "elevenlabs"
+        assert "env:ELEVENLABS_API_KEY" in entry["dependencies"]
+
+    def test_setup_offer_groups_by_env_var(self, monkeypatch):
+        """Without the key the tool must show up as a 1-minute env-var fix,
+        grouped with the other ELEVENLABS_API_KEY tools.
+
+        Status is forced rather than unset via the environment: registry
+        discovery reloads .env, so a developer machine with a real key would
+        otherwise skip this assertion silently.
+        """
+        monkeypatch.setattr(SfxGen, "get_status", lambda self: ToolStatus.UNAVAILABLE)
+        reg = ToolRegistry()
+        reg.discover("tools")
+        offers = reg.provider_menu_summary()["setup_offers"]
+        offer = next((o for o in offers if o["tool"] == "sfx_gen"), None)
+        assert offer is not None, "sfx_gen must be offered as a setup upgrade"
+        assert offer["kind"] == "env_var"
+        assert "ELEVENLABS_API_KEY" in offer["env_vars"]
+
+    def test_capability_counted_in_summary(self, monkeypatch):
+        monkeypatch.setattr(SfxGen, "get_status", lambda self: ToolStatus.AVAILABLE)
+        reg = ToolRegistry()
+        reg.discover("tools")
+        caps = {c["capability"]: c for c in reg.provider_menu_summary()["capabilities"]}
+        assert "sfx_generation" in caps
+        assert "elevenlabs" in caps["sfx_generation"]["available_providers"]
 
 
 # ---- Status ----
@@ -116,7 +208,7 @@ class TestExecute:
 
         assert res.success
         assert res.model == "elevenlabs-sound-generation"
-        assert res.cost_usd == pytest.approx(0.03)
+        assert res.cost_usd == pytest.approx(0.5 / 60 * 0.12, abs=1e-4)
         assert out.read_bytes() == FAKE_MP3
         assert res.artifacts == [str(out)]
         assert captured["url"] == "https://api.elevenlabs.io/v1/sound-generation"

--- a/tools/analysis/repo_design_extractor.py
+++ b/tools/analysis/repo_design_extractor.py
@@ -1,0 +1,448 @@
+"""Deterministic design-system scanner for product source repositories.
+
+First half of the product-motion pipeline's repo_analysis stage. This tool is
+a *scanner*, not the artifact author: it detects the frontend framework,
+classifies candidate design files, parses CSS custom properties and Tailwind
+v4 ``@theme`` blocks with file+line provenance, best-effort evaluates JS
+tailwind configs (by shelling out to ``node``; degrades to ``null``), and
+indexes screen/component source files.
+
+The agent then reads the flagged files directly (guided by the
+``repo-design-extraction`` skill) and authors the schema-validated
+``design_system`` and ``ui_inventory`` artifacts. Determinism: all directory
+walks are sorted; the same repo state always yields the same scan report.
+
+The analyzed repository is only ever read, never written.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+# Directories never worth walking for design tokens.
+_SKIP_DIRS = {
+    "node_modules", ".git", ".next", ".nuxt", ".svelte-kit", "dist", "build",
+    "out", "coverage", ".turbo", ".cache", "__pycache__", ".venv", "venv",
+    "storybook-static", ".output", "vendor",
+}
+
+# CSS custom property declaration, e.g. `--color-primary: #6366f1;`
+_CSS_VAR_RE = re.compile(r"(--[\w-]+)\s*:\s*([^;{}]+);")
+# Tailwind v4 CSS-first theme block: `@theme { ... }`
+_THEME_BLOCK_RE = re.compile(r"@theme\b")
+# @font-face family declaration
+_FONT_FACE_RE = re.compile(r"font-family\s*:\s*['\"]?([^'\";,}]+)")
+# next/font google imports, e.g. `import { Inter } from "next/font/google"`
+_NEXT_FONT_RE = re.compile(r"import\s*\{([^}]+)\}\s*from\s*['\"]next/font/google['\"]")
+
+_STYLE_EXTS = {".css", ".scss", ".sass", ".less"}
+_SOURCE_EXTS = {".tsx", ".jsx", ".ts", ".js", ".vue", ".svelte"}
+
+# Screen/route roots checked in order; (glob root, kind)
+_SCREEN_ROOTS = [
+    "app", "src/app", "pages", "src/pages", "src/views", "src/screens",
+    "src/routes", "src/features",
+]
+_COMPONENT_ROOTS = ["components", "src/components", "app/components", "src/ui"]
+
+
+class RepoDesignExtractor(BaseTool):
+    name = "repo_design_extractor"
+    version = "0.1.0"
+    tier = ToolTier.ANALYZE
+    capability = "analysis"
+    provider = "local"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.DETERMINISTIC
+    runtime = ToolRuntime.LOCAL
+
+    dependencies = []  # pure stdlib; node is probed at runtime and optional
+    install_instructions = (
+        "No installation required. Optional: having `node` on PATH lets the "
+        "scanner evaluate JS tailwind configs; without it tailwind_theme "
+        "degrades to null and the agent reads the config file directly."
+    )
+    fallback_tools = []
+    agent_skills = ["repo-design-extraction"]
+
+    capabilities = [
+        "detect_frontend_framework",
+        "scan_design_token_sources",
+        "parse_css_custom_properties",
+        "index_screens_and_components",
+    ]
+    supports = {"offline": True, "readonly_on_target": True}
+    best_for = [
+        "grounding a product-motion run in a repo's real design tokens",
+        "finding which files define a web app's design system",
+        "indexing screens/components before UI-replica planning",
+    ]
+    not_good_for = [
+        "live-URL extraction (use `npx hyperframes capture` / website-to-video)",
+        "non-web repos (backend, mobile) — v1 targets web frontends",
+    ]
+
+    input_schema = {
+        "type": "object",
+        "required": ["repo_path"],
+        "properties": {
+            "repo_path": {
+                "type": "string",
+                "description": "Path to the product repository to analyze (read-only)",
+            },
+            "output_path": {
+                "type": "string",
+                "description": "Optional path to write the scan_report JSON (should live under projects/<id>/artifacts/)",
+            },
+            "max_files": {
+                "type": "integer",
+                "default": 5000,
+                "description": "Cap on files walked; larger repos are truncated (reported in the result)",
+            },
+        },
+    }
+
+    output_schema = {
+        "type": "object",
+        "properties": {
+            "framework": {"type": "string"},
+            "styling_systems": {"type": "array"},
+            "candidate_files": {"type": "array"},
+            "css_custom_properties": {"type": "array"},
+            "tailwind_theme": {},
+            "fonts": {"type": "array"},
+            "screen_candidates": {"type": "array"},
+            "components_index": {"type": "array"},
+            "truncated": {"type": "boolean"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=10, network_required=False
+    )
+    retry_policy = RetryPolicy(max_retries=0, retryable_errors=[])
+    idempotency_key_fields = ["repo_path", "max_files"]
+    side_effects = ["writes scan_report JSON to output_path (never writes to repo_path)"]
+    user_visible_verification = [
+        "Spot-check a few reported css_custom_properties against the cited file+line",
+    ]
+
+    def get_status(self) -> ToolStatus:
+        return ToolStatus.AVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        return 0.0
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        return 15.0
+
+    # ---- execution ----
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        repo = Path(inputs["repo_path"]).expanduser()
+        if not repo.is_dir():
+            return ToolResult(
+                success=False, error=f"repo_path is not a directory: {repo}"
+            )
+
+        start = time.time()
+        try:
+            report = self._scan(repo, int(inputs.get("max_files", 5000)))
+        except Exception as e:
+            return ToolResult(success=False, error=f"Repo scan failed: {e}")
+
+        artifacts: list[str] = []
+        output_path = inputs.get("output_path")
+        if output_path:
+            out = Path(output_path)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(json.dumps(report, indent=2))
+            artifacts.append(str(out))
+
+        return ToolResult(
+            success=True,
+            data=report,
+            artifacts=artifacts,
+            duration_seconds=round(time.time() - start, 2),
+            cost_usd=0.0,
+        )
+
+    # ---- scanning ----
+
+    def _scan(self, repo: Path, max_files: int) -> dict[str, Any]:
+        files, truncated = self._walk(repo, max_files)
+
+        pkg = self._read_package_json(repo)
+        framework = self._detect_framework(pkg)
+        candidate_files: list[dict[str, str]] = []
+        css_vars: list[dict[str, Any]] = []
+        fonts: list[dict[str, Any]] = []
+        theme_files: list[Path] = []
+
+        for rel in files:
+            path = repo / rel
+            name = path.name.lower()
+            ext = path.suffix.lower()
+
+            if re.fullmatch(r"tailwind\.config\.(js|cjs|mjs|ts)", name):
+                candidate_files.append({"path": rel, "kind": "tailwind_config",
+                                        "reason": "Tailwind theme configuration"})
+                theme_files.append(path)
+                continue
+
+            if ext in _STYLE_EXTS:
+                text = self._read_text(path)
+                if text is None:
+                    continue
+                has_root = ":root" in text
+                has_theme = bool(_THEME_BLOCK_RE.search(text))
+                if has_root or has_theme:
+                    candidate_files.append({
+                        "path": rel,
+                        "kind": "theme_css" if has_theme else "css_variables",
+                        "reason": "@theme block (Tailwind v4)" if has_theme
+                        else ":root custom properties",
+                    })
+                    css_vars.extend(self._parse_css_vars(text, rel))
+                if "@font-face" in text:
+                    for m in _FONT_FACE_RE.finditer(text):
+                        family = m.group(1).strip()
+                        if family and not family.startswith("var("):
+                            fonts.append({"family": family, "source": "font-face",
+                                          "file": rel})
+                continue
+
+            if ext in _SOURCE_EXTS:
+                if "theme" in name or "tokens" in name or "design" in name:
+                    candidate_files.append({"path": rel, "kind": "theme_source",
+                                            "reason": "theme/token module by name"})
+                if framework in ("next", "react") and (
+                    name.startswith("layout.") or name.startswith("_app.")
+                    or name.startswith("_document.")
+                ):
+                    text = self._read_text(path)
+                    if text:
+                        for m in _NEXT_FONT_RE.finditer(text):
+                            for f in m.group(1).split(","):
+                                f = f.strip()
+                                if f:
+                                    fonts.append({"family": f, "source": "next/font",
+                                                  "file": rel})
+                        candidate_files.append({"path": rel, "kind": "app_shell",
+                                                "reason": "root layout / app shell"})
+
+        # de-dup fonts deterministically
+        seen: set[tuple[str, str]] = set()
+        fonts = [f for f in fonts
+                 if (key := (f["family"].lower(), f["file"])) not in seen
+                 and not seen.add(key)]
+
+        report: dict[str, Any] = {
+            "repo_path": str(repo),
+            "framework": framework,
+            "styling_systems": self._detect_styling_systems(pkg, candidate_files, css_vars, files),
+            "candidate_files": candidate_files,
+            "css_custom_properties": css_vars,
+            "tailwind_theme": self._eval_tailwind_config(theme_files),
+            "fonts": fonts,
+            "screen_candidates": self._index_screens(repo, files, framework),
+            "components_index": self._index_components(files),
+            "files_scanned": len(files),
+            "truncated": truncated,
+        }
+        return report
+
+    def _walk(self, repo: Path, max_files: int) -> tuple[list[str], bool]:
+        """Sorted, capped, skip-listed walk. Returns repo-relative paths."""
+        collected: list[str] = []
+        truncated = False
+        for root, dirs, filenames in os.walk(repo):
+            dirs[:] = sorted(d for d in dirs
+                             if d not in _SKIP_DIRS and not d.startswith("."))
+            rel_root = Path(root).relative_to(repo)
+            for fname in sorted(filenames):
+                if len(collected) >= max_files:
+                    return collected, True
+                rel = str(rel_root / fname) if str(rel_root) != "." else fname
+                collected.append(rel)
+        return collected, truncated
+
+    @staticmethod
+    def _read_text(path: Path, limit: int = 512_000) -> str | None:
+        try:
+            if path.stat().st_size > limit:
+                return None
+            return path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return None
+
+    def _read_package_json(self, repo: Path) -> dict[str, Any]:
+        pkg_path = repo / "package.json"
+        text = self._read_text(pkg_path)
+        if not text:
+            return {}
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return {}
+
+    @staticmethod
+    def _detect_framework(pkg: dict[str, Any]) -> str:
+        deps: dict[str, str] = {}
+        for key in ("dependencies", "devDependencies"):
+            deps.update(pkg.get(key) or {})
+        if "next" in deps:
+            return "next"
+        if "nuxt" in deps or "nuxt3" in deps:
+            return "nuxt"
+        if "svelte" in deps or "@sveltejs/kit" in deps:
+            return "svelte"
+        if "vue" in deps:
+            return "vue"
+        if "react" in deps:
+            return "react"
+        return "other"
+
+    @staticmethod
+    def _detect_styling_systems(
+        pkg: dict[str, Any],
+        candidate_files: list[dict[str, str]],
+        css_vars: list[dict[str, Any]],
+        files: list[str],
+    ) -> list[str]:
+        deps: dict[str, str] = {}
+        for key in ("dependencies", "devDependencies"):
+            deps.update(pkg.get(key) or {})
+        systems: list[str] = []
+        if "tailwindcss" in deps or any(
+            c["kind"] in ("tailwind_config", "theme_css") for c in candidate_files
+        ):
+            systems.append("tailwind")
+        if css_vars:
+            systems.append("css-variables")
+        if "styled-components" in deps:
+            systems.append("styled-components")
+        if any(d.startswith("@emotion/") for d in deps):
+            systems.append("emotion")
+        if any(f.endswith((".module.css", ".module.scss")) for f in files):
+            systems.append("css-modules")
+        if "sass" in deps or "node-sass" in deps or any(
+            f.endswith((".scss", ".sass")) for f in files
+        ):
+            systems.append("sass")
+        return systems
+
+    @staticmethod
+    def _parse_css_vars(text: str, rel: str) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        for i, line in enumerate(text.splitlines(), start=1):
+            for m in _CSS_VAR_RE.finditer(line):
+                out.append({
+                    "name": m.group(1),
+                    "value": m.group(2).strip(),
+                    "file": rel,
+                    "line": i,
+                })
+        return out
+
+    @staticmethod
+    def _eval_tailwind_config(theme_files: list[Path]) -> Any:
+        """Best-effort JS tailwind config evaluation via node. TS configs and
+        missing node degrade to None — the agent reads the file directly."""
+        node = shutil.which("node")
+        if not node:
+            return None
+        for cfg in theme_files:
+            if cfg.suffix == ".ts":
+                continue
+            expr = (
+                f"const c = require({json.dumps(str(cfg))});"
+                "JSON.stringify((c && (c.theme || (c.default && c.default.theme))) || null)"
+            )
+            try:
+                proc = subprocess.run(
+                    [node, "-p", expr],
+                    capture_output=True, text=True, timeout=20,
+                    cwd=str(cfg.parent),
+                )
+                if proc.returncode == 0 and proc.stdout.strip() not in ("", "null"):
+                    return json.loads(proc.stdout)
+            except (subprocess.SubprocessError, json.JSONDecodeError, OSError):
+                continue
+        return None
+
+    @staticmethod
+    def _index_screens(
+        repo: Path, files: list[str], framework: str
+    ) -> list[dict[str, str]]:
+        screens: list[dict[str, str]] = []
+        for rel in files:
+            p = Path(rel)
+            parts = p.parts
+            root = None
+            for candidate in _SCREEN_ROOTS:
+                croot = tuple(candidate.split("/"))
+                if parts[: len(croot)] == croot:
+                    root = candidate
+                    break
+            if root is None or p.suffix.lower() not in _SOURCE_EXTS:
+                continue
+            stem = p.stem.lower()
+            inner = Path(*parts[len(root.split("/")):])
+            if root in ("app", "src/app"):
+                # Next app router: only page files are screens. Route groups
+                # like (auth) organize files without affecting the URL.
+                if stem != "page":
+                    continue
+                segs = [s for s in inner.parent.parts
+                        if not (s.startswith("(") and s.endswith(")"))]
+                route = "/" + "/".join(segs)
+            elif root in ("pages", "src/pages"):
+                if stem.startswith("_") or inner.parts[:1] == ("api",):
+                    continue
+                segs = list(inner.parent.parts) + ([] if stem == "index" else [stem])
+                route = "/" + "/".join(segs)
+            else:
+                route = ""
+            screens.append({
+                "path": rel,
+                "route": route if route else "/" + inner.stem,
+                "root": root,
+            })
+        return screens
+
+    @staticmethod
+    def _index_components(files: list[str]) -> list[dict[str, str]]:
+        comps: list[dict[str, str]] = []
+        for rel in files:
+            p = Path(rel)
+            parts = p.parts
+            for candidate in _COMPONENT_ROOTS:
+                croot = tuple(candidate.split("/"))
+                if parts[: len(croot)] == croot and p.suffix.lower() in _SOURCE_EXTS:
+                    if p.stem.lower() in ("index", "types", "utils"):
+                        break
+                    comps.append({"name": p.stem, "path": rel})
+                    break
+        return comps

--- a/tools/analysis/repo_design_extractor.py
+++ b/tools/analysis/repo_design_extractor.py
@@ -3,16 +3,31 @@
 First half of the product-motion pipeline's repo_analysis stage. This tool is
 a *scanner*, not the artifact author: it detects the frontend framework,
 classifies candidate design files, parses CSS custom properties and Tailwind
-v4 ``@theme`` blocks with file+line provenance, best-effort evaluates JS
-tailwind configs (by shelling out to ``node``; degrades to ``null``), and
-indexes screen/component source files.
+v4 ``@theme`` blocks with file+line provenance, statically parses tailwind
+config theme literals, and indexes screen/component source files.
 
 The agent then reads the flagged files directly (guided by the
 ``repo-design-extraction`` skill) and authors the schema-validated
 ``design_system`` and ``ui_inventory`` artifacts. Determinism: all directory
 walks are sorted; the same repo state always yields the same scan report.
 
-The analyzed repository is only ever read, never written.
+Safety contract:
+
+* **The analyzed repository is only ever read, never written.** ``output_path``
+  is rejected when it resolves inside ``repo_path``.
+* **No code from the target repo is executed by default.** A tailwind config is
+  executable JavaScript, so ``tailwind.config.*`` is parsed *statically* (the
+  ``theme`` object literal is extracted and converted to JSON; anything
+  containing calls, spreads, or template literals is refused rather than
+  guessed at). Executing the config via ``node`` is available only as the
+  explicit ``allow_config_execution`` opt-in, and every run that uses it says
+  so in ``warnings[]`` and ``tailwind_theme_source``. Never enable it for a
+  repository you do not trust.
+
+Repo-relative paths in the report are always POSIX (``a/b.css``), on every
+platform — they are contract values that flow into artifact provenance, and
+downstream consumers (route derivation, candidate classification, the
+``design_system`` schema) compare them with ``/`` separators.
 """
 
 from __future__ import annotations
@@ -58,12 +73,29 @@ _NEXT_FONT_RE = re.compile(r"import\s*\{([^}]+)\}\s*from\s*['\"]next/font/google
 _STYLE_EXTS = {".css", ".scss", ".sass", ".less"}
 _SOURCE_EXTS = {".tsx", ".jsx", ".ts", ".js", ".vue", ".svelte"}
 
-# Screen/route roots checked in order; (glob root, kind)
+# Screen/route roots checked in order. Only the roots whose URL mapping is a
+# documented framework convention yield a route; the rest are reported as
+# screen *candidates* with route=None (see _index_screens).
 _SCREEN_ROOTS = [
     "app", "src/app", "pages", "src/pages", "src/views", "src/screens",
     "src/routes", "src/features",
 ]
 _COMPONENT_ROOTS = ["components", "src/components", "app/components", "src/ui"]
+
+# --- static tailwind-config parsing ---
+# A `theme: { ... }` object literal is extracted and converted to JSON. Any
+# construct that would need evaluation to resolve disqualifies the parse — we
+# report null rather than a guess.
+_JS_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.S)
+_JS_LINE_COMMENT_RE = re.compile(r"(?<!:)//[^\n]*")
+_JS_BARE_KEY_RE = re.compile(r"([{,]\s*)([A-Za-z_$][\w$.-]*)\s*:")
+_JS_TRAILING_COMMA_RE = re.compile(r",(\s*[}\]])")
+_JS_SINGLE_QUOTED_RE = re.compile(r"'([^'\\\n]*)'")
+_JS_THEME_KEY_RE = re.compile(r"(?<![\w$])theme\s*:\s*\{")
+# Tokens that mean "this literal is really code" — parsing stops.
+_JS_DYNAMIC_TOKENS = (
+    "require(", "import(", "=>", "function", "`", "...", "process.", "new ",
+)
 
 
 class RepoDesignExtractor(BaseTool):
@@ -77,11 +109,12 @@ class RepoDesignExtractor(BaseTool):
     determinism = Determinism.DETERMINISTIC
     runtime = ToolRuntime.LOCAL
 
-    dependencies = []  # pure stdlib; node is probed at runtime and optional
+    dependencies = []  # pure stdlib; node is only used under an explicit opt-in
     install_instructions = (
-        "No installation required. Optional: having `node` on PATH lets the "
-        "scanner evaluate JS tailwind configs; without it tailwind_theme "
-        "degrades to null and the agent reads the config file directly."
+        "No installation required. Tailwind config themes are parsed "
+        "statically. `node` on PATH is only used by the "
+        "`allow_config_execution` opt-in, which RUNS the target repo's config "
+        "as JavaScript — enable it for trusted repos only."
     )
     fallback_tools = []
     agent_skills = ["repo-design-extraction"]
@@ -92,7 +125,13 @@ class RepoDesignExtractor(BaseTool):
         "parse_css_custom_properties",
         "index_screens_and_components",
     ]
-    supports = {"offline": True, "readonly_on_target": True}
+    supports = {
+        "offline": True,
+        "readonly_on_target": True,
+        # True only in the default configuration; the allow_config_execution
+        # opt-in runs the target repo's tailwind config through node.
+        "no_target_code_execution": True,
+    }
     best_for = [
         "grounding a product-motion run in a repo's real design tokens",
         "finding which files define a web app's design system",
@@ -113,12 +152,29 @@ class RepoDesignExtractor(BaseTool):
             },
             "output_path": {
                 "type": "string",
-                "description": "Optional path to write the scan_report JSON (should live under projects/<id>/artifacts/)",
+                "description": (
+                    "Optional path to write the scan_report JSON (should live "
+                    "under projects/<id>/artifacts/). Rejected if it resolves "
+                    "inside repo_path — the target repo is never written to."
+                ),
             },
             "max_files": {
                 "type": "integer",
                 "default": 5000,
                 "description": "Cap on files walked; larger repos are truncated (reported in the result)",
+            },
+            "allow_config_execution": {
+                "type": "boolean",
+                "default": False,
+                "description": (
+                    "DANGEROUS — opt in to EXECUTING the target repo's "
+                    "tailwind.config.js through `node` when static parsing "
+                    "cannot resolve the theme. A tailwind config is arbitrary "
+                    "JavaScript: requiring it can read secrets, write files, "
+                    "and make network calls with your privileges. Only enable "
+                    "for a repository you trust; the report records the "
+                    "execution in warnings[]."
+                ),
             },
         },
     }
@@ -131,9 +187,11 @@ class RepoDesignExtractor(BaseTool):
             "candidate_files": {"type": "array"},
             "css_custom_properties": {"type": "array"},
             "tailwind_theme": {},
+            "tailwind_theme_source": {"type": ["string", "null"]},
             "fonts": {"type": "array"},
             "screen_candidates": {"type": "array"},
             "components_index": {"type": "array"},
+            "warnings": {"type": "array"},
             "truncated": {"type": "boolean"},
         },
     }
@@ -142,10 +200,15 @@ class RepoDesignExtractor(BaseTool):
         cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=10, network_required=False
     )
     retry_policy = RetryPolicy(max_retries=0, retryable_errors=[])
-    idempotency_key_fields = ["repo_path", "max_files"]
-    side_effects = ["writes scan_report JSON to output_path (never writes to repo_path)"]
+    idempotency_key_fields = ["repo_path", "max_files", "allow_config_execution"]
+    side_effects = [
+        "writes scan_report JSON to output_path (never writes to repo_path)",
+        "allow_config_execution=true only: runs the target repo's tailwind "
+        "config through node, with whatever side effects that config has",
+    ]
     user_visible_verification = [
         "Spot-check a few reported css_custom_properties against the cited file+line",
+        "Check warnings[] — it reports any execution of target-repo code",
     ]
 
     def get_status(self) -> ToolStatus:
@@ -165,17 +228,39 @@ class RepoDesignExtractor(BaseTool):
             return ToolResult(
                 success=False, error=f"repo_path is not a directory: {repo}"
             )
+        repo_resolved = repo.resolve()
+
+        # Enforce the "never writes to repo_path" guarantee before scanning:
+        # an output_path under the target repo would mutate the analyzed
+        # product, and the caller should hear about it up front, not after
+        # paying for the walk.
+        output_path = inputs.get("output_path")
+        out: Path | None = None
+        if output_path:
+            out = Path(output_path).expanduser()
+            if self._is_within(out, repo_resolved):
+                return ToolResult(
+                    success=False,
+                    error=(
+                        f"output_path {out} resolves inside repo_path "
+                        f"{repo_resolved}. This tool never writes to the "
+                        f"analyzed repository — write the scan report under "
+                        f"projects/<project-id>/artifacts/ instead."
+                    ),
+                )
 
         start = time.time()
         try:
-            report = self._scan(repo, int(inputs.get("max_files", 5000)))
+            report = self._scan(
+                repo,
+                int(inputs.get("max_files", 5000)),
+                allow_config_execution=bool(inputs.get("allow_config_execution", False)),
+            )
         except Exception as e:
             return ToolResult(success=False, error=f"Repo scan failed: {e}")
 
         artifacts: list[str] = []
-        output_path = inputs.get("output_path")
-        if output_path:
-            out = Path(output_path)
+        if out is not None:
             out.parent.mkdir(parents=True, exist_ok=True)
             out.write_text(json.dumps(report, indent=2))
             artifacts.append(str(out))
@@ -190,8 +275,32 @@ class RepoDesignExtractor(BaseTool):
 
     # ---- scanning ----
 
-    def _scan(self, repo: Path, max_files: int) -> dict[str, Any]:
+    @staticmethod
+    def _is_within(candidate: Path, parent_resolved: Path) -> bool:
+        """Whether `candidate` would land inside `parent_resolved`.
+
+        Resolves symlinks and `..` so neither can be used to slip a write into
+        the target repo. The candidate usually does not exist yet, so
+        `resolve()` is used in its non-strict form.
+        """
+        resolved = candidate.resolve()
+        return resolved == parent_resolved or parent_resolved in resolved.parents
+
+    @staticmethod
+    def _rel_parts(rel: str) -> tuple[str, ...]:
+        """Split a repo-relative path into segments, separator-agnostically.
+
+        Report paths are POSIX-normalized at the walk boundary, but this stays
+        tolerant of native separators so a caller (or a future producer of
+        these paths) on Windows cannot silently break route derivation.
+        """
+        return tuple(p for p in re.split(r"[\\/]+", rel) if p and p != ".")
+
+    def _scan(
+        self, repo: Path, max_files: int, *, allow_config_execution: bool = False
+    ) -> dict[str, Any]:
         files, truncated = self._walk(repo, max_files)
+        warnings: list[str] = []
 
         pkg = self._read_package_json(repo)
         framework = self._detect_framework(pkg)
@@ -258,33 +367,46 @@ class RepoDesignExtractor(BaseTool):
                  if (key := (f["family"].lower(), f["file"])) not in seen
                  and not seen.add(key)]
 
+        theme, theme_source = self._read_tailwind_theme(
+            theme_files, allow_config_execution=allow_config_execution,
+            warnings=warnings,
+        )
+
         report: dict[str, Any] = {
             "repo_path": str(repo),
             "framework": framework,
             "styling_systems": self._detect_styling_systems(pkg, candidate_files, css_vars, files),
             "candidate_files": candidate_files,
             "css_custom_properties": css_vars,
-            "tailwind_theme": self._eval_tailwind_config(theme_files),
+            "tailwind_theme": theme,
+            "tailwind_theme_source": theme_source,
             "fonts": fonts,
-            "screen_candidates": self._index_screens(repo, files, framework),
+            "screen_candidates": self._index_screens(files, framework),
             "components_index": self._index_components(files),
             "files_scanned": len(files),
+            "warnings": warnings,
             "truncated": truncated,
         }
         return report
 
     def _walk(self, repo: Path, max_files: int) -> tuple[list[str], bool]:
-        """Sorted, capped, skip-listed walk. Returns repo-relative paths."""
+        """Sorted, capped, skip-listed walk.
+
+        Returns repo-relative paths in POSIX form on every platform: these
+        strings are contract values (they end up in artifact provenance and
+        drive candidate classification and route derivation), so they must not
+        vary with the host separator.
+        """
         collected: list[str] = []
         truncated = False
         for root, dirs, filenames in os.walk(repo):
             dirs[:] = sorted(d for d in dirs
                              if d not in _SKIP_DIRS and not d.startswith("."))
-            rel_root = Path(root).relative_to(repo)
+            rel_root = Path(root).relative_to(repo).as_posix()
             for fname in sorted(filenames):
                 if len(collected) >= max_files:
                     return collected, True
-                rel = str(rel_root / fname) if str(rel_root) != "." else fname
+                rel = fname if rel_root == "." else f"{rel_root}/{fname}"
                 collected.append(rel)
         return collected, truncated
 
@@ -366,13 +488,53 @@ class RepoDesignExtractor(BaseTool):
                 })
         return out
 
-    @staticmethod
-    def _eval_tailwind_config(theme_files: list[Path]) -> Any:
-        """Best-effort JS tailwind config evaluation via node. TS configs and
-        missing node degrade to None — the agent reads the file directly."""
+    # ---- tailwind config ----
+
+    def _read_tailwind_theme(
+        self,
+        theme_files: list[Path],
+        *,
+        allow_config_execution: bool,
+        warnings: list[str],
+    ) -> tuple[Any, str | None]:
+        """Resolve the tailwind `theme` object without running the repo.
+
+        Static parsing first (works for both .js and .ts configs). Execution is
+        attempted only when the caller explicitly opted in, and is recorded in
+        `warnings` so the risk is never invisible in the run record.
+
+        Returns (theme_or_None, source) where source is "static", "executed",
+        or None.
+        """
+        for cfg in theme_files:
+            text = self._read_text(cfg)
+            if text is None:
+                continue
+            theme = self._static_parse_theme(text)
+            if theme is not None:
+                return theme, "static"
+
+        if not theme_files:
+            return None, None
+
+        if not allow_config_execution:
+            warnings.append(
+                "tailwind config theme could not be resolved statically "
+                "(it computes values at runtime). Read the config file "
+                "directly — it is listed in candidate_files. Executing it is "
+                "available via allow_config_execution=true, which runs the "
+                "target repo's JavaScript and is unsafe for untrusted repos."
+            )
+            return None, None
+
         node = shutil.which("node")
         if not node:
-            return None
+            warnings.append(
+                "allow_config_execution=true but `node` is not on PATH; "
+                "tailwind_theme stays null."
+            )
+            return None, None
+
         for cfg in theme_files:
             if cfg.suffix == ".ts":
                 continue
@@ -387,47 +549,143 @@ class RepoDesignExtractor(BaseTool):
                     cwd=str(cfg.parent),
                 )
                 if proc.returncode == 0 and proc.stdout.strip() not in ("", "null"):
-                    return json.loads(proc.stdout)
+                    warnings.append(
+                        f"EXECUTED target-repo code: required {cfg.name} through "
+                        f"node under the allow_config_execution opt-in. Any side "
+                        f"effects in that config ran with this process's "
+                        f"privileges."
+                    )
+                    return json.loads(proc.stdout), "executed"
             except (subprocess.SubprocessError, json.JSONDecodeError, OSError):
                 continue
-        return None
+
+        warnings.append(
+            "allow_config_execution=true but no tailwind config could be "
+            "evaluated; tailwind_theme stays null."
+        )
+        return None, None
 
     @staticmethod
-    def _index_screens(
-        repo: Path, files: list[str], framework: str
-    ) -> list[dict[str, str]]:
-        screens: list[dict[str, str]] = []
+    def _static_parse_theme(text: str) -> Any:
+        """Extract a `theme: { ... }` object literal and convert it to JSON.
+
+        Deliberately conservative: a literal containing anything that needs
+        evaluation (function calls, spreads, template literals, `require`)
+        returns None rather than a partial guess. The agent then reads the
+        config file directly — that is the documented fallback.
+        """
+        match = _JS_THEME_KEY_RE.search(text)
+        if not match:
+            return None
+
+        # Balanced-brace scan from the literal's opening brace. Quoted strings
+        # are skipped so a `{` inside a value can't unbalance the scan.
+        start = match.end() - 1
+        depth = 0
+        quote: str | None = None
+        end = None
+        for i in range(start, len(text)):
+            ch = text[i]
+            if quote:
+                if ch == "\\":
+                    continue
+                if ch == quote:
+                    quote = None
+                continue
+            if ch in "\"'`":
+                quote = ch
+            elif ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    end = i + 1
+                    break
+        if end is None:
+            return None
+
+        src = text[start:end]
+        src = _JS_BLOCK_COMMENT_RE.sub("", src)
+        src = _JS_LINE_COMMENT_RE.sub("", src)
+        if any(token in src for token in _JS_DYNAMIC_TOKENS):
+            return None
+
+        src = _JS_SINGLE_QUOTED_RE.sub(lambda m: json.dumps(m.group(1)), src)
+        src = _JS_BARE_KEY_RE.sub(lambda m: f'{m.group(1)}"{m.group(2)}":', src)
+        src = _JS_TRAILING_COMMA_RE.sub(r"\1", src)
+        try:
+            parsed = json.loads(src)
+        except (json.JSONDecodeError, ValueError):
+            return None
+        return parsed if isinstance(parsed, dict) else None
+
+    # ---- indexing ----
+
+    @staticmethod
+    def _index_screens(files: list[str], framework: str) -> list[dict[str, Any]]:
+        """Index screen candidates, deriving a route only where the framework
+        convention actually determines one.
+
+        Next's app/pages routers and SvelteKit map directory structure to URLs
+        by documented convention, so a route is derivable from the path alone.
+        Roots like src/views, src/screens, and src/features do not — their URLs
+        live in a router config this scanner does not read. Those are reported
+        with `route: None` and `route_source: "not_derivable"` rather than a
+        route synthesized from the filename, which would look authoritative
+        while being invented.
+        """
+        screens: list[dict[str, Any]] = []
         for rel in files:
-            p = Path(rel)
-            parts = p.parts
+            parts = RepoDesignExtractor._rel_parts(rel)
+            if not parts:
+                continue
+            leaf = Path(parts[-1])
+            if leaf.suffix.lower() not in _SOURCE_EXTS:
+                continue
+
             root = None
             for candidate in _SCREEN_ROOTS:
                 croot = tuple(candidate.split("/"))
                 if parts[: len(croot)] == croot:
                     root = candidate
                     break
-            if root is None or p.suffix.lower() not in _SOURCE_EXTS:
+            if root is None:
                 continue
-            stem = p.stem.lower()
-            inner = Path(*parts[len(root.split("/")):])
+
+            inner = parts[len(root.split("/")):]
+            if not inner:
+                continue
+            stem = leaf.stem
+            stem_l = stem.lower()
+            route: str | None = None
+            route_source = "not_derivable"
+
             if root in ("app", "src/app"):
                 # Next app router: only page files are screens. Route groups
                 # like (auth) organize files without affecting the URL.
-                if stem != "page":
+                if stem_l != "page":
                     continue
-                segs = [s for s in inner.parent.parts
+                segs = [s for s in inner[:-1]
                         if not (s.startswith("(") and s.endswith(")"))]
                 route = "/" + "/".join(segs)
+                route_source = "next-app-router"
             elif root in ("pages", "src/pages"):
-                if stem.startswith("_") or inner.parts[:1] == ("api",):
+                if stem.startswith("_") or inner[:1] == ("api",):
                     continue
-                segs = list(inner.parent.parts) + ([] if stem == "index" else [stem])
+                segs = list(inner[:-1]) + ([] if stem_l == "index" else [stem])
                 route = "/" + "/".join(segs)
-            else:
-                route = ""
+                route_source = "next-pages-router"
+            elif root == "src/routes" and framework == "svelte":
+                # SvelteKit: only +page files are screens.
+                if stem_l != "+page":
+                    continue
+                route = "/" + "/".join(inner[:-1])
+                route_source = "sveltekit"
+
             screens.append({
                 "path": rel,
-                "route": route if route else "/" + inner.stem,
+                "route": route,
+                "route_source": route_source,
                 "root": root,
             })
         return screens
@@ -436,13 +694,15 @@ class RepoDesignExtractor(BaseTool):
     def _index_components(files: list[str]) -> list[dict[str, str]]:
         comps: list[dict[str, str]] = []
         for rel in files:
-            p = Path(rel)
-            parts = p.parts
+            parts = RepoDesignExtractor._rel_parts(rel)
+            if not parts:
+                continue
+            leaf = Path(parts[-1])
             for candidate in _COMPONENT_ROOTS:
                 croot = tuple(candidate.split("/"))
-                if parts[: len(croot)] == croot and p.suffix.lower() in _SOURCE_EXTS:
-                    if p.stem.lower() in ("index", "types", "utils"):
+                if parts[: len(croot)] == croot and leaf.suffix.lower() in _SOURCE_EXTS:
+                    if leaf.stem.lower() in ("index", "types", "utils"):
                         break
-                    comps.append({"name": p.stem, "path": rel})
+                    comps.append({"name": leaf.stem, "path": rel})
                     break
         return comps

--- a/tools/audio/music_gen.py
+++ b/tools/audio/music_gen.py
@@ -1,6 +1,8 @@
 """Music generation tool via ElevenLabs Music API.
 
-Generates background music and sound effects for video production.
+Generates background music for video production. For short sound effects
+(UI ticks, whooshes, impacts) use the dedicated ``sfx_gen`` tool — it calls
+the ElevenLabs sound-generation endpoint, which this tool does not.
 Reports unavailable when no API key is configured.
 """
 
@@ -47,7 +49,6 @@ class MusicGen(BaseTool):
 
     capabilities = [
         "generate_background_music",
-        "generate_sfx",
     ]
 
     input_schema = {

--- a/tools/audio/sfx_gen.py
+++ b/tools/audio/sfx_gen.py
@@ -1,0 +1,206 @@
+"""Sound-effect generation tool via the ElevenLabs sound-generation API.
+
+Generates short sound effects from text descriptions — UI ticks, whooshes,
+pops, impacts, ambient textures. This is the first-class SFX path; ``music_gen``
+handles full background-music tracks and does not generate SFX.
+
+Generated SFX are registered in the asset manifest (``type: "sfx"``) and are
+either placed as frame-accurate ``<Audio>`` cues inside a Remotion composition
+(the product-motion atelier path) or mixed in post via ``audio_mixer``'s ``sfx``
+track role using ``edit_decisions.audio.sfx[]``.
+
+Docs: https://elevenlabs.io/docs/api-reference/text-to-sound-effects/convert
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+
+class SfxGen(BaseTool):
+    name = "sfx_gen"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "sfx_generation"
+    provider = "elevenlabs"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = []  # checked dynamically via API key
+    install_instructions = (
+        "Set the ELEVENLABS_API_KEY environment variable:\n"
+        "  export ELEVENLABS_API_KEY=your_key_here\n"
+        "Get a key at https://elevenlabs.io"
+    )
+    fallback_tools = []
+    agent_skills = ["sound-effects", "elevenlabs"]
+
+    capabilities = [
+        "generate_sfx",
+    ]
+    supports = {
+        "looping": True,
+        "duration_control": True,
+        "offline": False,
+    }
+    best_for = [
+        "UI interaction sounds (ticks, clicks, pops) synced to motion",
+        "whooshes and risers for element-assembly animations",
+        "short cinematic impacts and ambient textures",
+    ]
+    not_good_for = [
+        "background music tracks (use music_gen)",
+        "speech (use a TTS tool)",
+    ]
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": (
+                    "Sound description (e.g. 'soft glass tick, short, subtle', "
+                    "'airy whoosh rising, 1 second'). Describe texture, length, "
+                    "and intensity."
+                ),
+            },
+            "duration_seconds": {
+                "type": "number",
+                "minimum": 0.5,
+                "maximum": 30,
+                "description": (
+                    "Duration 0.5-30s. Omit to let the API auto-calculate from "
+                    "the prompt. UI cue sounds are typically 0.5-1.5s."
+                ),
+            },
+            "prompt_influence": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.3,
+                "description": (
+                    "How literally to follow the prompt (0-1). Higher = closer "
+                    "adherence, lower = more creative interpretation."
+                ),
+            },
+            "loop": {
+                "type": "boolean",
+                "default": False,
+                "description": "Generate a seamlessly looping sound (for ambient beds).",
+            },
+            "output_path": {"type": "string"},
+        },
+    }
+
+    output_schema = {
+        "type": "object",
+        "properties": {
+            "provider": {"type": "string"},
+            "prompt": {"type": "string"},
+            "output": {"type": "string"},
+            "format": {"type": "string"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=10, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
+    idempotency_key_fields = ["prompt", "duration_seconds", "prompt_influence", "loop"]
+    side_effects = ["writes audio file to output_path", "calls ElevenLabs API"]
+    user_visible_verification = [
+        "Listen to the generated effect at the intended cue point in context",
+    ]
+
+    def get_status(self) -> ToolStatus:
+        if os.environ.get("ELEVENLABS_API_KEY"):
+            return ToolStatus.AVAILABLE
+        return ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        # ElevenLabs bills sound generation per effect (credit-based);
+        # roughly $0.03 per generated effect on paid tiers.
+        return 0.03
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        return 10.0
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        api_key = os.environ.get("ELEVENLABS_API_KEY")
+        if not api_key:
+            return ToolResult(
+                success=False,
+                error="No ElevenLabs API key. " + self.install_instructions,
+            )
+
+        start = time.time()
+        try:
+            result = self._generate(inputs, api_key)
+        except Exception as e:
+            return ToolResult(success=False, error=f"SFX generation failed: {e}")
+
+        result.duration_seconds = round(time.time() - start, 2)
+        result.cost_usd = self.estimate_cost(inputs)
+        return result
+
+    def _generate(self, inputs: dict[str, Any], api_key: str) -> ToolResult:
+        import requests
+
+        prompt = inputs["prompt"]
+        url = "https://api.elevenlabs.io/v1/sound-generation"
+        headers = {
+            "xi-api-key": api_key,
+            "Content-Type": "application/json",
+        }
+
+        payload: dict[str, Any] = {
+            "text": prompt,
+            "prompt_influence": inputs.get("prompt_influence", 0.3),
+        }
+        if inputs.get("duration_seconds") is not None:
+            payload["duration_seconds"] = float(inputs["duration_seconds"])
+        if inputs.get("loop"):
+            payload["loop"] = True
+
+        response = requests.post(url, headers=headers, json=payload, timeout=120)
+        if response.status_code != 200:
+            detail = response.text[:500] if response.text else ""
+            return ToolResult(
+                success=False,
+                error=f"ElevenLabs sound generation returned HTTP {response.status_code}: {detail}",
+            )
+
+        output_path = Path(inputs.get("output_path", "sfx_output.mp3"))
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(response.content)
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": self.provider,
+                "prompt": prompt,
+                "output": str(output_path),
+                "format": "mp3",
+            },
+            artifacts=[str(output_path)],
+            model="elevenlabs-sound-generation",
+        )

--- a/tools/audio/sfx_gen.py
+++ b/tools/audio/sfx_gen.py
@@ -9,7 +9,11 @@ either placed as frame-accurate ``<Audio>`` cues inside a Remotion composition
 (the product-motion atelier path) or mixed in post via ``audio_mixer``'s ``sfx``
 track role using ``edit_decisions.audio.sfx[]``.
 
+Billing is per minute of generated audio, not per effect — see
+``estimate_cost``.
+
 Docs: https://elevenlabs.io/docs/api-reference/text-to-sound-effects/convert
+Pricing: https://elevenlabs.io/pricing/api
 """
 
 from __future__ import annotations
@@ -32,6 +36,15 @@ from tools.base_tool import (
     ToolTier,
 )
 
+# Published pay-as-you-go list price for sound-effect generation, billed per
+# minute of generated audio (https://elevenlabs.io/pricing/api). Subscription
+# tiers bundle a monthly generation allowance, so the effective cost of a run
+# is usually lower; this is the honest upper bound to quote.
+_USD_PER_MINUTE = 0.12
+# The API infers length from the prompt when duration_seconds is omitted.
+# Used only to keep cost estimation non-zero for auto-duration calls.
+_ASSUMED_AUTO_DURATION_S = 4.0
+
 
 class SfxGen(BaseTool):
     name = "sfx_gen"
@@ -44,7 +57,7 @@ class SfxGen(BaseTool):
     determinism = Determinism.STOCHASTIC
     runtime = ToolRuntime.API
 
-    dependencies = []  # checked dynamically via API key
+    dependencies = ["env:ELEVENLABS_API_KEY"]
     install_instructions = (
         "Set the ELEVENLABS_API_KEY environment variable:\n"
         "  export ELEVENLABS_API_KEY=your_key_here\n"
@@ -137,9 +150,24 @@ class SfxGen(BaseTool):
         return ToolStatus.UNAVAILABLE
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
-        # ElevenLabs bills sound generation per effect (credit-based);
-        # roughly $0.03 per generated effect on paid tiers.
-        return 0.03
+        """Estimate USD cost from generated audio length.
+
+        ElevenLabs bills sound generation by the minute of generated audio,
+        not per effect — a 0.6s UI tick and a 20s ambient bed are not the same
+        charge. The rate below is the published pay-as-you-go list price
+        (https://elevenlabs.io/pricing/api); subscription tiers include a
+        monthly generation allowance and bill overage at their own rate, so
+        treat this as an upper-bound list estimate, not a durable per-call
+        price. Re-check the pricing page before quoting figures to a user.
+
+        When `duration_seconds` is omitted the API picks the length from the
+        prompt, so the estimate falls back to a documented nominal duration.
+        """
+        duration = inputs.get("duration_seconds")
+        seconds = (
+            float(duration) if duration is not None else _ASSUMED_AUTO_DURATION_S
+        )
+        return round(seconds / 60.0 * _USD_PER_MINUTE, 4)
 
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         return 10.0

--- a/tools/base_tool.py
+++ b/tools/base_tool.py
@@ -384,10 +384,32 @@ class BaseTool(ABC):
     # ---- Idempotency ----
 
     def idempotency_key(self, inputs: dict[str, Any]) -> str:
-        """Compute a cache key from idempotency fields."""
-        key_data = {k: inputs.get(k) for k in self.idempotency_key_fields}
-        raw = json.dumps(key_data, sort_keys=True)
+        """Compute a cache key from idempotency fields.
+
+        Schema defaults are applied first: omitting an optional field and
+        passing its declared default describe the *same request*, so they must
+        hash the same. Without this, `{"prompt": "tick"}` and
+        `{"prompt": "tick", "prompt_influence": 0.3}` produce different keys
+        for an identical provider payload — defeating the cache and letting a
+        paid generation run twice.
+        """
+        key_data = {}
+        for field in self.idempotency_key_fields:
+            value = inputs.get(field)
+            # An explicit None means "unset" the same way omission does.
+            key_data[field] = (
+                self._schema_default(field) if value is None else value
+            )
+        raw = json.dumps(key_data, sort_keys=True, default=str)
         return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+    def _schema_default(self, field: str) -> Any:
+        """The input_schema default for `field`, or None when it has none."""
+        properties = (self.input_schema or {}).get("properties") or {}
+        spec = properties.get(field)
+        if isinstance(spec, dict):
+            return spec.get("default")
+        return None
 
     # ---- Execution ----
 


### PR DESCRIPTION
## Summary

Adds the **`product-motion` pipeline**: point OpenMontage at a product's source repository (web frontends — React/Next/Vue/Tailwind) and produce polished-SaaS product screen animations — the product's **real UI rebuilt faithfully** in a hand-authored (atelier) Remotion composition, staged on glassmorphic surfaces, assembling element-by-element with spring motion and frame-accurate sound effects.

The core design goal is **truthfulness to the actual product**, enforced by a provenance chain rather than good intentions:

```
repo file+line → design_system token → replica scene component
repo source_files → ui_inventory screen → scene_plan scene → asset provenance
```

`design_system` tokens are schema-invalid without provenance; `ui_inventory` screens require `reviewed: true` (inspected-not-assumed, same contract as `source_media_review`); derived values (e.g. the glass spec) go in an explicit `gaps[]` honesty ledger; and the assets stage is a **fidelity gate** where per-scene snapshot stills are reviewed against the cited repo sources before any motion/render work locks in.

## Related issue

N/A — new capability. Grounding today is live-URL only (`hyperframes capture` / `website-to-video`); nothing previously read a source repo.

## Changes

- **Pipeline** `pipeline_defs/product-motion.yaml` — 8 stages (`repo_analysis → proposal → script → scene_plan → assets → edit → compose → publish`); `repo_analysis` is a first-class gated stage; atelier composition mode by default; the proposal-director satisfies the both-runtimes HARD RULE honestly (Remotion recommended for React/Next repos — near-1:1 JSX ports + in-composition SFX; HyperFrames as the genuine alternative for Vue/Nuxt or Tailwind-heavy markup where HTML replicas reuse the repo's markup verbatim)
- **Schemas** — new `design_system` (provenance-required tokens, component styles, gaps ledger) and `ui_inventory` (screens/components with source files); additive optional `provenance` object on `asset_manifest` items; `lib/checkpoint.py` wiring (`repo_analysis` → canonical `design_system`, supplementary `ui_inventory`; legacy fallback STAGES order untouched)
- **Tools** — `tools/analysis/repo_design_extractor.py`: deterministic scanner (framework detection from package.json, candidate design-file classification, CSS custom properties with file+line provenance, Tailwind v4 `@theme` support, JS tailwind-config evaluation via `node` degrading to `null`, Next app/pages-router screen indexing with route-group handling, component index; sorted walks for determinism; read-only on the target repo). `tools/audio/sfx_gen.py`: first-class ElevenLabs sound-generation tool; `music_gen` drops its declared-but-unimplemented `generate_sfx` capability
- **Layer-3 skills** (+ `.claude/skills/` mirrors) — `repo-design-extraction` (scanner-first workflow, per-styling-system reading guides incl. Tailwind v3 config vs v4 `@theme`, shadcn-style CSS-var indirection, provenance discipline, flagship scoring) and `glass-ui-motion` (truthful-replica method with grep-auditable tokens-only styling, glass surface recipes themed from the product's own palette, assembly choreography — semantic build order, spring presets, `measureSpring` settle frames — and SFX cue taxonomy/derivation with in-composition `<Audio>` for frame-accurate sync)
- **Director skills** `skills/pipelines/product-motion/` — executive-producer + 8 stage directors
- **Tests** — `tests/tools/test_repo_design_extractor.py` (fixture mini-repos: detection, provenance, node degradation, truncation reporting, determinism, never-writes-to-target), `tests/tools/test_sfx_gen.py` (mocked network), `tests/contracts/test_product_motion_pipeline.py` (manifest validates against the pipeline schema, skill files exist, produces ∈ ARTIFACT_NAMES, checkpoint roundtrip + gate enforcement, golden/invalid artifact fixtures)
- **Registration** — `AGENT_GUIDE.md` (pipelines table, Layer-3 lookup row) and `skills/INDEX.md` (directors section, grounding skills row)

## Testing

- New tests: 53 passed; existing contract suites (runtime-presentation, phase0, backlot) pass with the new pipeline auto-covered — 853 passed overall locally (the only failures are the pre-existing Google GenAI ones that CI resolves by installing the SDK)
- Real-world scanner run against `shadcn-ui/taxonomy`: `framework=next`, 40 CSS tokens with file+line provenance, 14 screens with clean routes (route groups stripped), 67 components, `truncated=false`; ESM tailwind config correctly degraded to `null` per the documented fallback
- Schema fixtures verified both ways: golden payloads validate; missing provenance / `reviewed=false` / empty `planning_implications` are rejected

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [x] I updated docs/README if behavior or usage changed.
- [x] No unrelated files (build artifacts, local config) are included in the diff.


