### PR TITLE
fix: sanitize os.system() shell injection in manimgl scene templates

### DIFF
--- a/.agents/skills/manimgl-best-practices/templates/3d_scene.py
+++ b/.agents/skills/manimgl-best-practices/templates/3d_scene.py
@@ -254,5 +254,5 @@ class LightingTemplate(Scene):
 
 
 if __name__ == "__main__":
-    import os
-    os.system(f"manimgl {__file__} ThreeDSceneTemplate")
+    import subprocess
+    subprocess.run(["manimgl", __file__, "ThreeDSceneTemplate"])

--- a/.agents/skills/manimgl-best-practices/templates/basic_scene.py
+++ b/.agents/skills/manimgl-best-practices/templates/basic_scene.py
@@ -130,5 +130,5 @@ class AnimationShowcase(Scene):
 if __name__ == "__main__":
     # This allows you to run: python basic_scene.py
     # (though using manimgl is recommended)
-    import os
-    os.system(f"manimgl {__file__} BasicSceneTemplate")
+    import subprocess
+    subprocess.run(["manimgl", __file__, "BasicSceneTemplate"])

--- a/.agents/skills/manimgl-best-practices/templates/math_scene.py
+++ b/.agents/skills/manimgl-best-practices/templates/math_scene.py
@@ -329,5 +329,5 @@ class MatrixTemplate(Scene):
 
 
 if __name__ == "__main__":
-    import os
-    os.system(f"manimgl {__file__} MathSceneTemplate")
+    import subprocess
+    subprocess.run(["manimgl", __file__, "MathSceneTemplate"])

--- a/.claude/skills/manimgl-best-practices/templates/3d_scene.py
+++ b/.claude/skills/manimgl-best-practices/templates/3d_scene.py
@@ -254,5 +254,5 @@ class LightingTemplate(Scene):
 
 
 if __name__ == "__main__":
-    import os
-    os.system(f"manimgl {__file__} ThreeDSceneTemplate")
+    import subprocess
+    subprocess.run(["manimgl", __file__, "ThreeDSceneTemplate"])

--- a/.claude/skills/manimgl-best-practices/templates/basic_scene.py
+++ b/.claude/skills/manimgl-best-practices/templates/basic_scene.py
@@ -130,5 +130,5 @@ class AnimationShowcase(Scene):
 if __name__ == "__main__":
     # This allows you to run: python basic_scene.py
     # (though using manimgl is recommended)
-    import os
-    os.system(f"manimgl {__file__} BasicSceneTemplate")
+    import subprocess
+    subprocess.run(["manimgl", __file__, "BasicSceneTemplate"])

--- a/.claude/skills/manimgl-best-practices/templates/math_scene.py
+++ b/.claude/skills/manimgl-best-practices/templates/math_scene.py
@@ -329,5 +329,5 @@ class MatrixTemplate(Scene):
 
 
 if __name__ == "__main__":
-    import os
-    os.system(f"manimgl {__file__} MathSceneTemplate")
+    import subprocess
+    subprocess.run(["manimgl", __file__, "MathSceneTemplate"])


### PR DESCRIPTION
Follow-up to the private vulnerability report sent by email — thanks for enabling private vulnerability reporting and inviting a PR, Ishan.

## The issue

`os.system(f"manimgl {__file__} ClassName")` interpolates the script's own file path into a shell string. These templates are meant to be copied and renamed per scene by an agent, so a scene/folder name containing shell metacharacters is a realistic injection path, not just malformed input — not a theoretical concern given how these files get generated and placed.

Same root cause, 3 templates, duplicated under both `.claude/skills/` and `.agents/skills/` (identical files):
- `templates/3d_scene.py`
- `templates/basic_scene.py`
- `templates/math_scene.py`

## The fix

Switched each to `subprocess.run([...])` with a real argument list instead of a shell string (no `shell=True`), so there's nothing left for a shell to interpret regardless of what the path contains.

## Note on the other finding from the original report

The email also flagged `hyperframes-media`'s `scripts/lib/tts.mjs` (child_process usage) as worth checking. I traced every caller in that file as part of this PR — none set `shell: true`, and args are always passed as a real array (e.g. `["hyperframes", "tts", text, "--voice", voiceId, ...]`), never string-concatenated. Node's `spawn()` with an array and no `shell` option doesn't invoke a shell, so it isn't actually exploitable. Leaving it untouched rather than "fixing" something that isn't broken — flagging here so it doesn't sit as an open question on your end.