### PR TITLE
Add Contributor License Agreement and CLA signature gate

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,36 @@
+# CLA Assistant Lite — gates every PR on a CLA signature.
+# Install at: .github/workflows/cla.yml in the OpenMontage repo.
+# Signatures are stored in the repo on the 'cla-signatures' branch (no external service).
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: ".github/cla-signatures/signatures.json"
+          path-to-document: "https://github.com/calesthio/OpenMontage/blob/main/CLA.md"
+          branch: "cla-signatures"
+          allowlist: "calesthio,dependabot[bot],*[bot]"
+          custom-notsigned-prcomment: >
+            Thanks for the contribution! Before we can merge, please read our
+            [Contributor License Agreement](https://github.com/calesthio/OpenMontage/blob/main/CLA.md)
+            and sign by commenting the sentence below. The engine stays open source forever —
+            the CLA simply lets the project also offer commercial licensing as it grows.
+          custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA"

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,40 @@
+# OpenMontage Individual Contributor License Agreement
+
+Thank you for your interest in contributing to OpenMontage ("the Project"), maintained by Calesthio ("the Maintainer").
+
+This Contributor License Agreement ("Agreement") clarifies the intellectual-property rights granted with Contributions from any person to the Maintainer. This license is for your protection as a Contributor as well as for the protection of the Project and its users; it does not change your rights to use your own Contributions for any other purpose.
+
+By commenting "I have read the CLA Document and I hereby sign the CLA" on a Project pull request or on the designated signing issue, you accept and agree to the following terms for your present and future Contributions submitted to the Project.
+
+## 1. Definitions
+
+**"You"** means the individual who submits a Contribution.
+
+**"Contribution"** means any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to the Project for inclusion in, or documentation of, the Project.
+
+## 2. Grant of Copyright License
+
+Subject to the terms of this Agreement, You hereby grant to the Maintainer and to recipients of software distributed by the Maintainer a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works, **under any license terms, including without limitation open-source licenses and commercial or proprietary licenses**.
+
+## 3. Grant of Patent License
+
+Subject to the terms of this Agreement, You hereby grant to the Maintainer and to recipients of software distributed by the Maintainer a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer Your Contributions, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution alone or by combination of Your Contribution with the Project. If any entity institutes patent litigation against You or any other entity alleging that Your Contribution, or the Project to which You have contributed, constitutes direct or contributory patent infringement, then any patent licenses granted to that entity under this Agreement for that Contribution or Project shall terminate as of the date such litigation is filed.
+
+## 4. Representations
+
+You represent that:
+(a) You are legally entitled to grant the above licenses.
+(b) Each of Your Contributions is Your original creation, or You have identified any third-party material and its license within the Contribution.
+(c) If Your employer has rights to intellectual property that You create that includes Your Contributions, You have received permission to make Contributions on behalf of that employer, or Your employer has waived such rights for Your Contributions to the Project.
+
+## 5. No Support Obligation; Disclaimer
+
+You are not expected to provide support for Your Contributions, except to the extent You desire to provide support. Unless required by applicable law or agreed to in writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+## 6. Project License Commitment
+
+The Maintainer commits that the OpenMontage engine will always remain available under an OSI-approved open-source license. This Agreement exists to allow the Maintainer to additionally offer the Project under other license terms (for example, commercial licenses for organizations that cannot use AGPLv3), and to keep that possible as the Project grows.
+
+## 7. Notification
+
+You agree to notify the Maintainer of any facts or circumstances of which You become aware that would make these representations inaccurate in any respect.


### PR DESCRIPTION
## What

- **CLA.md** — individual Contributor License Agreement. Contributors keep all rights to their own work and grant the project the right to offer contributions under additional license terms. Section 6 is a written commitment that the OpenMontage engine always remains open source.
- **.github/workflows/cla.yml** — CLA Assistant Lite: every new PR gets a bot check; signing = commenting one sentence on the PR. Signatures are stored in this repo on a `cla-signatures` branch (no external service).

## Why

OpenMontage is being productized (desktop Studio app + optional cloud services on top of the engine). To keep dual-licensing possible (e.g. offering the engine under a non-AGPL license to organizations that cannot use AGPLv3), the project needs relicensing rights for contributed code going forward.

## Notes

- The workflow only activates once merged to the default branch.
- A pinned issue inviting past contributors to sign retroactively will follow after this merges.
- Until this merges, external PRs should not be merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)