### PR TITLE
fix: add encoding="utf-8" to bare open() calls for non-UTF-8 locales

### DIFF
--- a/fix_encoding.py
+++ b/fix_encoding.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Fix bare open() calls: add encoding="utf-8" so JSON/YAML loaders work on GBK Windows.
+   Run once from repo root: PYTHONUTF8=1 python fix_encoding.py
+   (Yes this script itself needs PYTHONUTF8=1 on first run — once fixed, not needed.)"""
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent
+
+FIXES = {
+    "lib/checkpoint.py": [
+        # Schema loader (line 100 — the critical crash site)
+        (r'open\(CHECKPOINT_SCHEMA_PATH\)',
+         'open(CHECKPOINT_SCHEMA_PATH, encoding="utf-8")'),
+        # Read project marker
+        (r'open\(marker_path\)',
+         'open(marker_path, encoding="utf-8")'),
+        # Write project marker
+        (r'open\(marker_path, "w"\)',
+         'open(marker_path, "w", encoding="utf-8")'),
+        # Read checkpoint data (3 sites: archive / merge / read)
+        (r'with open\(path\) as',
+         'with open(path, encoding="utf-8") as'),
+        # Write decision_log
+        (r'open\(path, "w"\)',
+         'open(path, "w", encoding="utf-8")'),
+        # Write temp checkpoint
+        (r'open\(tmp_path, "w"\)',
+         'open(tmp_path, "w", encoding="utf-8")'),
+        # Read latest checkpoint
+        (r'open\(checkpoints\[0\]\)',
+         'open(checkpoints[0], encoding="utf-8")'),
+    ],
+    "lib/pipeline_loader.py": [
+        (r'open\(SCHEMA_PATH\)',
+         'open(SCHEMA_PATH, encoding="utf-8")'),
+        (r'open\(path\)',
+         'open(path, encoding="utf-8")'),
+    ],
+    "schemas/artifacts/__init__.py": [
+        (r'open\(path\)',
+         'open(path, encoding="utf-8")'),
+    ],
+}
+
+ok = 0
+for rel_path, replacements in FIXES.items():
+    fp = REPO / rel_path
+    if not fp.exists():
+        print(f"SKIP: {rel_path} not found")
+        continue
+    text = fp.read_text(encoding="utf-8")
+    for pattern, replacement in replacements:
+        new_text = re.sub(pattern, replacement, text, count=0)
+        if new_text != text:
+            text = new_text
+            print(f"  FIX {rel_path}: {pattern[:55]}...")
+    fp.write_text(text, encoding="utf-8")
+    ok += 1
+    print(f"OK: {rel_path}")
+
+print(f"\nFixed {ok} files. Verify: grep for remaining bare open() calls.")

--- a/lib/checkpoint.py
+++ b/lib/checkpoint.py
@@ -97,7 +97,7 @@ class CheckpointValidationError(ValueError):
 
 @lru_cache(maxsize=1)
 def _load_checkpoint_schema() -> dict[str, Any]:
-    with open(CHECKPOINT_SCHEMA_PATH) as f:
+    with open(CHECKPOINT_SCHEMA_PATH, encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -208,7 +208,7 @@ def init_project(
     marker: dict[str, Any] = {}
     if marker_path.exists():
         try:
-            with open(marker_path) as f:
+            with open(marker_path, encoding="utf-8") as f:
                 marker = json.load(f)
         except (json.JSONDecodeError, OSError):
             marker = {}
@@ -221,7 +221,7 @@ def init_project(
     if style_playbook is not None:
         marker["style_playbook"] = style_playbook
 
-    with open(marker_path, "w") as f:
+    with open(marker_path, "w", encoding="utf-8") as f:
         json.dump(marker, f, indent=2)
 
     return project_dir
@@ -275,7 +275,7 @@ def _archive_superseded_checkpoint(path: Path, stage: str) -> None:
     if not path.exists():
         return
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             existing = json.load(f)
     except (json.JSONDecodeError, OSError):
         existing = {}
@@ -314,7 +314,7 @@ def _merge_decision_log(
     """
     path = _decision_log_path(pipeline_dir, project_id)
     if path.exists():
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             existing = json.load(f)
     else:
         existing = {
@@ -329,7 +329,7 @@ def _merge_decision_log(
             existing["decisions"].append(decision)
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         json.dump(existing, f, indent=2)
 
 
@@ -358,7 +358,7 @@ def write_checkpoint(
         marker_path = pipeline_dir / project_id / PROJECT_MARKER_FILENAME
         if marker_path.exists():
             try:
-                with open(marker_path) as f:
+                with open(marker_path, encoding="utf-8") as f:
                     marker = json.load(f)
             except (json.JSONDecodeError, OSError):
                 marker = None
@@ -456,7 +456,7 @@ def write_checkpoint(
     # current checkpoint; then archive the superseded file and swap in the
     # new one atomically.
     tmp_path = path.with_suffix(".json.tmp")
-    with open(tmp_path, "w") as f:
+    with open(tmp_path, "w", encoding="utf-8") as f:
         json.dump(checkpoint, f, indent=2)
     # Preserve run history: a superseded completed/awaiting_human checkpoint
     # is copied to history/ (stage versioning, gate audit trail, replay).
@@ -474,7 +474,7 @@ def read_checkpoint(
     path = _checkpoint_path(pipeline_dir, project_id, stage)
     if not path.exists():
         return None
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         checkpoint = json.load(f)
     validate_checkpoint(checkpoint)
     return checkpoint
@@ -496,7 +496,7 @@ def get_latest_checkpoint(
     if not checkpoints:
         return None
 
-    with open(checkpoints[0]) as f:
+    with open(checkpoints[0], encoding="utf-8") as f:
         checkpoint = json.load(f)
     validate_checkpoint(checkpoint)
     return checkpoint

--- a/lib/pipeline_loader.py
+++ b/lib/pipeline_loader.py
@@ -26,7 +26,7 @@ from functools import lru_cache
 
 @lru_cache(maxsize=1)
 def _load_manifest_schema() -> dict:
-    with open(SCHEMA_PATH) as f:
+    with open(SCHEMA_PATH, encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -61,7 +61,7 @@ def load_pipeline(name: str, defs_dir: Optional[Path] = None) -> dict[str, Any]:
     if not path.exists():
         raise FileNotFoundError(f"Pipeline manifest not found: {path}")
 
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         manifest = yaml.safe_load(f)
 
     schema = _load_manifest_schema()

--- a/schemas/artifacts/__init__.py
+++ b/schemas/artifacts/__init__.py
@@ -39,7 +39,7 @@ def load_schema(name: str) -> dict:
     path = SCHEMA_DIR / f"{name}.schema.json"
     if not path.exists():
         raise FileNotFoundError(f"Schema not found: {path}")
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         return json.load(f)
 
 


### PR DESCRIPTION
## Problem

On Windows with a non-UTF-8 system locale (e.g. Chinese/GBK, Japanese/Shift-JIS, Korean/EUC-KR), Python's default `open()` uses the locale encoding. When opening UTF-8 JSON schemas and YAML manifests checked into the repo, every bare `open(path)` raises:

```
UnicodeDecodeError: 'gbk' codec can't decode byte 0x94
```

This `_load_checkpoint_schema` crash breaks `validate_checkpoint` which breaks `write_checkpoint` — the **entire checkpoint/pipeline-loading/artifact-validation stack is unusable** on non-UTF-8 Windows before the user can write a single checkpoint.

The same bug surfaces in `pipeline_loader.py` (manifest loading warns "Gate policy unavailable … gbk codec") and `schemas/artifacts/__init__.py` (artifact schema loading fails silently or with similar decode errors).

## Fix

Three files, ~10 bare `open()` calls → `open(…, encoding="utf-8")`:

- `lib/checkpoint.py` — `_load_checkpoint_schema`, marker reads, checkpoint reads, decision-log merge, temp-write
- `lib/pipeline_loader.py` — manifest schema read + YAML load
- `schemas/artifacts/__init__.py` — artifact schema discovery

Also ships `fix_encoding.py` — a one-shot script that rewrites any remaining bare `open()` calls in those files (committed here for provenance; safe to delete if not wanted in-tree).

## Testing

- On Windows 11 (Chinese locale, GBK), was: `write_checkpoint` → `UnicodeDecodeError: 'gbk' …` on first call. After fix: all pipeline stages write valid checkpoints with no decode errors (tested through a full `screen-demo` pipeline run: idea → script → scene_plan → assets → edit → compose, 7 stages, all checkpoint writes clean).
- No functional change on UTF-8-locale machines (the explicit `encoding="utf-8"` changes nothing where UTF-8 is already the default).

## Scope

Minimal, zero-risk. Each site gains exactly `, encoding="utf-8"` (12 characters). No logic changes, no schema changes, no API changes.