### PR TITLE
fix(checkpoint): fail closed on an unresolvable style_playbook name

### DIFF
--- a/lib/checkpoint.py
+++ b/lib/checkpoint.py
@@ -85,9 +85,32 @@ CHECKPOINT_SCHEMA_PATH = (
 # live under PROJECTS_DIR/<project_id>/ — this is the location the Backlot
 # board watches. Callers may still pass a different pipeline_dir (tests do),
 # but production runs should use the default.
-from lib.paths import PROJECTS_DIR  # noqa: E402  (single source of truth)
+from lib.paths import PROJECTS_DIR, REPO_ROOT  # noqa: E402  (single source of truth)
 
 PROJECT_MARKER_FILENAME = "project.json"
+
+
+def _validate_style_playbook(style_playbook: Optional[str]) -> None:
+    """Fail closed on an unresolvable style_playbook name.
+
+    Unlike pipeline_dir/project_id (where a missing marker can mean a
+    legitimate first-time bootstrap), a style_playbook name is never
+    lazily created — it must already exist as styles/<name>.yaml. A typo
+    or unwritten playbook here previously passed through silently: every
+    downstream consumer (video_compose's playbook loads) wraps the load in
+    a bare try/except, so the project's declared visual identity would be
+    silently dropped with no warning anywhere, not even in the checkpoint
+    or the Backlot board.
+    """
+    if style_playbook is None:
+        return
+    styles_dir = REPO_ROOT / "styles"
+    if not (styles_dir / f"{style_playbook}.yaml").exists():
+        available = sorted(p.stem for p in styles_dir.glob("*.yaml"))
+        raise CheckpointValidationError(
+            f"Unknown style_playbook {style_playbook!r} — no "
+            f"styles/{style_playbook}.yaml found. Available: {available}"
+        )
 HISTORY_DIRNAME = "history"
 
 
@@ -192,6 +215,7 @@ def init_project(
     Idempotent: re-running preserves the original created_at and merges fields.
     Returns the project directory.
     """
+    _validate_style_playbook(style_playbook)
     base = pipeline_dir or PROJECTS_DIR
     project_dir = base / project_id
     for sub in (
@@ -351,6 +375,8 @@ def write_checkpoint(
     metadata: Optional[dict] = None,
 ) -> Path:
     """Write a checkpoint file for a pipeline stage."""
+    _validate_style_playbook(style_playbook)
+
     # Backfill a missing pipeline_type from the project marker so that
     # omitting the kwarg doesn't quietly bypass gate enforcement.
     if not pipeline_type:

--- a/tools/video/video_compose.py
+++ b/tools/video/video_compose.py
@@ -1064,7 +1064,9 @@ class VideoCompose(BaseTool):
                 from styles.playbook_loader import load_playbook
                 playbook = load_playbook(playbook_name)
             except Exception:
-                pass
+                logging.getLogger("video_compose").warning(
+                    "Playbook %r not found, falling back to defaults", playbook_name
+                )
 
         if playbook:
             vl = playbook.get("visual_language", {})
@@ -1547,6 +1549,9 @@ class VideoCompose(BaseTool):
                     from styles.playbook_loader import load_playbook  # type: ignore
                     playbook_data = load_playbook(playbook_name)
                 except Exception:
+                    logging.getLogger("video_compose").warning(
+                        "Playbook %r not found, falling back to defaults", playbook_name
+                    )
                     playbook_data = None
 
         hf_inputs: dict[str, Any] = {


### PR DESCRIPTION
Closes #415

## Problem

`init_project()`/`write_checkpoint()` accepted any `style_playbook` string with zero validation against real files in `styles/`. A typo or a name for a playbook that was never actually written silently passed through: every downstream consumer (`tools/video/video_compose.py`, two call sites) wraps the load in a bare except-and-continue, so the project's declared visual identity would be quietly dropped with no warning anywhere.

## Fix

Adds `_validate_style_playbook()`, called from both `init_project()` and `write_checkpoint()`, raising `CheckpointValidationError` (listing the real available playbooks) when the name doesn't resolve to `styles/<name>.yaml`. Mirrors the existing fail-closed pattern already used for a typo'd `pipeline_type` in `_stage_requires_approval()`.

Also hardens the two `video_compose.py` call sites that swallow a failed load with a bare `except`, to at least log a warning — defense in depth for checkpoints written before this validation existed.

## Tests

Verified against the full checkpoint test suite (148 tests) and the video_compose-related test suite (133 tests) with zero regressions.