### PR TITLE
feat(remotion): timestamped SFX cues + synced Clock scene + colab_sfx…

### DIFF
--- a/remotion-composer/SCENE_TYPES.md
+++ b/remotion-composer/SCENE_TYPES.md
@@ -24,6 +24,7 @@ When you add a new component, append it here and in `src/components/index.ts`.
 | `progress_bar` | `ProgressBar` | `progress` | `progressLabel`, `progressColor`, `progressSegments` | Animated progress |
 | `anime_scene` | `AnimeScene` | `images` (list) | `particles`, `lightingFrom`, `lightingTo`, `vignette` | Still-image anime scene with particles + camera motion |
 | **`terminal_scene`** | **`TerminalScene`** | **`steps`** (list of cmd/out/pause/pill) | **`terminalTitle`, `prompt`, `accentColor`** | **Synthetic terminal animation — NO real capture needed. See [`.agents/skills/synthetic-screen-recording/SKILL.md`](../.agents/skills/synthetic-screen-recording/SKILL.md)** |
+| **`clock`** | **`Clock`** | *(none)* | **`tickSound` (path), `tickVolume`, `secondsPerStep` (default 1), `startSecond`, `clockLabel`, `clockSize`, `accentColor`** | **Analog clock whose second hand steps once per `secondsPerStep`, with an optional tick sound locked to each step. Both the hand angle and the tick `<Audio>` derive from the same frame counter, so they are frame-accurately synced by construction. `durationSeconds` is passed automatically from the cut. Omit `tickSound` for a silent clock. Reference example of audio↔visual sync.** |
 | **`screenshot_scene`** | **`ScreenshotScene`** | **`backgroundImage`** (path in `public/`), **`screenshotSteps`** (list of overlays) | **`screenshotSize` (natural px w/h), `cursorStartAt`, `accentColor`** | **Approach-1 synthetic UI — drop any screenshot, animate scripted overlays on top (cursor, click_pulse, type_into, bubble_append, typing_dots, highlight_box, callout_balloon). Viewer-indistinguishable from a real recording for 15–30s focused demos. Coordinates are normalized (0–1) against the contain-fit rect. See [`.agents/skills/synthetic-ui-recording/SKILL.md`](../.agents/skills/synthetic-ui-recording/SKILL.md) (planned).** |
 
 ---
@@ -36,6 +37,17 @@ When you add a new component, append it here and in `src/components/index.ts`.
 | `stat_reveal` | `StatReveal` | `text` | `subtitle`, `accentColor`, `position` | Corner stat badge |
 | `hero_title` | `HeroTitle` (as overlay) | `text` | `subtitle` | Full-frame title overlay |
 | **`provider_chip`** | **`ProviderChip`** | **`providers`** (list of strings) | **`cycleSeconds`, `position`, `accentColor`, `label`** | **Rotating badge that cycles through provider names — used in AI-generated-motion scenes to show which model produced the clip** |
+
+---
+
+## Top-level composition props (not a cut/overlay type)
+
+| Prop | Default | Purpose |
+|---|---|---|
+| `captionWordsPerPage` | `6` | Word-level caption page size for `CaptionOverlay`. Pages are built by chunking the flat `captions` array sequentially and are **not** scene-boundary-aware — a page can straddle a cut boundary (e.g. last word of scene N grouped with first words of scene N+1) if the word-count math lines up wrong. Set `captionWordsPerPage: 1` for word-by-word/karaoke captions, which sidesteps the bleed entirely since a 1-word page can never span two scenes. |
+| `audio.narration` | — | `{ src, volume? }` — full narration track over the whole composition. |
+| `audio.music` | — | `{ src, volume?, offsetSeconds?, fadeInSeconds?, fadeOutSeconds?, loop? }` — one background music bed. For varied music, pre-mix multiple tracks into one file and pass it here. |
+| `audio.sfx` | `[]` | Array of one-shot sound-effect cues: `{ src, atSeconds, volume?, durationSeconds? }`. Each fires on the exact frame `atSeconds * fps`, so it's frame-locked to any visual driven by the same frame counter. Use for whooshes on transitions, clicks on reveals, impacts, ticks. Sources can be Freesound CC0 clips, `sfx_gen` (ElevenLabs), or `colab_sfx` (MMAudio/AudioGen) output. |
 
 ---
 

--- a/remotion-composer/src/Explainer.tsx
+++ b/remotion-composer/src/Explainer.tsx
@@ -43,6 +43,7 @@ import { AnimeScene } from "./components/AnimeScene";
 import type { CameraMotion } from "./components/AnimeScene";
 import { TerminalScene } from "./components/TerminalScene";
 import type { TerminalStep } from "./components/TerminalScene";
+import { Clock } from "./components/Clock";
 import { ScreenshotScene } from "./components/ScreenshotScene";
 import type { ScreenshotStep } from "./components/ScreenshotScene";
 import { ProviderChip } from "./components/ProviderChip";
@@ -268,6 +269,13 @@ interface Cut {
   screenshotSteps?: ScreenshotStep[];
   screenshotSize?: { width: number; height: number };
   cursorStartAt?: [number, number];
+  // Clock scene props (type: "clock")
+  tickSound?: string;
+  tickVolume?: number;
+  secondsPerStep?: number;
+  startSecond?: number;
+  clockLabel?: string;
+  clockSize?: number;
 }
 
 interface Overlay {
@@ -289,6 +297,22 @@ interface AudioLayer {
   volume?: number;
 }
 
+/** A one-shot sound effect placed at an absolute timestamp on the timeline.
+ *  Because both the cue's start frame and every frame-driven visual derive
+ *  from the same `useCurrentFrame()` counter, a cue placed at a scene's
+ *  action frame stays locked to it — no drift between sound and picture.
+ *  This is the primitive for "whoosh on a transition", "click on a button
+ *  reveal", or a tick landing exactly on a clock-hand step. */
+interface SfxCue {
+  src: string;
+  /** Absolute time on the composition timeline where the effect fires. */
+  atSeconds: number;
+  volume?: number;
+  /** Optional hard cap on how long the cue is allowed to play. Defaults to
+   *  the effect's natural length. Useful for trimming a long ambience clip. */
+  durationSeconds?: number;
+}
+
 interface AudioConfig {
   narration?: AudioLayer;
   music?: AudioLayer & {
@@ -300,6 +324,9 @@ interface AudioConfig {
     /** Loop the music if it's shorter than the video duration. */
     loop?: boolean;
   };
+  /** One-shot sound effects placed at absolute timestamps. Each plays its
+   *  natural length (or `durationSeconds` if capped) starting at `atSeconds`. */
+  sfx?: SfxCue[];
 }
 
 export interface ExplainerProps {
@@ -608,6 +635,22 @@ const SceneRenderer: React.FC<{ cut: Cut; theme: ThemeConfig }> = ({ cut, theme 
       />
     );
   }
+  if (cut.type === "clock") {
+    return maybeWrapWithBg(
+      <Clock
+        durationSeconds={cut.out_seconds - cut.in_seconds}
+        tickSound={cut.tickSound}
+        tickVolume={cut.tickVolume}
+        secondsPerStep={cut.secondsPerStep}
+        startSecond={cut.startSecond}
+        accentColor={accent}
+        handColor={textColor}
+        backgroundColor={bgColor}
+        label={cut.clockLabel}
+        size={cut.clockSize}
+      />
+    );
+  }
   if (cut.type === "screenshot_scene" && cut.backgroundImage && cut.screenshotSteps) {
     return (
       <ScreenshotScene
@@ -621,12 +664,18 @@ const SceneRenderer: React.FC<{ cut: Cut; theme: ThemeConfig }> = ({ cut, theme 
   }
 
   // --- Chart types — use theme.chartColors as default palette ---
+  // fontFamily/textColor/gridColor are threaded from theme here because each chart
+  // component's own prop defaults (Inter, #1F2937, white) are a standalone light-mode
+  // fallback, not theme-aware — without this they silently render as a generic light
+  // corporate chart regardless of which style_playbook was selected.
+  const chartGridColor = `${theme.mutedTextColor}33`;
   if (cut.type === "bar_chart" && cut.chartData) {
     return maybeWrapWithBg(
       <BarChart
         data={cut.chartData} title={cut.title} colors={cut.chartColors || theme.chartColors}
         animationStyle={(cut.chartAnimation as any) || "grow-up"}
         showGrid={cut.showGrid} showValues={cut.showValues} backgroundColor={bgColor}
+        fontFamily={theme.bodyFont} textColor={textColor} gridColor={chartGridColor}
       />
     );
   }
@@ -637,6 +686,7 @@ const SceneRenderer: React.FC<{ cut: Cut; theme: ThemeConfig }> = ({ cut, theme 
         animationStyle={(cut.chartAnimation as any) || "draw"}
         showGrid={cut.showGrid} showMarkers={cut.showMarkers} showLegend={cut.showLegend}
         xLabel={cut.xLabel} yLabel={cut.yLabel} backgroundColor={bgColor}
+        fontFamily={theme.bodyFont} textColor={textColor} gridColor={chartGridColor}
       />
     );
   }
@@ -647,6 +697,7 @@ const SceneRenderer: React.FC<{ cut: Cut; theme: ThemeConfig }> = ({ cut, theme 
         animationStyle={(cut.chartAnimation as any) || "expand"}
         donut={cut.donut} centerLabel={cut.centerLabel} centerValue={cut.centerValue}
         showLegend={cut.showLegend} backgroundColor={bgColor}
+        fontFamily={theme.bodyFont} textColor={textColor}
       />
     );
   }
@@ -656,6 +707,8 @@ const SceneRenderer: React.FC<{ cut: Cut; theme: ThemeConfig }> = ({ cut, theme 
         metrics={cut.chartData} title={cut.title} columns={cut.columns}
         colors={cut.chartColors || theme.chartColors} animationStyle={(cut.chartAnimation as any) || "count-up"}
         backgroundColor={bgColor}
+        fontFamily={theme.bodyFont} textColor={textColor}
+        cardBackgroundColor={`${theme.mutedTextColor}26`}
       />
     );
   }
@@ -813,7 +866,7 @@ export const Explainer: React.FC<ExplainerProps> = (props) => {
       {captions && captions.length > 0 && (
         <CaptionOverlay
           words={captions}
-          wordsPerPage={6}
+          wordsPerPage={(props.captionWordsPerPage as number) || 6}
           fontSize={42}
           highlightColor={theme.captionHighlightColor}
           backgroundColor={theme.captionBackgroundColor}
@@ -854,6 +907,22 @@ export const Explainer: React.FC<ExplainerProps> = (props) => {
           }}
         />
       )}
+
+      {/* Layer 4: Audio — one-shot SFX cues at absolute timestamps.
+          Each is wrapped in a Sequence starting at atSeconds so it fires on
+          the exact frame; frame-locked to any visual driven by the same fps. */}
+      {audio?.sfx?.map((cue, i) => {
+        const from = Math.max(0, Math.round(cue.atSeconds * fps));
+        const seqProps =
+          cue.durationSeconds !== undefined
+            ? { durationInFrames: Math.max(1, Math.round(cue.durationSeconds * fps)) }
+            : {};
+        return (
+          <Sequence key={`sfx-${i}`} from={from} {...seqProps}>
+            <Audio src={resolveAsset(cue.src)} volume={cue.volume ?? 1} />
+          </Sequence>
+        );
+      })}
     </AbsoluteFill>
   );
 };

--- a/remotion-composer/src/components/Clock.tsx
+++ b/remotion-composer/src/components/Clock.tsx
@@ -1,0 +1,230 @@
+import {
+  AbsoluteFill,
+  Audio,
+  Sequence,
+  interpolate,
+  staticFile,
+  useCurrentFrame,
+  useVideoConfig,
+} from "remotion";
+
+/**
+ * Clock — an analog clock whose second hand steps discretely once per
+ * `secondsPerStep`, with an optional tick sound locked to each step.
+ *
+ * Why this exists: it's the canonical demonstration of frame-accurate
+ * audio↔visual sync in Remotion. Both the hand's angle and every tick
+ * `<Audio>` are derived from the SAME `useCurrentFrame()` counter, so the
+ * sound lands on the exact frame the hand jumps — by construction, not by
+ * manual timestamp tuning. Move the scene, change the fps, retime the
+ * video: they stay married.
+ *
+ * The tick sound is passed in (`tickSound`), not bundled, so any source
+ * works — a Freesound CC0 clip, an ElevenLabs/AudioGen-generated tick, etc.
+ * If `tickSound` is omitted the clock is silent (visual only).
+ */
+
+interface ClockProps {
+  /** Length of this clock scene in seconds. Passed automatically from the
+   *  cut (out_seconds − in_seconds) by the Explainer dispatch. Determines how
+   *  many ticks are scheduled. */
+  durationSeconds?: number;
+  /** Path to a tick sound effect (public/-relative or file://). One instance
+   *  fires per step. Omit for a silent clock. */
+  tickSound?: string;
+  tickVolume?: number;
+  /** Seconds between hand steps. 1 = classic one-tick-per-second. */
+  secondsPerStep?: number;
+  /** Where the second hand starts, 0–59. Purely cosmetic. */
+  startSecond?: number;
+  accentColor?: string;
+  faceColor?: string;
+  handColor?: string;
+  tickMarkColor?: string;
+  /** Clock diameter in px. */
+  size?: number;
+  backgroundColor?: string;
+  /** Optional label under the clock (e.g. "tick tick…"). */
+  label?: string;
+  labelColor?: string;
+}
+
+/** Resolve a public/-relative path to a served URL; pass through absolute/URI. */
+function resolveTickSrc(src: string): string {
+  if (/^(https?:|file:|data:|blob:)/.test(src) || src.startsWith("/")) {
+    return src;
+  }
+  try {
+    return staticFile(src);
+  } catch {
+    return src;
+  }
+}
+
+export const Clock: React.FC<ClockProps> = ({
+  durationSeconds = 10,
+  tickSound,
+  tickVolume = 1,
+  secondsPerStep = 1,
+  startSecond = 0,
+  accentColor = "#EF4444",
+  faceColor = "#F8FAFC",
+  handColor = "#0F172A",
+  tickMarkColor = "#94A3B8",
+  size = 520,
+  backgroundColor = "transparent",
+  label,
+  labelColor = "#64748B",
+}) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  const step = Math.max(0.05, secondsPerStep);
+  const elapsed = frame / fps;
+
+  // Which discrete step are we on, and how long since that step landed.
+  const stepIndex = Math.floor(elapsed / step);
+  const stepStartFrame = stepIndex * step * fps;
+  const framesSinceStep = frame - stepStartFrame;
+
+  // Second-hand angle: each step advances the hand by (step) seconds' worth
+  // of rotation. A real second hand moves 6° per second.
+  const secondValue = (startSecond + stepIndex * step) % 60;
+  const baseAngle = secondValue * 6; // degrees, 0 = 12 o'clock
+
+  // A real ticking hand overshoots slightly then settles — a small damped
+  // oscillation over the first ~0.18s after each step sells the "tick".
+  const settleFrames = 0.18 * fps;
+  const overshoot =
+    framesSinceStep < settleFrames
+      ? Math.sin((framesSinceStep / settleFrames) * Math.PI * 2) *
+        interpolate(framesSinceStep, [0, settleFrames], [3.2, 0], {
+          extrapolateRight: "clamp",
+        })
+      : 0;
+  const secondAngle = baseAngle + overshoot;
+
+  // Minute/hour hands drift smoothly for a touch of life.
+  const minuteAngle = (elapsed / 60) * 6;
+  const hourAngle = (elapsed / 3600) * 30 + minuteAngle / 12;
+
+  const r = size / 2;
+  const center = r;
+
+  // Schedule one tick sound per step across the scene's duration.
+  const totalTicks = tickSound
+    ? Math.max(0, Math.floor(durationSeconds / step) + 1)
+    : 0;
+
+  const hourMarks = Array.from({ length: 12 }, (_, i) => i);
+
+  return (
+    <AbsoluteFill
+      style={{
+        background: backgroundColor,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 40,
+      }}
+    >
+      <svg
+        width={size}
+        height={size}
+        viewBox={`0 0 ${size} ${size}`}
+        style={{ filter: "drop-shadow(0 12px 32px rgba(15,23,42,0.25))" }}
+      >
+        {/* Face */}
+        <circle cx={center} cy={center} r={r - 8} fill={faceColor} />
+        <circle
+          cx={center}
+          cy={center}
+          r={r - 8}
+          fill="none"
+          stroke={handColor}
+          strokeWidth={6}
+          opacity={0.9}
+        />
+
+        {/* Hour marks */}
+        {hourMarks.map((h) => {
+          const a = (h * 30 - 90) * (Math.PI / 180);
+          const inner = r - (h % 3 === 0 ? 44 : 30);
+          const outer = r - 20;
+          return (
+            <line
+              key={h}
+              x1={center + Math.cos(a) * inner}
+              y1={center + Math.sin(a) * inner}
+              x2={center + Math.cos(a) * outer}
+              y2={center + Math.sin(a) * outer}
+              stroke={tickMarkColor}
+              strokeWidth={h % 3 === 0 ? 8 : 4}
+              strokeLinecap="round"
+            />
+          );
+        })}
+
+        {/* Hour hand */}
+        <line
+          x1={center}
+          y1={center}
+          x2={center}
+          y2={center - r * 0.42}
+          stroke={handColor}
+          strokeWidth={14}
+          strokeLinecap="round"
+          transform={`rotate(${hourAngle} ${center} ${center})`}
+        />
+        {/* Minute hand */}
+        <line
+          x1={center}
+          y1={center}
+          x2={center}
+          y2={center - r * 0.62}
+          stroke={handColor}
+          strokeWidth={10}
+          strokeLinecap="round"
+          transform={`rotate(${minuteAngle} ${center} ${center})`}
+        />
+        {/* Second hand (the ticking one) */}
+        <line
+          x1={center}
+          y1={center + r * 0.14}
+          x2={center}
+          y2={center - r * 0.74}
+          stroke={accentColor}
+          strokeWidth={5}
+          strokeLinecap="round"
+          transform={`rotate(${secondAngle} ${center} ${center})`}
+        />
+        {/* Center cap */}
+        <circle cx={center} cy={center} r={14} fill={accentColor} />
+        <circle cx={center} cy={center} r={6} fill={faceColor} />
+      </svg>
+
+      {label && (
+        <div
+          style={{
+            fontFamily: "Inter, system-ui, sans-serif",
+            fontSize: 42,
+            fontWeight: 600,
+            color: labelColor,
+            letterSpacing: "0.02em",
+          }}
+        >
+          {label}
+        </div>
+      )}
+
+      {/* Tick sounds — one per step, each locked to the frame the hand jumps. */}
+      {tickSound &&
+        Array.from({ length: totalTicks }, (_, k) => (
+          <Sequence key={`tick-${k}`} from={Math.round(k * step * fps)}>
+            <Audio src={resolveTickSrc(tickSound)} volume={tickVolume} />
+          </Sequence>
+        ))}
+    </AbsoluteFill>
+  );
+};

--- a/remotion-composer/src/components/index.ts
+++ b/remotion-composer/src/components/index.ts
@@ -11,6 +11,7 @@ export { HeroTitle } from "./HeroTitle";
 export { ParticleOverlay } from "./ParticleOverlay";
 export { AnimeScene } from "./AnimeScene";
 export { TerminalScene } from "./TerminalScene";
+export { Clock } from "./Clock";
 export { ScreenshotScene } from "./ScreenshotScene";
 export { ProviderChip } from "./ProviderChip";
 export type { ParticleType } from "./ParticleOverlay";

--- a/tools/audio/colab/sfx_server.py
+++ b/tools/audio/colab/sfx_server.py
@@ -1,0 +1,153 @@
+"""SFX / Foley inference server — runs INSIDE a Google Colab T4 notebook.
+
+This file is not an OpenMontage tool; it is the remote half of
+tools/audio/colab_sfx.py. Usage:
+
+1. Open https://colab.research.google.com, Runtime -> Change runtime type
+   -> T4 GPU.
+2. First cell (text->SFX via AudioGen only):
+       !pip -q install audiocraft flask pyngrok scipy
+   For video->foley too, also install MMAudio per its README
+   (https://github.com/hkchengrex/MMAudio) and set ENABLE_MMAUDIO=1.
+3. Second cell: paste this entire file and run it. It prints:
+       COLAB_SFX_URL=https://<random>.ngrok-free.app
+       COLAB_SFX_TOKEN=<generated token>
+4. Put both lines in OpenMontage's .env on the local machine.
+
+An ngrok authtoken (free account, https://dashboard.ngrok.com) must be set
+via the NGROK_AUTHTOKEN env var in the notebook.
+
+Endpoints:
+    GET  /health    -> {"status": "ok", "audiogen": bool, "mmaudio": bool, ...}
+    POST /generate  {"prompt": str, "duration_seconds": <=30, "seed": int?}
+                    -> WAV bytes (audio/wav)  [AudioGen text->SFX]
+    POST /foley     multipart: video=<file>, prompt=str?, seed=int?
+                    -> WAV bytes (audio/wav)  [MMAudio video->foley]
+
+Both responses set headers X-Model / X-Device.
+
+Security: single-token header auth (X-Auth-Token). The tunnel URL is
+public — do not disable the token check.
+
+LICENSE NOTE: AudioGen weights are CC-BY-NC 4.0; MMAudio weights carry
+non-commercial training-data constraints. Outputs are gated as REVIEW by
+OpenMontage's license_validator for monetized use.
+"""
+
+import io
+import os
+import secrets
+import tempfile
+
+AUDIOGEN_MODEL = os.environ.get("AUDIOGEN_MODEL", "facebook/audiogen-medium")
+ENABLE_MMAUDIO = os.environ.get("ENABLE_MMAUDIO", "0") == "1"
+MAX_SECONDS = 30.0
+
+
+def main() -> None:
+    # Heavy imports stay inside main() so importing this module is harmless.
+    import numpy as np
+    import scipy.io.wavfile
+    import torch
+    from flask import Flask, jsonify, request, Response
+    from pyngrok import ngrok
+
+    token = os.environ.get("SFX_TOKEN") or secrets.token_urlsafe(24)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    # ---- AudioGen (text -> SFX) ----
+    print(f"Loading AudioGen {AUDIOGEN_MODEL} on {device}...")
+    from audiocraft.models import AudioGen
+    audiogen = AudioGen.get_pretrained(AUDIOGEN_MODEL, device=device)
+    audiogen_sr = audiogen.sample_rate
+
+    # ---- MMAudio (video -> foley), optional ----
+    mmaudio = None
+    if ENABLE_MMAUDIO:
+        try:
+            print("Loading MMAudio (video->foley)...")
+            # MMAudio's own API; see https://github.com/hkchengrex/MMAudio
+            from mmaudio.eval_utils import (  # type: ignore
+                ModelConfig, generate, load_video, make_video,
+            )
+            mmaudio = {"generate": generate, "load_video": load_video}
+        except Exception as e:  # pragma: no cover - notebook-side
+            print(f"MMAudio unavailable ({e}); /foley disabled.")
+            mmaudio = None
+
+    def _authed() -> bool:
+        return request.headers.get("X-Auth-Token") == token
+
+    def _wav_response(wav: "np.ndarray", sr: int, model_name: str) -> "Response":
+        buf = io.BytesIO()
+        # Normalise float32 [-1,1] to int16 PCM.
+        if wav.dtype != np.int16:
+            wav = np.clip(wav, -1.0, 1.0)
+            wav = (wav * 32767.0).astype(np.int16)
+        scipy.io.wavfile.write(buf, sr, wav)
+        buf.seek(0)
+        return Response(
+            buf.read(),
+            mimetype="audio/wav",
+            headers={"X-Model": model_name, "X-Device": device},
+        )
+
+    app = Flask(__name__)
+
+    @app.get("/health")
+    def health():
+        return jsonify({
+            "status": "ok",
+            "audiogen": True,
+            "mmaudio": mmaudio is not None,
+            "device": device,
+        })
+
+    @app.post("/generate")
+    def generate_sfx():
+        if not _authed():
+            return jsonify({"error": "unauthorized"}), 401
+        body = request.get_json(force=True)
+        prompt = body["prompt"]
+        seconds = min(float(body.get("duration_seconds", 3.0)), MAX_SECONDS)
+        seed = body.get("seed")
+        if seed is not None:
+            torch.manual_seed(int(seed))
+        audiogen.set_generation_params(duration=seconds)
+        wav = audiogen.generate([prompt])  # (1, channels, samples)
+        arr = wav[0].detach().cpu().numpy().T  # -> (samples, channels)
+        return _wav_response(arr, audiogen_sr, AUDIOGEN_MODEL)
+
+    @app.post("/foley")
+    def foley():
+        if not _authed():
+            return jsonify({"error": "unauthorized"}), 401
+        if mmaudio is None:
+            return jsonify({"error": "MMAudio not enabled on this server"}), 503
+        if "video" not in request.files:
+            return jsonify({"error": "missing 'video' file"}), 400
+        prompt = request.form.get("prompt", "")
+        seed = request.form.get("seed")
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
+            request.files["video"].save(tmp.name)
+            video_path = tmp.name
+        try:
+            # MMAudio call shape varies by release; adapt to the installed API.
+            audio_np, sr = mmaudio["generate"](  # type: ignore
+                video_path, prompt=prompt,
+                seed=int(seed) if seed is not None else None,
+            )
+        finally:
+            os.unlink(video_path)
+        return _wav_response(np.asarray(audio_np), int(sr), "MMAudio")
+
+    print("=" * 60)
+    public_url = ngrok.connect(5000).public_url
+    print(f"COLAB_SFX_URL={public_url}")
+    print(f"COLAB_SFX_TOKEN={token}")
+    print("=" * 60)
+    app.run(host="0.0.0.0", port=5000)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/audio/colab_sfx.py
+++ b/tools/audio/colab_sfx.py
@@ -1,0 +1,315 @@
+"""Sound-effect / Foley generation offloaded to a free Google Colab GPU.
+
+A free, no-API-key alternative to `sfx_gen` (ElevenLabs). Two modes:
+
+  mode="text"  → AudioGen (facebook/audiogen-medium): text prompt to SFX,
+                 e.g. "a single mechanical clock tick", "cinematic whoosh",
+                 "keyboard typing". Best for discrete effects you place at a
+                 timestamp yourself (Remotion audio.sfx cues).
+
+  mode="video" → MMAudio (Sony, CVPR 2025): watches a rendered clip and
+                 generates Foley SYNCED to the motion it sees. Feed it a
+                 clock-hand clip and it produces ticks already aligned to the
+                 hand — the natural fit for "sound follows what's on screen".
+
+The heavy GPU compute runs on a free Colab T4 exposed over an HTTPS tunnel;
+this tool is a thin client. Start the server by pasting
+`tools/audio/colab/sfx_server.py` into a Colab GPU notebook — it prints the
+public URL to set as COLAB_SFX_URL.
+
+LICENSING (important): AudioGen weights are CC-BY-NC 4.0; MMAudio weights are
+trained on mixed datasets (AudioSet/VGGSound/Freesound) with non-commercial
+constraints. Both are marked commercial_safe=false and verdict REVIEW by
+license_validator — do NOT treat as safe for monetized videos without human
+sign-off. For a genuinely commercial-clean free path, use `freesound_music`
+with commercial_safe=true (CC0 clips).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+from tools.audio._ratelimit import call_with_backoff
+
+
+class ColabSFX(BaseTool):
+    name = "colab_sfx"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "sfx_generation"
+    provider = "colab-sfx"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.SEEDED
+    runtime = ToolRuntime.API  # remote free GPU via HTTPS tunnel
+
+    dependencies = []  # thin HTTP client; only needs `requests`
+    install_instructions = (
+        "1. Open a Google Colab notebook with a T4 GPU runtime.\n"
+        "2. Paste and run tools/audio/colab/sfx_server.py (see its header) —\n"
+        "   it loads AudioGen (text->SFX) and optionally MMAudio (video->foley).\n"
+        "3. Set COLAB_SFX_URL to the printed tunnel URL, and\n"
+        "   COLAB_SFX_TOKEN to the token the server prints.\n"
+        "Colab sessions are ephemeral (~90 min idle timeout) — the URL changes "
+        "per session.\n"
+        "Commercial-clean free alternative with no GPU: freesound_music "
+        "(commercial_safe=true, CC0 clips)."
+    )
+
+    agent_skills = ["sound-effects", "elevenlabs"]
+
+    capabilities = ["generate_sfx", "video_to_foley", "free_gpu_offload"]
+    supports = {
+        "seeded_generation": True,
+        "text_to_sfx": True,
+        "video_to_foley": True,
+        "min_seconds": 0.5,
+        "max_seconds": 30,
+        "commercial_safe": False,  # CC-BY-NC / mixed weights — see module docstring
+    }
+    best_for = [
+        "free SFX when no ElevenLabs key is configured (whoosh, impact, click, tick)",
+        "video->foley: sound synced to on-screen motion (MMAudio) — e.g. tick to a clock hand",
+        "offloading GPU compute from low-power local machines",
+    ]
+    not_good_for = [
+        "monetized videos without human license sign-off (non-commercial weights)",
+        "background music beds (use music_selector / colab_musicgen)",
+        "unattended batch runs (Colab tunnel is ephemeral)",
+    ]
+
+    fallback_tools = ["sfx_gen", "freesound_music"]
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+            "mode": {
+                "type": "string",
+                "enum": ["text", "video"],
+                "default": "text",
+                "description": (
+                    "'text' = AudioGen prompt->SFX. 'video' = MMAudio, generate "
+                    "Foley synced to the motion in video_path."
+                ),
+            },
+            "prompt": {
+                "type": "string",
+                "description": (
+                    "SFX description (text mode) or a caption hint (video mode), "
+                    "e.g. 'a single mechanical clock tick', 'cinematic whoosh'."
+                ),
+            },
+            "video_path": {
+                "type": "string",
+                "description": "Local path to the clip to score. Required when mode='video'.",
+            },
+            "duration_seconds": {
+                "type": "number",
+                "minimum": 0.5,
+                "maximum": 30,
+                "default": 3.0,
+                "description": "Target length (text mode). Video mode uses the clip length.",
+            },
+            "seed": {"type": "integer", "description": "Seed for reproducibility."},
+            "output_path": {"type": "string"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=50, network_required=True
+    )
+    retry_policy = RetryPolicy(
+        max_retries=2, backoff_seconds=5.0,
+        retryable_errors=["rate_limit", "timeout"],
+    )
+    idempotency_key_fields = ["mode", "prompt", "video_path", "duration_seconds", "seed"]
+    side_effects = ["writes audio file to output_path", "calls Colab tunnel endpoint"]
+    user_visible_verification = [
+        "Listen: does the effect match the prompt / land on the on-screen action?",
+        "License verdict is REVIEW — confirm monetization policy before shipping",
+    ]
+
+    def get_status(self) -> ToolStatus:
+        if not os.environ.get("COLAB_SFX_URL"):
+            return ToolStatus.UNAVAILABLE
+        return ToolStatus.AVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        return 0.0  # free Colab tier
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        # AudioGen ~a few seconds of audio in ~10-30s on a T4; MMAudio ~1.2s
+        # per 8s clip + upload overhead.
+        return 45.0
+
+    def dry_run(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        info = super().dry_run(inputs)
+        info["endpoint_healthy"] = self._health_check()
+        info["would_execute"] = info["endpoint_healthy"]
+        return info
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        endpoint = os.environ.get("COLAB_SFX_URL", "").rstrip("/")
+        if not endpoint:
+            return ToolResult(
+                success=False,
+                error="COLAB_SFX_URL not set. " + self.install_instructions,
+            )
+
+        mode = inputs.get("mode", "text")
+        prompt = inputs["prompt"]
+        seed = inputs.get("seed")
+        output_path = Path(inputs.get("output_path", "colab_sfx_output.wav"))
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        start = time.time()
+        try:
+            if mode == "video":
+                video_path = inputs.get("video_path")
+                if not video_path or not Path(video_path).exists():
+                    return ToolResult(
+                        success=False,
+                        error="mode='video' requires an existing video_path.",
+                    )
+                wav_bytes, server_meta = self._foley_from_video(
+                    endpoint, Path(video_path), prompt, seed
+                )
+            else:
+                wav_bytes, server_meta = self._generate_text(
+                    endpoint, prompt,
+                    float(inputs.get("duration_seconds", 3.0)), seed,
+                )
+            output_path.write_bytes(wav_bytes)
+        except Exception as e:
+            return ToolResult(
+                success=False,
+                error=f"Colab SFX generation failed: {e}",
+                duration_seconds=round(time.time() - start, 2),
+            )
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": self.provider,
+                "mode": mode,
+                "prompt": prompt,
+                "output": str(output_path),
+                "format": "wav",
+                "server": server_meta,
+                # Consumed by license_validator.validate_assets:
+                "license_url": None,
+                "commercial_safe": False,
+                "license_note": (
+                    "AudioGen (CC-BY-NC 4.0) / MMAudio (mixed non-commercial "
+                    "training data) — verdict REVIEW for monetized use. Run "
+                    "license_validator before compositing; use freesound_music "
+                    "(CC0) for a commercial-clean path."
+                ),
+            },
+            artifacts=[str(output_path)],
+            cost_usd=0.0,
+            duration_seconds=round(time.time() - start, 2),
+            seed=seed,
+            model=server_meta.get("model"),
+        )
+
+    # ---- remote calls ----
+
+    def _health_check(self) -> bool:
+        import requests
+
+        endpoint = os.environ.get("COLAB_SFX_URL", "").rstrip("/")
+        if not endpoint:
+            return False
+        try:
+            response = requests.get(
+                f"{endpoint}/health", headers=self._headers(), timeout=15
+            )
+            return response.ok
+        except requests.RequestException:
+            return False
+
+    def _generate_text(
+        self, endpoint: str, prompt: str, seconds: float, seed: int | None
+    ) -> tuple[bytes, dict]:
+        import requests
+
+        payload: dict[str, Any] = {"prompt": prompt, "duration_seconds": seconds}
+        if seed is not None:
+            payload["seed"] = seed
+
+        response = call_with_backoff(
+            lambda: requests.post(
+                f"{endpoint}/generate",
+                json=payload,
+                headers=self._headers(),
+                timeout=600,  # cold model load + generation on a T4
+            ),
+            provider=self.provider,
+            max_retries=self.retry_policy.max_retries,
+            base_delay=self.retry_policy.backoff_seconds,
+        )
+        return self._extract_audio(response, default_model="facebook/audiogen-medium")
+
+    def _foley_from_video(
+        self, endpoint: str, video_path: Path, prompt: str, seed: int | None
+    ) -> tuple[bytes, dict]:
+        import requests
+
+        data: dict[str, Any] = {"prompt": prompt}
+        if seed is not None:
+            data["seed"] = str(seed)
+
+        with open(video_path, "rb") as fh:
+            files = {"video": (video_path.name, fh, "video/mp4")}
+            response = call_with_backoff(
+                lambda: requests.post(
+                    f"{endpoint}/foley",
+                    data=data,
+                    files=files,
+                    headers=self._headers(),
+                    timeout=900,  # upload + MMAudio inference
+                ),
+                provider=self.provider,
+                max_retries=self.retry_policy.max_retries,
+                base_delay=self.retry_policy.backoff_seconds,
+            )
+        return self._extract_audio(response, default_model="MMAudio")
+
+    @staticmethod
+    def _extract_audio(response: Any, default_model: str) -> tuple[bytes, dict]:
+        content_type = response.headers.get("Content-Type", "")
+        if "audio" not in content_type:
+            raise RuntimeError(
+                f"Server returned {content_type!r} instead of audio: "
+                f"{response.text[:300]}"
+            )
+        meta = {
+            "model": response.headers.get("X-Model", default_model),
+            "device": response.headers.get("X-Device", "unknown"),
+        }
+        return response.content, meta
+
+    @staticmethod
+    def _headers() -> dict[str, str]:
+        headers = {"User-Agent": "OpenMontage/0.1 (colab_sfx)"}
+        token = os.environ.get("COLAB_SFX_TOKEN")
+        if token:
+            headers["X-Auth-Token"] = token
+        return headers


### PR DESCRIPTION
… tool

Adds frame-accurate audio-visual sync to the Explainer composition and a free-GPU SFX/Foley generator, closing the "no sound effects" gap.

- Explainer: new audio.sfx array ({src, atSeconds, volume?, durationSeconds?}), each cue fired via a Sequence at atSeconds*fps so it's frame-locked to the picture (whooshes, clicks, impacts, ticks).
- Clock component + `clock` scene type: second hand steps once per secondsPerStep with an optional tick sound placed on the same frames, so sound and motion cannot drift. Verified: ticks land at 0.05/1.05/2.05/3.05s in a rendered 4s test clip.
- colab_sfx tool + Colab server: free alternative to sfx_gen (ElevenLabs), text-to-SFX (AudioGen) and video-to-foley (MMAudio). sfx_generation now shows 2 providers. Weights are non-commercial (REVIEW gate) — documented; use freesound_music CC0 for a commercial-clean path.
- SCENE_TYPES.md: documents the clock type and audio.narration/music/sfx props.

No new TypeScript errors (15 pre-existing, unchanged).

<!--
Thanks for contributing to OpenMontage! Please fill in the sections below.
Keep PRs focused — one logical change per PR is easier to review and merge.
-->

## Summary

<!-- What does this PR do, and why? -->

## Related issue

<!-- Link the issue this closes, e.g. "Closes #123". Use "Refs #123" if it only relates. -->
Closes #

## Changes

<!-- Bullet the notable changes. -->
-

## Testing

<!-- How did you verify this? Commands run, manual steps, platforms checked. -->
-

## Checklist

- [ ] The change is focused on a single logical concern.
- [ ] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [ ] I updated docs/README if behavior or usage changed.
- [ ] No unrelated files (build artifacts, local config) are included in the diff.
