### PR TITLE
docs(checkpoint): document pipeline_dir/project_id path semantics

### DIFF
--- a/lib/checkpoint.py
+++ b/lib/checkpoint.py
@@ -350,7 +350,21 @@ def write_checkpoint(
     error: Optional[str] = None,
     metadata: Optional[dict] = None,
 ) -> Path:
-    """Write a checkpoint file for a pipeline stage."""
+    """Write a checkpoint file for a pipeline stage.
+
+    ``pipeline_dir`` and ``project_id`` together determine where the
+    checkpoint lands: ``pipeline_dir / project_id / checkpoint_<stage>.json``.
+    ``pipeline_dir`` does not have to be pre-initialized via ``init_project()``
+    — this function will create ``pipeline_dir / project_id`` on demand if it
+    doesn't exist yet (this is relied on by tests that call ``write_checkpoint``
+    directly against a fresh temp directory). The common mistake is passing a
+    project's *own* directory as ``pipeline_dir`` when you meant its parent —
+    that computes an unintended, doubly-nested path
+    (``pipeline_dir / project_id / project_id / ...``) rather than raising,
+    since a missing marker file is indistinguishable from a legitimate
+    first-time bootstrap. Double-check the resulting path if a checkpoint
+    doesn't show up where you expected it.
+    """
     # Backfill a missing pipeline_type from the project marker so that
     # omitting the kwarg doesn't quietly bypass gate enforcement.
     if not pipeline_type:


### PR DESCRIPTION
Closes #416

## Problem

`write_checkpoint()`'s `pipeline_dir` argument was undocumented — nothing stated that it's meant to be the parent of `pipeline_dir/project_id`, nor that a missing `project.json` marker there is treated as a legitimate first-time bootstrap (relied on by tests calling `write_checkpoint` directly against a fresh `tmp_path`) rather than an error. Passing a project's own directory as `pipeline_dir` (instead of its parent) silently produces an unintended, doubly-nested path with no error.

## Why this is docs-only, not a validation fix

I initially drafted this as a hard validation error (raise if the marker is missing). Running the existing test suite immediately surfaced 13 failures — tests intentionally call `write_checkpoint` directly on fresh temp dirs with no prior `init_project()` call, which is a real, relied-upon bootstrap path. A missing marker file is genuinely indistinguishable from a legitimate first-time bootstrap from inside the function, so I downgraded this to a docs-only fix rather than ship a fix that breaks a real, intentional usage pattern.

## Fix

Expands `write_checkpoint`'s docstring to state the path contract precisely, so the mistake is at least easy to spot on read.

## Tests

Docstring-only change, verified zero behavioral difference: full checkpoint test suite (144 tests) passes identically before and after.