### PR TITLE
fix(compose): add cuts to scenes adapter for CinematicRenderer

### DIFF
--- a/tests/tools/test_documentary_governance.py
+++ b/tests/tools/test_documentary_governance.py
@@ -410,3 +410,61 @@ def test_direct_clip_search_reports_downloaded_clip_when_thumbnail_times_out(
     assert result.data["total_clips"] == 1
     assert result.data["clips"][0]["clip_id"] == "thumb_source_thumb-1"
     assert result.data["clips"][0]["thumbnail"] == ""
+
+
+def test_cinematic_renderer_cuts_adapter(monkeypatch, tmp_path):
+    import json
+    import subprocess
+    from tools.base_tool import ToolResult
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    
+    tool = VideoCompose()
+
+    # Mock Remotion CLI execution
+    def mock_run(*args, **kwargs):
+        # Read the props file that was passed to Remotion
+        props_arg = next(arg for arg in args[0] if arg.startswith("--props="))
+        props_path = props_arg.split("=", 1)[1]
+        with open(props_path, "r") as f:
+            props = json.load(f)
+        
+        # Verify the adapter successfully created scenes from cuts
+        assert "scenes" in props
+        assert len(props["scenes"]) == 2
+        assert props["scenes"][0]["kind"] == "title"
+        assert props["scenes"][1]["kind"] == "video"
+        
+        # Create dummy output file
+        out_path = Path(args[0][5])
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_bytes(b"dummy_video")
+        
+        return subprocess.CompletedProcess(args[0], 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+    monkeypatch.setattr(tool, "_get_composition_id", lambda family: "CinematicRenderer")
+    monkeypatch.setattr(tool, "_run_final_review", lambda *args, **kwargs: {"status": "pass", "issues_found": [], "checks": {}})
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda name: "dummy" if name == "npx" else None)
+
+    result = tool.execute(
+        {
+            "operation": "render",
+            "output_path": str(tmp_path / "renders" / "final.mp4"),
+            "edit_decisions": {
+                "version": "1.0",
+                "renderer_family": "documentary-montage",
+                "render_runtime": "remotion",
+                "cuts": [
+                    {"type": "hero_title", "text": "Hello", "in_seconds": 0, "out_seconds": 2},
+                    {"source": "test.mp4", "in_seconds": 2, "out_seconds": 5},
+                ],
+            },
+            "asset_manifest": {"assets": []},
+        }
+    )
+
+    assert result.success
+

--- a/tools/video/video_compose.py
+++ b/tools/video/video_compose.py
@@ -1710,6 +1710,32 @@ class VideoCompose(BaseTool):
                     posix = resolved.as_posix()
                     cut["source"] = f"file:///{posix}" if not posix.startswith("/") else f"file://{posix}"
 
+        # Adapter: CinematicRenderer expects scenes, but edit_decisions produces cuts.
+        # Map them if we are routing to a cinematic composition.
+        renderer_family = (composition_data or {}).get("renderer_family", "explainer-data")
+        if renderer_family in {"documentary-montage", "cinematic-trailer"} and "scenes" not in props and "cuts" in props:
+            scenes = []
+            current_time = 0.0
+            for i, cut in enumerate(props["cuts"]):
+                in_s = float(cut.get("in_seconds", 0) or 0)
+                out_s = float(cut.get("out_seconds", 0) or 0)
+                duration = max(0.1, out_s - in_s)
+                
+                scene = {
+                    "id": f"scene-{i}",
+                    "startSeconds": current_time,
+                    "durationSeconds": duration,
+                }
+                if cut.get("type") in {"text_card", "hero_title", "callout"} or not cut.get("source"):
+                    scene["kind"] = "title"
+                    scene["text"] = cut.get("text") or cut.get("title") or ""
+                else:
+                    scene["kind"] = "video"
+                    scene["src"] = cut.get("source")
+                scenes.append(scene)
+                current_time += duration
+            props["scenes"] = scenes
+
         # Build a custom themeConfig from the playbook's actual colors.
         # This ensures every video gets a unique visual identity derived
         # from its production decisions — not picked from a preset menu.


### PR DESCRIPTION
## Summary
Fixes a silent failure where `video_compose operation="render"` would produce a 30s black video without error for `renderer_family="documentary-montage"`. It correctly routed to `CinematicRenderer`, but blindly passed the `edit_decisions` dictionary directly as React props. `CinematicRenderer` expects `scenes`, but `edit_decisions` has `cuts`, so it defaulted to an empty `scenes` array.

## Related issue
Closes #358

## Changes
- Modified `tools/video/video_compose.py` to add an adapter that translates `cuts` into `scenes` on the fly for cinematic compositions before passing them to the Remotion CLI.
- Added `test_cinematic_renderer_cuts_adapter` in `tests/tools/test_documentary_governance.py` to verify this mapping.

## Testing
- Ran the new test via `make test` which passes locally.
- Verified the adapter properly translates title strings and asset sources to `CinematicVideoScene` schemas.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [ ] I updated docs/README if behavior or usage changed.
- [x] No unrelated files (build artifacts, local config) are included in the diff.