### PR TITLE
VideoScene: honor transition_in/transition_out and per-cut backgroundColor

### DIFF
--- a/remotion-composer/src/Explainer.tsx
+++ b/remotion-composer/src/Explainer.tsx
@@ -425,22 +425,27 @@ const ImageScene: React.FC<{ src: string; animation?: string }> = ({
 // Enhanced Video Scene
 // ---------------------------------------------------------------------------
 
-const VideoScene: React.FC<{ src: string; startFrom?: number }> = ({
-  src,
-  startFrom = 0,
-}) => {
+const VideoScene: React.FC<{
+  src: string;
+  startFrom?: number;
+  fadeInEnabled?: boolean;
+  fadeOutEnabled?: boolean;
+  bg?: string;
+}> = ({ src, startFrom = 0, fadeInEnabled = true, fadeOutEnabled = true, bg = "#0F172A" }) => {
   const frame = useCurrentFrame();
   const { fps, durationInFrames } = useVideoConfig();
 
-  const fadeIn = spring({ frame, fps, config: { damping: 20 } });
+  const fadeIn = fadeInEnabled ? spring({ frame, fps, config: { damping: 20 } }) : 1;
   const fadeOutStart = durationInFrames - 8;
-  const fadeOut = interpolate(frame, [fadeOutStart, durationInFrames], [1, 0.3], {
-    extrapolateLeft: "clamp",
-    extrapolateRight: "clamp",
-  });
+  const fadeOut = fadeOutEnabled
+    ? interpolate(frame, [fadeOutStart, durationInFrames], [1, 0.3], {
+        extrapolateLeft: "clamp",
+        extrapolateRight: "clamp",
+      })
+    : 1;
 
   return (
-    <AbsoluteFill style={{ background: "#0F172A" }}>
+    <AbsoluteFill style={{ background: bg }}>
       <OffthreadVideo
         src={resolveAsset(src)}
         startFrom={Math.round(startFrom * fps)}
@@ -721,7 +726,15 @@ const SceneRenderer: React.FC<{ cut: Cut; theme: ThemeConfig }> = ({ cut, theme 
   }
 
   if (cut.source && isVideo(cut.source)) {
-    return maybeWrapWithBg(<VideoScene src={cut.source} startFrom={cut.source_in_seconds ?? 0} />);
+    return maybeWrapWithBg(
+      <VideoScene
+        src={cut.source}
+        startFrom={cut.source_in_seconds ?? 0}
+        fadeInEnabled={cut.transition_in !== "none"}
+        fadeOutEnabled={cut.transition_out !== "none"}
+        bg={cut.backgroundColor || "#0F172A"}
+      />
+    );
   }
 
   // Final fallback — try as image if source exists, otherwise show text_card


### PR DESCRIPTION
## Problem

The `Cut` type declares `transition_in` / `transition_out`, but `VideoScene` never consumes them. Every video cut runs a hardcoded spring fade-in plus an 8-frame fade-out over the hardcoded `#0F172A` backing color. When an edit strings consecutive video cuts together (e.g. an ad-style hard-cut sequence), the navy background flashes at every cut boundary.

## Change

- `transition_in: "none"` on a cut disables the entrance fade
- `transition_out: "none"` disables the exit fade
- `cut.backgroundColor` overrides the backing color behind the video
- Defaults are unchanged, so existing projects render identically

## Verification

On a 6-cut, 30 s edit (five 5 s generated clips + end card), boundary frames were sampled before/after the patch. Before: frames at every boundary averaged RGB(12,19,36) — the backing color showing through the fades. After (with `transition_in/out: "none"`): all boundary frames contain full source content; with defaults, output is byte-comparable to the previous behavior.

Found while building a hard-cut commercial on top of this project — thanks for the excellent architecture.