### PR TITLE
Enforce daily budget hard cap and bounded provider costs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,11 +7,26 @@ llm:
   max_tokens: 4096
 
 budget:
-  mode: warn                     # observe | warn | cap
-  total_usd: 10.00
-  reserve_pct: 0.10              # holdback for retries / cleanup
-  single_action_approval_usd: 0.50
-  require_approval_for_new_paid_tool: true
+  # HARD CAP. $10.00 is the aggregate provider-spend ceiling per CALENDAR DAY,
+  # summed across all projects and all processes (not per-project, not per-run).
+  # A request landing exactly at the cap is ALLOWED; a request that would push
+  # the day's total OVER the cap is refused BEFORE any provider dispatch.
+  mode: cap                          # observe | warn | cap  (overrides the WARN model default)
+  total_usd: 10.00                   # aggregate paid-provider spend cap, per day
+  # Daily rollover is automatic at midnight in the timezone below. Historical
+  # ledger entries are preserved (never cleared to free budget), and an
+  # unresolved reservation stays attached to its immutable ORIGINAL budget_date
+  # even if it settles on a later day.
+  period: daily                      # only "daily" is implemented; other values fail closed
+  timezone: system_local             # "system_local" or an IANA name; unresolvable -> fail closed
+  # The three controls below are INDEPENDENT safeguards, evaluated in every mode:
+  reserve_pct: 0.10                  # warn-mode planning holdback; cap enforces the true
+                                     #   daily total, so an exact-cap request is still allowed
+  single_action_approval_usd: 0.50   # refuse any single call estimated above this
+  require_approval_for_new_paid_tool: true   # refuse the first paid use of each tool until approved
+  # A paid tool that has not declared a defensible max_cost_usd() bound remains
+  # FAIL-CLOSED (its calls are refused). Free/local operations with cost 0 are
+  # unaffected by any of the above.
 
 checkpoint:
   policy: guided                 # guided | manual_all | auto_noncreative

--- a/lib/budget_gate.py
+++ b/lib/budget_gate.py
@@ -28,9 +28,23 @@ control" is worse than none, because it looks like protection.
 
 Scope
 -----
-Only tools whose `runtime` is API or HYBRID *and* whose `estimate_cost()`
-returns > 0 are gated. LOCAL/LOCAL_GPU tools and free operations never touch
-this module, so zero-key and local pipelines behave exactly as before.
+Whether the gate applies is decided by CLASSIFICATION (`BaseTool.paid`), not
+by the size of the estimate:
+
+- LOCAL/LOCAL_GPU tools are free -- they never touch this module -- unless a
+  tool explicitly marks itself `paid = True`.
+- API/HYBRID tools are treated as PAID unless they explicitly declare
+  `paid = False` (the genuinely free stock-media-search tools).
+- A paid tool is gated even when its `estimate_cost()` returns zero: a zero
+  estimate means "unknown", never "free".
+- Every paid request must provide a defensible `max_cost_usd()` bound, or the
+  call is refused (fail closed).
+- An explicit ZERO bound is honoured only for requests that are guaranteed
+  not to dispatch to a paid provider (a selector's rank mode, requests
+  execute() refuses locally).
+
+Zero-key and local pipelines therefore behave exactly as before, while a
+broken or information-starved estimate can no longer skip the gate.
 """
 
 from __future__ import annotations

--- a/lib/budget_gate.py
+++ b/lib/budget_gate.py
@@ -1,0 +1,149 @@
+"""Budget enforcement gate: the wiring between config.yaml and paid calls.
+
+This module is what makes the hard cap real. Prior to it, `CostTracker` was a
+fully-tested library that nothing ever called, and the `budget:` block in
+config.yaml was inert -- a paid provider key would have spent without limit.
+
+Design
+------
+Enforcement rides on BaseTool's execute() wrapper (see tools/base_tool.py), so
+every tool -- current and future -- is covered without per-tool changes. A
+safety control that must be remembered on each new provider is a checklist,
+not a control.
+
+The ledger is a single shared one at `pipeline/cost_log.json` (path from config
+`paths.pipeline_dir`; `pipeline/` is gitignored). `budget.total_usd` is the
+maximum provider spend PER CALENDAR DAY, across all projects and all
+processes -- not per project, and not per process. Day boundaries come from
+`budget.timezone`; history is preserved, never cleared to free budget.
+
+What is reserved is the tool's max_cost_usd() upper bound, not its
+estimate_cost() approximation -- see tools/base_tool.py:_enforce_budget.
+
+Fail closed
+-----------
+Every failure path here refuses the paid call: unreadable ledger, unparseable
+config, unwritable log. A budget control whose failure mode is "no budget
+control" is worse than none, because it looks like protection.
+
+Scope
+-----
+Only tools whose `runtime` is API or HYBRID *and* whose `estimate_cost()`
+returns > 0 are gated. LOCAL/LOCAL_GPU tools and free operations never touch
+this module, so zero-key and local pipelines behave exactly as before.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from pathlib import Path
+from typing import NamedTuple, Optional
+
+from lib.config_model import OpenMontageConfig
+from tools.cost_tracker import CostTracker
+
+
+class BudgetHandle(NamedTuple):
+    """An accepted reservation, to be settled exactly once."""
+    tracker: CostTracker
+    entry_id: str
+    estimated_usd: float
+
+
+# Guards the cached tracker. The tracker itself has its own lock covering the
+# check-and-reserve critical section.
+_LOCK = threading.Lock()
+_TRACKER: Optional[CostTracker] = None
+_TRACKER_KEY: Optional[tuple] = None
+
+
+def _config_path() -> Optional[Path]:
+    override = os.environ.get("OPENMONTAGE_CONFIG")
+    return Path(override) if override else None
+
+
+def cost_log_path(cfg: OpenMontageConfig) -> Path:
+    """Resolve the cumulative ledger path. OPENMONTAGE_COST_LOG overrides."""
+    override = os.environ.get("OPENMONTAGE_COST_LOG")
+    if override:
+        return Path(override)
+    return cfg.resolve_path("pipeline_dir") / "cost_log.json"
+
+
+def get_tracker() -> CostTracker:
+    """Return the process-wide tracker, rebuilt if config changed.
+
+    Shared by every caller so that concurrent reservations contend on one
+    ledger and one lock.
+    """
+    global _TRACKER, _TRACKER_KEY
+    with _LOCK:
+        cfg = OpenMontageConfig.load(_config_path())
+        b = cfg.budget
+        path = cost_log_path(cfg)
+        key = (
+            str(path), b.mode, b.total_usd, b.reserve_pct,
+            b.single_action_approval_usd, b.require_approval_for_new_paid_tool,
+            b.period, b.timezone,
+        )
+        if _TRACKER is None or _TRACKER_KEY != key:
+            # Config is the sole authority for these -- CostTracker._load()
+            # deliberately does not restore mode or total from the log.
+            _TRACKER = CostTracker(
+                budget_total_usd=b.total_usd,
+                reserve_pct=b.reserve_pct,
+                single_action_approval_usd=b.single_action_approval_usd,
+                require_approval_for_new_paid_tool=b.require_approval_for_new_paid_tool,
+                mode=b.mode,
+                cost_log_path=path,
+                period=b.period,
+                tz_name=b.timezone,
+            )
+            _TRACKER_KEY = key
+        return _TRACKER
+
+
+def reset() -> None:
+    """Drop the cached tracker. For tests and after a deliberate config change."""
+    global _TRACKER, _TRACKER_KEY
+    with _LOCK:
+        _TRACKER = None
+        _TRACKER_KEY = None
+
+
+def reserve(tool: str, operation: str, bound_usd: float) -> BudgetHandle:
+    """Account for a paid call BEFORE it runs, against its day's bucket.
+
+    `bound_usd` must be the tool's max_cost_usd() upper bound, not its
+    estimate: the cap is only guaranteed if the worst case is what we hold.
+
+    Raises BudgetExceededError (day's cap reached, or the day is marked over
+    budget), ApprovalRequiredError (a configured safeguard fired),
+    CostLogCorruptError (spend unknown), or LedgerLockError (ledger busy).
+    In every case the caller must not proceed to the provider.
+    """
+    tracker = get_tracker()
+    entry_id = tracker.estimate(tool, operation, bound_usd)
+    try:
+        tracker.reserve(entry_id)
+    except BaseException:
+        # A rejected call never reached the provider, so releasing is correct
+        # here -- and it stops a refusal from leaving a dangling ESTIMATED row.
+        tracker.refund(entry_id)
+        raise
+    return BudgetHandle(tracker, entry_id, round(max(0.0, bound_usd), 4))
+
+
+def settle(handle: BudgetHandle, actual_usd: Optional[float], success: bool) -> None:
+    """Resolve a reservation after the call finished, failed, or was cancelled.
+
+    Lands in the entry's original budget_date, whatever today is now.
+
+    `actual_usd=None` means the real cost is unknown (the tool raised, or
+    reported no cost). We charge the reserved bound rather than releasing: a
+    provider that errored may still have billed, and under-counting spend is
+    the failure that breaks the cap.
+    """
+    actual = handle.estimated_usd if actual_usd is None else actual_usd
+    handle.tracker.reconcile(handle.entry_id, actual, success=success)

--- a/lib/budget_gate.py
+++ b/lib/budget_gate.py
@@ -41,7 +41,7 @@ from pathlib import Path
 from typing import NamedTuple, Optional
 
 from lib.config_model import OpenMontageConfig
-from tools.cost_tracker import CostTracker
+from tools.cost_tracker import CostTracker, quantize_usd
 
 
 class BudgetHandle(NamedTuple):
@@ -132,7 +132,9 @@ def reserve(tool: str, operation: str, bound_usd: float) -> BudgetHandle:
         # here -- and it stops a refusal from leaving a dangling ESTIMATED row.
         tracker.refund(entry_id)
         raise
-    return BudgetHandle(tracker, entry_id, round(max(0.0, bound_usd), 4))
+    # Ceiling-quantized so a positive bound settled as "actual unknown" can
+    # never charge zero -- it matches exactly what the ledger reserved.
+    return BudgetHandle(tracker, entry_id, quantize_usd(bound_usd))
 
 
 def settle(handle: BudgetHandle, actual_usd: Optional[float], success: bool) -> None:

--- a/lib/config_model.py
+++ b/lib/config_model.py
@@ -33,10 +33,30 @@ class LLMConfig(BaseModel):
 
 
 class BudgetConfig(BaseModel):
+    """Budget governance settings. Enforced by lib/budget_gate.py.
+
+    `mode` governs the aggregate daily total ONLY. The two approval
+    safeguards below are independent of it and are evaluated in every mode.
+    """
+
+    # observe = record only | warn = flag and proceed | cap = hard stop
     mode: BudgetMode = BudgetMode.WARN
+    # Maximum spend per `period`, in the `timezone` below.
     total_usd: float = 10.0
+    # Only "daily" is implemented; any other value fails closed rather than
+    # silently applying daily semantics.
+    period: str = "daily"
+    # "system_local" or an IANA name (e.g. "America/New_York"). Defines the
+    # midnight boundary between daily buckets; unresolvable values fail closed.
+    timezone: str = "system_local"
+    # warn-mode planning holdback. cap enforces the true daily total instead,
+    # so an exact-cap request is allowed.
     reserve_pct: float = 0.10
-    single_action_approval_usd: float = 0.50
+    # Independent safeguard: refuse any single call estimated above this.
+    # None (or <= 0) disables it. Not coupled to `mode`.
+    single_action_approval_usd: Optional[float] = 0.50
+    # Independent safeguard: refuse the first paid use of each tool.
+    # Not coupled to `mode`.
     require_approval_for_new_paid_tool: bool = True
 
 

--- a/lib/ledger_lock.py
+++ b/lib/ledger_lock.py
@@ -1,0 +1,112 @@
+"""Cross-process advisory file lock for the cost ledger.
+
+Why this exists
+---------------
+OpenMontage drives tools through separate `python -c "..."` invocations (see
+AGENT_GUIDE.md). Separate processes share no threading.Lock, so an in-process
+lock gives no protection at all: two concurrent tool calls would each read the
+ledger, each see the same remaining daily budget, and each proceed. This is an
+OS-level lock so the read-modify-write of cost_log.json is serialized across
+processes.
+
+Deliberately minimal: stdlib only, one context manager, no lock server, no
+daemon, no backoff strategy, no abstraction layer. Windows uses msvcrt byte
+locking; POSIX uses fcntl.flock. Both are released by the OS when the owning
+process exits, so a crash cannot permanently wedge the ledger.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+try:  # Windows
+    import msvcrt
+except ImportError:  # POSIX
+    msvcrt = None  # type: ignore[assignment]
+
+try:  # POSIX
+    import fcntl
+except ImportError:  # Windows
+    fcntl = None  # type: ignore[assignment]
+
+
+DEFAULT_TIMEOUT_SECONDS = 5.0
+_POLL_SECONDS = 0.05
+
+
+class LedgerLockError(Exception):
+    """Raised when the ledger lock cannot be acquired within the timeout.
+
+    Callers must treat this as fail-closed: without the lock the remaining
+    budget cannot be read consistently, so no paid call may proceed.
+    """
+    pass
+
+
+def _try_lock(fd: int) -> None:
+    """One non-blocking attempt. Raises OSError if already held."""
+    if msvcrt is not None:
+        # Byte-range lock at offset 0. Must seek there first: msvcrt.locking
+        # locks relative to the current file position.
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+    elif fcntl is not None:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    else:  # pragma: no cover - no stdlib locking primitive available
+        raise LedgerLockError(
+            "Neither msvcrt nor fcntl is available; the cost ledger cannot be "
+            "locked safely. Refusing to proceed (fail closed)."
+        )
+
+
+def _unlock(fd: int) -> None:
+    if msvcrt is not None:
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+    elif fcntl is not None:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+@contextmanager
+def ledger_lock(
+    target: Path,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> Iterator[None]:
+    """Hold an exclusive cross-process lock for `target`'s read-modify-write.
+
+    The lock is taken on a sibling `<target>.lock` file rather than on the
+    ledger itself, so the atomic os.replace() of the ledger cannot disturb it.
+
+    Raises LedgerLockError on timeout. Bounded wait, not indefinite: a caller
+    blocked forever on a budget check is its own kind of failure.
+    """
+    lock_path = target.with_suffix(target.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT)
+    try:
+        deadline = time.monotonic() + timeout
+        while True:
+            try:
+                _try_lock(fd)
+                break
+            except OSError:
+                if time.monotonic() >= deadline:
+                    raise LedgerLockError(
+                        f"Could not acquire the cost ledger lock at {lock_path} "
+                        f"within {timeout:.1f}s. Another OpenMontage process is "
+                        f"holding it. Refusing the paid call (fail closed): "
+                        f"remaining budget cannot be read consistently."
+                    )
+                time.sleep(_POLL_SECONDS)
+        try:
+            yield
+        finally:
+            _unlock(fd)
+    finally:
+        # Closing the fd also drops the OS lock; the OS does this for us if the
+        # process dies here, which is what makes a crash non-wedging.
+        os.close(fd)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,71 @@
+"""Shared, opt-in test fixtures.
+
+Nothing in this file is autouse. Every fixture here applies only to tests that
+request it by name, so placing it at the ``tests/`` root adds no repo-wide
+behavior -- a test that does not name a fixture is completely unaffected.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def budget_gate_isolated(tmp_path, monkeypatch):
+    """Isolate the budget gate onto a private config + ledger for one test.
+
+    Purpose is DETERMINISM, not neutralization. Every control of the gate stays
+    fully in force; only the *environment the gate reads* is redirected:
+
+      - ``OPENMONTAGE_CONFIG`` -> a private ``config.yaml`` under ``tmp_path``,
+        so the repo's real ``config.yaml`` (and any future edit to it) cannot
+        make these tests flap.
+      - ``OPENMONTAGE_COST_LOG`` -> a private ledger under ``tmp_path``, so tests
+        never touch ``pipeline/cost_log.json`` and never contend with each other.
+
+    What remains ENFORCED, exactly as in production:
+
+      - the fail-closed ``None``-bound refusal -- a paid production tool that has
+        not yet declared ``max_cost_usd()`` still raises ``BudgetGateError``.
+        This fixture therefore CANNOT hide a missing or broken bound; a test
+        that opts in will keep failing until the tool declares a real bound.
+      - the daily aggregate cap (``mode: cap``).
+      - both approval safeguards: ``single_action_approval_usd`` (a $5.00 test
+        ceiling -- still refuses anything above it) and
+        ``require_approval_for_new_paid_tool`` (still refuses the first paid use
+        of any tool that was not explicitly approved).
+
+    A test that legitimately expects a paid provider call to proceed approves
+    that specific tool through the gate's OWN api -- it does not disable the
+    safeguard::
+
+        def test_veo_execute(budget_gate_isolated):
+            budget_gate_isolated.approve_tool("veo_video")
+            ...
+
+    Yields the process-wide :class:`CostTracker` the gate will use, so the test
+    can call ``approve_tool`` on the very instance ``execute()`` later reserves
+    against.
+    """
+    import lib.budget_gate as gate
+
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "budget:\n"
+        "  mode: cap\n"
+        "  total_usd: 100.00\n"
+        "  period: daily\n"
+        "  timezone: system_local\n"
+        "  reserve_pct: 0.0\n"
+        "  single_action_approval_usd: 5.00\n"
+        "  require_approval_for_new_paid_tool: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENMONTAGE_CONFIG", str(cfg))
+    monkeypatch.setenv("OPENMONTAGE_COST_LOG", str(tmp_path / "cost_log.json"))
+
+    gate.reset()
+    try:
+        yield gate.get_tracker()
+    finally:
+        gate.reset()

--- a/tests/contracts/test_dashscope_tools.py
+++ b/tests/contracts/test_dashscope_tools.py
@@ -337,9 +337,10 @@ class TestDashscopeImageMultiOutput:
         paths = DashscopeImage._resolve_output_paths("foo", 2)
         assert paths == [Path("foo_1"), Path("foo_2")]
 
-    def test_execute_downloads_all_images(self, monkeypatch, tmp_path):
+    def test_execute_downloads_all_images(self, monkeypatch, tmp_path, budget_gate_isolated):
         """The bug: n=3 returned images_generated=3 but downloaded 1 file.
         Mock the DashScope response with 3 URLs and verify all 3 are saved."""
+        budget_gate_isolated.approve_tool("dashscope_image")
         monkeypatch.setenv("DASHSCOPE_API_KEY", "fake-key")
 
         class FakeResp:
@@ -386,8 +387,9 @@ class TestDashscopeImageMultiOutput:
         assert (tmp_path / "shot_2.png").exists()
         assert (tmp_path / "shot_3.png").exists()
 
-    def test_execute_single_image_uses_base_path(self, monkeypatch, tmp_path):
+    def test_execute_single_image_uses_base_path(self, monkeypatch, tmp_path, budget_gate_isolated):
         """n=1 must keep the legacy single-path behavior (no _1 suffix)."""
+        budget_gate_isolated.approve_tool("dashscope_image")
         monkeypatch.setenv("DASHSCOPE_API_KEY", "fake-key")
 
         class FakeResp:

--- a/tests/contracts/test_kling_official_avatar.py
+++ b/tests/contracts/test_kling_official_avatar.py
@@ -79,7 +79,7 @@ def test_avatar_requires_image_and_audio():
         raise AssertionError("Kling avatar must require audio input")
 
 
-def test_execute_downloads_avatar_video(monkeypatch, tmp_path):
+def test_execute_downloads_avatar_video(monkeypatch, tmp_path, budget_gate_isolated):
     class FakeClient:
         def create_classic_task(self, path, payload):
             self.path = path
@@ -95,8 +95,12 @@ def test_execute_downloads_avatar_video(monkeypatch, tmp_path):
             return output_path
 
     monkeypatch.setenv("KLING_API_KEY", "test-key")
-    monkeypatch.setattr("tools.avatar.kling_avatar.KlingClient", lambda: FakeClient())
+    # Stub accepts the max_retries kwarg execute() now passes; behavior unchanged.
+    monkeypatch.setattr("tools.avatar.kling_avatar.KlingClient", lambda *args, **kwargs: FakeClient())
     monkeypatch.setattr("tools.avatar.kling_avatar.probe_output", lambda path: {"duration_seconds": 5.0})
+
+    # Gate active; approve this paid tool via the gate's real API.
+    budget_gate_isolated.approve_tool("kling_avatar")
 
     result = KlingAvatar().execute(
         {
@@ -261,7 +265,7 @@ def test_advanced_lip_sync_rejects_conflicting_top_level_and_nested_values(
         KlingLipSync()._build_advanced_request(inputs)
 
 
-def test_identify_face_execute_writes_faces_artifact(monkeypatch, tmp_path):
+def test_identify_face_execute_writes_faces_artifact(monkeypatch, tmp_path, budget_gate_isolated):
     class FakeClient:
         def post(self, path, payload):
             assert path == "/v1/videos/identify-face"
@@ -281,7 +285,13 @@ def test_identify_face_execute_writes_faces_artifact(monkeypatch, tmp_path):
             }
 
     monkeypatch.setenv("KLING_API_KEY", "test-key")
-    monkeypatch.setattr("tools.avatar.kling_lip_sync.KlingClient", lambda: FakeClient())
+    # Stub accepts the max_retries kwarg execute() now passes; behavior unchanged.
+    monkeypatch.setattr(
+        "tools.avatar.kling_lip_sync.KlingClient", lambda *args, **kwargs: FakeClient()
+    )
+
+    # Gate active; approve this paid tool via the gate's real API.
+    budget_gate_isolated.approve_tool("kling_lip_sync")
 
     artifact_path = tmp_path / "faces.json"
     result = KlingLipSync().execute(
@@ -299,7 +309,7 @@ def test_identify_face_execute_writes_faces_artifact(monkeypatch, tmp_path):
     assert data["face_count"] == 1
 
 
-def test_full_lip_sync_requires_confirmation_for_multiple_faces(monkeypatch, tmp_path):
+def test_full_lip_sync_requires_confirmation_for_multiple_faces(monkeypatch, tmp_path, budget_gate_isolated):
     class FakeClient:
         def post(self, path, payload):
             return {
@@ -314,7 +324,13 @@ def test_full_lip_sync_requires_confirmation_for_multiple_faces(monkeypatch, tmp
             }
 
     monkeypatch.setenv("KLING_API_KEY", "test-key")
-    monkeypatch.setattr("tools.avatar.kling_lip_sync.KlingClient", lambda: FakeClient())
+    # Stub accepts the max_retries kwarg execute() now passes; behavior unchanged.
+    monkeypatch.setattr(
+        "tools.avatar.kling_lip_sync.KlingClient", lambda *args, **kwargs: FakeClient()
+    )
+
+    # Gate active; approve this paid tool via the gate's real API.
+    budget_gate_isolated.approve_tool("kling_lip_sync")
 
     result = KlingLipSync().execute(
         {
@@ -332,7 +348,7 @@ def test_full_lip_sync_requires_confirmation_for_multiple_faces(monkeypatch, tmp
     assert Path(result.artifacts[0]).is_file()
 
 
-def test_full_lip_sync_auto_selects_largest_face_and_downloads(monkeypatch, tmp_path):
+def test_full_lip_sync_auto_selects_largest_face_and_downloads(monkeypatch, tmp_path, budget_gate_isolated):
     class FakeClient:
         def post(self, path, payload):
             return {
@@ -369,8 +385,14 @@ def test_full_lip_sync_auto_selects_largest_face_and_downloads(monkeypatch, tmp_
             return output_path
 
     monkeypatch.setenv("KLING_API_KEY", "test-key")
-    monkeypatch.setattr("tools.avatar.kling_lip_sync.KlingClient", lambda: FakeClient())
+    # Stub accepts the max_retries kwarg execute() now passes; behavior unchanged.
+    monkeypatch.setattr(
+        "tools.avatar.kling_lip_sync.KlingClient", lambda *args, **kwargs: FakeClient()
+    )
     monkeypatch.setattr("tools.avatar.kling_lip_sync.probe_output", lambda path: {"duration_seconds": 4.0})
+
+    # Gate active; approve this paid tool via the gate's real API.
+    budget_gate_isolated.approve_tool("kling_lip_sync")
 
     result = KlingLipSync().execute(
         {
@@ -407,7 +429,7 @@ def test_auto_select_face_area_avoids_position_inflation():
     assert tool._face_area({"box": {"width": 80, "height": 90}}) == 80 * 90
 
 
-def test_advanced_lip_sync_execute_downloads_video(monkeypatch, tmp_path):
+def test_advanced_lip_sync_execute_downloads_video(monkeypatch, tmp_path, budget_gate_isolated):
     audio_path = tmp_path / "voice.mp3"
     audio_path.write_bytes(b"audio")
 
@@ -433,8 +455,14 @@ def test_advanced_lip_sync_execute_downloads_video(monkeypatch, tmp_path):
             return output_path
 
     monkeypatch.setenv("KLING_API_KEY", "test-key")
-    monkeypatch.setattr("tools.avatar.kling_lip_sync.KlingClient", lambda: FakeClient())
+    # Stub accepts the max_retries kwarg execute() now passes; behavior unchanged.
+    monkeypatch.setattr(
+        "tools.avatar.kling_lip_sync.KlingClient", lambda *args, **kwargs: FakeClient()
+    )
     monkeypatch.setattr("tools.avatar.kling_lip_sync.probe_output", lambda path: {"duration_seconds": 4.0})
+
+    # Gate active; approve this paid tool via the gate's real API.
+    budget_gate_isolated.approve_tool("kling_lip_sync")
 
     result = KlingLipSync().execute(
         {
@@ -470,3 +498,243 @@ def test_lip_sync_cost_estimate_is_not_zero():
     assert tool.estimate_cost({"operation": "identify_face"}) > 0
     assert tool.estimate_cost({"operation": "advanced_lip_sync"}) > tool.estimate_cost({"operation": "identify_face"})
     assert tool.dry_run({"operation": "advanced_lip_sync"})["cost_estimate_confidence"] == "low"
+
+
+class TestKlingAvatarMaxCostBound:
+    """max_cost_usd() is a worst-case upper bound whose retry multiplier is the
+    same retry_policy.max_retries execute() passes to KlingClient. These touch
+    only KlingAvatar -- no network, no real key."""
+
+    def test_bound_scales_with_retry_setting(self):
+        from tools.base_tool import RetryPolicy
+
+        # Worst single attempt = pro + local audio = $0.635; bound must equal
+        # that times (1 + max_retries), not a hardcoded x3.
+        tool = KlingAvatar()
+        tool.retry_policy = RetryPolicy(max_retries=0)
+        assert tool.max_cost_usd({"prompt": "x"}) == pytest.approx(0.635)
+        tool.retry_policy = RetryPolicy(max_retries=2)
+        assert tool.max_cost_usd({"prompt": "x"}) == pytest.approx(1.905)
+        tool.retry_policy = RetryPolicy(max_retries=5)
+        assert tool.max_cost_usd({"prompt": "x"}) == pytest.approx(3.81)
+
+    def test_execute_passes_same_retry_setting_to_client(
+        self, monkeypatch, tmp_path, budget_gate_isolated
+    ):
+        from tools.base_tool import RetryPolicy
+
+        captured = {}
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            def create_classic_task(self, path, payload):
+                return "avatar-task-1"
+
+            def poll_classic(self, path, task_id, result_key, timeout_seconds, poll_interval):
+                return [{"url": "https://example.com/avatar.mp4"}]
+
+            def download(self, url, output_path):
+                output_path.write_bytes(b"video")
+                return output_path
+
+        monkeypatch.setenv("KLING_API_KEY", "test-key")
+        monkeypatch.setattr("tools.avatar.kling_avatar.KlingClient", FakeClient)
+        monkeypatch.setattr(
+            "tools.avatar.kling_avatar.probe_output",
+            lambda path: {"duration_seconds": 5.0},
+        )
+
+        tool = KlingAvatar()
+        tool.retry_policy = RetryPolicy(max_retries=4)
+        budget_gate_isolated.approve_tool("kling_avatar")
+
+        result = tool.execute(
+            {
+                "image_url": "https://example.com/avatar.png",
+                "audio_id": "audio-a",
+                "output_path": str(tmp_path / "avatar.mp4"),
+            }
+        )
+
+        assert result.success, result.error
+        # The client received exactly the tool's retry_policy setting -- the
+        # same value max_cost_usd() multiplies by.
+        assert captured.get("max_retries") == 4
+
+    def test_invalid_mode_fails_before_provider_dispatch(
+        self, monkeypatch, tmp_path, budget_gate_isolated
+    ):
+        calls = {"create_classic_task": 0}
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                pass
+
+            def create_classic_task(self, path, payload):
+                calls["create_classic_task"] += 1
+                return "avatar-task-1"
+
+            def poll_classic(self, *args, **kwargs):
+                return [{"url": "https://example.com/avatar.mp4"}]
+
+            def download(self, url, output_path):
+                output_path.write_bytes(b"video")
+                return output_path
+
+        monkeypatch.setenv("KLING_API_KEY", "test-key")
+        monkeypatch.setattr("tools.avatar.kling_avatar.KlingClient", FakeClient)
+
+        tool = KlingAvatar()
+        budget_gate_isolated.approve_tool("kling_avatar")
+
+        result = tool.execute(
+            {
+                "image_url": "https://example.com/avatar.png",
+                "audio_id": "audio-a",
+                "mode": "ultra",  # not in AVATAR_MODES
+                "output_path": str(tmp_path / "avatar.mp4"),
+            }
+        )
+
+        assert result.success is False
+        assert "mode must be one of" in (result.error or "")
+        assert calls["create_classic_task"] == 0, "provider must not be dispatched"
+
+    def test_bound_is_ge_estimate_for_every_valid_mode(self):
+        from tools._kling.schemas import AVATAR_MODES
+
+        tool = KlingAvatar()
+        bound = tool.max_cost_usd({"prompt": "x"})
+        for mode in AVATAR_MODES:
+            for audio in ({}, {"audio_path": "a"}):
+                assert bound >= tool.estimate_cost({"mode": mode, **audio})
+
+
+class TestKlingLipSyncMaxCostBound:
+    """max_cost_usd() bounds every operation's full billing path. full_lip_sync
+    bills two sequential requests, so its bound sums both before the shared
+    retry multiplier. No network, no real key."""
+
+    def test_bounds_per_operation(self):
+        tool = KlingLipSync()  # default retry_policy.max_retries == 2
+        assert tool.max_cost_usd({"operation": "identify_face"}) == pytest.approx(0.06)
+        assert tool.max_cost_usd({"operation": "advanced_lip_sync"}) == pytest.approx(0.96)
+        assert tool.max_cost_usd({"operation": "full_lip_sync"}) == pytest.approx(1.02)
+
+    def test_full_bound_sums_both_billed_requests_not_max(self):
+        tool = KlingLipSync()
+        identify = tool.estimate_cost({"operation": "identify_face"})
+        advanced = tool.estimate_cost({"operation": "advanced_lip_sync"})
+        full = tool.max_cost_usd({"operation": "full_lip_sync"})
+        # Summed then multiplied -- strictly greater than either single-request
+        # bound, so it cannot be a max() over operation costs.
+        assert full == pytest.approx((identify + advanced) * 3)
+        assert full > tool.max_cost_usd({"operation": "advanced_lip_sync"})
+        assert full > tool.max_cost_usd({"operation": "identify_face"})
+
+    def test_bound_scales_with_retry_setting(self):
+        from tools.base_tool import RetryPolicy
+
+        tool = KlingLipSync()
+        tool.retry_policy = RetryPolicy(max_retries=0)
+        assert tool.max_cost_usd({"operation": "full_lip_sync"}) == pytest.approx(0.34)
+        tool.retry_policy = RetryPolicy(max_retries=5)
+        assert tool.max_cost_usd({"operation": "full_lip_sync"}) == pytest.approx(2.04)
+
+    def test_account_usage_flag_fails_closed(self):
+        tool = KlingLipSync()
+        for op in ("identify_face", "advanced_lip_sync", "full_lip_sync"):
+            assert (
+                tool.max_cost_usd({"operation": op, "include_account_usage": True})
+                is None
+            )
+
+    def test_bound_is_ge_estimate_per_operation(self):
+        tool = KlingLipSync()
+        for op in ("identify_face", "advanced_lip_sync", "full_lip_sync"):
+            assert tool.max_cost_usd({"operation": op}) >= tool.estimate_cost(
+                {"operation": op}
+            )
+
+    def test_execute_passes_same_retry_setting_to_client(
+        self, monkeypatch, tmp_path, budget_gate_isolated
+    ):
+        from tools.base_tool import RetryPolicy
+
+        captured = {}
+
+        class FakeClient:
+            def __init__(self, *args, **kwargs):
+                captured.update(kwargs)
+
+            def post(self, path, payload):
+                return {
+                    "code": 0,
+                    "data": {
+                        "session_id": "session-a",
+                        "face_data": [
+                            {
+                                "face_id": "face-a",
+                                "face_image": "https://example.com/face.png",
+                                "start_time": 0,
+                                "end_time": 5200,
+                            }
+                        ],
+                    },
+                }
+
+        monkeypatch.setenv("KLING_API_KEY", "test-key")
+        monkeypatch.setattr("tools.avatar.kling_lip_sync.KlingClient", FakeClient)
+
+        tool = KlingLipSync()
+        tool.retry_policy = RetryPolicy(max_retries=4)
+        budget_gate_isolated.approve_tool("kling_lip_sync")
+
+        result = tool.execute(
+            {
+                "operation": "identify_face",
+                "video_url": "https://example.com/source.mp4",
+                "faces_artifact_path": str(tmp_path / "faces.json"),
+            }
+        )
+
+        assert result.success, result.error
+        assert captured.get("max_retries") == tool.retry_policy.max_retries
+
+    def test_invalid_operation_fails_before_provider_dispatch(
+        self, monkeypatch, tmp_path, budget_gate_isolated
+    ):
+        calls = {"post": 0, "create_classic_task": 0}
+        captured = {}
+
+        class FakeClient:
+            def __init__(self, *args, **kwargs):
+                captured.update(kwargs)
+
+            def post(self, path, payload):
+                calls["post"] += 1
+                return {"code": 0, "data": {}}
+
+            def create_classic_task(self, path, payload):
+                calls["create_classic_task"] += 1
+                return "task-1"
+
+        monkeypatch.setenv("KLING_API_KEY", "test-key")
+        monkeypatch.setattr("tools.avatar.kling_lip_sync.KlingClient", FakeClient)
+
+        tool = KlingLipSync()
+        budget_gate_isolated.approve_tool("kling_lip_sync")
+
+        result = tool.execute(
+            {"operation": "bogus_op", "video_url": "https://example.com/source.mp4"}
+        )
+
+        assert result.success is False
+        assert "Unsupported Kling lip-sync operation" in (result.error or "")
+        assert calls["post"] == 0
+        assert calls["create_classic_task"] == 0
+        # Client was constructed with the tool's retry setting even on the
+        # no-dispatch path -- but no billed request was ever issued.
+        assert captured.get("max_retries") == tool.retry_policy.max_retries

--- a/tests/contracts/test_kling_official_image.py
+++ b/tests/contracts/test_kling_official_image.py
@@ -180,7 +180,9 @@ def test_image_model_must_match_api_family():
         raise AssertionError("omni requests must reject generation image models")
 
 
-def test_execute_downloads_all_image_results(monkeypatch, tmp_path):
+def test_execute_downloads_all_image_results(monkeypatch, tmp_path, budget_gate_isolated):
+    budget_gate_isolated.approve_tool("kling_official_image")
+
     class FakeClient:
         def create_classic_task(self, path, payload):
             return "img-task-1"
@@ -196,7 +198,7 @@ def test_execute_downloads_all_image_results(monkeypatch, tmp_path):
             return output_path
 
     monkeypatch.setenv("KLING_API_KEY", "test-key")
-    monkeypatch.setattr("tools.graphics.kling_official_image.KlingClient", lambda: FakeClient())
+    monkeypatch.setattr("tools.graphics.kling_official_image.KlingClient", lambda *args, **kwargs: FakeClient())
     output_path = tmp_path / "image.png"
     result = KlingOfficialImage().execute({"prompt": "x", "n": 2, "output_path": str(output_path)})
     assert result.success
@@ -209,7 +211,11 @@ def test_execute_downloads_all_image_results(monkeypatch, tmp_path):
     assert result.cost_usd > 0
 
 
-def test_execute_image_omni_series_records_references_callback_and_artifacts(monkeypatch, tmp_path):
+def test_execute_image_omni_series_records_references_callback_and_artifacts(
+    monkeypatch, tmp_path, budget_gate_isolated
+):
+    budget_gate_isolated.approve_tool("kling_official_image")
+
     class FakeClient:
         def create_classic_task(self, path, payload):
             self.path = path
@@ -227,7 +233,7 @@ def test_execute_image_omni_series_records_references_callback_and_artifacts(mon
             return output_path
 
     monkeypatch.setenv("KLING_API_KEY", "test-key")
-    monkeypatch.setattr("tools.graphics.kling_official_image.KlingClient", lambda: FakeClient())
+    monkeypatch.setattr("tools.graphics.kling_official_image.KlingClient", lambda *args, **kwargs: FakeClient())
     result = KlingOfficialImage().execute(
         {
             "prompt": "series from references",
@@ -252,7 +258,10 @@ def test_execute_image_omni_series_records_references_callback_and_artifacts(mon
     assert Path(result.artifacts[1]).name == "series_2.png"
 
 
-def test_image_selector_prefers_official_provider(monkeypatch, isolated_tool_registry):
+def test_image_selector_prefers_official_provider(monkeypatch, isolated_tool_registry, budget_gate_isolated):
+    # The selector is the outermost (gated) call; its reservation delegates
+    # to the selected provider's bound.
+    budget_gate_isolated.approve_tool("image_selector")
     monkeypatch.setenv("KLING_API_KEY", "test-key")
     isolated_tool_registry.discover("tools")
 

--- a/tests/contracts/test_kling_official_video.py
+++ b/tests/contracts/test_kling_official_video.py
@@ -6,6 +6,8 @@ import base64
 import sys
 from pathlib import Path
 
+import pytest
+
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
@@ -274,7 +276,9 @@ def test_video_model_must_match_api_family():
         raise AssertionError("omni requests must reject classic video models")
 
 
-def test_execute_downloads_video_and_returns_artifact(monkeypatch, tmp_path):
+def test_execute_downloads_video_and_returns_artifact(monkeypatch, tmp_path, budget_gate_isolated):
+    budget_gate_isolated.approve_tool("kling_official_video")
+
     class FakeClient:
         def create_classic_task(self, path, payload):
             self.path = path
@@ -289,7 +293,7 @@ def test_execute_downloads_video_and_returns_artifact(monkeypatch, tmp_path):
             return output_path
 
     monkeypatch.setenv("KLING_API_KEY", "test-key")
-    monkeypatch.setattr("tools.video.kling_official_video.KlingClient", lambda: FakeClient())
+    monkeypatch.setattr("tools.video.kling_official_video.KlingClient", lambda *args, **kwargs: FakeClient())
     monkeypatch.setattr("tools.video.kling_official_video.probe_output", lambda path: {"duration_seconds": 5.0})
     output_path = tmp_path / "out.mp4"
     result = KlingOfficialVideo().execute({"prompt": "x", "output_path": str(output_path)})
@@ -301,7 +305,10 @@ def test_execute_downloads_video_and_returns_artifact(monkeypatch, tmp_path):
     assert result.cost_usd > 0
 
 
-def test_execute_downloads_all_omni_video_outputs_and_records_metadata(monkeypatch, tmp_path):
+def test_execute_downloads_all_omni_video_outputs_and_records_metadata(
+    monkeypatch, tmp_path, budget_gate_isolated
+):
+    budget_gate_isolated.approve_tool("kling_official_video")
     reset_account_usage_cache()
 
     class FakeClient:
@@ -320,12 +327,8 @@ def test_execute_downloads_all_omni_video_outputs_and_records_metadata(monkeypat
             output_path.write_bytes(url.encode("utf-8"))
             return output_path
 
-        def get(self, path, params=None):
-            assert path == "/account/costs"
-            return {"code": 0, "data": {"resource_pack_subscribe_infos": [{"name": "pack-a"}]}}
-
     monkeypatch.setenv("KLING_API_KEY", "test-key")
-    monkeypatch.setattr("tools.video.kling_official_video.KlingClient", lambda: FakeClient())
+    monkeypatch.setattr("tools.video.kling_official_video.KlingClient", lambda *args, **kwargs: FakeClient())
     monkeypatch.setattr("tools.video.kling_official_video.probe_output", lambda path: {"duration_seconds": 5.0})
     result = KlingOfficialVideo().execute(
         {
@@ -335,7 +338,6 @@ def test_execute_downloads_all_omni_video_outputs_and_records_metadata(monkeypat
             "video_list": [{"video_url": "https://example.com/ref.mp4", "refer_type": "base"}],
             "element_list": [789],
             "callback_url": "https://example.com/callback",
-            "include_account_usage": True,
             "output_path": str(tmp_path / "out.mp4"),
         }
     )
@@ -345,16 +347,39 @@ def test_execute_downloads_all_omni_video_outputs_and_records_metadata(monkeypat
     assert result.data["element_ids"] == [789]
     assert result.data["callback_requested"] is True
     assert result.data["polling_used"] is True
-    assert result.data["account_usage"]["resource_pack_subscribe_infos"][0]["name"] == "pack-a"
-    assert result.data["cost_source"] == "estimate_with_account_usage_context"
     assert result.cost_usd > 0
     assert len(result.artifacts) == 2
     assert Path(result.artifacts[1]).name == "out_2.mp4"
 
 
+def test_video_account_usage_request_is_fail_closed(monkeypatch, budget_gate_isolated):
+    """include_account_usage requests cannot be cost-bounded (that endpoint's
+    billing is unverified -- same rule as kling_lip_sync), so the gate must
+    refuse them by name before any provider call, even for an approved tool."""
+    from tools.base_tool import BudgetGateError
+
+    budget_gate_isolated.approve_tool("kling_official_video")
+    monkeypatch.setenv("KLING_API_KEY", "test-key")
+
+    reached = {"provider": False}
+
+    class FakeClient:
+        def create_classic_task(self, path, payload):
+            reached["provider"] = True
+            return "task-x"
+
+    monkeypatch.setattr("tools.video.kling_official_video.KlingClient", lambda *args, **kwargs: FakeClient())
+    with pytest.raises(BudgetGateError, match="kling_official_video"):
+        KlingOfficialVideo().execute({"prompt": "x", "include_account_usage": True})
+    assert reached["provider"] is False
+
+
 def test_video_selector_prefers_official_provider_without_fal_upload(
-    monkeypatch, tmp_path, isolated_tool_registry
+    monkeypatch, tmp_path, isolated_tool_registry, budget_gate_isolated
 ):
+    # The selector is the outermost (gated) call; its reservation delegates
+    # to the selected provider's bound.
+    budget_gate_isolated.approve_tool("video_selector")
     monkeypatch.setenv("KLING_API_KEY", "test-key")
     image_path = tmp_path / "ref.png"
     image_path.write_bytes(b"fake")
@@ -407,13 +432,15 @@ def test_video_cost_estimate_is_not_zero():
     assert dry_run["cost_estimate_confidence"] == "low"
 
 
-def test_video_account_resource_error_includes_diagnostic(monkeypatch):
+def test_video_account_resource_error_includes_diagnostic(monkeypatch, budget_gate_isolated):
+    budget_gate_isolated.approve_tool("kling_official_video")
+
     class FakeClient:
         def create_classic_task(self, path, payload):
             raise KlingAPIError("resource pack exhausted", code=1102, request_id="req-1")
 
     monkeypatch.setenv("KLING_API_KEY", "test-key")
-    monkeypatch.setattr("tools.video.kling_official_video.KlingClient", lambda: FakeClient())
+    monkeypatch.setattr("tools.video.kling_official_video.KlingClient", lambda *args, **kwargs: FakeClient())
     result = KlingOfficialVideo().execute({"prompt": "x"})
     assert not result.success
     assert result.data["account_usage_diagnostic"]["reason"] == "account_balance_or_resource_pack"

--- a/tests/contracts/test_kling_tts.py
+++ b/tests/contracts/test_kling_tts.py
@@ -64,7 +64,9 @@ def test_tts_payload_and_validation():
             raise AssertionError(f"Invalid TTS inputs should fail: {bad_inputs}")
 
 
-def test_execute_downloads_all_audio_results(monkeypatch, tmp_path):
+def test_execute_downloads_all_audio_results(monkeypatch, tmp_path, budget_gate_isolated):
+    budget_gate_isolated.approve_tool("kling_tts")
+
     class FakeClient:
         def create_classic_task(self, path, payload):
             self.path = path
@@ -83,7 +85,7 @@ def test_execute_downloads_all_audio_results(monkeypatch, tmp_path):
             return output_path
 
     monkeypatch.setenv("KLING_API_KEY", "test-key")
-    monkeypatch.setattr("tools.audio.kling_tts.KlingClient", lambda: FakeClient())
+    monkeypatch.setattr("tools.audio.kling_tts.KlingClient", lambda *args, **kwargs: FakeClient())
     monkeypatch.setattr("tools.audio.kling_tts.probe_duration", lambda path: 1.23)
 
     output_path = tmp_path / "speech.mp3"
@@ -105,7 +107,9 @@ def test_execute_downloads_all_audio_results(monkeypatch, tmp_path):
     assert result.cost_usd > 0
 
 
-def test_execute_accepts_synchronous_create_response(monkeypatch, tmp_path):
+def test_execute_accepts_synchronous_create_response(monkeypatch, tmp_path, budget_gate_isolated):
+    budget_gate_isolated.approve_tool("kling_tts")
+
     class FakeClient:
         def post(self, path, payload):
             assert path == "/v1/audio/tts"
@@ -133,7 +137,7 @@ def test_execute_accepts_synchronous_create_response(monkeypatch, tmp_path):
             return output_path
 
     monkeypatch.setenv("KLING_API_KEY", "test-key")
-    monkeypatch.setattr("tools.audio.kling_tts.KlingClient", lambda: FakeClient())
+    monkeypatch.setattr("tools.audio.kling_tts.KlingClient", lambda *args, **kwargs: FakeClient())
     monkeypatch.setattr("tools.audio.kling_tts.probe_duration", lambda path: 2.5)
 
     result = KlingTTS().execute(
@@ -150,7 +154,10 @@ def test_execute_accepts_synchronous_create_response(monkeypatch, tmp_path):
     assert result.data["audio_duration_seconds"] == 2.5
 
 
-def test_tts_selector_prefers_kling_official(monkeypatch, isolated_tool_registry):
+def test_tts_selector_prefers_kling_official(monkeypatch, isolated_tool_registry, budget_gate_isolated):
+    # The selector is the outermost (gated) call; its reservation delegates
+    # to the selected provider's bound.
+    budget_gate_isolated.approve_tool("tts_selector")
     monkeypatch.setenv("KLING_API_KEY", "test-key")
     isolated_tool_registry.discover("tools")
 

--- a/tests/contracts/test_phase0_contracts.py
+++ b/tests/contracts/test_phase0_contracts.py
@@ -476,7 +476,15 @@ class TestToolRegistry:
 
 class TestCostTracker:
     def test_estimate_reserve_reconcile(self):
-        tracker = CostTracker(budget_total_usd=10.0, mode=BudgetMode.OBSERVE)
+        # require_approval_for_new_paid_tool is an INDEPENDENT safeguard: it is
+        # evaluated in every mode, so observe no longer implicitly suppresses
+        # it. Disable it explicitly to isolate the estimate/reserve/reconcile
+        # lifecycle under test.
+        tracker = CostTracker(
+            budget_total_usd=10.0,
+            mode=BudgetMode.OBSERVE,
+            require_approval_for_new_paid_tool=False,
+        )
         entry_id = tracker.estimate("image_selector", "generate", 0.05)
         tracker.reserve(entry_id)
         assert tracker.budget_reserved_usd == 0.05
@@ -485,19 +493,26 @@ class TestCostTracker:
         assert tracker.budget_reserved_usd == 0.0
 
     def test_cap_mode_blocks_overspend(self):
+        # cap no longer inherits warn's approval raises, so the budget check is
+        # reached without having to defuse the two safeguards first.
         tracker = CostTracker(
             budget_total_usd=1.0,
             mode=BudgetMode.CAP,
-            single_action_approval_usd=10.0,  # raise threshold so budget check triggers
+            single_action_approval_usd=None,
+            require_approval_for_new_paid_tool=False,
         )
-        tracker.approve_tool("expensive")
         eid = tracker.estimate("expensive", "op", 5.0)
         with pytest.raises(BudgetExceededError):
             tracker.reserve(eid)
 
     def test_persistence(self, tmp_path):
         log_path = tmp_path / "cost_log.json"
-        t1 = CostTracker(budget_total_usd=10.0, mode=BudgetMode.OBSERVE, cost_log_path=log_path)
+        t1 = CostTracker(
+            budget_total_usd=10.0,
+            mode=BudgetMode.OBSERVE,
+            require_approval_for_new_paid_tool=False,
+            cost_log_path=log_path,
+        )
         eid = t1.estimate("tool", "op", 0.10)
         t1.reserve(eid)
         t1.reconcile(eid, 0.08)

--- a/tests/contracts/test_phase2_contracts.py
+++ b/tests/contracts/test_phase2_contracts.py
@@ -167,17 +167,34 @@ class TestPhase2ErrorHandling:
         r = tool.execute({"input_path": "/nonexistent.mp4"})
         assert not r.success
 
-    def test_image_selector_no_provider(self):
-        tool = ImageSelector()
-        # Will fail if no API key or local model
-        r = tool.execute({"prompt": "test"})
-        # Either succeeds (provider available) or fails gracefully
-        assert isinstance(r, ToolResult)
+    def test_image_selector_no_provider(self, monkeypatch, budget_gate_isolated, tmp_path):
+        """With no provider configured the selector must fail locally --
+        graceful ToolResult, nothing dispatched, nothing reserved.
 
-    def test_diagram_gen_empty_boxes(self):
+        Providers are stubbed to none (rather than relying on which API keys
+        happen to be set on this machine) so environment credentials can
+        never turn this test into a real provider call.
+        """
+        tool = ImageSelector()
+        monkeypatch.setattr(ImageSelector, "_providers", lambda self: [])
+        r = tool.execute({"prompt": "test"})
+        assert isinstance(r, ToolResult)
+        assert r.success is False
+        # No provider was resolvable, so the budget gate saw a $0 request and
+        # the isolated ledger was never written.
+        import os
+        assert not Path(os.environ["OPENMONTAGE_COST_LOG"]).exists()
+
+    def test_diagram_gen_empty_boxes(self, tmp_path):
         tool = DiagramGen()
         if tool.get_status() == ToolStatus.AVAILABLE:
-            r = tool.execute({"diagram_type": "boxes", "boxes": []})
+            # Explicit output_path: without it the tool defaults to
+            # ./diagram.png and overwrites the tracked repo-root file.
+            r = tool.execute({
+                "diagram_type": "boxes",
+                "boxes": [],
+                "output_path": str(tmp_path / "empty_boxes.png"),
+            })
             assert isinstance(r, ToolResult)
 
 

--- a/tests/contracts/test_phase3_contracts.py
+++ b/tests/contracts/test_phase3_contracts.py
@@ -187,8 +187,10 @@ class TestGoogleMusic:
         assert info["capability"] == "music_generation"
         assert info["provider"] == "google"
 
-    def test_duration_validation(self):
+    def test_duration_validation(self, budget_gate_isolated):
         tool = GoogleMusic()
+        # Gate active; approve this paid tool via the gate's real API.
+        budget_gate_isolated.approve_tool("google_music")
         mock_client = MagicMock()
 
         mock_interaction = MagicMock()
@@ -225,8 +227,10 @@ class TestGoogleMusic:
             assert res.error is not None
             assert "maximum duration is 184" in res.error
 
-    def test_execute_success_convenience_extraction(self, tmp_path):
+    def test_execute_success_convenience_extraction(self, tmp_path, budget_gate_isolated):
         tool = GoogleMusic()
+        # Gate active; approve this paid tool via the gate's real API.
+        budget_gate_isolated.approve_tool("google_music")
         mock_client = MagicMock()
 
         mock_interaction = MagicMock()
@@ -254,8 +258,10 @@ class TestGoogleMusic:
             assert res.data["output"] == str(output_file)
             assert output_file.read_bytes() == b"my_fake_google_lyria_audio"
 
-    def test_execute_success_fallback_extraction(self, tmp_path):
+    def test_execute_success_fallback_extraction(self, tmp_path, budget_gate_isolated):
         tool = GoogleMusic()
+        # Gate active; approve this paid tool via the gate's real API.
+        budget_gate_isolated.approve_tool("google_music")
         mock_client = MagicMock()
 
         mock_interaction = MagicMock()
@@ -291,8 +297,10 @@ class TestGoogleMusic:
 
     @patch("os.path.exists")
     @patch("requests.get")
-    def test_multimodal_image(self, mock_get, mock_exists, tmp_path):
+    def test_multimodal_image(self, mock_get, mock_exists, tmp_path, budget_gate_isolated):
         tool = GoogleMusic()
+        # Gate active; approve this paid tool via the gate's real API.
+        budget_gate_isolated.approve_tool("google_music")
         mock_client = MagicMock()
 
         mock_interaction = MagicMock()
@@ -359,10 +367,12 @@ class TestGoogleMusic:
                 b"url_image_bytes"
             ).decode("utf-8")
 
-    def test_minimum_duration_validation(self, caplog):
+    def test_minimum_duration_validation(self, caplog, budget_gate_isolated):
         import logging
 
         tool = GoogleMusic()
+        # Gate active; approve this paid tool via the gate's real API.
+        budget_gate_isolated.approve_tool("google_music")
         mock_client = MagicMock()
 
         mock_interaction = MagicMock()
@@ -411,8 +421,10 @@ class TestGoogleMusic:
             assert res.error is not None
             assert "minimum duration is 5" in res.error
 
-    def test_missing_image_path_error(self, tmp_path):
+    def test_missing_image_path_error(self, tmp_path, budget_gate_isolated):
         tool = GoogleMusic()
+        # Gate active; approve this paid tool via the gate's real API.
+        budget_gate_isolated.approve_tool("google_music")
         with patch.dict(os.environ, {"GEMINI_API_KEY": "test_key"}):
             inputs = {
                 "prompt": "music with missing image",

--- a/tests/contracts/test_phase3_contracts.py
+++ b/tests/contracts/test_phase3_contracts.py
@@ -488,7 +488,8 @@ class TestVeoVideo:
             assert tool.get_status() == ToolStatus.AVAILABLE
 
     @patch("tools.video._shared.probe_output")
-    def test_duration_coercion(self, mock_probe):
+    def test_duration_coercion(self, mock_probe, budget_gate_isolated):
+        budget_gate_isolated.approve_tool("veo_video")
         tool = VeoVideo()
         mock_probe.return_value = {"width": 1920, "height": 1080, "duration": 8.0}
 
@@ -527,8 +528,9 @@ class TestVeoVideo:
     @patch("os.path.exists")
     @patch("requests.get")
     def test_operations_mapping(
-        self, mock_req_get, mock_exists, mock_img_open, mock_probe
+        self, mock_req_get, mock_exists, mock_img_open, mock_probe, budget_gate_isolated
     ):
+        budget_gate_isolated.approve_tool("veo_video")
         tool = VeoVideo()
         mock_probe.return_value = {"width": 1920, "height": 1080, "duration": 8.0}
         mock_exists.return_value = True
@@ -582,7 +584,8 @@ class TestVeoVideo:
             called_kwargs = mock_client.models.generate_videos.call_args[1]
             assert called_kwargs["image"] is not None
 
-    def test_vertex_ai_mode_rejection(self):
+    def test_vertex_ai_mode_rejection(self, budget_gate_isolated):
+        budget_gate_isolated.approve_tool("veo_video")
         tool = VeoVideo()
         mock_client = MagicMock()
         mock_client.vertexai = True
@@ -602,7 +605,8 @@ class TestVeoVideo:
             assert res.error is not None
             assert "only supported using the Gemini Developer API" in res.error
 
-    def test_missing_local_image_paths(self):
+    def test_missing_local_image_paths(self, budget_gate_isolated):
+        budget_gate_isolated.approve_tool("veo_video")
         tool = VeoVideo()
         with patch.dict(
             os.environ,
@@ -618,7 +622,8 @@ class TestVeoVideo:
             assert res.success is False
             assert "Local input image not found" in res.error
 
-    def test_missing_reference_image_paths(self):
+    def test_missing_reference_image_paths(self, budget_gate_isolated):
+        budget_gate_isolated.approve_tool("veo_video")
         tool = VeoVideo()
         with patch.dict(
             os.environ,

--- a/tests/tools/test_azure_stt.py
+++ b/tests/tools/test_azure_stt.py
@@ -184,6 +184,19 @@ class TestParsePayload:
 
 # ---- execute() guardrails + mocked success ----
 
+def _write_real_wav(path, seconds=1.0, rate=8000):
+    """Write a genuine (silent) WAV so the budget gate's local ffprobe can
+    price the call. Garbage bytes would be unprobeable and correctly refused."""
+    import wave
+
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(rate)
+        w.writeframes(b"\x00\x00" * int(rate * seconds))
+    return path
+
+
 class TestExecute:
     def test_missing_file(self, azure_env, tmp_path):
         res = AzureSpeechToText().execute({"input_path": str(tmp_path / "nope.wav")})
@@ -199,9 +212,10 @@ class TestExecute:
         assert not res.success
         assert "not configured" in res.error.lower()
 
-    def test_success_path_mocked(self, azure_env, tmp_path, monkeypatch):
+    def test_success_path_mocked(self, azure_env, tmp_path, monkeypatch, budget_gate_isolated):
         import requests
 
+        budget_gate_isolated.approve_tool("azure_stt")
         captured = {}
 
         def fake_post(url, headers=None, files=None, timeout=None):
@@ -211,8 +225,7 @@ class TestExecute:
 
         monkeypatch.setattr(requests, "post", fake_post)
 
-        audio = tmp_path / "a.wav"
-        audio.write_bytes(b"RIFF....")
+        audio = _write_real_wav(tmp_path / "a.wav")
         res = AzureSpeechToText().execute(
             {"input_path": str(audio), "language": "en", "output_dir": str(tmp_path)}
         )
@@ -228,15 +241,15 @@ class TestExecute:
         assert "transcriptions:transcribe" in captured["url"]
         assert captured["headers"]["Ocp-Apim-Subscription-Key"] == "fake-key"
 
-    def test_http_error_surfaced(self, azure_env, tmp_path, monkeypatch):
+    def test_http_error_surfaced(self, azure_env, tmp_path, monkeypatch, budget_gate_isolated):
         import requests
 
+        budget_gate_isolated.approve_tool("azure_stt")
         monkeypatch.setattr(
             requests, "post",
             lambda *a, **k: _FakeResponse(None, status_code=401, text="Unauthorized"),
         )
-        audio = tmp_path / "a.wav"
-        audio.write_bytes(b"RIFF....")
+        audio = _write_real_wav(tmp_path / "a.wav")
         res = AzureSpeechToText().execute({"input_path": str(audio), "output_dir": str(tmp_path)})
         assert not res.success
         assert "401" in res.error

--- a/tests/tools/test_budget_gate.py
+++ b/tests/tools/test_budget_gate.py
@@ -1,0 +1,633 @@
+"""Budget hard-cap enforcement tests.
+
+These cover the daily bucket model, cross-process locking, the max_cost_usd
+boundedness contract, and the fail-closed paths. The load-bearing ones are the
+tests that prove a blocked call never reached the provider, and that two
+separate PROCESSES cannot jointly exceed the daily cap -- an in-process lock
+passes the thread test while leaving the real (python -c per tool) process
+model unprotected.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+import threading
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from lib.config_model import BudgetMode
+from tools.base_tool import BaseTool, BudgetGateError, ToolResult, ToolRuntime
+from tools.cost_tracker import (
+    ApprovalRequiredError,
+    BudgetExceededError,
+    BudgetPeriodError,
+    CostLogCorruptError,
+    CostTracker,
+)
+
+
+def make_tracker(log_path, **kw):
+    """Tracker with both independent safeguards off, so tests isolate `mode`."""
+    defaults = dict(
+        budget_total_usd=10.0,
+        reserve_pct=0.0,
+        single_action_approval_usd=None,
+        require_approval_for_new_paid_tool=False,
+        mode=BudgetMode.CAP,
+        cost_log_path=log_path,
+    )
+    defaults.update(kw)
+    return CostTracker(**defaults)
+
+
+def spend(tracker, amount, tool="paid_tool"):
+    eid = tracker.estimate(tool, "op", amount)
+    tracker.reserve(eid)
+    tracker.reconcile(eid, amount, success=True)
+    return eid
+
+
+# ===================== Daily bucket: allow / block =====================
+
+class TestDailyCap:
+    def test_below_cap_allowed(self, tmp_path):
+        t = make_tracker(tmp_path / "cost_log.json")
+        eid = t.estimate("paid_tool", "op", 4.0)
+        t.reserve(eid)
+        assert t.entries[-1]["status"] == "reserved"
+
+    def test_exact_cap_allowed(self, tmp_path):
+        t = make_tracker(tmp_path / "cost_log.json")
+        spend(t, 7.0)
+        eid = t.estimate("paid_tool", "op", 3.0)  # exactly hits $10.00
+        t.reserve(eid)
+        assert t.entries[-1]["status"] == "reserved"
+        assert t.remaining_on(t.current_budget_date()) == pytest.approx(0.0)
+
+    def test_over_cap_blocked(self, tmp_path):
+        t = make_tracker(tmp_path / "cost_log.json")
+        spend(t, 9.5)
+        eid = t.estimate("paid_tool", "op", 0.75)
+        with pytest.raises(BudgetExceededError) as exc:
+            t.reserve(eid)
+        assert t.entries[-1]["status"] == "estimated"  # rejected: consumed nothing
+
+        msg = str(exc.value)
+        for expected in ["10.00", "9.50", "0.75", "0.50"]:
+            assert expected in msg, f"refusal must state {expected}: {msg}"
+
+    def test_reservations_consume_budget_before_reconcile(self, tmp_path):
+        t = make_tracker(tmp_path / "cost_log.json")
+        t.reserve(t.estimate("paid_tool", "op", 6.0))  # in flight, unresolved
+        eid = t.estimate("paid_tool", "op", 5.0)
+        with pytest.raises(BudgetExceededError):
+            t.reserve(eid)
+
+
+# ===================== Daily bucket: day isolation =====================
+
+class FakeClock:
+    def __init__(self, moment: datetime):
+        self.moment = moment
+
+    def __call__(self) -> datetime:
+        return self.moment
+
+
+class TestDayIsolation:
+    def test_yesterday_spend_does_not_consume_today(self, tmp_path):
+        log = tmp_path / "cost_log.json"
+        clock = FakeClock(datetime(2026, 7, 16, 12, 0, tzinfo=timezone.utc))
+        t = make_tracker(log, clock=clock)
+        spend(t, 10.0)  # exhaust 07-16
+        assert t.remaining_on("2026-07-16") == pytest.approx(0.0)
+
+        clock.moment = datetime(2026, 7, 17, 9, 0, tzinfo=timezone.utc)
+        assert t.remaining_on("2026-07-17") == pytest.approx(10.0)
+        t.reserve(t.estimate("paid_tool", "op", 10.0))  # fresh bucket
+        assert t.entries[-1]["budget_date"] == "2026-07-17"
+
+    def test_today_spend_does_not_alter_yesterday(self, tmp_path):
+        log = tmp_path / "cost_log.json"
+        clock = FakeClock(datetime(2026, 7, 16, 12, 0, tzinfo=timezone.utc))
+        t = make_tracker(log, clock=clock)
+        spend(t, 4.0)
+        clock.moment = datetime(2026, 7, 17, 9, 0, tzinfo=timezone.utc)
+        spend(t, 6.0)
+        assert t.spent_on("2026-07-16") == pytest.approx(4.0)
+        assert t.spent_on("2026-07-17") == pytest.approx(6.0)
+
+    def test_history_is_preserved_not_cleared(self, tmp_path):
+        log = tmp_path / "cost_log.json"
+        clock = FakeClock(datetime(2026, 7, 16, 12, 0, tzinfo=timezone.utc))
+        t = make_tracker(log, clock=clock)
+        spend(t, 10.0)
+        clock.moment = datetime(2026, 7, 17, 9, 0, tzinfo=timezone.utc)
+        spend(t, 1.0)
+        dates = {e["budget_date"] for e in t.entries}
+        assert dates == {"2026-07-16", "2026-07-17"}
+        assert t.spent_on("2026-07-16") == pytest.approx(10.0)
+
+
+# ===================== Midnight =====================
+
+class TestMidnight:
+    def test_reservation_keeps_original_date_across_midnight(self, tmp_path):
+        log = tmp_path / "cost_log.json"
+        clock = FakeClock(datetime(2026, 7, 16, 23, 59, 30, tzinfo=timezone.utc))
+        t = make_tracker(log, clock=clock)
+        eid = t.estimate("paid_tool", "op", 6.0)
+        t.reserve(eid)
+
+        clock.moment = datetime(2026, 7, 17, 0, 0, 30, tzinfo=timezone.utc)
+
+        entry = next(e for e in t.entries if e["id"] == eid)
+        assert entry["budget_date"] == "2026-07-16"      # immutable
+        assert entry["status"] == "reserved"             # did not vanish
+        assert t.reserved_on("2026-07-16") == pytest.approx(6.0)
+        assert t.reserved_on("2026-07-17") == pytest.approx(0.0)
+        assert t.remaining_on("2026-07-17") == pytest.approx(10.0)
+
+    def test_reconcile_after_midnight_updates_original_bucket(self, tmp_path):
+        log = tmp_path / "cost_log.json"
+        clock = FakeClock(datetime(2026, 7, 16, 23, 59, 30, tzinfo=timezone.utc))
+        t = make_tracker(log, clock=clock)
+        eid = t.estimate("paid_tool", "op", 6.0)
+        t.reserve(eid)
+
+        clock.moment = datetime(2026, 7, 17, 0, 5, 0, tzinfo=timezone.utc)
+        t.reconcile(eid, 6.0, success=True)
+
+        assert t.spent_on("2026-07-16") == pytest.approx(6.0)  # original day
+        assert t.spent_on("2026-07-17") == pytest.approx(0.0)  # not today
+
+    def test_unresolved_reservation_survives_restart_in_original_date(self, tmp_path):
+        log = tmp_path / "cost_log.json"
+        clock = FakeClock(datetime(2026, 7, 16, 23, 59, 30, tzinfo=timezone.utc))
+        t1 = make_tracker(log, clock=clock)
+        t1.reserve(t1.estimate("paid_tool", "op", 6.0))  # never reconciled
+
+        after = FakeClock(datetime(2026, 7, 17, 0, 10, 0, tzinfo=timezone.utc))
+        t2 = make_tracker(log, clock=after)
+        assert t2.reserved_on("2026-07-16") == pytest.approx(6.0)
+        assert t2.remaining_on("2026-07-17") == pytest.approx(10.0)
+
+
+# ===================== Restart / persistence =====================
+
+class TestPersistence:
+    def test_spend_survives_restart(self, tmp_path):
+        log = tmp_path / "cost_log.json"
+        clock = FakeClock(datetime(2026, 7, 16, 12, 0, tzinfo=timezone.utc))
+        spend(make_tracker(log, clock=clock), 9.5)
+
+        t2 = make_tracker(log, clock=clock)
+        assert t2.spent_on("2026-07-16") == pytest.approx(9.5)
+        with pytest.raises(BudgetExceededError):
+            t2.reserve(t2.estimate("paid_tool", "op", 1.0))
+
+    def test_corrupt_ledger_fails_closed(self, tmp_path):
+        log = tmp_path / "cost_log.json"
+        spend(make_tracker(log), 1.0)
+        log.write_text('{"version": "2.0", "entries": [{"id": "x"')  # truncated
+
+        with pytest.raises(CostLogCorruptError):
+            make_tracker(log)
+
+    def test_stale_log_cannot_raise_cap_or_downgrade_mode(self, tmp_path):
+        log = tmp_path / "cost_log.json"
+        spend(make_tracker(log), 1.0)
+        data = json.loads(log.read_text())
+        data["budget_total_usd"] = 999.0   # attacker/stale value
+        data["budget_mode"] = "observe"
+        log.write_text(json.dumps(data))
+
+        t = make_tracker(log)  # config says $10 / cap
+        assert t.budget_total_usd == 10.0
+        assert t.mode == BudgetMode.CAP
+        with pytest.raises(BudgetExceededError):
+            t.reserve(t.estimate("paid_tool", "op", 50.0))
+
+    def test_atomic_write_leaves_no_partial_file(self, tmp_path):
+        log = tmp_path / "cost_log.json"
+        t = make_tracker(log)
+        for _ in range(5):
+            spend(t, 0.1)
+            json.loads(log.read_text())  # always complete, never truncated
+        assert not list(tmp_path.glob("*.tmp"))
+
+    def test_unsupported_period_fails_closed(self, tmp_path):
+        with pytest.raises(BudgetPeriodError):
+            make_tracker(tmp_path / "cost_log.json", period="monthly")
+
+    def test_unresolvable_timezone_fails_closed(self, tmp_path):
+        with pytest.raises(BudgetPeriodError):
+            make_tracker(tmp_path / "cost_log.json", tz_name="Not/AZone")
+
+
+# ===================== Overrun =====================
+
+class TestOverrun:
+    def test_actual_over_reservation_records_full_actual(self, tmp_path):
+        t = make_tracker(tmp_path / "cost_log.json")
+        eid = t.estimate("paid_tool", "op", 2.0)
+        t.reserve(eid)
+        t.reconcile(eid, 5.0, success=True)  # provider billed more than bounded
+
+        entry = next(e for e in t.entries if e["id"] == eid)
+        assert entry["actual_usd"] == 5.0            # full, never truncated
+        assert entry["actual_exceeded_reservation"] is True
+        assert t.spent_on(t.current_budget_date()) == pytest.approx(5.0)
+
+    def test_overrun_blocks_further_calls_that_date(self, tmp_path):
+        t = make_tracker(tmp_path / "cost_log.json")
+        eid = t.estimate("paid_tool", "op", 2.0)
+        t.reserve(eid)
+        t.reconcile(eid, 5.0, success=True)
+
+        today = t.current_budget_date()
+        assert t.is_overrun(today)
+        with pytest.raises(BudgetExceededError, match="OVER BUDGET"):
+            t.reserve(t.estimate("paid_tool", "op", 0.01))  # would otherwise fit
+
+    def test_overrun_is_sticky_across_restart(self, tmp_path):
+        log = tmp_path / "cost_log.json"
+        t = make_tracker(log)
+        eid = t.estimate("paid_tool", "op", 2.0)
+        t.reserve(eid)
+        t.reconcile(eid, 5.0, success=True)
+        today = t.current_budget_date()
+
+        assert make_tracker(log).is_overrun(today)
+
+    def test_overrun_does_not_block_the_next_day(self, tmp_path):
+        log = tmp_path / "cost_log.json"
+        clock = FakeClock(datetime(2026, 7, 16, 12, 0, tzinfo=timezone.utc))
+        t = make_tracker(log, clock=clock)
+        eid = t.estimate("paid_tool", "op", 2.0)
+        t.reserve(eid)
+        t.reconcile(eid, 5.0, success=True)
+        assert t.is_overrun("2026-07-16")
+
+        clock.moment = datetime(2026, 7, 17, 9, 0, tzinfo=timezone.utc)
+        assert not t.is_overrun("2026-07-17")
+        t.reserve(t.estimate("paid_tool", "op", 1.0))  # new day is open
+
+
+# ===================== Failure / retry accounting =====================
+
+class TestFailureAccounting:
+    def test_failed_call_still_consumes_budget(self, tmp_path):
+        t = make_tracker(tmp_path / "cost_log.json")
+        eid = t.estimate("paid_tool", "op", 4.0)
+        t.reserve(eid)
+        t.reconcile(eid, 4.0, success=False)  # provider billed, then errored
+
+        assert t.spent_on(t.current_budget_date()) == pytest.approx(4.0)
+        assert t.entries[-1]["status"] == "failed"
+
+    def test_retries_accumulate_and_cannot_bypass_cap(self, tmp_path):
+        t = make_tracker(tmp_path / "cost_log.json")
+        for _ in range(2):
+            eid = t.estimate("paid_tool", "op", 4.0)
+            t.reserve(eid)
+            t.reconcile(eid, 4.0, success=False)
+
+        assert t.spent_on(t.current_budget_date()) == pytest.approx(8.0)
+        with pytest.raises(BudgetExceededError):  # third retry refused
+            t.reserve(t.estimate("paid_tool", "op", 4.0))
+
+    def test_spend_never_recorded_below_zero(self, tmp_path):
+        t = make_tracker(tmp_path / "cost_log.json")
+        eid = t.estimate("paid_tool", "op", 1.0)
+        t.reserve(eid)
+        t.reconcile(eid, -50.0, success=True)  # provider returns nonsense
+        assert t.entries[-1]["actual_usd"] == 0.0
+        assert t.spent_on(t.current_budget_date()) >= 0.0
+
+    def test_refund_releases_only_undispatched_calls(self, tmp_path):
+        t = make_tracker(tmp_path / "cost_log.json")
+        eid = t.estimate("paid_tool", "op", 6.0)
+        t.reserve(eid)
+        t.refund(eid)
+        assert t.remaining_on(t.current_budget_date()) == pytest.approx(10.0)
+
+
+# ===================== Independent safeguards =====================
+
+class TestIndependentSafeguards:
+    def test_cap_does_not_raise_on_first_paid_tool_use(self, tmp_path):
+        """The old coupling: cap inherited warn's approval raise. It must not."""
+        t = make_tracker(
+            tmp_path / "cost_log.json",
+            mode=BudgetMode.CAP,
+            require_approval_for_new_paid_tool=False,
+        )
+        t.reserve(t.estimate("never_approved", "op", 1.0))  # no ApprovalRequiredError
+        assert t.entries[-1]["status"] == "reserved"
+
+    def test_single_action_threshold_fires_in_every_mode(self, tmp_path):
+        for mode in (BudgetMode.OBSERVE, BudgetMode.WARN, BudgetMode.CAP):
+            t = make_tracker(
+                tmp_path / f"log_{mode.value}.json",
+                mode=mode,
+                single_action_approval_usd=0.50,
+            )
+            with pytest.raises(ApprovalRequiredError, match="independent of budget mode"):
+                t.reserve(t.estimate("paid_tool", "op", 0.75))
+
+    def test_single_action_threshold_disabled_by_none(self, tmp_path):
+        t = make_tracker(tmp_path / "cost_log.json", single_action_approval_usd=None)
+        t.reserve(t.estimate("paid_tool", "op", 9.0))
+        assert t.entries[-1]["status"] == "reserved"
+
+    def test_new_paid_tool_approval_fires_in_every_mode(self, tmp_path):
+        for mode in (BudgetMode.OBSERVE, BudgetMode.WARN, BudgetMode.CAP):
+            t = make_tracker(
+                tmp_path / f"log_{mode.value}.json",
+                mode=mode,
+                require_approval_for_new_paid_tool=True,
+            )
+            with pytest.raises(ApprovalRequiredError, match="First paid use"):
+                t.reserve(t.estimate("paid_tool", "op", 1.0))
+
+    def test_warn_flags_but_proceeds_where_cap_blocks(self, tmp_path):
+        warn = make_tracker(
+            tmp_path / "warn.json", mode=BudgetMode.WARN, reserve_pct=0.0
+        )
+        spend(warn, 9.0)
+        warn.reserve(warn.estimate("paid_tool", "op", 5.0))
+        assert warn.entries[-1]["status"] == "reserved"
+        assert warn.entries[-1]["budget_warning"] is True
+
+        cap = make_tracker(tmp_path / "cap.json", mode=BudgetMode.CAP)
+        spend(cap, 9.0)
+        with pytest.raises(BudgetExceededError):
+            cap.reserve(cap.estimate("paid_tool", "op", 5.0))
+
+    def test_observe_records_but_never_blocks(self, tmp_path):
+        t = make_tracker(tmp_path / "cost_log.json", mode=BudgetMode.OBSERVE)
+        spend(t, 9.0)
+        t.reserve(t.estimate("paid_tool", "op", 50.0))
+        assert t.entries[-1]["status"] == "reserved"
+
+
+# ===================== Concurrency: threads =====================
+
+class TestThreadConcurrency:
+    def test_threads_cannot_jointly_exceed_daily_cap(self, tmp_path):
+        t = make_tracker(tmp_path / "cost_log.json")
+        accepted, errors = [], []
+
+        def attempt():
+            try:
+                eid = t.estimate("paid_tool", "op", 4.0)
+                t.reserve(eid)
+                accepted.append(eid)
+            except BudgetExceededError:
+                errors.append(1)
+
+        threads = [threading.Thread(target=attempt) for _ in range(8)]
+        for th in threads:
+            th.start()
+        for th in threads:
+            th.join()
+
+        assert len(accepted) == 2, "only 2 x $4 fit in $10 alongside no other spend"
+        assert len(errors) == 6
+        assert t.reserved_on(t.current_budget_date()) <= 10.0 + 1e-6
+
+
+# ===================== Concurrency: processes =====================
+
+_CHILD = textwrap.dedent(
+    """
+    import sys, json
+    sys.path.insert(0, {root!r})
+    from pathlib import Path
+    from lib.config_model import BudgetMode
+    from tools.cost_tracker import CostTracker, BudgetExceededError
+
+    t = CostTracker(
+        budget_total_usd=10.0, reserve_pct=0.0,
+        single_action_approval_usd=None,
+        require_approval_for_new_paid_tool=False,
+        mode=BudgetMode.CAP, cost_log_path=Path({log!r}),
+    )
+    try:
+        eid = t.estimate("paid_tool", "op", 4.0)
+        t.reserve(eid)
+        print("ACCEPTED")
+    except BudgetExceededError:
+        print("BLOCKED")
+    """
+)
+
+
+class TestProcessConcurrency:
+    """The tests that justify the OS file lock.
+
+    OpenMontage invokes tools as separate `python -c` processes, so a
+    threading.Lock protects nothing here. These fail against an in-process
+    lock and pass with the ledger lock.
+    """
+
+    def test_separate_processes_cannot_reserve_same_remaining_budget(self, tmp_path):
+        log = tmp_path / "cost_log.json"
+        code = _CHILD.format(root=str(ROOT), log=str(log))
+
+        procs = [
+            subprocess.Popen(
+                [sys.executable, "-c", code],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            )
+            for _ in range(6)
+        ]
+        outs = [p.communicate() for p in procs]
+
+        for out, err in outs:
+            assert "Traceback" not in err, err
+        accepted = sum("ACCEPTED" in out for out, _ in outs)
+        blocked = sum("BLOCKED" in out for out, _ in outs)
+
+        assert accepted + blocked == 6
+        assert accepted == 2, f"only 2 x $4 fit in $10; {accepted} were accepted"
+
+    def test_combined_process_reservations_never_exceed_cap(self, tmp_path):
+        log = tmp_path / "cost_log.json"
+        code = _CHILD.format(root=str(ROOT), log=str(log))
+        procs = [
+            subprocess.Popen(
+                [sys.executable, "-c", code],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            )
+            for _ in range(6)
+        ]
+        for p in procs:
+            p.communicate()
+
+        t = CostTracker(
+            budget_total_usd=10.0, reserve_pct=0.0,
+            single_action_approval_usd=None,
+            require_approval_for_new_paid_tool=False,
+            mode=BudgetMode.CAP, cost_log_path=log,
+        )
+        assert t.reserved_on(t.current_budget_date()) <= 10.0 + 1e-6
+
+    def test_crashed_process_does_not_permanently_block_ledger(self, tmp_path):
+        """OS locks die with the process; a crash must not wedge the ledger."""
+        log = tmp_path / "cost_log.json"
+        crash = textwrap.dedent(
+            f"""
+            import sys, os
+            sys.path.insert(0, {str(ROOT)!r})
+            from pathlib import Path
+            from lib.ledger_lock import ledger_lock
+            with ledger_lock(Path({str(log)!r})):
+                os._exit(1)   # hard kill while holding the lock
+            """
+        )
+        proc = subprocess.run([sys.executable, "-c", crash], capture_output=True)
+        assert proc.returncode == 1
+
+        t = make_tracker(log)  # must not hang or raise
+        t.reserve(t.estimate("paid_tool", "op", 1.0))
+        assert t.entries[-1]["status"] == "reserved"
+
+
+# ===================== The gate: boundedness + free paths =====================
+
+class _Recorder:
+    def __init__(self):
+        self.called = False
+
+
+class UnboundedPaidTool(BaseTool):
+    """A paid tool that cannot bound its cost -- i.e. every tool in the repo today."""
+    name = "unbounded_paid"
+    runtime = ToolRuntime.API
+
+    def __init__(self, recorder):
+        self.recorder = recorder
+
+    def estimate_cost(self, inputs):
+        return 1.0
+
+    def execute(self, inputs):
+        self.recorder.called = True  # would be the provider call
+        return ToolResult(success=True, cost_usd=1.0)
+
+
+class BoundedPaidTool(UnboundedPaidTool):
+    name = "bounded_paid"
+
+    def max_cost_usd(self, inputs):
+        return 2.0
+
+
+class FreeLocalTool(BaseTool):
+    name = "free_local"
+    runtime = ToolRuntime.LOCAL
+
+    def __init__(self, recorder):
+        self.recorder = recorder
+
+    def execute(self, inputs):
+        self.recorder.called = True
+        return ToolResult(success=True, cost_usd=0.0)
+
+
+class ZeroCostApiTool(UnboundedPaidTool):
+    name = "zero_cost_api"
+
+    def estimate_cost(self, inputs):
+        return 0.0
+
+
+class BadBoundTool(UnboundedPaidTool):
+    name = "bad_bound"
+
+    def max_cost_usd(self, inputs):
+        return 0.5  # below its own estimate of 1.0 -- not a bound
+
+
+@pytest.fixture
+def gate_env(tmp_path, monkeypatch):
+    """Point the gate at an isolated config + ledger."""
+    import lib.budget_gate as gate
+
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "budget:\n"
+        "  mode: cap\n"
+        "  total_usd: 10.00\n"
+        "  period: daily\n"
+        "  timezone: system_local\n"
+        "  reserve_pct: 0.0\n"
+        "  single_action_approval_usd: null\n"
+        "  require_approval_for_new_paid_tool: false\n"
+    )
+    monkeypatch.setenv("OPENMONTAGE_CONFIG", str(cfg))
+    monkeypatch.setenv("OPENMONTAGE_COST_LOG", str(tmp_path / "cost_log.json"))
+    gate.reset()
+    yield tmp_path
+    gate.reset()
+
+
+class TestGateBoundedness:
+    def test_unbounded_paid_tool_fails_closed_and_names_the_tool(self, gate_env):
+        rec = _Recorder()
+        with pytest.raises(BudgetGateError, match="unbounded_paid"):
+            UnboundedPaidTool(rec).execute({})
+        assert rec.called is False, "provider must not be reached"
+
+    def test_bound_below_estimate_fails_closed(self, gate_env):
+        rec = _Recorder()
+        with pytest.raises(BudgetGateError, match="not an upper bound"):
+            BadBoundTool(rec).execute({})
+        assert rec.called is False
+
+    def test_bounded_paid_tool_proceeds_and_is_recorded(self, gate_env):
+        rec = _Recorder()
+        result = BoundedPaidTool(rec).execute({})
+        assert result.success and rec.called
+
+        log = json.loads((gate_env / "cost_log.json").read_text())
+        assert log["entries"][-1]["tool"] == "bounded_paid"
+        assert log["entries"][-1]["reserved_usd"] == 0.0     # settled
+        assert log["entries"][-1]["actual_usd"] == 1.0       # actual, not the bound
+        assert log["entries"][-1]["budget_date"]
+
+    def test_gate_blocks_before_provider_when_cap_reached(self, gate_env):
+        import lib.budget_gate as gate
+
+        t = gate.get_tracker()
+        spend(t, 9.5, tool="prior")
+        gate.reset()
+
+        rec = _Recorder()
+        with pytest.raises(BudgetExceededError):
+            BoundedPaidTool(rec).execute({})  # bound $2.00 > $0.50 remaining
+        assert rec.called is False, "blocked call must never reach the provider"
+
+
+class TestGateFreePaths:
+    def test_local_tool_untouched_and_writes_no_ledger(self, gate_env):
+        rec = _Recorder()
+        assert FreeLocalTool(rec).execute({}).success
+        assert rec.called
+        assert not (gate_env / "cost_log.json").exists()
+
+    def test_zero_cost_api_tool_allowed(self, gate_env):
+        rec = _Recorder()
+        assert ZeroCostApiTool(rec).execute({}).success
+        assert rec.called
+        assert not (gate_env / "cost_log.json").exists()

--- a/tests/tools/test_budget_gate.py
+++ b/tests/tools/test_budget_gate.py
@@ -546,10 +546,18 @@ class FreeLocalTool(BaseTool):
 
 
 class ZeroCostApiTool(UnboundedPaidTool):
+    """API runtime, zero estimate, no bound, no free declaration -- the
+    azure_stt/dashscope_asr shape that used to slip past the gate."""
     name = "zero_cost_api"
 
     def estimate_cost(self, inputs):
         return 0.0
+
+
+class DeclaredFreeApiTool(ZeroCostApiTool):
+    """API runtime but explicitly classified free (stock-search shape)."""
+    name = "declared_free_api"
+    paid = False
 
 
 class BadBoundTool(UnboundedPaidTool):
@@ -626,8 +634,17 @@ class TestGateFreePaths:
         assert rec.called
         assert not (gate_env / "cost_log.json").exists()
 
-    def test_zero_cost_api_tool_allowed(self, gate_env):
+    def test_zero_estimate_paid_api_tool_fails_closed(self, gate_env):
+        """A paid tool's zero estimate means 'unknown', not 'free': without a
+        declared bound or an explicit paid=False, the gate must refuse."""
         rec = _Recorder()
-        assert ZeroCostApiTool(rec).execute({}).success
+        with pytest.raises(BudgetGateError, match="zero_cost_api"):
+            ZeroCostApiTool(rec).execute({})
+        assert rec.called is False, "provider must not be reached"
+        assert not (gate_env / "cost_log.json").exists()
+
+    def test_declared_free_api_tool_allowed(self, gate_env):
+        rec = _Recorder()
+        assert DeclaredFreeApiTool(rec).execute({}).success
         assert rec.called
         assert not (gate_env / "cost_log.json").exists()

--- a/tests/tools/test_cost_tracker_governance.py
+++ b/tests/tools/test_cost_tracker_governance.py
@@ -9,7 +9,7 @@ ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 
 from lib.config_model import BudgetMode
-from tools.cost_tracker import CostTracker
+from tools.cost_tracker import BudgetExceededError, CostTracker
 
 
 class CostTrackerGovernanceTests(unittest.TestCase):
@@ -54,6 +54,63 @@ class CostTrackerGovernanceTests(unittest.TestCase):
             entry_id = restarted.estimate("paid_video", "generate", 0.01)
             restarted.reserve(entry_id)
             self.assertEqual(restarted.entries[-1]["status"], "reserved")
+
+    def test_cap_mode_blocks_where_warn_only_flags(self) -> None:
+        """The counterpart to the warn test above.
+
+        Warn recording a flag and proceeding is what the default config did --
+        it is the absence of enforcement, not enforcement. Cap must refuse.
+        """
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            tracker = CostTracker(
+                budget_total_usd=1.0,
+                reserve_pct=0.0,
+                single_action_approval_usd=None,
+                require_approval_for_new_paid_tool=False,
+                mode=BudgetMode.CAP,
+                cost_log_path=Path(temp_dir) / "cost_log.json",
+            )
+            entry_id = tracker.estimate("paid_video", "generate", 2.0)
+
+            with self.assertRaises(BudgetExceededError):
+                tracker.reserve(entry_id)
+
+            # Rejected reservations consume nothing.
+            self.assertEqual(tracker.entries[0]["status"], "estimated")
+            self.assertEqual(tracker.budget_reserved_usd, 0.0)
+
+    def test_daily_bucket_resets_but_history_is_preserved(self) -> None:
+        import tempfile
+        from datetime import datetime, timezone
+        from pathlib import Path
+
+        moment = {"now": datetime(2026, 7, 16, 12, 0, tzinfo=timezone.utc)}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            tracker = CostTracker(
+                budget_total_usd=1.0,
+                reserve_pct=0.0,
+                single_action_approval_usd=None,
+                require_approval_for_new_paid_tool=False,
+                mode=BudgetMode.CAP,
+                cost_log_path=Path(temp_dir) / "cost_log.json",
+                clock=lambda: moment["now"],
+            )
+            eid = tracker.estimate("paid_video", "generate", 1.0)
+            tracker.reserve(eid)
+            tracker.reconcile(eid, 1.0, success=True)
+            self.assertEqual(tracker.remaining_on("2026-07-16"), 0.0)
+
+            moment["now"] = datetime(2026, 7, 17, 0, 1, tzinfo=timezone.utc)
+
+            # New day: fresh budget, and yesterday's record still on the books.
+            self.assertEqual(tracker.remaining_on("2026-07-17"), 1.0)
+            self.assertEqual(tracker.spent_on("2026-07-16"), 1.0)
+            tracker.reserve(tracker.estimate("paid_video", "generate", 1.0))
+            self.assertEqual(tracker.entries[-1]["budget_date"], "2026-07-17")
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_gemini_omni_video.py
+++ b/tests/tools/test_gemini_omni_video.py
@@ -51,9 +51,12 @@ def _install_fake_requests(monkeypatch, post_responses, get_responses):
 
 
 @pytest.fixture()
-def gemini_env(monkeypatch):
+def gemini_env(monkeypatch, budget_gate_isolated):
     monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
     monkeypatch.setenv("GEMINI_API_KEY", "test-gemini-key")
+    # Budget gate active on an isolated ledger; approve this paid tool via
+    # the gate's real API so mocked-provider execute() paths can run.
+    budget_gate_isolated.approve_tool("gemini_omni_video")
 
 
 def test_gemini_omni_is_discovered_as_video_provider():

--- a/tests/tools/test_ledger_precision.py
+++ b/tests/tools/test_ledger_precision.py
@@ -1,0 +1,229 @@
+"""Ledger monetary precision: no positive paid amount can become ledger zero.
+
+The ledger's explicit quantum is $0.0001 (LEDGER_QUANTUM_USD). Positive
+amounts quantize UPWARD in Decimal (ROUND_CEILING) at the central accounting
+layer -- estimate/reservation, actual-cost reconciliation, and the gate's
+settle-fallback handle. Provider estimators return raw floats and perform no
+monetary rounding of their own, so a genuine sub-quantum charge (a
+1-character TTS request, a sub-second transcription) reaches the gate as a
+positive number and reserves at least one quantum. Repeated sub-quantum
+calls therefore accumulate against the cap instead of slipping under it.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from lib.config_model import BudgetMode
+from tools.base_tool import BaseTool, ToolResult, ToolRuntime
+from tools.cost_tracker import (
+    BudgetExceededError,
+    CostTracker,
+    LEDGER_QUANTUM_USD,
+    format_usd,
+    quantize_usd,
+)
+
+
+def make_tracker(log_path, **kw):
+    defaults = dict(
+        budget_total_usd=10.0,
+        reserve_pct=0.0,
+        single_action_approval_usd=None,
+        require_approval_for_new_paid_tool=False,
+        mode=BudgetMode.CAP,
+        cost_log_path=log_path,
+    )
+    defaults.update(kw)
+    return CostTracker(**defaults)
+
+
+# ---- The quantization rule itself ----
+
+class TestQuantizeUsd:
+    def test_quantum_is_declared(self):
+        assert float(LEDGER_QUANTUM_USD) == 0.0001
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (0.0, 0.0),                # exactly zero stays exactly zero
+            (-1.0, 0.0),               # negatives can never credit the ledger
+            (0.00001, 0.0001),         # sub-quantum positives ceil to one quantum
+            (0.00004, 0.0001),
+            (0.0001, 0.0001),          # exact quantum unchanged
+            (0.00012, 0.0002),         # ceiling, not nearest
+            (0.0003, 0.0003),
+            (3.20, 3.20),              # normal values keep exact precision
+            (10.0, 10.0),
+        ],
+    )
+    def test_grid(self, raw, expected):
+        assert quantize_usd(raw) == pytest.approx(expected, abs=1e-12)
+
+    def test_positive_never_becomes_zero(self):
+        for raw in (1e-7, 1e-6, 1e-5, 5.4e-5, 9.9e-5):
+            assert quantize_usd(raw) >= float(LEDGER_QUANTUM_USD)
+
+
+# ---- Reservation and reconciliation on the grid ----
+
+class TestLedgerAccounting:
+    def test_sub_quantum_bound_reserves_one_quantum(self, tmp_path):
+        t = make_tracker(tmp_path / "log.json")
+        eid = t.estimate("tiny_paid", "op", 0.00004)
+        entry = next(e for e in t.entries if e["id"] == eid)
+        assert entry["estimated_usd"] == pytest.approx(0.0001)
+        t.reserve(eid)
+        assert t.reserved_on(t.current_budget_date()) == pytest.approx(0.0001)
+
+    def test_positive_actual_cannot_be_recorded_as_zero(self, tmp_path):
+        t = make_tracker(tmp_path / "log.json")
+        eid = t.estimate("tiny_paid", "op", 0.00004)
+        t.reserve(eid)
+        t.reconcile(eid, 0.00004, success=True)
+        entry = next(e for e in t.entries if e["id"] == eid)
+        assert entry["actual_usd"] == pytest.approx(0.0001)
+        assert t.spent_on(t.current_budget_date()) > 0
+
+    def test_repeated_sub_quantum_calls_reach_a_small_cap(self, tmp_path):
+        """Five $0.00004 calls fill a $0.0005 cap; the sixth is refused.
+        Without upward quantization they would all record zero forever."""
+        t = make_tracker(tmp_path / "log.json", budget_total_usd=0.0005)
+        for _ in range(5):
+            eid = t.estimate("tiny_paid", "op", 0.00004)
+            t.reserve(eid)
+            t.reconcile(eid, 0.00004, success=True)
+        assert t.spent_on(t.current_budget_date()) == pytest.approx(0.0005)
+        with pytest.raises(BudgetExceededError):
+            t.reserve(t.estimate("tiny_paid", "op", 0.00004))
+
+    def test_exact_cap_at_quantum_scale_still_allowed(self, tmp_path):
+        t = make_tracker(tmp_path / "log.json", budget_total_usd=0.0003)
+        for _ in range(3):
+            t.reserve(t.estimate("tiny_paid", "op", 0.0001))
+        assert t.reserved_on(t.current_budget_date()) == pytest.approx(0.0003)
+        with pytest.raises(BudgetExceededError):
+            t.reserve(t.estimate("tiny_paid", "op", 0.0001))
+
+    def test_refund_releases_exactly_the_quantized_reservation(self, tmp_path):
+        t = make_tracker(tmp_path / "log.json")
+        eid = t.estimate("tiny_paid", "op", 0.00004)
+        t.reserve(eid)
+        t.refund(eid)
+        assert t.reserved_on(t.current_budget_date()) == pytest.approx(0.0)
+        assert t.remaining_on(t.current_budget_date()) == pytest.approx(10.0)
+
+    def test_reconcile_clears_reservation_and_records_grid_actual(self, tmp_path):
+        t = make_tracker(tmp_path / "log.json")
+        eid = t.estimate("tiny_paid", "op", 0.00025)
+        t.reserve(eid)
+        t.reconcile(eid, 0.00013, success=True)
+        entry = next(e for e in t.entries if e["id"] == eid)
+        assert entry["reserved_usd"] == 0.0
+        assert entry["actual_usd"] == pytest.approx(0.0002)  # ceiling of 0.00013
+        assert t.remaining_on(t.current_budget_date()) == pytest.approx(10.0 - 0.0002)
+
+    def test_zero_estimate_records_exactly_zero(self, tmp_path):
+        t = make_tracker(tmp_path / "log.json")
+        eid = t.estimate("free_row", "op", 0.0)
+        entry = next(e for e in t.entries if e["id"] == eid)
+        assert entry["estimated_usd"] == 0.0
+
+
+# ---- Short-input estimators no longer fabricate zero ----
+
+class TestShortInputEstimators:
+    def test_one_char_kling_tts_is_positive_before_quantization(self):
+        from tools.audio.kling_tts import KlingTTS
+
+        tool = KlingTTS()
+        estimate = tool.estimate_cost({"text": "x"})
+        bound = tool.max_cost_usd({"text": "x"})
+        assert estimate == pytest.approx(0.000018)
+        assert bound == pytest.approx(0.000054)
+        assert bound >= estimate
+        assert quantize_usd(bound) >= 0.0001  # what the ledger will reserve
+
+    @pytest.mark.parametrize(
+        "module,cls,inputs",
+        [
+            ("tools.audio.openai_tts", "OpenAITTS", {"text": "x"}),
+            ("tools.audio.doubao_tts", "DoubaoTTS", {"text": "x"}),
+            ("tools.audio.dashscope_tts", "DashscopeTTS", {"text": "x"}),
+            ("tools.audio.google_tts", "GoogleTTS", {"text": "x", "voice": "en-US-Standard-A"}),
+            ("tools.audio.music_gen", "MusicGen", {"prompt": "p", "duration_seconds": 0.05}),
+            ("tools.analysis.azure_stt", "AzureSpeechToText", {"duration_seconds": 0.1}),
+        ],
+    )
+    def test_genuine_paid_request_never_estimates_zero(self, module, cls, inputs):
+        import importlib
+
+        tool = getattr(importlib.import_module(module), cls)()
+        estimate = tool.estimate_cost(inputs)
+        assert estimate > 0, f"{tool.name}: positive paid request estimated zero"
+        bound = tool.max_cost_usd(inputs)
+        assert bound is not None and bound >= estimate
+        assert quantize_usd(bound) >= float(LEDGER_QUANTUM_USD)
+
+
+# ---- End-to-end through the gate ----
+
+class _SubQuantumPaidTool(BaseTool):
+    name = "sub_quantum_paid"
+    runtime = ToolRuntime.API
+
+    def estimate_cost(self, inputs):
+        return 0.00002
+
+    def max_cost_usd(self, inputs):
+        return 0.00004
+
+    def execute(self, inputs):
+        return ToolResult(success=True, cost_usd=0.00004)
+
+
+class TestGateEndToEnd:
+    def test_sub_quantum_call_is_gated_reserved_and_settled_nonzero(
+        self, budget_gate_isolated, monkeypatch
+    ):
+        import os
+
+        budget_gate_isolated.approve_tool("sub_quantum_paid")
+        result = _SubQuantumPaidTool().execute({})
+        assert result.success
+
+        log = json.loads(Path(os.environ["OPENMONTAGE_COST_LOG"]).read_text())
+        entry = log["entries"][-1]
+        assert entry["tool"] == "sub_quantum_paid"
+        assert entry["status"] == "completed"
+        assert entry["actual_usd"] == pytest.approx(0.0001)  # never zero
+        assert entry["reserved_usd"] == 0.0                  # settled
+
+    def test_three_sub_quantum_calls_accumulate_in_the_ledger(
+        self, budget_gate_isolated
+    ):
+        import os
+
+        budget_gate_isolated.approve_tool("sub_quantum_paid")
+        for _ in range(3):
+            assert _SubQuantumPaidTool().execute({}).success
+        log = json.loads(Path(os.environ["OPENMONTAGE_COST_LOG"]).read_text())
+        total = sum(e["actual_usd"] for e in log["entries"])
+        assert total == pytest.approx(0.0003)
+
+
+# ---- Operator messages stay accurate at this scale ----
+
+class TestMessages:
+    def test_quantum_scale_amounts_display_accurately(self):
+        assert format_usd(0.0001) == "$0.0001"
+        assert format_usd(0.00004) == "$0.000040"
+        assert format_usd(0.0018) == "$0.0018"

--- a/tests/tools/test_max_cost_bounds.py
+++ b/tests/tools/test_max_cost_bounds.py
@@ -1,0 +1,346 @@
+"""Bound-safety tests for every paid tool that declares max_cost_usd().
+
+The hard cap is only real if each declared bound is a true ceiling: finite,
+non-negative, and never below what the exact request can bill -- including
+provider-side escalations the estimate does not price (duration coercion,
+"auto" tiers, unknown variants). Selector bounds must be the SELECTED
+provider's bound: the selector itself never adds a charge, and an unbounded
+provider must stay blocked even when reached through a selector.
+"""
+
+from __future__ import annotations
+
+import importlib
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from tools.base_tool import BaseTool, BudgetGateError, ToolResult, ToolRuntime
+from tools.cost_tracker import ApprovalRequiredError, format_usd
+
+
+def _make(module: str, cls: str) -> BaseTool:
+    return getattr(importlib.import_module(module), cls)()
+
+
+def _case(module, cls, inputs, id_):
+    return pytest.param(module, cls, inputs, id=id_)
+
+
+# One entry per newly bounded tool, with the billable-parameter variations
+# that could plausibly break the bound: durations, counts, quality tiers,
+# resolution tiers, unknown variant strings, and provider-chosen "auto".
+BOUND_CASES = [
+    # veo_video -- explicit backend avoids env-dependent resolution
+    _case("tools.video.veo_video", "VeoVideo", {"backend": "google", "duration": "4s"}, "veo-google-4s-coercible"),
+    _case("tools.video.veo_video", "VeoVideo", {"backend": "google", "duration": "8s"}, "veo-google-8s"),
+    _case("tools.video.veo_video", "VeoVideo", {"backend": "google", "duration": "16s"}, "veo-google-16s"),
+    _case("tools.video.veo_video", "VeoVideo", {"backend": "google", "duration": "nonsense"}, "veo-google-badduration"),
+    _case("tools.video.veo_video", "VeoVideo", {"backend": "fal", "duration": "8s"}, "veo-fal-audio-default"),
+    _case("tools.video.veo_video", "VeoVideo", {"backend": "fal", "duration": "8s", "generate_audio": False}, "veo-fal-noaudio"),
+    _case("tools.video.veo_video", "VeoVideo", {"backend": "fal", "resolution": "4k", "duration": "8s"}, "veo-fal-4k"),
+    _case("tools.video.veo_video", "VeoVideo", {"backend": "fal", "resolution": "8K-weird", "duration": "8s"}, "veo-fal-unknown-resolution"),
+    _case("tools.video.veo_video", "VeoVideo", {"backend": "fal", "model_variant": "veo3.1/fast", "duration": "8s"}, "veo-fal-fast"),
+    # gemini_omni_video -- clamp ceiling
+    _case("tools.video.gemini_omni_video", "GeminiOmniVideo", {"prompt": "x"}, "gemini-default"),
+    _case("tools.video.gemini_omni_video", "GeminiOmniVideo", {"prompt": "x", "duration": "3"}, "gemini-3s"),
+    _case("tools.video.gemini_omni_video", "GeminiOmniVideo", {"prompt": "x", "duration": "30"}, "gemini-30s-clamped"),
+    # kling_official_video
+    _case("tools.video.kling_official_video", "KlingOfficialVideo", {"prompt": "x"}, "klingvid-default"),
+    _case("tools.video.kling_official_video", "KlingOfficialVideo", {"prompt": "x", "mode": "4k", "duration": "10", "sound": "on"}, "klingvid-4k-10s-sound"),
+    _case("tools.video.kling_official_video", "KlingOfficialVideo", {"prompt": "x", "mode": "hyperreal-9000"}, "klingvid-unknown-mode"),
+    _case("tools.video.kling_official_video", "KlingOfficialVideo", {"prompt": "x", "api_family": "next-gen"}, "klingvid-unknown-family"),
+    _case("tools.video.kling_official_video", "KlingOfficialVideo",
+          {"prompt": "x", "api_family": "omni", "multi_prompt": [{"prompt": "a"}, {"prompt": "b"}],
+           "video_list": [{"video_url": "https://e/x.mp4"}], "element_list": [1, 2]},
+          "klingvid-omni-references"),
+    # kling_official_image
+    _case("tools.graphics.kling_official_image", "KlingOfficialImage", {"prompt": "x"}, "klingimg-default"),
+    _case("tools.graphics.kling_official_image", "KlingOfficialImage", {"prompt": "x", "n": 3, "resolution": "4k"}, "klingimg-n3-4k"),
+    _case("tools.graphics.kling_official_image", "KlingOfficialImage", {"prompt": "x", "resolution": "16k"}, "klingimg-unknown-resolution"),
+    _case("tools.graphics.kling_official_image", "KlingOfficialImage",
+          {"prompt": "x", "result_type": "series", "series_amount": "4"}, "klingimg-series"),
+    # kling_tts
+    _case("tools.audio.kling_tts", "KlingTTS", {"text": "hi"}, "klingtts-short"),
+    _case("tools.audio.kling_tts", "KlingTTS", {"text": "word " * 2000}, "klingtts-long"),
+    # openai_image
+    _case("tools.graphics.openai_image", "OpenAIImage", {"prompt": "x", "quality": "low", "n": 1}, "openaiimg-low"),
+    _case("tools.graphics.openai_image", "OpenAIImage", {"prompt": "x", "quality": "high", "n": 4}, "openaiimg-high-n4"),
+    _case("tools.graphics.openai_image", "OpenAIImage", {"prompt": "x", "quality": "auto", "n": 2}, "openaiimg-auto"),
+    _case("tools.graphics.openai_image", "OpenAIImage", {"prompt": "x", "quality": "mystery"}, "openaiimg-unknown-quality"),
+    # dashscope_image
+    _case("tools.graphics.dashscope_image", "DashscopeImage", {"prompt": "x"}, "dashscope-1"),
+    _case("tools.graphics.dashscope_image", "DashscopeImage", {"prompt": "x", "n": 5}, "dashscope-5"),
+    # TTS providers
+    _case("tools.audio.elevenlabs_tts", "ElevenLabsTTS", {"text": "hello world"}, "elevenlabs"),
+    _case("tools.audio.openai_tts", "OpenAITTS", {"text": "hello world"}, "openaitts"),
+    _case("tools.audio.doubao_tts", "DoubaoTTS", {"text": "hello world"}, "doubao"),
+    _case("tools.audio.dashscope_tts", "DashscopeTTS", {"text": "hello world"}, "dashscopetts"),
+    _case("tools.audio.google_tts", "GoogleTTS", {"text": "hello", "voice": "en-US-Chirp3-HD-Orus"}, "gtts-chirp"),
+    _case("tools.audio.google_tts", "GoogleTTS", {"text": "hello", "voice": "en-US-Studio-O"}, "gtts-studio"),
+    _case("tools.audio.google_tts", "GoogleTTS", {"text": "hello", "voice": "en-US-FutureVoice-X"}, "gtts-unknown-voice"),
+    # music
+    _case("tools.audio.suno_music", "SunoMusic", {"prompt": "calm"}, "suno"),
+    _case("tools.audio.music_gen", "MusicGen", {"prompt": "calm", "duration_seconds": 30}, "musicgen-30s"),
+    _case("tools.audio.music_gen", "MusicGen", {"prompt": "calm", "duration_seconds": 180}, "musicgen-180s"),
+    # image providers
+    _case("tools.graphics.flux_image", "FluxImage", {"prompt": "x", "model": "flux-pro/v1.1"}, "flux-pro"),
+    _case("tools.graphics.flux_image", "FluxImage", {"prompt": "x", "model": "flux-dev"}, "flux-dev"),
+    _case("tools.graphics.flux_image", "FluxImage", {"prompt": "x", "model": "flux-ultra-9"}, "flux-unknown"),
+    _case("tools.graphics.recraft_image", "RecraftImage", {"prompt": "x", "model": "v4"}, "recraft-v4"),
+    _case("tools.graphics.recraft_image", "RecraftImage", {"prompt": "x", "model": "v4-pro"}, "recraft-v4pro"),
+    _case("tools.graphics.recraft_image", "RecraftImage", {"prompt": "x", "model": "v5"}, "recraft-unknown"),
+    _case("tools.graphics.google_imagen", "GoogleImagen", {"prompt": "x"}, "imagen-default"),
+    _case("tools.graphics.google_imagen", "GoogleImagen", {"prompt": "x", "model": "imagen-4.0-ultra-generate-001", "number_of_images": 3}, "imagen-ultra-n3"),
+    _case("tools.graphics.google_imagen", "GoogleImagen", {"prompt": "x", "model": "imagen-5-mystery"}, "imagen-unknown-model"),
+    _case("tools.graphics.grok_image", "GrokImage", {"prompt": "x", "n": 2}, "grokimg-n2"),
+    _case("tools.graphics.image_gen", "ImageGen", {"prompt": "x", "provider": "openai"}, "imagegen-openai"),
+    _case("tools.graphics.image_gen", "ImageGen", {"prompt": "x", "provider": "flux"}, "imagegen-flux"),
+    # video providers
+    _case("tools.video.grok_video", "GrokVideo", {"prompt": "x", "duration": 10}, "grokvid-10s"),
+    _case("tools.video.grok_video", "GrokVideo", {"prompt": "x", "duration": 5, "resolution": "480p"}, "grokvid-480p"),
+    _case("tools.video.kling_video", "KlingVideo", {"prompt": "x", "model_variant": "v2.1/master", "duration": "10"}, "klingfal-master-10s"),
+    _case("tools.video.kling_video", "KlingVideo", {"prompt": "x", "model_variant": "v4/imaginary"}, "klingfal-unknown-variant"),
+    _case("tools.video.minimax_video", "MiniMaxVideo", {"prompt": "x", "model_variant": "hailuo-02/fast"}, "minimax-fast"),
+    _case("tools.video.minimax_video", "MiniMaxVideo", {"prompt": "x", "model_variant": "hailuo-03/unknown"}, "minimax-unknown"),
+    _case("tools.video.seedance_video", "SeedanceVideo", {"prompt": "x", "duration": "5"}, "seedance-5s"),
+    _case("tools.video.seedance_video", "SeedanceVideo", {"prompt": "x", "duration": "auto"}, "seedance-auto"),
+    _case("tools.video.seedance_replicate", "SeedanceReplicate", {"prompt": "x", "duration": "auto"}, "seedance-repl-auto"),
+    _case("tools.video.runway_video", "RunwayVideo", {"prompt": "x", "model": "gen4_turbo", "duration": 10}, "runway-gen4"),
+    _case("tools.video.runway_video", "RunwayVideo", {"prompt": "x", "model": "gen9_future", "duration": 5}, "runway-unknown-model"),
+    _case("tools.video.higgsfield_video", "HiggsFieldVideo", {"prompt": "x", "model": "kling_3.0", "duration": 5}, "higgs-kling"),
+    _case("tools.video.higgsfield_video", "HiggsFieldVideo", {"prompt": "x", "model": "mystery_model", "duration": 5}, "higgs-unknown-model"),
+    _case("tools.video.ltx_video_modal", "LTXVideoModal", {"prompt": "x"}, "ltx-modal"),
+    _case("tools.video.heygen_video", "HeyGenVideo", {"prompt": "x"}, "heygen-default"),
+    _case("tools.video.heygen_video", "HeyGenVideo", {"prompt": "x", "provider_variant": "not-a-variant"}, "heygen-unknown-variant"),
+    # azure_stt (bounded when duration is supplied)
+    _case("tools.analysis.azure_stt", "AzureSpeechToText", {"input_path": "a.wav", "duration_seconds": 3600}, "azurestt-1h"),
+]
+
+
+@pytest.mark.parametrize("module,cls,inputs", BOUND_CASES)
+def test_bound_is_declared_finite_and_covers_estimate(module, cls, inputs):
+    tool = _make(module, cls)
+    bound = tool.max_cost_usd(inputs)
+    estimate = tool.estimate_cost(inputs)
+
+    assert bound is not None, f"{tool.name} must declare a bound for {inputs}"
+    assert isinstance(bound, (int, float)) and not isinstance(bound, bool)
+    assert math.isfinite(bound)
+    assert bound >= 0
+    assert bound + 1e-9 >= estimate, (
+        f"{tool.name}: bound {bound} below its own estimate {estimate} for {inputs}"
+    )
+
+
+# ---- Escalations the estimate does not price ----
+
+def test_veo_bound_covers_auto_fix_duration_coercion():
+    """auto_fix can raise a 4s request to 8 billed seconds; the bound for the
+    4s request must cover the 8s reality."""
+    from tools.video.veo_video import VeoVideo
+
+    tool = VeoVideo()
+    short = {"backend": "google", "duration": "4s"}
+    coerced = {"backend": "google", "duration": "8s"}
+    assert tool.max_cost_usd(short) >= tool.estimate_cost(coerced)
+
+
+def test_openai_image_auto_quality_bounded_at_dearest_tier():
+    from tools.graphics.openai_image import OpenAIImage
+
+    tool = OpenAIImage()
+    auto = {"prompt": "x", "quality": "auto", "n": 2}
+    high = {"prompt": "x", "quality": "high", "n": 2}
+    assert tool.max_cost_usd(auto) >= tool.estimate_cost(high)
+
+
+def test_seedance_auto_duration_bounded_at_schema_maximum():
+    from tools.video.seedance_video import SeedanceVideo
+
+    tool = SeedanceVideo()
+    auto = {"prompt": "x", "duration": "auto"}
+    longest = {"prompt": "x", "duration": "15"}
+    assert tool.max_cost_usd(auto) >= tool.estimate_cost(longest)
+
+
+@pytest.mark.parametrize("known_mode", ["std", "pro", "4k"])
+def test_kling_video_unknown_mode_bounds_above_every_known_mode(known_mode):
+    from tools.video.kling_official_video import KlingOfficialVideo
+
+    tool = KlingOfficialVideo()
+    unknown = {"prompt": "x", "mode": "definitely-not-a-mode"}
+    known = {"prompt": "x", "mode": known_mode}
+    assert tool.max_cost_usd(unknown) >= tool.estimate_cost(known)
+
+
+def test_google_tts_unknown_voice_bounds_at_dearest_family():
+    from tools.audio.google_tts import GoogleTTS
+
+    tool = GoogleTTS()
+    text = "hello " * 100
+    unknown = {"text": text, "voice": "en-US-FutureVoice-X"}
+    studio = {"text": text, "voice": "en-US-Studio-O"}
+    assert tool.max_cost_usd(unknown) >= tool.estimate_cost(studio)
+
+
+# ---- Fail-closed paths that must stay fail-closed ----
+
+@pytest.mark.parametrize(
+    "module,cls",
+    [
+        ("tools.video.kling_official_video", "KlingOfficialVideo"),
+        ("tools.graphics.kling_official_image", "KlingOfficialImage"),
+        ("tools.audio.kling_tts", "KlingTTS"),
+    ],
+)
+def test_kling_account_usage_requests_remain_unbounded(module, cls):
+    """The account-usage diagnostic's billing is unverified: requesting it
+    must return None (fail closed), never a number and never zero."""
+    tool = _make(module, cls)
+    inputs = {"prompt": "x", "text": "x", "include_account_usage": True}
+    assert tool.max_cost_usd(inputs) is None
+
+
+# ---- Selector bound contract ----
+
+class _RecordingProvider(BaseTool):
+    """Fake bounded paid provider; records whether execute was reached."""
+
+    name = "fake_paid_provider"
+    provider = "fake"
+    capability = "image_generation"
+    runtime = ToolRuntime.API
+
+    def __init__(self):
+        self.executed = False
+
+    def estimate_cost(self, inputs):
+        return 0.10
+
+    def max_cost_usd(self, inputs):
+        return 0.20
+
+    def execute(self, inputs):
+        self.executed = True
+        return ToolResult(success=True, cost_usd=0.10)
+
+
+class _UnboundedProvider(_RecordingProvider):
+    name = "fake_unbounded_provider"
+
+    def max_cost_usd(self, inputs):
+        return None
+
+
+def _selector_with(monkeypatch, provider):
+    from tools.graphics.image_selector import ImageSelector
+
+    monkeypatch.setattr(ImageSelector, "_providers", lambda self: [provider])
+    monkeypatch.setattr(ImageSelector, "_filter_candidates", lambda self, i, c: c)
+    monkeypatch.setattr(
+        ImageSelector, "_select_best_tool", lambda self, i, c, t: (provider, None)
+    )
+    return ImageSelector()
+
+
+def test_selector_bound_is_selected_providers_bound(monkeypatch):
+    provider = _RecordingProvider()
+    selector = _selector_with(monkeypatch, provider)
+    assert selector.max_cost_usd({"prompt": "x"}) == pytest.approx(0.20)
+
+
+def test_selector_bound_is_none_when_selected_provider_is_unbounded(monkeypatch):
+    provider = _UnboundedProvider()
+    selector = _selector_with(monkeypatch, provider)
+    assert selector.max_cost_usd({"prompt": "x"}) is None
+
+
+@pytest.mark.parametrize(
+    "module,cls",
+    [
+        ("tools.graphics.image_selector", "ImageSelector"),
+        ("tools.audio.tts_selector", "TTSSelector"),
+        ("tools.video.video_selector", "VideoSelector"),
+    ],
+)
+def test_selector_rank_mode_is_free_and_unbounded_by_zero(module, cls):
+    """Rank mode never dispatches a provider: estimate and bound are both 0,
+    so the gate treats it as the free call it is."""
+    selector = _make(module, cls)
+    inputs = {"prompt": "x", "text": "x", "operation": "rank"}
+    assert selector.estimate_cost(inputs) == 0.0
+    assert selector.max_cost_usd(inputs) == 0.0
+
+
+def test_selector_with_no_candidates_is_free(monkeypatch):
+    from tools.graphics.image_selector import ImageSelector
+
+    monkeypatch.setattr(ImageSelector, "_providers", lambda self: [])
+    selector = ImageSelector()
+    assert selector.estimate_cost({"prompt": "x"}) == 0.0
+    assert selector.max_cost_usd({"prompt": "x"}) == 0.0
+
+
+def test_selector_cannot_silently_dispatch_unapproved_provider(monkeypatch, budget_gate_isolated):
+    """Environment keys alone must never let a selector reach a paid provider:
+    with the gate active and the selector unapproved, execute() is refused by
+    the first-paid-use safeguard BEFORE the provider runs."""
+    provider = _RecordingProvider()
+    selector = _selector_with(monkeypatch, provider)
+    with pytest.raises(ApprovalRequiredError):
+        selector.execute({"prompt": "x"})
+    assert provider.executed is False
+
+
+def test_selector_with_unbounded_provider_is_blocked_even_when_approved(
+    monkeypatch, budget_gate_isolated
+):
+    provider = _UnboundedProvider()
+    selector = _selector_with(monkeypatch, provider)
+    budget_gate_isolated.approve_tool("image_selector")
+    with pytest.raises(BudgetGateError, match="image_selector"):
+        selector.execute({"prompt": "x"})
+    assert provider.executed is False
+
+
+# ---- Operator message formatting ----
+
+class TestUsdFormatting:
+    def test_normal_amounts_keep_two_decimals(self):
+        assert format_usd(3.2) == "$3.20"
+        assert format_usd(10) == "$10.00"
+        assert format_usd(0.5) == "$0.50"
+        assert format_usd(0) == "$0.00"
+
+    def test_sub_cent_positives_never_display_as_zero(self):
+        assert format_usd(0.0018) == "$0.0018"
+        assert format_usd(0.004) == "$0.0040"
+        assert format_usd(0.000018) == "$0.000018"
+        for value in (0.0049, 0.0001, 0.00003):
+            assert format_usd(value) != "$0.00"
+            assert float(format_usd(value).lstrip("$")) > 0
+
+    def test_gate_refusal_shows_sub_cent_estimate(self):
+        """The unbounded-tool refusal must show the true sub-cent estimate,
+        not a misleading $0.00."""
+
+        class TinyPaidTool(BaseTool):
+            name = "tiny_paid"
+            runtime = ToolRuntime.API
+
+            def estimate_cost(self, inputs):
+                return 0.0018
+
+            def execute(self, inputs):
+                return ToolResult(success=True)
+
+        with pytest.raises(BudgetGateError) as exc:
+            TinyPaidTool().execute({})
+        assert "$0.0018" in str(exc.value)
+        assert "$0.00 " not in str(exc.value)

--- a/tests/tools/test_openai_image_multi_output.py
+++ b/tests/tools/test_openai_image_multi_output.py
@@ -39,12 +39,15 @@ class _FakeClient:
 
 
 @pytest.fixture
-def openai_tool(monkeypatch):
+def openai_tool(monkeypatch, budget_gate_isolated):
     # Stub the `openai` SDK so execute() runs fully offline.
     fake = types.ModuleType("openai")
     fake.OpenAI = _FakeClient
     monkeypatch.setitem(sys.modules, "openai", fake)
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    # Budget gate active on an isolated ledger; approve this paid tool via
+    # the gate's real API so the stubbed execute() paths can run.
+    budget_gate_isolated.approve_tool("openai_image")
     from tools.graphics.openai_image import OpenAIImage
 
     return OpenAIImage()

--- a/tests/tools/test_paid_classification.py
+++ b/tests/tools/test_paid_classification.py
@@ -1,0 +1,237 @@
+"""Paid/free classification: a zero estimate can no longer bypass the gate.
+
+The gate previously trusted `estimate_cost() > 0` to decide whether a call
+was paid, so a paid API whose estimate returned 0 -- sub-cent rounding,
+unknown duration, missing billing info -- ran ungated. Classification now
+comes from `BaseTool.paid` (API/HYBRID default to paid; genuinely free
+tools declare `paid = False`), and a paid tool must produce a bound even
+for a zero estimate. These tests pin that contract for the two real tools
+that had the hole (azure_stt, dashscope_asr) and for selector routing.
+
+No real provider client is constructed anywhere here: requests is
+monkeypatched to explode on contact, and all audio is a local stdlib-`wave`
+fixture.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import wave
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from tools.analysis.azure_stt import AzureSpeechToText
+from tools.analysis.dashscope_asr import DashscopeAsr
+from tools.base_tool import BaseTool, BudgetGateError, ToolResult, ToolRuntime
+
+HAS_FFPROBE = shutil.which("ffprobe") is not None
+
+
+def _write_real_wav(path: Path, seconds: float = 2.0, rate: int = 8000) -> Path:
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(rate)
+        w.writeframes(b"\x00\x00" * int(rate * seconds))
+    return path
+
+
+def _forbid_network(monkeypatch):
+    """Any HTTP attempt in these tests is a test failure, not a charge."""
+    import requests
+
+    def _explode(*args, **kwargs):
+        raise AssertionError("network dispatch attempted -- gate failed")
+
+    monkeypatch.setattr(requests, "post", _explode)
+    monkeypatch.setattr(requests, "get", _explode)
+
+
+# ---- The classification itself ----
+
+class TestClassification:
+    def test_azure_and_dashscope_are_explicitly_paid(self):
+        assert AzureSpeechToText.paid is True
+        assert DashscopeAsr.paid is True
+
+    def test_stock_search_tools_are_explicitly_free(self):
+        from tools.audio.freesound_music import FreesoundMusic
+        from tools.graphics.pexels_image import PexelsImage
+        from tools.graphics.pixabay_image import PixabayImage
+
+        for cls in (FreesoundMusic, PexelsImage, PixabayImage):
+            assert cls.paid is False, f"{cls.__name__} must stay declared-free"
+
+    def test_every_free_declaration_estimates_zero(self):
+        """A tool may only claim paid = False while its estimate agrees."""
+        from tools.tool_registry import ToolRegistry
+
+        registry = ToolRegistry()
+        registry.discover()
+        free_tools = [
+            t for t in registry._tools.values() if getattr(t, "paid", None) is False
+        ]
+        assert free_tools, "expected explicit free classifications in the registry"
+        for tool in free_tools:
+            assert tool.estimate_cost({}) == 0.0, (
+                f"{tool.name} declares paid=False but estimates money"
+            )
+
+
+# ---- Azure STT: locally derived bound ----
+
+class TestAzureSttBound:
+    @pytest.fixture
+    def azure_env(self, monkeypatch):
+        monkeypatch.setenv("AZURE_SPEECH_KEY", "fake-key")
+        monkeypatch.setenv("AZURE_SPEECH_REGION", "eastus")
+
+    @pytest.mark.skipif(not HAS_FFPROBE, reason="ffprobe not on PATH")
+    def test_bound_derived_from_local_audio_probe(self, azure_env, tmp_path):
+        audio = _write_real_wav(tmp_path / "two_seconds.wav", seconds=2.0)
+        tool = AzureSpeechToText()
+        inputs = {"input_path": str(audio)}
+
+        bound = tool.max_cost_usd(inputs)
+        assert bound is not None and bound > 0
+        # ~2s at $1/audio-hour, allowing for container rounding.
+        assert bound == pytest.approx(2.0 / 3600.0, rel=0.25)
+        assert tool.estimate_cost(inputs) == pytest.approx(bound)
+
+    def test_explicit_duration_still_priced_exactly(self):
+        tool = AzureSpeechToText()
+        assert tool.max_cost_usd({"duration_seconds": 3600}) == pytest.approx(1.0)
+        assert tool.estimate_cost({"duration_seconds": 3600}) == pytest.approx(1.0)
+
+    def test_unprobeable_file_is_unbounded_and_blocked_before_dispatch(
+        self, azure_env, tmp_path, monkeypatch, budget_gate_isolated
+    ):
+        budget_gate_isolated.approve_tool("azure_stt")
+        _forbid_network(monkeypatch)
+        garbage = tmp_path / "garbage.wav"
+        garbage.write_bytes(b"this is not audio")
+
+        tool = AzureSpeechToText()
+        assert tool.max_cost_usd({"input_path": str(garbage)}) is None
+        with pytest.raises(BudgetGateError, match="azure_stt"):
+            tool.execute({"input_path": str(garbage)})
+
+    def test_missing_file_and_missing_credentials_stay_graceful(
+        self, monkeypatch, tmp_path, budget_gate_isolated
+    ):
+        """Guaranteed-local refusals bill nothing and keep their error UX."""
+        _forbid_network(monkeypatch)
+        monkeypatch.setenv("AZURE_SPEECH_KEY", "fake-key")
+        monkeypatch.setenv("AZURE_SPEECH_REGION", "eastus")
+        res = AzureSpeechToText().execute({"input_path": str(tmp_path / "nope.wav")})
+        assert not res.success and "not found" in res.error.lower()
+
+        monkeypatch.delenv("AZURE_SPEECH_KEY", raising=False)
+        monkeypatch.delenv("AZURE_SPEECH_REGION", raising=False)
+        existing = tmp_path / "exists.wav"
+        existing.write_bytes(b"unprobeable")
+        res = AzureSpeechToText().execute({"input_path": str(existing)})
+        assert not res.success and "not configured" in res.error.lower()
+
+
+# ---- DashScope ASR: paid, unbounded, blocked ----
+
+class TestDashscopeAsrBlocked:
+    def test_dispatchable_request_is_blocked_before_provider(
+        self, monkeypatch, budget_gate_isolated
+    ):
+        """No repository-verified pricing exists, so a request that would
+        reach DashScope must be refused as a paid tool without a declared
+        maximum cost -- and the refusal must say so."""
+        budget_gate_isolated.approve_tool("dashscope_asr")
+        _forbid_network(monkeypatch)
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "fake-key")
+
+        tool = DashscopeAsr()
+        inputs = {"audio_url": "https://example.com/audio.mp3"}
+        assert tool.max_cost_usd(inputs) is None
+        with pytest.raises(BudgetGateError) as exc:
+            tool.execute(inputs)
+        message = str(exc.value)
+        assert "dashscope_asr" in message
+        assert "PAID" in message
+        assert "bounded maximum cost" in message
+
+    def test_local_guardrails_still_answer_gracefully(self, monkeypatch, budget_gate_isolated):
+        _forbid_network(monkeypatch)
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "fake-key")
+        res = DashscopeAsr().execute({"audio_url": "/local/path.mp3"})
+        assert not res.success and "publicly accessible URL" in res.error
+
+        monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+        res = DashscopeAsr().execute({"audio_url": "https://example.com/a.mp3"})
+        assert not res.success and "DASHSCOPE_API_KEY" in res.error
+
+
+# ---- Selector routing cannot launder a zero estimate ----
+
+class _ZeroEstimatePaidProvider(BaseTool):
+    """Paid API provider whose estimate is 0 and which declares no bound --
+    the exact shape that used to bypass the gate."""
+
+    name = "zero_estimate_paid_provider"
+    provider = "fake"
+    capability = "tts"
+    runtime = ToolRuntime.API
+
+    def __init__(self):
+        self.executed = False
+
+    def estimate_cost(self, inputs):
+        return 0.0
+
+    def execute(self, inputs):
+        self.executed = True
+        return ToolResult(success=True)
+
+
+class _FreeProvider(_ZeroEstimatePaidProvider):
+    name = "declared_free_provider"
+    paid = False
+
+
+def _tts_selector_with(monkeypatch, provider):
+    from tools.audio.tts_selector import TTSSelector
+
+    monkeypatch.setattr(TTSSelector, "_providers", lambda self: [provider])
+    monkeypatch.setattr(
+        TTSSelector, "_select_best_tool", lambda self, i, c, t: (provider, None)
+    )
+    return TTSSelector()
+
+
+class TestSelectorRouting:
+    def test_selector_routed_zero_estimate_paid_provider_is_blocked(
+        self, monkeypatch, budget_gate_isolated
+    ):
+        provider = _ZeroEstimatePaidProvider()
+        selector = _tts_selector_with(monkeypatch, provider)
+        budget_gate_isolated.approve_tool("tts_selector")
+
+        assert selector.max_cost_usd({"text": "x"}) is None
+        with pytest.raises(BudgetGateError, match="tts_selector"):
+            selector.execute({"text": "x"})
+        assert provider.executed is False
+
+    def test_selector_routed_declared_free_provider_still_runs(
+        self, monkeypatch, budget_gate_isolated
+    ):
+        provider = _FreeProvider()
+        selector = _tts_selector_with(monkeypatch, provider)
+
+        assert selector.max_cost_usd({"text": "x"}) == 0.0
+        result = selector.execute({"text": "x"})
+        assert result.success and provider.executed
+        # Free routing writes nothing to the ledger.
+        import os
+        assert not Path(os.environ["OPENMONTAGE_COST_LOG"]).exists()

--- a/tests/tools/test_sora_video.py
+++ b/tests/tools/test_sora_video.py
@@ -73,7 +73,9 @@ def test_sora_video_reports_unavailable_when_openai_sdk_lacks_video_api(monkeypa
     assert SoraVideo().get_status() == ToolStatus.UNAVAILABLE
 
 
-def test_sora_video_executes_with_current_create_and_poll_sdk_surface(monkeypatch, tmp_path):
+def test_sora_video_executes_with_current_create_and_poll_sdk_surface(
+    monkeypatch, tmp_path, budget_gate_isolated
+):
     from tools.video.sora_video import SoraVideo
 
     calls = {}
@@ -105,6 +107,10 @@ def test_sora_video_executes_with_current_create_and_poll_sdk_surface(monkeypatc
     monkeypatch.setitem(sys.modules, "openai", fake_openai)
     monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
 
+    # Gate stays active (isolated config + ledger); approve this paid tool via
+    # the gate's real API so the reservation proceeds ($1.50 bound < ceiling).
+    budget_gate_isolated.approve_tool("sora_video")
+
     output_path = tmp_path / "sample.mp4"
     result = SoraVideo().execute(
         {
@@ -121,3 +127,70 @@ def test_sora_video_executes_with_current_create_and_poll_sdk_surface(monkeypatc
     assert calls["payload"]["model"] == "sora-2"
     assert calls["payload"]["seconds"] == "4"
     assert calls["download"] == ("video_test", "video")
+
+
+class TestSoraVideoMaxCostBound:
+    """max_cost_usd() is a true, drift-proof upper bound.
+
+    The three pure-method tests touch no gate, provider, or key. The
+    invalid-duration test drives execute() through the ACTIVE budget gate to
+    prove rejection happens before any billed provider call.
+    """
+
+    def test_bound_is_one_dollar_fifty(self):
+        from tools.video.sora_video import SoraVideo
+
+        assert SoraVideo().max_cost_usd({"prompt": "x"}) == pytest.approx(1.50)
+
+    def test_bound_is_ge_estimate_for_every_allowed_duration(self):
+        from tools.video.sora_video import SoraVideo, _ALLOWED_SECONDS
+
+        tool = SoraVideo()
+        bound = tool.max_cost_usd({"prompt": "x"})
+        for seconds in _ALLOWED_SECONDS:
+            assert bound >= tool.estimate_cost({"seconds": seconds})
+
+    def test_invalid_duration_fails_before_provider_dispatch(
+        self, monkeypatch, budget_gate_isolated
+    ):
+        # execute() runs through the active gate (isolated here onto a private
+        # config + ledger). An invalid duration must fail before any billed
+        # request: the gate evaluates estimate_cost() before dispatch, and
+        # _normalize_seconds raises there -- so create_and_poll is never
+        # reached. No real key, no network.
+        import sys
+        import types
+
+        from tools.video.sora_video import SoraVideo
+
+        calls = {"create_and_poll": 0}
+
+        class FakeVideos:
+            def create_and_poll(self, **kwargs):
+                calls["create_and_poll"] += 1
+                return None
+
+        class FakeOpenAI:
+            def __init__(self, *args, **kwargs):
+                self.videos = FakeVideos()
+
+        fake_openai = types.ModuleType("openai")
+        fake_openai.__version__ = "2.44.0"
+        fake_openai.OpenAI = FakeOpenAI
+        monkeypatch.setitem(sys.modules, "openai", fake_openai)
+        monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
+
+        with pytest.raises(ValueError, match="seconds must be one of"):
+            SoraVideo().execute({"prompt": "x", "seconds": "7"})
+
+        assert calls["create_and_poll"] == 0, "provider must not be dispatched"
+
+    def test_bound_tracks_authoritative_max_duration(self, monkeypatch):
+        from tools.video.sora_video import SoraVideo
+
+        # Extend the authoritative enum; the bound must move in lockstep, since
+        # it derives from _ALLOWED_SECONDS + estimate_cost(), not a constant.
+        monkeypatch.setattr(
+            "tools.video.sora_video._ALLOWED_SECONDS", ["4", "8", "12", "16"]
+        )
+        assert SoraVideo().max_cost_usd({"prompt": "x"}) == pytest.approx(2.00)

--- a/tools/analysis/azure_stt.py
+++ b/tools/analysis/azure_stt.py
@@ -87,6 +87,10 @@ class AzureSpeechToText(BaseTool):
     execution_mode = ExecutionMode.SYNC
     determinism = Determinism.DETERMINISTIC
     runtime = ToolRuntime.API
+    # Azure bills per audio-hour: this is a PAID tool even when the estimate
+    # cannot price a request up front. Explicit so the classification is
+    # auditable rather than inferred.
+    paid = True
 
     # Availability is decided by get_status() (env var check), mirroring the
     # ElevenLabs provider tool — dependencies stays empty.
@@ -193,11 +197,63 @@ class AzureSpeechToText(BaseTool):
     # roughly $1.00/audio-hour at time of writing).
     COST_PER_AUDIO_HOUR = 1.0
 
+    def _local_duration_seconds(self, inputs: dict[str, Any]) -> float | None:
+        """Billable duration, determined WITHOUT contacting Azure.
+
+        Preference order: an explicit duration_seconds input, else a local
+        ffprobe of input_path (tools.analysis.audio_probe.probe_duration).
+        Returns None when neither yields a positive duration -- the caller
+        must treat that as unboundable, never as zero.
+        """
+        explicit = inputs.get("duration_seconds")
+        if explicit:
+            try:
+                value = float(explicit)
+            except (TypeError, ValueError):
+                return None
+            return value if value > 0 else None
+        path = inputs.get("input_path")
+        if path and Path(str(path)).is_file():
+            from tools.analysis.audio_probe import probe_duration
+
+            duration = probe_duration(path)
+            if duration and duration > 0:
+                return duration
+        return None
+
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
-        # Duration is unknown until the audio is transcribed; return the actual
-        # cost by passing duration_seconds, else 0.0 as a pre-call estimate.
-        seconds = inputs.get("duration_seconds", 0) or 0
-        return round((seconds / 3600.0) * self.COST_PER_AUDIO_HOUR, 4)
+        # Exact per-audio-hour pricing from an explicit duration_seconds or a
+        # local ffprobe of input_path. 0.0 only when neither is available --
+        # in which case max_cost_usd() returns None and the gate refuses the
+        # call, so the zero can never be mistaken for "free". Raw positive
+        # value, deliberately unrounded: the budget ledger's central ceiling
+        # quantization is the only monetary rounding, so a sub-second clip
+        # can never present itself as free.
+        seconds = self._local_duration_seconds(inputs) or 0
+        return (seconds / 3600.0) * self.COST_PER_AUDIO_HOUR
+
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Upper bound on a single call's spend, derived without any dispatch.
+
+        Requests execute() is guaranteed to refuse locally -- credentials
+        missing, or no duration given and no such file -- bill nothing and
+        return 0.0. Otherwise the bound is the exact per-audio-hour price for
+        the locally determined duration (explicit input or local ffprobe).
+        A file that exists but whose duration cannot be probed returns None:
+        fail closed rather than guess or silently zero.
+        """
+        seconds = self._local_duration_seconds(inputs)
+        if seconds is not None:
+            # Raw float, matching estimate_cost(); centrally quantized later.
+            return (seconds / 3600.0) * self.COST_PER_AUDIO_HOUR
+        # Duration unknown. Requests execute() is guaranteed to refuse
+        # locally bill nothing; anything else is unboundable.
+        if self.get_status() != ToolStatus.AVAILABLE:
+            return 0.0  # execute() refuses (credentials) before any dispatch
+        path = inputs.get("input_path")
+        if not path or not Path(str(path)).is_file():
+            return 0.0  # execute() refuses the missing file before any dispatch
+        return None  # file exists but duration is unprobeable: fail closed
 
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         # Fast Transcription is well under real-time; conservative default.

--- a/tools/analysis/dashscope_asr.py
+++ b/tools/analysis/dashscope_asr.py
@@ -43,6 +43,11 @@ class DashscopeAsr(BaseTool):
     execution_mode = ExecutionMode.ASYNC
     determinism = Determinism.DETERMINISTIC
     runtime = ToolRuntime.API
+    # DashScope bills ASR per audio minute: this is a PAID tool. The
+    # repository has no verified pricing constant for it, so dispatchable
+    # requests are refused by the budget gate (max_cost_usd returns None)
+    # until real pricing is recorded here. Explicitly NOT free.
+    paid = True
 
     dependencies = []
     install_instructions = (
@@ -153,8 +158,27 @@ class DashscopeAsr(BaseTool):
         return ToolStatus.UNAVAILABLE
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
-        # DashScope ASR pricing is per-minute; check console for actual cost.
+        # DashScope ASR bills per minute but the repository holds no verified
+        # rate; 0.0 here is "unknown", NOT "free" -- max_cost_usd() below
+        # keeps every dispatchable request fail-closed until pricing lands.
         return 0.0
+
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """No defensible bound exists: DashScope ASR is billed per audio
+        minute but the repository records no verified rate, and inventing one
+        would defeat the cap. Requests execute() is guaranteed to refuse
+        locally before any dispatch -- missing API key, or an audio_url that
+        is empty or not a public URL -- bill nothing and return 0.0 so those
+        guardrails still answer. Every dispatchable request returns None and
+        is refused by the budget gate as a paid tool without a declared
+        maximum cost.
+        """
+        if not os.environ.get("DASHSCOPE_API_KEY"):
+            return 0.0  # execute() refuses before any dispatch
+        audio_url = str(inputs.get("audio_url", "") or "").strip()
+        if not audio_url or not self._is_public_url(audio_url):
+            return 0.0  # execute() refuses before any dispatch
+        return None
 
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
         api_key = os.environ.get("DASHSCOPE_API_KEY")

--- a/tools/audio/dashscope_tts.py
+++ b/tools/audio/dashscope_tts.py
@@ -144,7 +144,18 @@ class DashscopeTTS(BaseTool):
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
         # Conservative per-character estimate; DashScope bills by character.
-        return round(len(inputs.get("text", "")) * 0.000015, 4)
+        # Raw positive value, deliberately unrounded: the budget ledger's
+        # central ceiling quantization is the only monetary rounding.
+        return len(inputs.get("text", "")) * 0.000015
+
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Upper bound on a single call's spend.
+
+        Per-character billing at the conservative flat rate above, fully
+        determined by the request text -- the estimate is itself the ceiling.
+        execute() issues one billed request; no internal retry loop re-bills.
+        """
+        return self.estimate_cost(inputs)
 
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
         api_key = os.environ.get("DASHSCOPE_API_KEY")

--- a/tools/audio/doubao_tts.py
+++ b/tools/audio/doubao_tts.py
@@ -182,8 +182,19 @@ class DoubaoTTS(BaseTool):
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
         # Volcengine bills Doubao Speech 2.0 by characters. Keep this conservative
-        # and prefer provider-returned usage when available.
-        return round(len(inputs.get("text", "")) * 0.000015, 4)
+        # and prefer provider-returned usage when available. Raw positive value,
+        # deliberately unrounded: the budget ledger's central ceiling
+        # quantization is the only monetary rounding.
+        return len(inputs.get("text", "")) * 0.000015
+
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Upper bound on a single call's spend.
+
+        Per-character billing at the conservative flat rate above, fully
+        determined by the request text -- the estimate is itself the ceiling.
+        execute() issues one billed request; no internal retry loop re-bills.
+        """
+        return self.estimate_cost(inputs)
 
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
         api_key = os.environ.get("DOUBAO_SPEECH_API_KEY")

--- a/tools/audio/elevenlabs_tts.py
+++ b/tools/audio/elevenlabs_tts.py
@@ -142,6 +142,16 @@ class ElevenLabsTTS(BaseTool):
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
         return round(len(inputs.get("text", "")) * 0.0003, 4)
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Upper bound on a single call's spend.
+
+        ElevenLabs bills per character at the flat rate above, fully
+        determined by the request text, so the estimate is itself the
+        ceiling. execute() issues one billed generation request (the declared
+        retry_policy is advisory metadata; no internal loop re-bills).
+        """
+        return self.estimate_cost(inputs)
+
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
         api_key = os.environ.get("ELEVENLABS_API_KEY")
         if not api_key:

--- a/tools/audio/freesound_music.py
+++ b/tools/audio/freesound_music.py
@@ -38,6 +38,8 @@ class FreesoundMusic(BaseTool):
     execution_mode = ExecutionMode.SYNC
     determinism = Determinism.DETERMINISTIC
     runtime = ToolRuntime.API
+    # Genuinely free: no provider charge can ever be incurred (see BaseTool.paid).
+    paid = False
 
     dependencies = []  # checked dynamically via env var
     install_instructions = (

--- a/tools/audio/google_music.py
+++ b/tools/audio/google_music.py
@@ -130,6 +130,15 @@ class GoogleMusic(BaseTool):
         # Lyria 3 Pro is a flat $0.08 per generation request
         return 0.08
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Guaranteed upper bound on a single call's spend.
+
+        Lyria 3 Pro bills a flat $0.08 per generation, independent of every
+        input, and execute() issues exactly one billed request (no retry loop
+        wraps it). The flat price is therefore itself the ceiling.
+        """
+        return 0.08
+
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
         """Execute the music generation tool using the Google GenAI SDK."""
         if not self._get_google_credentials_status():

--- a/tools/audio/google_tts.py
+++ b/tools/audio/google_tts.py
@@ -180,7 +180,26 @@ class GoogleTTS(BaseTool):
             rate_per_char = 0.000016  # $16/1M chars
         else:
             rate_per_char = 0.000004  # $4/1M chars (Standard)
-        return round(char_count * rate_per_char, 4)
+        # Raw positive value, deliberately unrounded: the budget ledger's
+        # central ceiling quantization is the only monetary rounding, so a
+        # short text can never present itself as free.
+        return char_count * rate_per_char
+
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Upper bound on a single call's spend.
+
+        For voices whose family the estimate recognizes by substring, the
+        per-character rate is exact and the estimate is its own ceiling. A
+        voice name matching NO known family falls into the cheap Standard
+        branch of the estimate, which could under-price an unknown premium
+        family -- so those are bounded at the dearest published rate (Studio)
+        instead. execute() issues one billed synthesis request.
+        """
+        voice = str(inputs.get("voice", "en-US-Chirp3-HD-Orus"))
+        known = ("Chirp3-HD", "Studio", "Neural2", "Journey", "WaveNet", "Standard")
+        if any(family in voice for family in known):
+            return self.estimate_cost(inputs)
+        return self.estimate_cost({**inputs, "voice": "Studio"})
 
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
         # Prefer an API key (cheapest path); otherwise mint a Bearer token from

--- a/tools/audio/kling_tts.py
+++ b/tools/audio/kling_tts.py
@@ -118,8 +118,28 @@ class KlingTTS(BaseTool):
     latency_p50_seconds = 20.0
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        # Raw positive value, deliberately unrounded: quantization happens
+        # once, centrally, in the budget ledger (ceiling to $0.0001), so a
+        # 1-character request can never present itself as free.
         text_length = len(str(inputs.get("text") or ""))
-        return round(max(text_length, 1) * 0.000018, 4)
+        return max(text_length, 1) * 0.000018
+
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Worst-case upper bound on a single call's spend.
+
+        Fail closed on the opt-in account-usage diagnostic (billing not
+        authoritatively verified -- same rule as kling_lip_sync). Otherwise
+        the character-based estimate is fully determined by the request text,
+        so the bound is that per-attempt cost times
+        1 + retry_policy.max_retries -- the SAME setting execute() passes to
+        KlingClient, so bound and real retry loop read one authority.
+        """
+        if inputs.get("include_account_usage"):
+            return None
+        billed_attempts = 1 + self.retry_policy.max_retries
+        # Raw float; the ledger's central ceiling quantization is the only
+        # rounding a monetary value receives.
+        return self.estimate_cost(inputs) * billed_attempts
 
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         return 30.0
@@ -144,7 +164,8 @@ class KlingTTS(BaseTool):
         start = time.time()
         try:
             request = self._build_request(inputs)
-            client = KlingClient()
+            # Same retry setting the bound in max_cost_usd() reserves against.
+            client = KlingClient(max_retries=self.retry_policy.max_retries)
             task_id, outputs = self._create_and_collect_audios(client, request, inputs)
             paths = self._download_audios(client, outputs, inputs)
             audio_duration = probe_duration(paths[0])

--- a/tools/audio/music_gen.py
+++ b/tools/audio/music_gen.py
@@ -107,8 +107,21 @@ class MusicGen(BaseTool):
                 "Derive it from the approved target runtime in the script/proposal. "
                 "Silent defaults are not permitted."
             )
-        # Approximate: ~$0.05 per 30 seconds
-        return round(duration / 30 * 0.05, 4)
+        # Approximate: ~$0.05 per 30 seconds. Raw positive value, deliberately
+        # unrounded: the budget ledger's central ceiling quantization is the
+        # only monetary rounding, so a tiny duration can never present itself
+        # as free.
+        return duration / 30 * 0.05
+
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Upper bound on a single call's spend.
+
+        Per-generation pricing scales with the mandatory duration_seconds
+        input (estimate_cost refuses to guess it), so the estimate is fully
+        request-determined and is itself the ceiling. execute() issues one
+        billed generation request; no internal retry loop re-bills.
+        """
+        return self.estimate_cost(inputs)
 
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
         api_key = os.environ.get("ELEVENLABS_API_KEY")

--- a/tools/audio/openai_tts.py
+++ b/tools/audio/openai_tts.py
@@ -117,7 +117,20 @@ class OpenAITTS(BaseTool):
         return ToolStatus.UNAVAILABLE
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
-        return round(len(inputs.get("text", "")) * 0.000015, 4)
+        # Raw positive value, deliberately unrounded: the budget ledger's
+        # central ceiling quantization is the only monetary rounding, so a
+        # short text can never present itself as free.
+        return len(inputs.get("text", "")) * 0.000015
+
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Upper bound on a single call's spend.
+
+        OpenAI TTS bills per character at the flat rate above, fully
+        determined by the request text, so the estimate is itself the
+        ceiling. execute() issues one billed request; no internal retry loop
+        re-bills.
+        """
+        return self.estimate_cost(inputs)
 
     @staticmethod
     def _supports_instructions(model: str) -> bool:

--- a/tools/audio/pixabay_music.py
+++ b/tools/audio/pixabay_music.py
@@ -42,6 +42,8 @@ class PixabayMusic(BaseTool):
     execution_mode = ExecutionMode.SYNC
     determinism = Determinism.DETERMINISTIC
     runtime = ToolRuntime.API
+    # Genuinely free: no provider charge can ever be incurred (see BaseTool.paid).
+    paid = False
 
     dependencies = []  # no API key needed — web scraping
     install_instructions = (

--- a/tools/audio/suno_music.py
+++ b/tools/audio/suno_music.py
@@ -143,6 +143,15 @@ class SunoMusic(BaseTool):
         # Suno credits cost $0.005 each; a generation is roughly 10 credits
         return 0.05
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Upper bound on a single call's spend.
+
+        Flat per-generation credit pricing independent of inputs; the
+        estimate is itself the ceiling. execute() issues one billed
+        generation request; no internal retry loop re-bills.
+        """
+        return self.estimate_cost(inputs)
+
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
         api_key = self._get_api_key()
         if not api_key:

--- a/tools/audio/tts_selector.py
+++ b/tools/audio/tts_selector.py
@@ -159,11 +159,37 @@ class TTSSelector(BaseTool):
         return ToolStatus.UNAVAILABLE
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        if inputs.get("operation") == "rank":
+            return 0.0  # rank mode returns scores without dispatching a provider
         candidates = self._providers()
         if not candidates:
             return 0.0
         tool, _ = self._select_best_tool(inputs, candidates, self._prepare_task_context(inputs))
         return tool.estimate_cost(inputs) if tool else 0.0
+
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Bound = the selected provider's bound; the selector adds no charge.
+
+        Resolves the provider with the same candidates and _select_best_tool
+        call execute() uses, then delegates to that provider's max_cost_usd()
+        for the request (execute() forwards the inputs unchanged). Rank mode
+        and requests that cannot resolve a provider return 0.0 because
+        execute() is guaranteed to answer locally without dispatching. An
+        unbounded selected provider propagates None, keeping the call
+        fail-closed.
+        """
+        if inputs.get("operation") == "rank":
+            return 0.0
+        candidates = self._providers()
+        if not candidates:
+            return 0.0
+        tool, _ = self._select_best_tool(inputs, candidates, self._prepare_task_context(inputs))
+        if tool is None:
+            return 0.0
+        if getattr(tool, "paid", None) is False:
+            # Declared-free provider (stock media search): nothing to bound.
+            return 0.0
+        return tool.max_cost_usd(inputs)
 
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
         from lib.scoring import rank_providers

--- a/tools/avatar/kling_avatar.py
+++ b/tools/avatar/kling_avatar.py
@@ -148,6 +148,24 @@ class KlingAvatar(BaseTool):
             base += 0.04
         return round(base, 4)
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Worst-case upper bound on a single call's spend.
+
+        Per-attempt cost is driven only by `mode` (AVATAR_MODES) and whether a
+        local audio path is supplied. Taking the max of estimate_cost() over
+        every valid mode with audio present yields the most expensive single
+        attempt without restating the price constants. The attempt count is
+        1 + retry_policy.max_retries -- the SAME setting execute() passes to
+        KlingClient (below) -- so the bound and the client's real retry loop
+        read one authority; there is no independent x3. -> $1.905 today.
+        """
+        worst_per_attempt = max(
+            self.estimate_cost({"mode": mode, "audio_path": "x"})
+            for mode in AVATAR_MODES
+        )
+        billed_attempts = 1 + self.retry_policy.max_retries
+        return round(worst_per_attempt * billed_attempts, 4)
+
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         return 240.0
 
@@ -171,7 +189,8 @@ class KlingAvatar(BaseTool):
         start = time.time()
         try:
             request = self._build_request(inputs)
-            client = KlingClient()
+            # Same retry setting the bound in max_cost_usd() reserves against.
+            client = KlingClient(max_retries=self.retry_policy.max_retries)
             task_id = client.create_classic_task(request["path"], request["payload"])
             outputs = client.poll_classic(
                 request["path"],

--- a/tools/avatar/kling_lip_sync.py
+++ b/tools/avatar/kling_lip_sync.py
@@ -174,6 +174,35 @@ class KlingLipSync(BaseTool):
             return 0.34
         return 0.32
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Worst-case upper bound on a single call's spend.
+
+        Fail closed on the opt-in account-usage diagnostic: that endpoint's
+        billing is not authoritatively verified, so a call that requests it
+        cannot be bounded and is refused rather than assumed free.
+
+        Otherwise the bound is the operation's worst-case billed cost times
+        1 + retry_policy.max_retries -- the SAME setting execute() passes to
+        KlingClient below, so bound and client's real retry loop share one
+        authority (no independent x3). full_lip_sync bills TWO sequential
+        requests in one execute() (identify THEN advanced), each retried
+        independently, so their per-request costs are summed BEFORE the shared
+        retry multiplier -- never max(). -> identify $0.06 / advanced $0.96 /
+        full $1.02 today.
+        """
+        if inputs.get("include_account_usage"):
+            return None
+        operation = str(inputs.get("operation") or "advanced_lip_sync")
+        billed_attempts = 1 + self.retry_policy.max_retries
+        if operation == "full_lip_sync":
+            worst_per_attempt = (
+                self.estimate_cost({"operation": "identify_face"})
+                + self.estimate_cost({"operation": "advanced_lip_sync"})
+            )
+        else:
+            worst_per_attempt = self.estimate_cost(inputs)
+        return round(worst_per_attempt * billed_attempts, 4)
+
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         if inputs.get("operation") == "identify_face":
             return 15.0
@@ -198,7 +227,8 @@ class KlingLipSync(BaseTool):
 
         operation = str(inputs.get("operation") or "advanced_lip_sync")
         start = time.time()
-        client = KlingClient()
+        # Same retry setting the bound in max_cost_usd() reserves against.
+        client = KlingClient(max_retries=self.retry_policy.max_retries)
         try:
             if operation == "identify_face":
                 identify = self._identify_faces(client, inputs)

--- a/tools/base_tool.py
+++ b/tools/base_tool.py
@@ -244,8 +244,14 @@ def _enforce_budget(fn: Callable) -> Callable:
 
     Untouched paths (no tracker involvement, no cost log written):
       - runtime LOCAL / LOCAL_GPU  (FFmpeg, Remotion, HyperFrames, Piper, ...)
-      - any tool whose estimate_cost() is 0  (free operations)
-    This is what preserves the zero-key and local pipelines exactly.
+      - tools that declare `paid = False`  (genuinely free API-backed search)
+        while their estimate is 0
+      - paid tools whose max_cost_usd() EXPLICITLY returns 0.0 for a request
+        that bills nothing (selector rank mode, guaranteed-local refusals)
+    A paid tool whose estimate_cost() merely RETURNS 0 -- sub-cent rounding,
+    unknown duration, missing billing info -- is NOT free: it must still
+    declare a bound or be refused. This is what preserves the zero-key and
+    local pipelines exactly without letting a broken estimate skip the gate.
     """
     if getattr(fn, "_budget_enforced", False):
         return fn
@@ -258,7 +264,11 @@ def _enforce_budget(fn: Callable) -> Callable:
             return fn(self, inputs, *args, **kwargs)
 
         runtime = getattr(self, "runtime", ToolRuntime.LOCAL)
-        if runtime in (ToolRuntime.LOCAL, ToolRuntime.LOCAL_GPU):
+        declared_paid = getattr(self, "paid", None)
+        if (
+            runtime in (ToolRuntime.LOCAL, ToolRuntime.LOCAL_GPU)
+            and declared_paid is not True
+        ):
             return fn(self, inputs, *args, **kwargs)
 
         tool_name = getattr(self, "name", "") or type(self).__name__
@@ -271,17 +281,28 @@ def _enforce_budget(fn: Callable) -> Callable:
                 f"can spend money must return a number. Refusing to execute "
                 f"(fail closed)."
             )
-        if estimated <= 0:
+        # Classification, not the estimate, decides whether the gate applies:
+        # API/HYBRID tools are paid unless they declare paid = False. A paid
+        # tool whose estimate is 0 (sub-cent, unknown duration, missing
+        # billing info) still has to produce a bound; a declared-free tool
+        # whose estimate claims money is gated as paid (the safe reading of
+        # the contradiction).
+        is_paid = True if declared_paid is None else bool(declared_paid)
+        if not is_paid and estimated <= 0:
             return fn(self, inputs, *args, **kwargs)
+
+        from tools.cost_tracker import format_usd
 
         bound = self.max_cost_usd(safe_inputs)
         if bound is None:
             raise BudgetGateError(
-                f"{tool_name} cannot declare a bounded maximum cost for this call "
-                f"(estimate ${float(estimated):.2f}). Refusing to execute (fail "
+                f"{tool_name} is classified as a PAID tool but cannot declare a "
+                f"bounded maximum cost for this call (estimate "
+                f"{format_usd(float(estimated))}). Refusing to execute (fail "
                 f"closed): a daily hard cap cannot be guaranteed against an "
-                f"unbounded cost. estimate_cost() is an approximation, not a "
-                f"ceiling. Override max_cost_usd() on {tool_name} to declare a "
+                f"unbounded cost, and a zero estimate does not make a paid tool "
+                f"free. estimate_cost() is an approximation, not a ceiling. "
+                f"Override max_cost_usd() on {tool_name} to declare a "
                 f"defensible upper bound -- it must cover every provider request "
                 f"the call can make, including retry_policy.max_retries."
             )
@@ -297,10 +318,16 @@ def _enforce_budget(fn: Callable) -> Callable:
             )
         if float(bound) - float(estimated) < -1e-6:
             raise BudgetGateError(
-                f"{tool_name}.max_cost_usd() returned ${float(bound):.4f}, which is "
-                f"below its own estimate_cost() of ${float(estimated):.4f}. That is "
+                f"{tool_name}.max_cost_usd() returned {format_usd(float(bound))}, which is "
+                f"below its own estimate_cost() of {format_usd(float(estimated))}. That is "
                 f"not an upper bound. Refusing to execute (fail closed)."
             )
+        if float(bound) <= 0 and estimated <= 0:
+            # The tool has EXPLICITLY declared this exact request bills
+            # nothing (selector rank mode, a request execute() is guaranteed
+            # to refuse locally). Distinct from the None case above: a
+            # declared zero is an answer, a missing bound is not.
+            return fn(self, inputs, *args, **kwargs)
 
         from lib.budget_gate import reserve, settle
 
@@ -353,6 +380,18 @@ class BaseTool(ABC):
     execution_mode: ExecutionMode = ExecutionMode.SYNC
     determinism: Determinism = Determinism.DETERMINISTIC
     runtime: ToolRuntime = ToolRuntime.LOCAL
+
+    # --- Budget classification ---
+    # Whether this tool can incur provider charges. None (the default) infers
+    # it from runtime: LOCAL/LOCAL_GPU tools are free; API/HYBRID tools are
+    # treated as PAID and must declare max_cost_usd() -- returning 0.0 only
+    # for a request that genuinely bills nothing (a selector's rank mode, a
+    # request execute() is guaranteed to refuse locally). Genuinely free
+    # API-backed tools (stock media search) set paid = False explicitly.
+    # This is what stops a paid tool whose estimate_cost() returns 0 --
+    # sub-cent, unknown duration, missing billing info -- from slipping past
+    # the budget gate on the strength of that zero.
+    paid: Optional[bool] = None
 
     # --- Dependencies ---
     # For API tools, add "env:ENVVAR_NAME" to signal required API keys

--- a/tools/base_tool.py
+++ b/tools/base_tool.py
@@ -10,6 +10,7 @@ import functools
 import hashlib
 import inspect
 import json
+import math
 import os
 import platform
 import subprocess
@@ -224,15 +225,125 @@ def _instrument_execute(fn: Callable) -> Callable:
     return wrapper
 
 
+def _enforce_budget(fn: Callable) -> Callable:
+    """Wrap a tool's execute() with the budget hard cap.
+
+    This is the choke point: every paid provider call in OpenMontage goes
+    through a BaseTool.execute(), so gating here covers every tool that exists
+    and every tool added later, with no per-tool wiring to forget.
+
+    Unlike the event layer above, this wrapper is strictly FAIL-CLOSED. If the
+    budget cannot be evaluated -- bad config, unreadable cost log, a paid tool
+    with a broken estimate_cost() -- the call is refused rather than allowed.
+
+    What is reserved is max_cost_usd(), NOT estimate_cost(). estimate_cost()
+    is an approximation whose errors across this repo are biased downward (see
+    the `.get(model, <cheap default>)` pattern), so reserving it would let a
+    day's true spend exceed the cap. A tool that cannot state a defensible
+    upper bound is refused by name rather than gambling the cap on a guess.
+
+    Untouched paths (no tracker involvement, no cost log written):
+      - runtime LOCAL / LOCAL_GPU  (FFmpeg, Remotion, HyperFrames, Piper, ...)
+      - any tool whose estimate_cost() is 0  (free operations)
+    This is what preserves the zero-key and local pipelines exactly.
+    """
+    if getattr(fn, "_budget_enforced", False):
+        return fn
+
+    @functools.wraps(fn)
+    def wrapper(self, inputs: Any, *args: Any, **kwargs: Any):
+        # Selectors delegate to provider tools; both reach this wrapper. Gate
+        # only the outermost call, or one logical spend would reserve twice.
+        if getattr(_EXECUTE_DEPTH, "value", 0) != 0:
+            return fn(self, inputs, *args, **kwargs)
+
+        runtime = getattr(self, "runtime", ToolRuntime.LOCAL)
+        if runtime in (ToolRuntime.LOCAL, ToolRuntime.LOCAL_GPU):
+            return fn(self, inputs, *args, **kwargs)
+
+        tool_name = getattr(self, "name", "") or type(self).__name__
+        safe_inputs = inputs if isinstance(inputs, dict) else {}
+
+        estimated = self.estimate_cost(safe_inputs)
+        if not isinstance(estimated, (int, float)) or isinstance(estimated, bool):
+            raise BudgetGateError(
+                f"{tool_name}.estimate_cost() returned {estimated!r}; a tool that "
+                f"can spend money must return a number. Refusing to execute "
+                f"(fail closed)."
+            )
+        if estimated <= 0:
+            return fn(self, inputs, *args, **kwargs)
+
+        bound = self.max_cost_usd(safe_inputs)
+        if bound is None:
+            raise BudgetGateError(
+                f"{tool_name} cannot declare a bounded maximum cost for this call "
+                f"(estimate ${float(estimated):.2f}). Refusing to execute (fail "
+                f"closed): a daily hard cap cannot be guaranteed against an "
+                f"unbounded cost. estimate_cost() is an approximation, not a "
+                f"ceiling. Override max_cost_usd() on {tool_name} to declare a "
+                f"defensible upper bound -- it must cover every provider request "
+                f"the call can make, including retry_policy.max_retries."
+            )
+        if (
+            isinstance(bound, bool)
+            or not isinstance(bound, (int, float))
+            or not math.isfinite(bound)
+            or bound < 0
+        ):
+            raise BudgetGateError(
+                f"{tool_name}.max_cost_usd() returned {bound!r}; a bound must be "
+                f"finite and non-negative. Refusing to execute (fail closed)."
+            )
+        if float(bound) - float(estimated) < -1e-6:
+            raise BudgetGateError(
+                f"{tool_name}.max_cost_usd() returned ${float(bound):.4f}, which is "
+                f"below its own estimate_cost() of ${float(estimated):.4f}. That is "
+                f"not an upper bound. Refusing to execute (fail closed)."
+            )
+
+        from lib.budget_gate import reserve, settle
+
+        # Reserve the BOUND. Actual spend replaces it at reconcile.
+        handle = reserve(tool_name, "execute", float(bound))
+        try:
+            result = fn(self, inputs, *args, **kwargs)
+        except BaseException:
+            # Includes KeyboardInterrupt/cancellation. The provider may already
+            # have billed, so charge the bound rather than release. Never leave
+            # the reservation unresolved.
+            settle(handle, None, success=False)
+            raise
+        actual = getattr(result, "cost_usd", None)
+        settle(
+            handle,
+            actual if isinstance(actual, (int, float)) else None,
+            success=bool(getattr(result, "success", True)),
+        )
+        return result
+
+    wrapper._budget_enforced = True  # type: ignore[attr-defined]
+    return wrapper
+
+
+class BudgetGateError(Exception):
+    """Raised when a paid call's cost cannot be bounded before dispatch."""
+    pass
+
+
 class BaseTool(ABC):
     """Abstract base class for all OpenMontage tools."""
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
-        """Auto-instrument every concrete execute() with Backlot events."""
+        """Auto-instrument every concrete execute() with events + budget gate.
+
+        The budget gate wraps outermost so it reads the nesting depth before
+        the event layer increments it.
+        """
         super().__init_subclass__(**kwargs)
         impl = cls.__dict__.get("execute")
         if impl is not None and not getattr(impl, "__isabstractmethod__", False):
-            cls.execute = _instrument_execute(impl)
+            cls.execute = _enforce_budget(_instrument_execute(impl))
 
     # --- Identity (override in subclasses) ---
     name: str = ""
@@ -374,8 +485,31 @@ class BaseTool(ABC):
     # ---- Cost estimation ----
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
-        """Estimate cost in USD for the given inputs. Override for paid tools."""
+        """Estimate cost in USD for the given inputs. Override for paid tools.
+
+        This is an APPROXIMATION for planning and provider ranking. It is NOT a
+        guaranteed ceiling and must never be treated as one -- see
+        max_cost_usd() for the value the budget gate actually reserves.
+        """
         return 0.0
+
+    def max_cost_usd(self, inputs: dict[str, Any]) -> Optional[float]:
+        """Defensible UPPER BOUND on what this call can cost, or None.
+
+        Returning None means "I cannot bound this", and the budget gate will
+        refuse the call by name. That default is deliberate: a daily hard cap
+        is only real if every paid call's worst case is known in advance, and
+        it is safer to block a provider than to silently blow the cap.
+
+        A correct override must cover EVERY provider request the call can make
+        under the worst-case inputs, including:
+          - retry_policy.max_retries (one execute() can bill many times)
+          - provider-chosen quantities (e.g. duration="auto")
+          - the most expensive model/quality the inputs could resolve to
+
+        Return a finite, non-negative float >= estimate_cost(inputs).
+        """
+        return None
 
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         """Estimate runtime in seconds. Override for long-running tools."""

--- a/tools/capture/screen_capture_selector.py
+++ b/tools/capture/screen_capture_selector.py
@@ -34,6 +34,8 @@ class ScreenCaptureSelector(BaseTool):
     execution_mode = ExecutionMode.SYNC
     determinism = Determinism.DETERMINISTIC
     runtime = ToolRuntime.HYBRID
+    # Genuinely free: no provider charge can ever be incurred (see BaseTool.paid).
+    paid = False
 
     agent_skills = ["screen-demo"]
 

--- a/tools/cost_tracker.py
+++ b/tools/cost_tracker.py
@@ -50,6 +50,7 @@ import threading
 import uuid
 from contextlib import contextmanager
 from datetime import datetime, timezone
+from decimal import ROUND_CEILING, Decimal
 from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Iterator, Optional
@@ -57,10 +58,52 @@ from typing import Any, Callable, Iterator, Optional
 from lib.config_model import BudgetMode
 from lib.ledger_lock import ledger_lock
 
-# Comparisons are made against values rounded to 4dp; this tolerance keeps an
-# exact-cap request (estimated == remaining) on the allowed side of the line
-# rather than losing it to float representation error.
+# Comparisons are made against values quantized to the ledger grid below;
+# this tolerance keeps an exact-cap request (estimated == remaining) on the
+# allowed side of the line rather than losing it to float representation
+# error. All recorded amounts are exact multiples of LEDGER_QUANTUM_USD, so
+# float error on them (~1e-16 per term) never approaches this epsilon.
 _EPSILON = 1e-6
+
+# ---- Monetary precision ----
+# The ledger's explicit monetary quantum. Every recorded amount -- estimate,
+# reservation, actual spend -- is an exact multiple of $0.0001. Positive
+# amounts quantize UPWARD (Decimal ROUND_CEILING), so no positive paid
+# amount can ever be recorded as zero: $0.00004 reserves $0.0001, and
+# repeated sub-quantum calls accumulate against the cap instead of slipping
+# under it. Zero and negative inputs record exactly $0. Ceiling can only
+# OVERSTATE spend (by < one quantum per entry), never understate it.
+LEDGER_QUANTUM_USD = Decimal("0.0001")
+
+
+def quantize_usd(amount: float) -> float:
+    """Quantize a dollar amount onto the ledger's $0.0001 grid, upward.
+
+    The quantization itself is done in Decimal (no binary-float rounding);
+    only the final exact grid multiple is returned as a float. $0 stays
+    exactly $0; any positive amount yields at least one quantum.
+    """
+    value = Decimal(str(float(amount)))
+    if value <= 0:
+        return 0.0
+    return float(value.quantize(LEDGER_QUANTUM_USD, rounding=ROUND_CEILING))
+
+
+def format_usd(amount: float) -> str:
+    """Render a dollar amount so a positive cost never displays as $0.00.
+
+    Sub-cent positives widen to 4 (then 6) decimal places; everything else
+    keeps the familiar $X.XX form. Refusal messages use this so an operator
+    reading "estimate $0.0018" understands the call was genuinely paid.
+    """
+    a = float(amount)
+    if a > 0:
+        for fmt in ("%.2f", "%.4f", "%.6f"):
+            text = fmt % a
+            if float(text) > 0:
+                return f"${text}"
+        return f"${a:.6f}"
+    return f"${a:.2f}"
 
 
 class EntryStatus(str, Enum):
@@ -287,9 +330,10 @@ class CostTracker:
                 "status": EntryStatus.ESTIMATED.value,
                 # Immutable. Assigned once, never recalculated on reconcile.
                 "budget_date": self.current_budget_date(),
-                # Never record a negative cost: a provider or estimator that
-                # returns one must not be able to credit the ledger.
-                "estimated_usd": round(max(0.0, estimated_usd), 4),
+                # Quantized upward onto the ledger grid: a positive estimate
+                # can never round to a recorded zero, and a negative one can
+                # never credit the ledger.
+                "estimated_usd": quantize_usd(estimated_usd),
                 "reserved_usd": 0.0,
                 "actual_usd": 0.0,
                 "timestamp": self._now(),
@@ -332,8 +376,8 @@ class CostTracker:
             threshold = self.single_action_approval_usd
             if threshold is not None and threshold > 0 and estimated - threshold > _EPSILON:
                 raise ApprovalRequiredError(
-                    f"Action costs ${estimated:.2f}, which exceeds the configured "
-                    f"single-action approval threshold of ${threshold:.2f}. "
+                    f"Action costs {format_usd(estimated)}, which exceeds the configured "
+                    f"single-action approval threshold of {format_usd(threshold)}. "
                     f"This safeguard is independent of budget mode "
                     f"({self.mode.value}); raise or disable "
                     f"budget.single_action_approval_usd to permit it."
@@ -361,8 +405,8 @@ class CostTracker:
             elif self.mode == BudgetMode.WARN:
                 if estimated > self.usable_budget_usd:
                     message = (
-                        f"Reservation of ${estimated:.2f} exceeds usable budget "
-                        f"${self.usable_budget_usd:.2f}"
+                        f"Reservation of {format_usd(estimated)} exceeds usable budget "
+                        f"{format_usd(self.usable_budget_usd)}"
                     )
                     entry["budget_warning"] = True
                     entry["budget_warning_message"] = message
@@ -378,11 +422,11 @@ class CostTracker:
             f"Daily budget hard cap reached for {budget_date}: this request is "
             f"blocked before any paid provider call was made.\n"
             f"  budget date:          {budget_date} (timezone: {self.tz_name})\n"
-            f"  configured daily cap: ${self.budget_total_usd:.2f}\n"
-            f"  recorded spend today: ${self.spent_on(budget_date):.2f}\n"
-            f"  reserved (in-flight): ${self.reserved_on(budget_date):.2f}\n"
-            f"  this request:         ${estimated:.2f}\n"
-            f"  remaining today:      ${self.remaining_on(budget_date):.2f}\n"
+            f"  configured daily cap: {format_usd(self.budget_total_usd)}\n"
+            f"  recorded spend today: {format_usd(self.spent_on(budget_date))}\n"
+            f"  reserved (in-flight): {format_usd(self.reserved_on(budget_date))}\n"
+            f"  this request:         {format_usd(estimated)}\n"
+            f"  remaining today:      {format_usd(self.remaining_on(budget_date))}\n"
             f"The budget resets at midnight ({self.tz_name}). Raise "
             f"budget.total_usd in config.yaml to permit more spend today."
         )
@@ -393,9 +437,9 @@ class CostTracker:
             f"exceeded what was reserved, so the cap for this date can no longer "
             f"be guaranteed. All further paid calls for {budget_date} are "
             f"blocked.\n"
-            f"  configured daily cap: ${self.budget_total_usd:.2f}\n"
-            f"  recorded spend today: ${self.spent_on(budget_date):.2f}\n"
-            f"  this request:         ${estimated:.2f}\n"
+            f"  configured daily cap: {format_usd(self.budget_total_usd)}\n"
+            f"  recorded spend today: {format_usd(self.spent_on(budget_date))}\n"
+            f"  this request:         {format_usd(estimated)}\n"
             f"The budget resets at midnight ({self.tz_name}). Prior-day history "
             f"is preserved and is not cleared to free budget."
         )
@@ -424,7 +468,9 @@ class CostTracker:
             entry = self._find(entry_id)
             budget_date = self._entry_date(entry)
             reserved_before = entry.get("reserved_usd", 0.0)
-            actual = round(max(0.0, actual_usd), 4)
+            # Ceiling-quantized: a positive actual charge can never be
+            # written as zero, and never below what the provider billed.
+            actual = quantize_usd(actual_usd)
 
             entry["status"] = (
                 EntryStatus.COMPLETED.value if success else EntryStatus.FAILED.value

--- a/tools/cost_tracker.py
+++ b/tools/cost_tracker.py
@@ -2,21 +2,65 @@
 
 Implements the budget governance rules from the spec:
 - Every paid operation produces a preflight estimate
-- The orchestrator reserves estimated budget before execution
-- Budget overruns trigger pauses (in warn/cap mode)
+- The budget gate reserves estimated budget before execution
+- Budget overruns are blocked (cap) or flagged (warn)
 - Actual spend is reconciled when the tool finishes or fails
+
+Enforcement is wired in via lib/budget_gate.py, which is called from
+BaseTool's execute() wrapper. This module is the ledger; it does not know
+about tools or providers.
+
+Daily buckets
+-------------
+`total_usd` is a per-CALENDAR-DAY cap, not a lifetime one. Every entry carries
+an immutable `budget_date` (YYYY-MM-DD in the configured timezone) assigned
+when the entry is created and never recomputed. A day's available budget is
+derived only from that day's spend and that day's unresolved reservations, so
+a reservation opened at 23:59 keeps consuming its own day's bucket after
+midnight and never leaks into the new day. History is never rewritten or
+cleared to free budget.
+
+Three independent controls
+--------------------------
+`mode` governs the AGGREGATE daily total ONLY:
+  observe - record, never block
+  warn    - flag an over-budget reservation, proceed (holdback-aware)
+  cap     - block when spent(day) + reserved(day) + estimated > total_usd
+
+`single_action_approval_usd` and `require_approval_for_new_paid_tool` are
+SEPARATE, explicitly configured safeguards. They are evaluated independently
+of `mode` -- set them to None/0/False to disable. They were previously
+coupled to `mode != OBSERVE`, which made `cap` implicitly inherit warn's
+"raise on first paid tool use" behavior; that coupling is removed.
+
+Concurrency
+-----------
+Every public operation runs inside _transaction(): an in-process reentrant
+lock plus a cross-process OS file lock, inside which the ledger is RELOADED
+from disk before the bucket is computed and atomically saved afterwards.
+Reloading under the lock is what makes concurrent processes safe -- in-memory
+state cannot be trusted when another process may have written since.
 """
 
 from __future__ import annotations
 
 import json
+import os
+import threading
 import uuid
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, Iterator, Optional
 
 from lib.config_model import BudgetMode
+from lib.ledger_lock import ledger_lock
+
+# Comparisons are made against values rounded to 4dp; this tolerance keeps an
+# exact-cap request (estimated == remaining) on the allowed side of the line
+# rather than losing it to float representation error.
+_EPSILON = 1e-6
 
 
 class EntryStatus(str, Enum):
@@ -37,146 +81,380 @@ class ApprovalRequiredError(Exception):
     pass
 
 
+class CostLogCorruptError(Exception):
+    """Raised when the persisted cost log exists but cannot be read.
+
+    Callers must treat this as fail-closed. An unreadable ledger means
+    accumulated spend is unknown, and unknown spend must never be allowed to
+    proceed to a paid provider.
+    """
+    pass
+
+
+class BudgetPeriodError(Exception):
+    """Raised when the configured budget period/timezone cannot be honoured."""
+    pass
+
+
 class CostTracker:
-    """Tracks estimated, reserved, and actual costs for a pipeline project."""
+    """Tracks estimated, reserved, and actual costs against a daily budget.
+
+    Safe across threads AND processes: every public operation reloads the
+    ledger from disk inside a cross-process file lock before computing the
+    day's bucket, so two callers cannot independently consume the same
+    remaining daily budget.
+    """
 
     def __init__(
         self,
         budget_total_usd: float = 10.0,
         reserve_pct: float = 0.10,
-        single_action_approval_usd: float = 0.50,
+        single_action_approval_usd: Optional[float] = 0.50,
         require_approval_for_new_paid_tool: bool = True,
         mode: BudgetMode = BudgetMode.WARN,
         cost_log_path: Optional[Path] = None,
+        period: str = "daily",
+        tz_name: str = "system_local",
+        clock: Optional[Callable[[], datetime]] = None,
     ) -> None:
+        if period != "daily":
+            raise BudgetPeriodError(
+                f"budget.period={period!r} is not supported; only 'daily' is "
+                f"implemented. Refusing to proceed (fail closed) rather than "
+                f"silently applying daily semantics to a different period."
+            )
         self.budget_total_usd = budget_total_usd
         self.reserve_pct = reserve_pct
         self.single_action_approval_usd = single_action_approval_usd
         self.require_approval_for_new_paid_tool = require_approval_for_new_paid_tool
         self.mode = mode
         self.cost_log_path = cost_log_path
+        self.period = period
+        self.tz_name = tz_name
+        self._tzinfo = self._resolve_tz(tz_name)
+        self._clock = clock or self._default_clock
         self.entries: list[dict[str, Any]] = []
         self._approved_tools: set[str] = set()
+        self._overrun_dates: set[str] = set()
+        # Reentrant: _transaction() is entered once per public op, and the
+        # helpers it calls must not try to re-acquire the cross-process lock
+        # (msvcrt byte locks are not reentrant across fds).
+        self._lock = threading.RLock()
 
         if cost_log_path and cost_log_path.exists():
-            self._load()
+            with self._lock:
+                self._load()
 
-    # ---- Budget calculations ----
+    # ---- Clock / period ----
 
-    @property
-    def budget_reserved_usd(self) -> float:
+    @staticmethod
+    def _resolve_tz(tz_name: str):
+        if tz_name == "system_local":
+            return None  # means: use the system local offset
+        try:
+            from zoneinfo import ZoneInfo
+            return ZoneInfo(tz_name)
+        except Exception as exc:
+            raise BudgetPeriodError(
+                f"budget.timezone={tz_name!r} could not be resolved ({exc}). "
+                f"Refusing to proceed (fail closed): the daily boundary must be "
+                f"unambiguous. Use 'system_local' or a valid IANA name."
+            ) from exc
+
+    def _default_clock(self) -> datetime:
+        if self._tzinfo is None:
+            return datetime.now().astimezone()
+        return datetime.now(self._tzinfo)
+
+    def current_budget_date(self) -> str:
+        """Today's bucket key (YYYY-MM-DD) in the configured timezone."""
+        return self._clock().date().isoformat()
+
+    def _entry_date(self, entry: dict[str, Any]) -> str:
+        """The entry's immutable bucket key.
+
+        Legacy v1.0 rows have no budget_date; derive one from the recorded
+        timestamp READ-ONLY. Prior-day history is never rewritten.
+        """
+        existing = entry.get("budget_date")
+        if existing:
+            return str(existing)
+        raw = entry.get("timestamp")
+        try:
+            parsed = datetime.fromisoformat(str(raw))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            local = (
+                parsed.astimezone() if self._tzinfo is None
+                else parsed.astimezone(self._tzinfo)
+            )
+            return local.date().isoformat()
+        except (TypeError, ValueError) as exc:
+            raise CostLogCorruptError(
+                f"Cost entry {entry.get('id')!r} has neither a budget_date nor a "
+                f"parseable timestamp ({raw!r}); its day's spend cannot be "
+                f"determined. Refusing to proceed (fail closed)."
+            ) from exc
+
+    # ---- Budget calculations (per-day) ----
+
+    def reserved_on(self, budget_date: str) -> float:
         return sum(
             e.get("reserved_usd", 0.0)
             for e in self.entries
             if e["status"] == EntryStatus.RESERVED.value
+            and self._entry_date(e) == budget_date
         )
 
-    @property
-    def budget_spent_usd(self) -> float:
+    def spent_on(self, budget_date: str) -> float:
         return sum(
             e.get("actual_usd", 0.0)
             for e in self.entries
             if e["status"] in (EntryStatus.COMPLETED.value, EntryStatus.FAILED.value)
+            and self._entry_date(e) == budget_date
         )
+
+    def remaining_on(self, budget_date: str) -> float:
+        return self.budget_total_usd - self.spent_on(budget_date) - self.reserved_on(budget_date)
+
+    def is_overrun(self, budget_date: str) -> bool:
+        """True once a day's actual spend has breached its reservation/cap."""
+        return budget_date in self._overrun_dates
+
+    # ---- Today-scoped conveniences (backwards-compatible property names) ----
+
+    @property
+    def budget_reserved_usd(self) -> float:
+        return self.reserved_on(self.current_budget_date())
+
+    @property
+    def budget_spent_usd(self) -> float:
+        return self.spent_on(self.current_budget_date())
 
     @property
     def budget_remaining_usd(self) -> float:
-        return self.budget_total_usd - self.budget_spent_usd - self.budget_reserved_usd
+        return self.remaining_on(self.current_budget_date())
 
     @property
     def usable_budget_usd(self) -> float:
-        """Budget minus the reserve holdback."""
+        """Today's budget minus the reserve holdback (warn-mode planning only)."""
         holdback = self.budget_total_usd * self.reserve_pct
         return max(0.0, self.budget_remaining_usd - holdback)
 
-    def cost_snapshot(self) -> dict[str, float]:
+    def cost_snapshot(self) -> dict[str, Any]:
+        today = self.current_budget_date()
         return {
-            "total_spent_usd": round(self.budget_spent_usd, 4),
-            "total_reserved_usd": round(self.budget_reserved_usd, 4),
-            "budget_remaining_usd": round(self.budget_remaining_usd, 4),
+            "budget_date": today,
+            "total_spent_usd": round(self.spent_on(today), 4),
+            "total_reserved_usd": round(self.reserved_on(today), 4),
+            "budget_remaining_usd": round(self.remaining_on(today), 4),
+            "overrun": self.is_overrun(today),
         }
+
+    # ---- Transaction ----
+
+    @contextmanager
+    def _transaction(self) -> Iterator[None]:
+        """Serialize a full read-modify-write across threads and processes.
+
+        Reload happens INSIDE the lock: another process may have reserved since
+        we last read, and a stale in-memory bucket is exactly how two callers
+        independently spend the same remaining budget.
+        """
+        with self._lock:
+            if self.cost_log_path is None:
+                yield  # in-memory tracker (tests): no file, nothing to lock
+                return
+            with ledger_lock(self.cost_log_path):
+                if self.cost_log_path.exists():
+                    self._load()
+                yield
 
     # ---- Core operations ----
 
     def estimate(self, tool: str, operation: str, estimated_usd: float) -> str:
-        """Record an estimate. Returns entry ID."""
-        entry_id = self._new_id()
-        self.entries.append({
-            "id": entry_id,
-            "tool": tool,
-            "operation": operation,
-            "status": EntryStatus.ESTIMATED.value,
-            "estimated_usd": round(estimated_usd, 4),
-            "reserved_usd": 0.0,
-            "actual_usd": 0.0,
-            "timestamp": self._now(),
-        })
-        self._save()
-        return entry_id
+        """Record an estimate and stamp its immutable budget_date.
+
+        The date is assigned here, at entry creation, and never recomputed --
+        that is what keeps a reservation opened at 23:59 bound to its own day.
+        """
+        with self._transaction():
+            entry_id = self._new_id()
+            self.entries.append({
+                "id": entry_id,
+                "tool": tool,
+                "operation": operation,
+                "status": EntryStatus.ESTIMATED.value,
+                # Immutable. Assigned once, never recalculated on reconcile.
+                "budget_date": self.current_budget_date(),
+                # Never record a negative cost: a provider or estimator that
+                # returns one must not be able to credit the ledger.
+                "estimated_usd": round(max(0.0, estimated_usd), 4),
+                "reserved_usd": 0.0,
+                "actual_usd": 0.0,
+                "timestamp": self._now(),
+            })
+            self._save()
+            return entry_id
 
     def reserve(self, entry_id: str) -> None:
-        """Reserve budget for an estimated entry.
+        """Reserve budget for an estimated entry, before the paid call runs.
 
-        Raises BudgetExceededError in cap mode, or ApprovalRequiredError
-        when the action exceeds the single-action approval threshold.
+        Three independent checks, in order:
+
+        1. single_action_approval_usd -- independent safeguard, evaluated
+           regardless of `mode`. None or <= 0 disables it.
+        2. require_approval_for_new_paid_tool -- independent safeguard,
+           evaluated regardless of `mode`. False disables it.
+        3. `mode` -- governs the aggregate total budget ONLY.
+           cap:     block if spent + reserved + estimated > total_usd.
+                    An exact-cap request (estimated == remaining) is ALLOWED.
+                    The reserve_pct holdback does not apply -- cap enforces the
+                    true aggregate the user configured, nothing tighter.
+           warn:    flag and proceed, measured against the holdback-aware
+                    usable budget (unchanged pre-existing semantics).
+           observe: record only.
+
+        The check is made against the entry's OWN budget_date bucket, not
+        today's -- so a reservation stamped 23:59 is measured against that day
+        even if reserve() runs a moment after midnight.
+
+        Raises ApprovalRequiredError or BudgetExceededError. The entry is left
+        ESTIMATED (not RESERVED) when a check rejects it, so a rejected call
+        consumes no budget.
         """
-        entry = self._find(entry_id)
-        estimated = entry["estimated_usd"]
+        with self._transaction():
+            entry = self._find(entry_id)
+            estimated = entry["estimated_usd"]
+            budget_date = self._entry_date(entry)
 
-        # Check single-action approval threshold
-        if estimated > self.single_action_approval_usd:
-            if self.mode != BudgetMode.OBSERVE:
+            # --- Safeguard 1: single-action threshold (independent of mode) ---
+            threshold = self.single_action_approval_usd
+            if threshold is not None and threshold > 0 and estimated - threshold > _EPSILON:
                 raise ApprovalRequiredError(
-                    f"Action costs ${estimated:.2f}, exceeds "
-                    f"single-action threshold ${self.single_action_approval_usd:.2f}"
+                    f"Action costs ${estimated:.2f}, which exceeds the configured "
+                    f"single-action approval threshold of ${threshold:.2f}. "
+                    f"This safeguard is independent of budget mode "
+                    f"({self.mode.value}); raise or disable "
+                    f"budget.single_action_approval_usd to permit it."
                 )
 
-        # Check new paid tool approval
-        if self.require_approval_for_new_paid_tool and estimated > 0:
-            if entry["tool"] not in self._approved_tools:
-                if self.mode != BudgetMode.OBSERVE:
+            # --- Safeguard 2: first paid use of a tool (independent of mode) ---
+            if self.require_approval_for_new_paid_tool and estimated > 0:
+                if entry["tool"] not in self._approved_tools:
                     raise ApprovalRequiredError(
-                        f"First paid use of tool {entry['tool']!r} requires approval"
+                        f"First paid use of tool {entry['tool']!r} requires approval. "
+                        f"This safeguard is independent of budget mode "
+                        f"({self.mode.value}); call approve_tool({entry['tool']!r}) or "
+                        f"disable budget.require_approval_for_new_paid_tool."
                     )
 
-        # Check budget
-        if estimated > self.usable_budget_usd:
-            message = (
-                f"Reservation of ${estimated:.2f} exceeds usable budget "
-                f"${self.usable_budget_usd:.2f}"
-            )
+            # --- Control 3: the day's aggregate budget (governed by mode) ---
             if self.mode == BudgetMode.CAP:
-                raise BudgetExceededError(message)
-            if self.mode == BudgetMode.WARN:
-                entry["budget_warning"] = True
-                entry["budget_warning_message"] = message
+                # A day whose actual spend already breached its reservations is
+                # closed for business, regardless of how small this request is.
+                if budget_date in self._overrun_dates:
+                    raise BudgetExceededError(self._overrun_message(budget_date, estimated))
+                remaining = self.remaining_on(budget_date)
+                if estimated - remaining > _EPSILON:
+                    raise BudgetExceededError(self._cap_message(budget_date, estimated))
+            elif self.mode == BudgetMode.WARN:
+                if estimated > self.usable_budget_usd:
+                    message = (
+                        f"Reservation of ${estimated:.2f} exceeds usable budget "
+                        f"${self.usable_budget_usd:.2f}"
+                    )
+                    entry["budget_warning"] = True
+                    entry["budget_warning_message"] = message
 
-        entry["status"] = EntryStatus.RESERVED.value
-        entry["reserved_usd"] = estimated
-        entry["timestamp"] = self._now()
-        self._save()
+            entry["status"] = EntryStatus.RESERVED.value
+            entry["reserved_usd"] = estimated
+            entry["timestamp"] = self._now()
+            self._save()
+
+    def _cap_message(self, budget_date: str, estimated: float) -> str:
+        """Operator-readable refusal. Contains no credentials or provider keys."""
+        return (
+            f"Daily budget hard cap reached for {budget_date}: this request is "
+            f"blocked before any paid provider call was made.\n"
+            f"  budget date:          {budget_date} (timezone: {self.tz_name})\n"
+            f"  configured daily cap: ${self.budget_total_usd:.2f}\n"
+            f"  recorded spend today: ${self.spent_on(budget_date):.2f}\n"
+            f"  reserved (in-flight): ${self.reserved_on(budget_date):.2f}\n"
+            f"  this request:         ${estimated:.2f}\n"
+            f"  remaining today:      ${self.remaining_on(budget_date):.2f}\n"
+            f"The budget resets at midnight ({self.tz_name}). Raise "
+            f"budget.total_usd in config.yaml to permit more spend today."
+        )
+
+    def _overrun_message(self, budget_date: str, estimated: float) -> str:
+        return (
+            f"Daily bucket {budget_date} is marked OVER BUDGET: actual spend "
+            f"exceeded what was reserved, so the cap for this date can no longer "
+            f"be guaranteed. All further paid calls for {budget_date} are "
+            f"blocked.\n"
+            f"  configured daily cap: ${self.budget_total_usd:.2f}\n"
+            f"  recorded spend today: ${self.spent_on(budget_date):.2f}\n"
+            f"  this request:         ${estimated:.2f}\n"
+            f"The budget resets at midnight ({self.tz_name}). Prior-day history "
+            f"is preserved and is not cleared to free budget."
+        )
 
     def approve_tool(self, tool: str) -> None:
         """Mark a tool as approved for paid operations."""
-        self._approved_tools.add(tool)
-        self._save()
+        with self._transaction():
+            self._approved_tools.add(tool)
+            self._save()
 
     def reconcile(self, entry_id: str, actual_usd: float, success: bool = True) -> None:
-        """Reconcile actual spend after tool execution."""
-        entry = self._find(entry_id)
-        entry["status"] = EntryStatus.COMPLETED.value if success else EntryStatus.FAILED.value
-        entry["actual_usd"] = round(actual_usd, 4)
-        entry["reserved_usd"] = 0.0
-        entry["timestamp"] = self._now()
-        self._save()
+        """Reconcile actual spend after tool execution.
+
+        Lands in the entry's ORIGINAL budget_date bucket -- never the date on
+        which reconciliation happens to run.
+
+        Called for successful AND failed calls: a provider that charged and
+        then errored still consumed real money, so FAILED entries keep their
+        actual spend and continue to count against that day (see spent_on).
+        Spend is never recorded below zero and never truncated to the
+        reservation: if actual exceeds what was reserved, the FULL actual is
+        recorded and the day is marked over budget, which blocks further paid
+        calls for that date.
+        """
+        with self._transaction():
+            entry = self._find(entry_id)
+            budget_date = self._entry_date(entry)
+            reserved_before = entry.get("reserved_usd", 0.0)
+            actual = round(max(0.0, actual_usd), 4)
+
+            entry["status"] = (
+                EntryStatus.COMPLETED.value if success else EntryStatus.FAILED.value
+            )
+            # Full actual, always. Truncating to the reservation would hide
+            # real money and make the ledger lie about the day's spend.
+            entry["actual_usd"] = actual
+            entry["reserved_usd"] = 0.0
+            entry["timestamp"] = self._now()
+
+            overran = actual - reserved_before > _EPSILON
+            entry["actual_exceeded_reservation"] = overran
+            if overran or self.spent_on(budget_date) - self.budget_total_usd > _EPSILON:
+                self._overrun_dates.add(budget_date)
+
+            self._save()
 
     def refund(self, entry_id: str) -> None:
-        """Cancel a reservation without executing."""
-        entry = self._find(entry_id)
-        entry["status"] = EntryStatus.REFUNDED.value
-        entry["reserved_usd"] = 0.0
-        entry["timestamp"] = self._now()
-        self._save()
+        """Release a reservation for a call that never reached the provider.
+
+        Only correct when the request was cancelled BEFORE dispatch. A call
+        that may have reached the provider must go through reconcile(), not
+        refund(), or real spend would be silently dropped from the ledger.
+        """
+        with self._transaction():
+            entry = self._find(entry_id)
+            entry["status"] = EntryStatus.REFUNDED.value
+            entry["reserved_usd"] = 0.0
+            entry["timestamp"] = self._now()
+            self._save()
 
     # ---- Reference-driven estimation ----
 
@@ -485,26 +763,75 @@ class CostTracker:
     # ---- Persistence ----
 
     def _save(self) -> None:
+        """Persist the ledger atomically.
+
+        Writes a sibling temp file and os.replace()s it onto the target
+        (atomic on Windows and POSIX). A crash mid-write can therefore leave
+        the previous complete ledger or the new one, never a truncated file
+        that would strand the cap on the next start.
+        """
         if self.cost_log_path is None:
             return
-        data = {
-            "version": "1.0",
-            "budget_total_usd": self.budget_total_usd,
-            "budget_reserved_usd": round(self.budget_reserved_usd, 4),
-            "budget_spent_usd": round(self.budget_spent_usd, 4),
-            "approved_tools": sorted(self._approved_tools),
-            "entries": self.entries,
-        }
-        self.cost_log_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(self.cost_log_path, "w") as f:
-            json.dump(data, f, indent=2)
+        with self._lock:
+            today = self.current_budget_date()
+            data = {
+                "version": "2.0",
+                "budget_total_usd": self.budget_total_usd,
+                # Recorded for audit only. Behaviour always comes from config
+                # via the constructor -- a stale log must never be able to
+                # downgrade cap to warn, or raise the cap, across a restart.
+                "budget_mode": self.mode.value,
+                "period": self.period,
+                "timezone": self.tz_name,
+                "overrun_dates": sorted(self._overrun_dates),
+                # Today's rollup, for humans reading the file. The authority is
+                # always the per-entry budget_date, recomputed on load.
+                "budget_date": today,
+                "budget_reserved_usd": round(self.reserved_on(today), 4),
+                "budget_spent_usd": round(self.spent_on(today), 4),
+                "approved_tools": sorted(self._approved_tools),
+                "entries": self.entries,
+            }
+            self.cost_log_path.parent.mkdir(parents=True, exist_ok=True)
+            # Unique temp name: two processes must never share one temp file.
+            tmp = self.cost_log_path.with_suffix(
+                f"{self.cost_log_path.suffix}.{os.getpid()}.tmp"
+            )
+            with open(tmp, "w") as f:
+                json.dump(data, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp, self.cost_log_path)
 
     def _load(self) -> None:
-        with open(self.cost_log_path) as f:  # type: ignore[arg-type]
-            data = json.load(f)
-        self.entries = data.get("entries", [])
-        self.budget_total_usd = data.get("budget_total_usd", self.budget_total_usd)
+        """Rehydrate spend and unresolved reservations from disk.
+
+        Fails closed: an unreadable ledger raises rather than silently
+        starting from zero spend, which would defeat the cap.
+
+        budget_total_usd and mode are deliberately NOT restored from the log --
+        config.yaml is the sole authority for both.
+        """
+        try:
+            with open(self.cost_log_path) as f:  # type: ignore[arg-type]
+                data = json.load(f)
+            if not isinstance(data, dict):
+                raise ValueError("cost log root is not an object")
+            entries = data.get("entries", [])
+            if not isinstance(entries, list):
+                raise ValueError("cost log 'entries' is not a list")
+        except (json.JSONDecodeError, ValueError, OSError) as exc:
+            raise CostLogCorruptError(
+                f"Cost log at {self.cost_log_path} could not be read ({exc}). "
+                f"Refusing to proceed: accumulated spend is unknown, so the "
+                f"budget cap cannot be enforced. Inspect or delete the file to "
+                f"reset recorded spend."
+            ) from exc
+
+        self.entries = entries
         self._approved_tools = set(data.get("approved_tools", []))
+        # Sticky: a day marked over budget stays marked across restarts.
+        self._overrun_dates = set(data.get("overrun_dates", []))
 
     # ---- Helpers ----
 

--- a/tools/enhancement/bg_remove.py
+++ b/tools/enhancement/bg_remove.py
@@ -34,6 +34,8 @@ class BgRemove(BaseTool):
     execution_mode = ExecutionMode.SYNC
     determinism = Determinism.DETERMINISTIC
     runtime = ToolRuntime.HYBRID
+    # Genuinely free: no provider charge can ever be incurred (see BaseTool.paid).
+    paid = False
 
     dependencies = ["python:rembg", "python:PIL"]
     install_instructions = (

--- a/tools/graphics/dashscope_image.py
+++ b/tools/graphics/dashscope_image.py
@@ -140,6 +140,16 @@ class DashscopeImage(BaseTool):
         n = int(inputs.get("n", 1))
         return n * 0.02
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Upper bound on a single call's spend.
+
+        DashScope bills per generated image and the per-image constant above
+        is already the repository's conservative ceiling, so the estimate --
+        fully determined by the requested n -- is itself the bound. execute()
+        issues one billed HTTP request with no retry loop.
+        """
+        return self.estimate_cost(inputs)
+
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
         api_key = os.environ.get("DASHSCOPE_API_KEY")
         if not api_key:

--- a/tools/graphics/flux_image.py
+++ b/tools/graphics/flux_image.py
@@ -94,6 +94,16 @@ class FluxImage(BaseTool):
             return 0.05
         return 0.03  # dev tier
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Upper bound on a single call's spend.
+
+        fal FLUX bills a flat per-generation price. An arbitrary model string
+        cannot be priced below the dearest published tier, so every call is
+        bounded at the pro rate via the same estimate the pricing lives in.
+        execute() issues one billed generation request.
+        """
+        return self.estimate_cost({**inputs, "model": "flux-pro/v1.1"})
+
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
         api_key = self._get_api_key()
         if not api_key:

--- a/tools/graphics/google_imagen.py
+++ b/tools/graphics/google_imagen.py
@@ -163,6 +163,20 @@ class GoogleImagen(BaseTool):
             return 0.02 * n
         return 0.04 * n
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Upper bound on a single call's spend.
+
+        Per-image pricing keyed off the model tier. Models in the imagen-4
+        family the estimate's branches were written for price exactly; any
+        other model string is bounded at the dearest published rate (ultra)
+        rather than the cheap default branch. execute() issues one billed
+        request for the requested image count.
+        """
+        model = str(inputs.get("model", "imagen-4.0-generate-001"))
+        if model.startswith("imagen-4"):
+            return self.estimate_cost(inputs)
+        return self.estimate_cost({**inputs, "model": "imagen-ultra"})
+
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
         # Two auth paths: an AI Studio API key, or a service-account JSON that
         # routes to Vertex AI (the AI Studio endpoint does not accept service

--- a/tools/graphics/grok_image.py
+++ b/tools/graphics/grok_image.py
@@ -156,6 +156,16 @@ class GrokImage(BaseTool):
         # image plus $0.002 per input image for edits or composites.
         return output_count * 0.02 + input_count * 0.002
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Upper bound on a single call's spend.
+
+        Published flat rates per generated image and per input image, both
+        counts fully determined by the request -- the estimate is itself the
+        ceiling. execute() issues one billed request; no internal retry loop
+        re-bills.
+        """
+        return self.estimate_cost(inputs)
+
     def _build_payload(self, inputs: dict[str, Any]) -> tuple[str, dict[str, Any]]:
         mode = inputs.get("generation_mode", "generate")
         payload: dict[str, Any] = {

--- a/tools/graphics/image_gen.py
+++ b/tools/graphics/image_gen.py
@@ -126,6 +126,23 @@ class ImageGen(BaseTool):
             return 0.03
         return 0.0  # local
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Upper bound on a single call's spend.
+
+        The OpenAI path requests auto quality, which the provider may resolve
+        to the dearest gpt-image-2 tier ($0.211 at 1024x1024 -- the "high"
+        constant in openai_image.estimate_cost). The FLUX path is bounded at
+        the dearest fal FLUX tier ($0.05 pro, see flux_image.estimate_cost).
+        Local diffusers or no provider bills nothing. One billed request per
+        execute(); no internal retry loop re-bills.
+        """
+        provider = inputs.get("provider") or self._detect_provider()
+        if provider == "openai":
+            return 0.211
+        if provider == "flux":
+            return 0.05
+        return 0.0
+
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
         provider = inputs.get("provider") or self._detect_provider()
         if not provider:

--- a/tools/graphics/image_selector.py
+++ b/tools/graphics/image_selector.py
@@ -205,11 +205,37 @@ class ImageSelector(BaseTool):
         return ToolStatus.UNAVAILABLE
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
-        candidates = self._providers()
+        if inputs.get("operation") == "rank":
+            return 0.0  # rank mode returns scores without dispatching a provider
+        candidates = self._filter_candidates(inputs, self._providers())
         if not candidates:
             return 0.0
         tool, _ = self._select_best_tool(inputs, candidates, self._prepare_task_context(inputs))
         return tool.estimate_cost(inputs) if tool else 0.0
+
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Bound = the selected provider's bound; the selector adds no charge.
+
+        Resolves the provider with the same candidates and _select_best_tool
+        call execute() uses, then delegates to that provider's max_cost_usd()
+        (input adaptation in execute() only adds routing fields -- every
+        billable parameter passes through unchanged). Rank mode and requests
+        that cannot resolve a provider return 0.0 because execute() is
+        guaranteed to answer locally without dispatching. An unbounded
+        selected provider propagates None, keeping the call fail-closed.
+        """
+        if inputs.get("operation") == "rank":
+            return 0.0
+        candidates = self._filter_candidates(inputs, self._providers())
+        if not candidates:
+            return 0.0
+        tool, _ = self._select_best_tool(inputs, candidates, self._prepare_task_context(inputs))
+        if tool is None:
+            return 0.0
+        if getattr(tool, "paid", None) is False:
+            # Declared-free provider (stock media search): nothing to bound.
+            return 0.0
+        return tool.max_cost_usd(inputs)
 
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
         import logging

--- a/tools/graphics/kling_official_image.py
+++ b/tools/graphics/kling_official_image.py
@@ -169,6 +169,24 @@ class KlingOfficialImage(BaseTool):
             base *= 1 + (0.08 * reference_count)
         return round(base * max(n, 1), 4)
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Worst-case upper bound on a single call's spend.
+
+        Fail closed on the opt-in account-usage diagnostic (billing not
+        authoritatively verified -- same rule as kling_lip_sync). Otherwise
+        the per-attempt cost is estimate_cost() with an UNRECOGNIZED
+        resolution upgraded to the dearest published tier (4k), times
+        1 + retry_policy.max_retries -- the SAME setting execute() passes to
+        KlingClient, so bound and real retry loop read one authority.
+        """
+        if inputs.get("include_account_usage"):
+            return None
+        worst = dict(inputs)
+        if str(inputs.get("resolution", "1k")) not in ("1k", "2k", "4k"):
+            worst["resolution"] = "4k"
+        billed_attempts = 1 + self.retry_policy.max_retries
+        return round(self.estimate_cost(worst) * billed_attempts, 4)
+
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         return 90.0
 
@@ -192,7 +210,8 @@ class KlingOfficialImage(BaseTool):
         start = time.time()
         try:
             request = self._build_request(inputs)
-            client = KlingClient()
+            # Same retry setting the bound in max_cost_usd() reserves against.
+            client = KlingClient(max_retries=self.retry_policy.max_retries)
             task_id = client.create_classic_task(request["path"], request["payload"])
             outputs = client.poll_classic(
                 request["path"],

--- a/tools/graphics/openai_image.py
+++ b/tools/graphics/openai_image.py
@@ -123,6 +123,21 @@ class OpenAIImage(BaseTool):
         cost_map = {"low": 0.006, "medium": 0.053, "high": 0.211, "auto": 0.053}
         return cost_map.get(quality, 0.053) * n
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Worst-case upper bound on a single call's spend.
+
+        For an explicit low/medium/high quality the estimate IS the per-image
+        price times n, so it is its own ceiling. "auto" (and any unrecognized
+        value) lets the provider resolve the tier, which can land on the
+        dearest one -- so those are priced as "high". Evaluating
+        estimate_cost() keeps the bound reading the same price map as the
+        estimate. execute() bills exactly one images.generate request.
+        """
+        quality = inputs.get("quality", "high")
+        if quality in ("low", "medium", "high"):
+            return self.estimate_cost(inputs)
+        return self.estimate_cost({**inputs, "quality": "high"})
+
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
         if not os.environ.get("OPENAI_API_KEY"):
             return ToolResult(

--- a/tools/graphics/pexels_image.py
+++ b/tools/graphics/pexels_image.py
@@ -31,6 +31,8 @@ class PexelsImage(BaseTool):
     execution_mode = ExecutionMode.SYNC
     determinism = Determinism.DETERMINISTIC
     runtime = ToolRuntime.API
+    # Genuinely free: no provider charge can ever be incurred (see BaseTool.paid).
+    paid = False
 
     dependencies = []
     install_instructions = (

--- a/tools/graphics/pixabay_image.py
+++ b/tools/graphics/pixabay_image.py
@@ -31,6 +31,8 @@ class PixabayImage(BaseTool):
     execution_mode = ExecutionMode.SYNC
     determinism = Determinism.DETERMINISTIC
     runtime = ToolRuntime.API
+    # Genuinely free: no provider charge can ever be incurred (see BaseTool.paid).
+    paid = False
 
     dependencies = []
     install_instructions = (

--- a/tools/graphics/recraft_image.py
+++ b/tools/graphics/recraft_image.py
@@ -120,6 +120,18 @@ class RecraftImage(BaseTool):
             return 0.25
         return 0.04
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Upper bound on a single call's spend.
+
+        Flat per-generation pricing: the two known models price exactly, and
+        an unrecognized model string is bounded at the dearest tier (v4-pro)
+        rather than assumed cheap. execute() issues one billed request.
+        """
+        model = inputs.get("model", "v4")
+        if model in ("v4", "v4-pro"):
+            return self.estimate_cost(inputs)
+        return self.estimate_cost({**inputs, "model": "v4-pro"})
+
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
         api_key = self._get_api_key()
         if not api_key:

--- a/tools/video/corpus_builder.py
+++ b/tools/video/corpus_builder.py
@@ -81,6 +81,8 @@ class CorpusBuilder(BaseTool):
     execution_mode = ExecutionMode.SYNC
     determinism = Determinism.DETERMINISTIC
     runtime = ToolRuntime.HYBRID  # local compute + network APIs
+    # Genuinely free: no provider charge can ever be incurred (see BaseTool.paid).
+    paid = False
 
     dependencies = [
         "python:cv2",

--- a/tools/video/direct_clip_search.py
+++ b/tools/video/direct_clip_search.py
@@ -68,6 +68,8 @@ class DirectClipSearch(BaseTool):
     execution_mode = ExecutionMode.SYNC
     determinism = Determinism.DETERMINISTIC
     runtime = ToolRuntime.HYBRID  # local disk + network APIs
+    # Genuinely free: no provider charge can ever be incurred (see BaseTool.paid).
+    paid = False
 
     dependencies = [
         "python:requests",

--- a/tools/video/gemini_omni_video.py
+++ b/tools/video/gemini_omni_video.py
@@ -200,6 +200,18 @@ class GeminiOmniVideo(BaseTool):
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
         return _COST_PER_SECOND * self._duration_hint(inputs)
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Flat upper bound over the whole input domain.
+
+        _duration_hint() clamps every request to at most 10 billable seconds,
+        so no valid call can cost more than 10x the per-second rate. Deriving
+        the bound from the same clamp ceiling and _COST_PER_SECOND constant
+        the estimate uses means the two cannot drift. execute() issues one
+        billed interaction per call (polling is free; no retry loop wraps the
+        billed request).
+        """
+        return round(_COST_PER_SECOND * 10, 4)
+
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         return 180.0
 

--- a/tools/video/grok_video.py
+++ b/tools/video/grok_video.py
@@ -175,6 +175,16 @@ class GrokVideo(BaseTool):
         # $0.07/sec for 720p, plus $0.002 per input image.
         return base_per_second * duration + input_image_cost
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Upper bound on a single call's spend.
+
+        Duration and input-image count come from the request; the only free
+        variable is the resolution tier, so the bound prices every call at
+        the dearest published per-second rate (720p) via the same estimate
+        the pricing lives in. execute() issues one billed request.
+        """
+        return self.estimate_cost({**inputs, "resolution": "720p"})
+
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         duration = int(inputs.get("duration", 5))
         return 90.0 + duration * 8.0

--- a/tools/video/heygen_video.py
+++ b/tools/video/heygen_video.py
@@ -99,6 +99,19 @@ class HeyGenVideo(BaseTool):
         meta = HEYGEN_PROVIDERS.get(inputs.get("provider_variant", "veo_3_1"), HEYGEN_PROVIDERS["veo_3_1"])
         return estimate_quality_cost(meta["quality"])
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Upper bound on a single call's spend.
+
+        A known provider_variant maps to a fixed quality tier, so the
+        estimate prices it exactly. An unknown variant is rejected by
+        generate_heygen_video before any billed dispatch, but is still
+        bounded at the dearest quality tier rather than the estimate's
+        default-variant guess. execute() issues one billed request.
+        """
+        if inputs.get("provider_variant", "veo_3_1") in HEYGEN_PROVIDERS:
+            return self.estimate_cost(inputs)
+        return estimate_quality_cost("highest")
+
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         meta = HEYGEN_PROVIDERS.get(inputs.get("provider_variant", "veo_3_1"), HEYGEN_PROVIDERS["veo_3_1"])
         return estimate_speed_runtime(meta["speed"])

--- a/tools/video/higgsfield_video.py
+++ b/tools/video/higgsfield_video.py
@@ -155,6 +155,23 @@ class HiggsFieldVideo(BaseTool):
         base = base_costs.get(model, 0.15)
         return base * (duration / 5)
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Upper bound on a single call's spend.
+
+        Known models price exactly through the estimate; an unrecognized
+        model string is bounded at the dearest catalog entry (seedance_2.0)
+        rather than the cheap default. Duration comes from the request.
+        execute() issues one billed request.
+        """
+        known_models = (
+            "seedance_2.0", "seedance_2.0_fast", "kling_3.0", "wan_2.5",
+            "veo_3.1", "sora_2", "soul_cinema",
+        )
+        model = inputs.get("model", _DEFAULT_MODEL)
+        if model in known_models:
+            return self.estimate_cost(inputs)
+        return self.estimate_cost({**inputs, "model": "seedance_2.0"})
+
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         model = inputs.get("model", _DEFAULT_MODEL)
         if model in ("veo_3.1", "sora_2", "seedance_2.0"):

--- a/tools/video/kling_official_video.py
+++ b/tools/video/kling_official_video.py
@@ -199,6 +199,31 @@ class KlingOfficialVideo(BaseTool):
                 base *= 1 + (0.10 * len(multi_prompt))
         return round(base * max(duration, 3) / 5, 4)
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Worst-case upper bound on a single call's spend.
+
+        Fail closed on the opt-in account-usage diagnostic: that endpoint's
+        billing is not authoritatively verified, so a call that requests it
+        cannot be bounded and is refused rather than assumed free (same rule
+        as kling_lip_sync).
+
+        Otherwise the per-attempt cost is estimate_cost() evaluated with any
+        UNRECOGNIZED mode or api_family upgraded to the dearest published
+        tier (4k / omni) so an unknown value can never price below reality.
+        The attempt count is 1 + retry_policy.max_retries -- the SAME setting
+        execute() passes to KlingClient below, so bound and real retry loop
+        read one authority.
+        """
+        if inputs.get("include_account_usage"):
+            return None
+        worst = dict(inputs)
+        if str(inputs.get("mode", "std")) not in ("std", "pro", "4k"):
+            worst["mode"] = "4k"
+        if str(inputs.get("api_family", "classic")) not in ("classic", "turbo", "omni"):
+            worst["api_family"] = "omni"
+        billed_attempts = 1 + self.retry_policy.max_retries
+        return round(self.estimate_cost(worst) * billed_attempts, 4)
+
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         return 180.0
 
@@ -222,7 +247,8 @@ class KlingOfficialVideo(BaseTool):
         start = time.time()
         try:
             request = self._build_request(inputs)
-            client = KlingClient()
+            # Same retry setting the bound in max_cost_usd() reserves against.
+            client = KlingClient(max_retries=self.retry_policy.max_retries)
             if request["protocol"] == "turbo":
                 task_id = client.create_turbo(request["path"], request["payload"])
                 outputs = client.poll_turbo(

--- a/tools/video/kling_video.py
+++ b/tools/video/kling_video.py
@@ -113,6 +113,19 @@ class KlingVideo(BaseTool):
             return 0.20 * (duration / 5)
         return 0.10 * (duration / 5)  # standard
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Upper bound on a single call's spend.
+
+        The schema's known variants price exactly through the estimate; an
+        unrecognized variant string is bounded at the dearest tier (master)
+        rather than the cheap standard fallback. Duration comes from the
+        request. execute() issues one billed request.
+        """
+        variant = inputs.get("model_variant", "v3/standard")
+        if variant in ("v3/standard", "v2.1/master", "v2.1/pro", "v2.1/standard"):
+            return self.estimate_cost(inputs)
+        return self.estimate_cost({**inputs, "model_variant": "v2.1/master"})
+
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         return 60.0  # ~1 minute typical
 

--- a/tools/video/ltx_video_modal.py
+++ b/tools/video/ltx_video_modal.py
@@ -89,6 +89,15 @@ class LTXVideoModal(BaseTool):
     def estimate_cost(self, inputs: dict[str, object]) -> float:
         return 0.25
 
+    def max_cost_usd(self, inputs: dict[str, object]) -> float | None:
+        """Upper bound on a single call's spend.
+
+        Flat per-generation Modal compute pricing independent of inputs; the
+        estimate is itself the ceiling. execute() issues one billed
+        generation; no internal retry loop re-bills.
+        """
+        return self.estimate_cost(inputs)
+
     def estimate_runtime(self, inputs: dict[str, object]) -> float:
         return 180.0
 

--- a/tools/video/minimax_video.py
+++ b/tools/video/minimax_video.py
@@ -103,6 +103,19 @@ class MiniMaxVideo(BaseTool):
             return 0.08
         return 0.10  # standard
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Upper bound on a single call's spend.
+
+        Flat per-generation pricing by variant tier; the bound is the dearest
+        published tier (pro) unless the request already prices there, so an
+        unrecognized variant can never underestimate. execute() issues one
+        billed request.
+        """
+        return max(
+            self.estimate_cost(inputs),
+            self.estimate_cost({**inputs, "model_variant": "hailuo-02/pro"}),
+        )
+
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         variant = inputs.get("model_variant", "hailuo-02/pro")
         if "fast" in variant:

--- a/tools/video/pexels_video.py
+++ b/tools/video/pexels_video.py
@@ -31,6 +31,8 @@ class PexelsVideo(BaseTool):
     execution_mode = ExecutionMode.SYNC
     determinism = Determinism.DETERMINISTIC
     runtime = ToolRuntime.API
+    # Genuinely free: no provider charge can ever be incurred (see BaseTool.paid).
+    paid = False
 
     dependencies = []
     install_instructions = (

--- a/tools/video/pixabay_video.py
+++ b/tools/video/pixabay_video.py
@@ -31,6 +31,8 @@ class PixabayVideo(BaseTool):
     execution_mode = ExecutionMode.SYNC
     determinism = Determinism.DETERMINISTIC
     runtime = ToolRuntime.API
+    # Genuinely free: no provider charge can ever be incurred (see BaseTool.paid).
+    paid = False
 
     dependencies = []
     install_instructions = (

--- a/tools/video/runway_video.py
+++ b/tools/video/runway_video.py
@@ -158,6 +158,21 @@ class RunwayVideo(BaseTool):
         duration = inputs.get("duration", 5)
         return _COST_PER_SECOND.get(model, 0.05) * duration
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Upper bound on a single call's spend.
+
+        Models present in _COST_PER_SECOND price exactly through the
+        estimate; an unrecognized model string is bounded at the dearest
+        published per-second rate in that same table rather than the cheap
+        default. Duration comes from the request. execute() issues one billed
+        request.
+        """
+        model = inputs.get("model", _DEFAULT_MODEL)
+        if model in _COST_PER_SECOND:
+            return self.estimate_cost(inputs)
+        dearest = max(_COST_PER_SECOND, key=_COST_PER_SECOND.get)
+        return self.estimate_cost({**inputs, "model": dearest})
+
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         model = inputs.get("model", _DEFAULT_MODEL)
         return _RUNTIME_SECONDS.get(model, 30.0)

--- a/tools/video/seedance_replicate.py
+++ b/tools/video/seedance_replicate.py
@@ -140,6 +140,19 @@ class SeedanceReplicate(BaseTool):
         rate = 0.24 if variant == "fast" else 0.30
         return round(rate * secs, 2)
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Upper bound on a single call's spend.
+
+        duration="auto" lets the MODEL choose the length, so the bound prices
+        it at the schema's maximum (15 seconds) instead of the estimate's 5s
+        guess. Explicit durations price exactly; the non-fast rate is already
+        the dearest and is the estimate's fallback for unknown variants.
+        execute() issues one billed request.
+        """
+        if inputs.get("duration", "5") == "auto":
+            return self.estimate_cost({**inputs, "duration": "15"})
+        return self.estimate_cost(inputs)
+
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         return 60.0 if inputs.get("model_variant") == "fast" else 120.0
 

--- a/tools/video/seedance_video.py
+++ b/tools/video/seedance_video.py
@@ -174,6 +174,19 @@ class SeedanceVideo(BaseTool):
         rate = 0.2419 if variant == "fast" else 0.3034
         return round(rate * secs, 2)
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Upper bound on a single call's spend.
+
+        duration="auto" lets the MODEL choose the length, so the bound prices
+        it at the schema's maximum (15 seconds) instead of the estimate's 5s
+        guess. Explicit durations price exactly; the non-fast rate is already
+        the dearest and is the estimate's fallback for unknown variants.
+        execute() issues one billed request.
+        """
+        if inputs.get("duration", "5") == "auto":
+            return self.estimate_cost({**inputs, "duration": "15"})
+        return self.estimate_cost(inputs)
+
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         variant = inputs.get("model_variant", "standard")
         return 60.0 if variant == "fast" else 120.0

--- a/tools/video/sora_video.py
+++ b/tools/video/sora_video.py
@@ -134,6 +134,20 @@ class SoraVideo(BaseTool):
         # Placeholder estimate until the registry has live OpenAI video pricing.
         return 0.50 * (seconds / 4)
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Flat upper bound on a single call's spend, over the whole domain.
+
+        Cost depends only on `seconds`, which _normalize_seconds constrains to
+        _ALLOWED_SECONDS (any other value raises before a billed call is made).
+        model, size, and output count do not affect price, and execute() bills
+        exactly one generation with no retry loop -- so no valid call can cost
+        more than the longest allowed duration. Evaluating estimate_cost() at
+        that duration derives the bound from the very same enum and pricing
+        constant as the estimate, so the two cannot drift. -> $1.50 today.
+        """
+        longest = max(_ALLOWED_SECONDS, key=int)
+        return self.estimate_cost({"seconds": longest})
+
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         seconds = int(self._normalize_seconds(inputs))
         return 120.0 * (seconds / 4)

--- a/tools/video/veo_video.py
+++ b/tools/video/veo_video.py
@@ -224,6 +224,50 @@ class VeoVideo(BaseTool):
 
         return (audio_per_second if generate_audio else base_per_second) * duration
 
+    def max_cost_usd(self, inputs: dict[str, Any]) -> float | None:
+        """Worst-case upper bound on a single call's spend.
+
+        Resolves the backend exactly as estimate_cost() does. Two facts make
+        the bound differ from the estimate:
+
+        - auto_fix can COERCE the billed duration up to exactly 8 seconds
+          (never higher), so the bound prices max(requested, 8) seconds.
+        - On fal, audio billing (generate_audio defaults to True) is the
+          dearer per-second rate, and an unrecognized resolution string is
+          priced at the 4k top tier rather than assumed cheap.
+
+        execute() issues one billed generation per call on both backends (no
+        internal retry loop wraps the provider request).
+        """
+        backend = inputs.get("backend", "auto")
+        if backend == "auto":
+            if self._get_google_credentials_status():
+                backend = "google"
+            elif self._get_fal_api_key():
+                backend = "fal"
+            else:
+                backend = "google"
+
+        duration_text = str(inputs.get("duration", "8s")).lower().replace("s", "")
+        try:
+            duration = int(duration_text)
+        except ValueError:
+            duration = 8
+        billable_seconds = max(duration, 8)
+
+        if backend == "google":
+            return round(billable_seconds * 0.40, 4)
+
+        variant = str(inputs.get("model_variant", "veo3.1"))
+        resolution = str(inputs.get("resolution", "1080p")).lower()
+        if "fast" in variant:
+            per_second = 0.20  # fast tier with audio
+        elif resolution in ("720p", "1080p"):
+            per_second = 0.40  # standard tier with audio
+        else:
+            per_second = 0.60  # 4k -- and anything unrecognized prices here
+        return round(per_second * billable_seconds, 4)
+
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         """Estimate the expected runtime in seconds."""
         backend = inputs.get("backend", "auto")

--- a/tools/video/video_selector.py
+++ b/tools/video/video_selector.py
@@ -258,11 +258,37 @@ class VideoSelector(BaseTool):
         return ToolStatus.UNAVAILABLE
 
     def estimate_cost(self, inputs: dict[str, object]) -> float:
+        if inputs.get("operation") == "rank":
+            return 0.0  # rank mode returns scores without dispatching a provider
         candidates = self._filter_candidates(inputs, self._providers())
         if not candidates:
             return 0.0
         tool, _ = self._select_best_tool(inputs, candidates, self._prepare_task_context(inputs))
         return tool.estimate_cost(inputs) if tool else 0.0
+
+    def max_cost_usd(self, inputs: dict[str, object]) -> float | None:
+        """Bound = the selected provider's bound; the selector adds no charge.
+
+        Resolves the provider with the same candidates and _select_best_tool
+        call execute() uses, then delegates to that provider's max_cost_usd()
+        (input adaptation in execute() only adds routing fields -- every
+        billable parameter passes through unchanged). Rank mode and requests
+        that cannot resolve a provider return 0.0 because execute() is
+        guaranteed to answer locally without dispatching. An unbounded
+        selected provider propagates None, keeping the call fail-closed.
+        """
+        if inputs.get("operation") == "rank":
+            return 0.0
+        candidates = self._filter_candidates(inputs, self._providers())
+        if not candidates:
+            return 0.0
+        tool, _ = self._select_best_tool(inputs, candidates, self._prepare_task_context(inputs))
+        if tool is None:
+            return 0.0
+        if getattr(tool, "paid", None) is False:
+            # Declared-free provider (stock media search): nothing to bound.
+            return 0.0
+        return tool.max_cost_usd(inputs)
 
     def estimate_runtime(self, inputs: dict[str, object]) -> float:
         candidates = self._providers()


### PR DESCRIPTION
## Summary

- Adds a $10 aggregate provider-spend hard cap per calendar day.
- Adds restart-safe daily budget buckets and immutable budget dates.
- Adds in-process and Windows cross-process ledger locking.
- Fails closed before provider dispatch.
- Adds verified cost bounds for Google Music, Sora Video, Kling Avatar, and Kling Lip Sync.
- Leaves all other unbounded paid tools safely fail-closed.

## Configuration

- `mode: cap`
- `total_usd: 10.00`
- `period: daily`
- `timezone: system_local`
- `reserve_pct: 0.10`
- `single_action_approval_usd: 0.50`
- `require_approval_for_new_paid_tool: true`

## Verification

- Phase A: 124 passed, 1 skipped, 0 failed.
- Phase B: 874 passed, 9 skipped, 1 deselected.
- 29 expected `BudgetGateError` cases for paid tools that do not yet declare `max_cost_usd()`.
- Zero real regressions.
- No provider calls, real API keys, HyperFrames, or unexpected file mutations.

## Important

This pull request should remain a draft until the project maintainers decide how the 29 intentionally fail-closed legacy provider tests should be represented in CI.