### PR TITLE
fix(checkpoint): enforce that earlier gated stages are approved before a later stage advances

### DIFF
--- a/lib/checkpoint.py
+++ b/lib/checkpoint.py
@@ -260,6 +260,33 @@ def _stage_requires_approval(pipeline_type: Optional[str], stage: str) -> Option
     return get_stage_human_approval_default(manifest, stage)
 
 
+def _first_unapproved_predecessor(
+    pipeline_dir: Path, project_id: str, pipeline_type: Optional[str], stage: str
+) -> Optional[str]:
+    """Return the name of the first prior stage (in pipeline order) that is
+    gated but not yet completed+approved, or None if every gated predecessor
+    is clear.
+
+    write_checkpoint()'s existing gate check only looks at the stage being
+    written right now — nothing previously checked that EARLIER gated stages
+    were actually approved before letting a later stage advance. That gap let
+    downstream stages get written while an earlier stage's checkpoint sat
+    unresolved indefinitely.
+    """
+    if not pipeline_type:
+        return None
+    stages = get_pipeline_stages(pipeline_type)
+    if stage not in stages:
+        return None
+    for predecessor in stages[: stages.index(stage)]:
+        if not _stage_requires_approval(pipeline_type, predecessor):
+            continue
+        cp = read_checkpoint(pipeline_dir, project_id, predecessor)
+        if not cp or cp.get("status") != "completed" or not cp.get("human_approved"):
+            return predecessor
+    return None
+
+
 def _archive_superseded_checkpoint(path: Path, stage: str) -> None:
     """Copy an existing checkpoint into history/ before it is overwritten.
 
@@ -402,6 +429,27 @@ def write_checkpoint(
                 f"status='awaiting_human', present the artifact summary to the "
                 f"user, END YOUR TURN, and only after the user approves "
                 f"re-write with status='completed', human_approved=True."
+            )
+
+    # --- Sequence gate enforcement ---
+    # The check above only guards the stage being written right now. It says
+    # nothing about whether EARLIER gated stages were ever actually approved.
+    # That gap lets a pipeline advance past an unresolved gate indefinitely
+    # (e.g. scene_plan sitting "awaiting_human" while assets/edit/compose get
+    # written anyway). Skip the check for "in_progress" writes so resume
+    # heartbeats and partial-progress refreshes (see checkpoint-protocol.md)
+    # keep working unblocked — only real stage advancement is gated here.
+    if status != "in_progress":
+        blocking_predecessor = _first_unapproved_predecessor(
+            pipeline_dir, project_id, pipeline_type, stage
+        )
+        if blocking_predecessor is not None:
+            raise CheckpointValidationError(
+                f"SEQUENCE GATE VIOLATION: stage {stage!r} cannot be written "
+                f"with status {status!r} because prior gated stage "
+                f"{blocking_predecessor!r} has not been completed and "
+                f"human-approved. Resolve the {blocking_predecessor!r} gate "
+                f"before advancing to {stage!r}."
             )
 
     checkpoint = {

--- a/tests/backlot/test_gate_scenarios.py
+++ b/tests/backlot/test_gate_scenarios.py
@@ -23,6 +23,28 @@ def _manifest_artifact() -> dict:
     return {"version": "1.0", "assets": [], "total_cost_usd": 0.0}
 
 
+def _proposal_artifact() -> dict:
+    from tests.contracts.test_phase0_contracts import sample_artifact
+    return sample_artifact("proposal_packet")
+
+
+def _approve_predecessors(tmp_path, project_id, pipeline_type, *stages) -> None:
+    """Write each given stage as completed+approved, in order, so a later
+    write to a stage past them satisfies the sequence-gate check."""
+    from lib.checkpoint import CANONICAL_STAGE_ARTIFACTS
+    from tests.contracts.test_phase0_contracts import sample_artifact
+
+    for predecessor in stages:
+        write_checkpoint(
+            tmp_path, project_id, predecessor, "completed",
+            artifacts={CANONICAL_STAGE_ARTIFACTS[predecessor]: sample_artifact(
+                CANONICAL_STAGE_ARTIFACTS[predecessor]
+            )},
+            pipeline_type=pipeline_type,
+            human_approved=True,
+        )
+
+
 def _write(path: Path, data: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data), encoding="utf-8")
@@ -73,6 +95,7 @@ def test_handwritten_completed_checkpoint_surfaces_gate_skip(tmp_path, monkeypat
 
 
 def test_awaiting_then_approved_archives_history_without_gate_skip(tmp_path):
+    _approve_predecessors(tmp_path, "film", "cinematic", "proposal", "script", "scene_plan")
     write_checkpoint(
         tmp_path,
         "film",
@@ -97,3 +120,72 @@ def test_awaiting_then_approved_archives_history_without_gate_skip(tmp_path):
     assert assets.get("gate_skipped") in (None, False)
     assert assets["versions"] == 2
     assert assets["history_entries"][0]["status"] == "awaiting_human"
+
+
+def test_later_stage_blocked_while_earlier_gated_stage_unapproved(tmp_path):
+    """A gated earlier stage sitting unapproved must block advancement to a
+    later stage — the sequence gate, not just the same-stage gate."""
+    write_checkpoint(
+        tmp_path, "film", "proposal", "awaiting_human",
+        {"proposal_packet": _proposal_artifact()},
+        pipeline_type="cinematic",
+    )
+    # proposal is still awaiting_human/unapproved — script must be blocked,
+    # both as a completed write and as a bare awaiting_human draft.
+    with pytest.raises(CheckpointValidationError, match="SEQUENCE GATE VIOLATION"):
+        write_checkpoint(
+            tmp_path, "film", "script", "completed",
+            {"script": _script_artifact()},
+            pipeline_type="cinematic",
+            human_approved=True,
+        )
+    with pytest.raises(CheckpointValidationError, match="SEQUENCE GATE VIOLATION"):
+        write_checkpoint(
+            tmp_path, "film", "script", "awaiting_human",
+            {"script": _script_artifact()},
+            pipeline_type="cinematic",
+        )
+
+
+def test_in_progress_write_is_not_blocked_by_sequence_gate(tmp_path):
+    """in_progress heartbeats/partial-progress refreshes must stay unblocked
+    even with an unapproved earlier gated stage — only real stage
+    advancement (awaiting_human/completed) is sequence-gated."""
+    write_checkpoint(
+        tmp_path, "film", "proposal", "awaiting_human",
+        {"proposal_packet": _proposal_artifact()},
+        pipeline_type="cinematic",
+    )
+    path = write_checkpoint(
+        tmp_path, "film", "assets", "in_progress",
+        {},
+        pipeline_type="cinematic",
+    )
+    assert path.exists()
+
+
+def test_sequence_gate_clears_once_predecessor_is_approved(tmp_path):
+    """Approving the blocking predecessor unblocks the later stage."""
+    write_checkpoint(
+        tmp_path, "film", "proposal", "awaiting_human",
+        {"proposal_packet": _proposal_artifact()},
+        pipeline_type="cinematic",
+    )
+    with pytest.raises(CheckpointValidationError, match="SEQUENCE GATE VIOLATION"):
+        write_checkpoint(
+            tmp_path, "film", "script", "awaiting_human",
+            {"script": _script_artifact()},
+            pipeline_type="cinematic",
+        )
+    write_checkpoint(
+        tmp_path, "film", "proposal", "completed",
+        {"proposal_packet": _proposal_artifact()},
+        pipeline_type="cinematic",
+        human_approved=True,
+    )
+    path = write_checkpoint(
+        tmp_path, "film", "script", "awaiting_human",
+        {"script": _script_artifact()},
+        pipeline_type="cinematic",
+    )
+    assert path.exists()

--- a/tests/contracts/test_backlot_contract.py
+++ b/tests/contracts/test_backlot_contract.py
@@ -6,6 +6,7 @@ import json
 import pytest
 
 from lib.checkpoint import (
+    CANONICAL_STAGE_ARTIFACTS,
     CheckpointValidationError,
     HISTORY_DIRNAME,
     PROJECT_MARKER_FILENAME,
@@ -27,6 +28,22 @@ def _minimal_script() -> dict:
     }
 
 
+def _approve_predecessors(tmp_path, project_id, pipeline_type, *stages) -> None:
+    """Write each given stage as completed+approved, in order, so a later
+    write to a stage past them satisfies the sequence-gate check."""
+    from tests.contracts.test_phase0_contracts import sample_artifact
+
+    for predecessor in stages:
+        write_checkpoint(
+            tmp_path, project_id, predecessor, "completed",
+            artifacts={CANONICAL_STAGE_ARTIFACTS[predecessor]: sample_artifact(
+                CANONICAL_STAGE_ARTIFACTS[predecessor]
+            )},
+            pipeline_type=pipeline_type,
+            human_approved=True,
+        )
+
+
 class TestGateEnforcement:
     """GI-4: gated stages cannot be completed without approval evidence."""
 
@@ -39,6 +56,7 @@ class TestGateEnforcement:
             )
 
     def test_awaiting_human_is_the_correct_gate_state(self, tmp_path):
+        _approve_predecessors(tmp_path, "proj", "animated-explainer", "proposal")
         path = write_checkpoint(
             tmp_path, "proj", "script", "awaiting_human",
             artifacts={"script": _minimal_script()},
@@ -51,6 +69,7 @@ class TestGateEnforcement:
         assert cp["human_approval_required"] is True
 
     def test_completed_with_approval_passes(self, tmp_path):
+        _approve_predecessors(tmp_path, "proj", "animated-explainer", "proposal")
         path = write_checkpoint(
             tmp_path, "proj", "script", "completed",
             artifacts={"script": _minimal_script()},
@@ -84,6 +103,7 @@ class TestCheckpointHistory:
     """Superseded checkpoints are archived, not destroyed."""
 
     def test_overwrite_archives_previous(self, tmp_path):
+        _approve_predecessors(tmp_path, "proj", "animated-explainer", "proposal")
         write_checkpoint(
             tmp_path, "proj", "script", "awaiting_human",
             artifacts={"script": _minimal_script()},


### PR DESCRIPTION
Closes #414

## Problem

`write_checkpoint()`'s existing GATE VIOLATION check only guards the stage being written right now — it never checked whether earlier stages in the pipeline sequence were actually approved before allowing a write to a later stage. Concretely, this let a `scene_plan` checkpoint sit `awaiting_human`/unapproved indefinitely while `assets`/`edit`/`compose` checkpoints were written anyway with no error.

## Fix

Adds `_first_unapproved_predecessor()`, called from `write_checkpoint()` right after the existing same-stage gate check. Walks `get_pipeline_stages(pipeline_type)` up to the stage being written; for each gated predecessor, reads its checkpoint via `read_checkpoint()` and raises a new `SEQUENCE GATE VIOLATION` `CheckpointValidationError` if it isn't `completed`+`human_approved`.

Skipped entirely for `status="in_progress"` writes, so existing resume/liveness heartbeats and partial-progress refreshes (per `checkpoint-protocol.md`) keep working unblocked — only real stage advancement (`awaiting_human`/`completed`) is sequence-gated.

## Tests

Four existing tests wrote directly to a mid-sequence stage in isolation (testing narrower behavior: gate-state correctness, history archiving) without setting up the earlier gated predecessor. Updated their setup via a small `_approve_predecessors()` test helper rather than weakening the fix, since their original intent is unaffected once the predecessor is properly approved first. Added three new tests exercising the sequence gate directly: blocked-while-unapproved, `in_progress` staying unblocked, and clearing once the predecessor is approved.

Full test suite: 711 passed, 8 skipped, 0 failed (up from 708 passed before the 3 new tests; the 8 skips and remaining collection errors for unrelated kling/comfyui contract tests are pre-existing, due to optional deps not installed in my environment, not related to this change).