### PR TITLE
fix(corpus): normalize diversify() position term so similarity can compete

### DIFF
--- a/lib/corpus.py
+++ b/lib/corpus.py
@@ -407,14 +407,21 @@ class Corpus:
             best_i = -1
             best_score = -1e9
             picked_mat = self.clip_embeddings[np.array(picked)]
-            for i in remaining:
+            # Normalize the position term to [0, 1] so it lives on the
+            # same scale as cosine similarity. An absolute index grows
+            # with the pool, drowning the similarity term: at the 0.5
+            # default a candidate one slot later needed a similarity gap
+            # > 1.0 to be preferred — impossible for non-negative
+            # cosines — so diversify() degenerated to input order.
+            denom = max(1, len(remaining) - 1)
+            for pos, i in enumerate(remaining):
                 sim_picked = float(np.max(self.clip_embeddings[i] @ picked_mat.T))
                 # We want LOW similarity, so we negate.
                 score = -sim_picked
                 # Diversity weights how hard we penalize similarity. At
                 # diversity=1 we always pick the most different; at
                 # diversity=0 we just take them in input order.
-                score = diversity * score + (1.0 - diversity) * (-remaining.index(i))
+                score = diversity * score + (1.0 - diversity) * (-pos / denom)
                 if score > best_score:
                     best_score = score
                     best_i = i

--- a/tests/lib/test_corpus_diversify_scale.py
+++ b/tests/lib/test_corpus_diversify_scale.py
@@ -1,0 +1,126 @@
+"""Regression tests: Corpus.diversify() must actually diversify at its default.
+
+The greedy score mixed two incommensurate scales:
+
+    score = diversity * (-sim_picked) + (1 - diversity) * (-remaining.index(i))
+
+`sim_picked` is a cosine in [-1, 1]; `remaining.index(i)` is an absolute
+list position, unbounded. At the default diversity=0.5 a candidate one
+slot later needed a similarity gap > 1.0 to be preferred — impossible for
+non-negative cosines — so diversify() returned the input order verbatim,
+even when the list held exact duplicates. Its one documented job ("make
+sure no two adjacent slots are visually redundant") never happened, and
+the effective meaning of `diversity` changed with pool size.
+
+The fix normalizes the position term to [0, 1] so both terms share a
+scale. diversity=0 still returns input order; diversity=1 still picks the
+most mutually dissimilar.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from lib.corpus import EMBED_DIM, ClipRecord, Corpus
+
+
+def _corpus(vectors: list[list[float]]) -> Corpus:
+    """Build an in-memory corpus from small L2-normalised vectors."""
+    corp = Corpus(Path("/nonexistent"))
+    emb = np.zeros((len(vectors), EMBED_DIM), dtype=np.float32)
+    for row, vec in enumerate(vectors):
+        emb[row, : len(vec)] = vec
+        emb[row] /= np.linalg.norm(emb[row])
+    corp.clip_embeddings = emb
+    corp.records = [
+        ClipRecord(
+            clip_id=f"c{row}",
+            source="test",
+            source_id=str(row),
+            source_url="",
+            local_path="",
+        )
+        for row in range(len(vectors))
+    ]
+    corp._id_to_row = {r.clip_id: i for i, r in enumerate(corp.records)}
+    return corp
+
+
+def test_default_diversity_separates_exact_duplicates():
+    # c1 is an exact duplicate of c0; c2/c3 are orthogonal to both.
+    corp = _corpus([[1, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+    kept = corp.diversify(["c0", "c1", "c2", "c3"], n=3)
+
+    # The duplicate must not sit adjacent to its twin at the default.
+    assert kept[0] == "c0"
+    assert kept[1] != "c1"
+
+
+def test_default_diversity_is_not_a_noop():
+    # Three exact duplicates (c0, c2, c5) interleaved with distinct clips.
+    # The old scoring returned the input order verbatim here.
+    corp = _corpus(
+        [
+            [1, 0, 0],
+            [0.8, 0.6, 0],
+            [1, 0, 0],
+            [0.6, 0.8, 0],
+            [0, 1, 0],
+            [1, 0, 0],
+        ]
+    )
+    ids = [f"c{i}" for i in range(6)]
+
+    kept = corp.diversify(ids, n=6)
+
+    assert kept != ids  # reorders when the input holds duplicates
+    for a, b in zip(kept, kept[1:]):  # and no two adjacent slots are twins
+        va = corp.clip_embeddings[corp._id_to_row[a]]
+        vb = corp.clip_embeddings[corp._id_to_row[b]]
+        assert float(va @ vb) < 0.999
+
+
+def test_diversity_semantics_do_not_collapse_with_pool_size():
+    # Duplicate of c0 right at position 1, moderately-related fillers,
+    # one orthogonal clip at the end. With the unnormalised position
+    # term the duplicate always won slot 2 at diversity=0.5 because the
+    # positional penalty scaled with the pool.
+    half_sqrt3 = np.sqrt(3) / 2
+    vectors = [[1, 0, 0], [1, 0, 0]] + [[0.5, half_sqrt3, 0]] * 8 + [[0, 0, 1]]
+    corp = _corpus(vectors)
+    ids = [f"c{i}" for i in range(len(vectors))]
+
+    kept = corp.diversify(ids, n=3, diversity=0.5)
+
+    assert kept[0] == "c0"
+    assert "c1" not in kept[:2]  # the exact duplicate no longer wins slot 2
+
+
+def test_diversity_zero_keeps_input_order():
+    corp = _corpus([[1, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    ids = ["c0", "c1", "c2", "c3"]
+
+    assert corp.diversify(ids, n=4, diversity=0.0) == ids
+
+
+def test_diversity_one_picks_most_dissimilar():
+    # c1 duplicates c0; c2 and c3 are mutually orthogonal.
+    corp = _corpus([[1, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+    kept = corp.diversify(["c0", "c1", "c2", "c3"], n=3, diversity=1.0)
+
+    assert kept == ["c0", "c2", "c3"]
+
+
+def test_empty_and_unknown_ids():
+    corp = _corpus([[1, 0, 0]])
+
+    assert corp.diversify([], n=3) == []
+    assert corp.diversify(["nope"], n=3) == []
+    assert corp.diversify(["c0", "nope"], n=3) == ["c0"]


### PR DESCRIPTION
## What

`Corpus.diversify()` promises to "make sure no two adjacent slots are visually redundant", but at its default `diversity=0.5` (also the `clip_search` tool's default for the `diversify` op) it was a no-op: it returned the candidate list in input order even when the list held exact duplicates — placing identical clips in adjacent edit slots.

Closes #392

## Root cause

The greedy score mixed two incommensurate scales:

```python
score = diversity * (-sim_picked) + (1.0 - diversity) * (-remaining.index(i))
```

`sim_picked` is a cosine in `[-1, 1]`; `remaining.index(i)` is an absolute position, unbounded. At `diversity=0.5` a candidate `j` slots later needed a similarity advantage `> j` to be preferred. Real-footage CLIP-style embeddings produce non-negative cosines, so the maximum achievable gap is 1.0 — never above `j >= 1`. Position always won.

Measured on a 4-candidate list where c1 is an exact duplicate of c0 and c2/c3 are orthogonal:

| diversity | before | after |
|---|---|---|
| 0.0 | `c0, c1, c2` (input order — correct) | `c0, c1, c2` (unchanged) |
| **0.5 (default)** | **`c0, c1, c2` — duplicate adjacent** | `c0, c2, c1` — duplicate separated |
| 1.0 | `c0, c2, c3` (correct) | `c0, c2, c3` (unchanged) |

The knob only began to act past `diversity≈0.66` at 4 candidates — and past `0.95` at 11 candidates, because the positional penalty scales with pool size, silently redefining what `diversity` means per call.

## How

Normalize the position term to `[0, 1]` (`pos / max(1, len(remaining) - 1)`) so both terms share a scale. Both documented endpoints hold exactly: `diversity=0` → input order, `diversity=1` → most mutually dissimilar. `find_similar_set()` in the same file already does this correctly — its MMR combines two same-range cosines; `diversify()` was the only scorer mixing bounded with unbounded.

Side effect of using `enumerate` for the position: drops the O(n²) `remaining.index(i)` lookup inside the scan loop.

## Tests

New `tests/lib/test_corpus_diversify_scale.py` (6 tests) building a small in-memory corpus with L2-normalised vectors — no I/O, no fixtures on disk.

Verified the tests catch the bug — against unfixed code **3 of 6 fail**:

```
FAILED test_default_diversity_separates_exact_duplicates
FAILED test_default_diversity_is_not_a_noop
FAILED test_diversity_semantics_do_not_collapse_with_pool_size
3 failed, 3 passed
```

The 3 that pass both ways are deliberate pins: `diversity=0` input order, `diversity=1` most-dissimilar, and empty/unknown-id edge cases — proving the fix changes nothing at the documented endpoints.

With the fix: `6 passed`.

## Full suite

`python -m pytest tests/ --ignore=tests/backlot` (backlot needs `fastapi`, not installed locally): `12 failed, 804 passed, 10 skipped` — the 12 are the pre-existing `TestVeoVideo` contract failures, identical on pristine main. Net: +6 passing, no new failures.