### PR TITLE
fix(corpus): fail closed when no candidate embeds into the corpus

### DIFF
--- a/tests/tools/test_corpus_builder_empty_index.py
+++ b/tests/tools/test_corpus_builder_empty_index.py
@@ -1,0 +1,60 @@
+import tools.video.stock_sources as stock_sources
+from lib.corpus import Corpus
+from tools.base_tool import ToolResult
+from tools.video.corpus_builder import CorpusBuilder
+
+
+class _FakeCandidate:
+    def __init__(self, clip_id):
+        self.clip_id = clip_id
+
+
+class _FakeSource:
+    name = "fake_source"
+
+    def is_available(self):
+        return True
+
+    def search(self, query, filters):
+        return [_FakeCandidate("clip-1"), _FakeCandidate("clip-2")]
+
+
+def test_execute_fails_when_every_candidate_fails_to_embed(tmp_path, monkeypatch):
+    # Mirrors the transformers>=5 CLIP break: every candidate raises at the
+    # embed step, so the corpus is saved with zero new rows. That must be a
+    # failure, not a success that hides an empty index from downstream retrieval.
+    monkeypatch.setattr(stock_sources, "available_sources", lambda: [_FakeSource()])
+
+    def _boom(self, **kwargs):
+        raise RuntimeError("clip embed failed")
+
+    monkeypatch.setattr(CorpusBuilder, "_process_candidate", _boom)
+
+    result = CorpusBuilder().execute({
+        "corpus_dir": str(tmp_path / "corpus"),
+        "queries": [{"query": "city timelapse"}],
+    })
+
+    assert isinstance(result, ToolResult)
+    assert result.success is False
+    assert result.error
+    assert result.data["candidates_seen"] == 2
+    assert result.data["clips_added"] == 0
+    assert result.data["clips_failed"] == 2
+
+
+def test_execute_succeeds_when_all_candidates_already_present(tmp_path, monkeypatch):
+    # A run that only skips already-present clips (no failures) has nothing new
+    # to add but is still a success — the failure floor must not trip on it.
+    monkeypatch.setattr(stock_sources, "available_sources", lambda: [_FakeSource()])
+    monkeypatch.setattr(Corpus, "has", lambda self, clip_id: True)
+
+    result = CorpusBuilder().execute({
+        "corpus_dir": str(tmp_path / "corpus"),
+        "queries": [{"query": "city timelapse"}],
+    })
+
+    assert result.success is True
+    assert result.error is None
+    assert result.data["clips_added"] == 0
+    assert result.data["clips_skipped_existing"] == 2

--- a/tools/video/corpus_builder.py
+++ b/tools/video/corpus_builder.py
@@ -392,8 +392,20 @@ class CorpusBuilder(BaseTool):
             except Exception as e:
                 cache_snapshot = {"error": f"{type(e).__name__}: {e}"}
 
+            # Every candidate we actually processed failed, so the corpus was
+            # saved with no new rows. Reporting success here lets downstream
+            # retrieval build on an empty index, so fail closed and surface why
+            # (per-candidate reasons are in data.errors). Runs that only skipped
+            # already-present clips (failed == 0) stay successful.
+            embedded_none = failed > 0 and not added_ids
+            error = (
+                f"{failed} candidate(s) processed, none embedded; no clips added"
+                if embedded_none
+                else None
+            )
+
             return ToolResult(
-                success=True,
+                success=not embedded_none,
                 data={
                     "corpus_dir": str(corpus_dir),
                     "queries_run": len(queries),
@@ -416,6 +428,7 @@ class CorpusBuilder(BaseTool):
                     "cache_stats": cache_snapshot,
                     "errors": errors[:25],  # cap log noise
                 },
+                error=error,
                 cost_usd=0.0,
                 duration_seconds=round(elapsed, 2),
             )


### PR DESCRIPTION
## Problem

`corpus_builder.execute()` collects per-candidate failures defensively (increment `failed`, record the reason in `errors[]`, `continue`) but then returned `success=True` unconditionally. When *every* processed candidate fails to embed — e.g. `transformers>=5` breaking CLIP in `lib/clip_embedder.py` — the run saves a corpus with zero new rows yet reports success and exits 0. The empty index only surfaces later as empty `clip_search` retrieval, after the pipeline has already built on it.

## Fix

Fail closed when candidates were processed but none embedded:

```python
embedded_none = failed > 0 and not added_ids
```

`success` becomes `False` and `ToolResult.error` carries the reason (per-candidate details stay in `data.errors`). This deliberately does **not** trip on a run that only skipped already-present clips (`failed == 0`), which is a legitimate "nothing new to add" success.

## Tests

Adds `tests/tools/test_corpus_builder_empty_index.py`:
- every candidate fails to embed → `success is False`, error set, `clips_added == 0`
- all candidates already present (skip-only) → stays `success is True`

`python -m pytest tests/tools/` → 254 passed.

Refs #357.
