### PR TITLE
fix(corpus_builder): fail when every candidate fails to process

### DIFF
--- a/tests/tools/test_corpus_builder_total_failure.py
+++ b/tests/tools/test_corpus_builder_total_failure.py
@@ -1,0 +1,152 @@
+"""Regression tests: corpus_builder must not report success on a total failure.
+
+Per-candidate errors are caught and collected so one flaky URL or broken codec
+cannot poison a run — that tolerance is deliberate and still holds. But
+`execute()` returned `success=True` unconditionally, so a run where every
+candidate failed the same way reported success with `clips_added: 0` and wrote
+a 0-row `index.jsonl`.
+
+The realistic trigger is a broken CLIP stack: `transformers` is unpinned, and
+`>=5.0` changed the `get_image_features` return type that `lib/clip_embedder.py`
+depends on. Every candidate then fails identically, the tool exits 0, and the
+empty corpus only surfaces later as a mystifying retrieval miss in
+`clip_search`.
+
+Systemic breakage is not per-candidate bad luck, so it must fail loudly at the
+point it happens. See issue #357.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+import tools.video.stock_sources as stock_sources  # noqa: E402
+from tools.video.corpus_builder import CorpusBuilder  # noqa: E402
+
+
+class _Candidate:
+    def __init__(self, index: int) -> None:
+        self.clip_id = f"fake_{index}"
+
+
+class _Record:
+    def __init__(self, clip_id: str) -> None:
+        self.clip_id = clip_id
+
+
+class _Source:
+    """Stock source that yields `count` candidates for any query."""
+
+    name = "fake"
+
+    def __init__(self, count: int) -> None:
+        self._count = count
+
+    def is_available(self) -> bool:
+        return True
+
+    def search(self, query, filters):
+        return [_Candidate(i) for i in range(self._count)]
+
+
+@pytest.fixture
+def build(monkeypatch, tmp_path):
+    """Run CorpusBuilder against a fake source with a stubbed processor."""
+
+    def _run(count, processor, **inputs):
+        monkeypatch.setattr(stock_sources, "available_sources", lambda: [_Source(count)])
+        monkeypatch.setattr(stock_sources, "source_summary", lambda: {})
+        monkeypatch.setattr(CorpusBuilder, "_process_candidate", processor)
+        payload = {
+            "corpus_dir": str(tmp_path / inputs.pop("dirname", "corpus")),
+            "queries": [{"query": "city at night"}],
+            "max_new_clips": 50,
+        }
+        payload.update(inputs)
+        return CorpusBuilder().execute(payload)
+
+    return _run
+
+
+def _clip_stack_broken(*args, **kwargs):
+    # What transformers>=5 raises through lib/clip_embedder.py.
+    raise AttributeError("'BaseModelOutput' object has no attribute 'norm'")
+
+
+def _always_ok(self, cand, **kwargs):
+    return _Record(cand.clip_id)
+
+
+def _every_other_fails(self, cand, **kwargs):
+    if int(cand.clip_id.split("_")[1]) % 2:
+        raise ValueError("unsupported codec")
+    return _Record(cand.clip_id)
+
+
+def test_total_embedding_failure_is_not_success(build):
+    result = build(705, _clip_stack_broken)
+
+    assert result.success is False
+    assert result.data["candidates_seen"] == 705
+    assert result.data["clips_added"] == 0
+    assert result.data["clips_failed"] == 705
+
+
+def test_total_failure_error_names_the_likely_cause(build):
+    result = build(12, _clip_stack_broken)
+
+    assert "705" not in (result.error or "")
+    assert "12" in result.error
+    # The operator needs to know where to look, not just that it broke.
+    assert "transformers" in result.error
+    assert "empty" in result.error.lower()
+    # And a sample of the underlying exception, not a bare count.
+    assert "BaseModelOutput" in result.error
+
+
+def test_total_failure_still_reports_diagnostics(build):
+    result = build(4, _clip_stack_broken)
+
+    # Failing must not cost the caller the payload it needs to debug.
+    assert result.data["errors"]
+    assert result.data["errors"][0]["phase"] == "process"
+    assert "corpus_dir" in result.data
+
+
+def test_partial_failure_remains_a_success(build):
+    """One bad codec must not poison a run — the documented contract."""
+    result = build(10, _every_other_fails)
+
+    assert result.success is True
+    assert result.data["clips_added"] == 5
+    assert result.data["clips_failed"] == 5
+
+
+def test_all_candidates_succeed(build):
+    result = build(10, _always_ok)
+
+    assert result.success is True
+    assert result.data["clips_added"] == 10
+    assert result.data["clips_failed"] == 0
+
+
+def test_no_candidates_found_is_not_a_failure(build):
+    """An empty search result is a legitimate outcome, not a broken run."""
+    result = build(0, _always_ok)
+
+    assert result.success is True
+    assert result.data["candidates_seen"] == 0
+    assert result.data["clips_added"] == 0
+
+
+def test_single_candidate_failure_is_a_total_failure(build):
+    # One candidate, one failure: nothing embedded, so the corpus is empty.
+    result = build(1, _clip_stack_broken)
+
+    assert result.success is False

--- a/tools/video/corpus_builder.py
+++ b/tools/video/corpus_builder.py
@@ -35,6 +35,12 @@ Caps
 - Per-source search errors and per-candidate processing errors are
   caught and collected into `errors` in the return payload. One flaky
   URL or one broken codec must not poison the whole run.
+- Tolerating per-candidate failures is not the same as tolerating a
+  *total* failure. When candidates were found but none survived
+  processing, the run failed — every candidate hitting the same fault
+  (a broken CLIP/`transformers` install, for example) is a systemic
+  break, not a run of bad luck, and reporting success for it hands the
+  pipeline an empty corpus that only surfaces much later in retrieval.
 
 Idempotence
 -----------
@@ -391,6 +397,39 @@ class CorpusBuilder(BaseTool):
                 cache_snapshot = cache.stats()
             except Exception as e:
                 cache_snapshot = {"error": f"{type(e).__name__}: {e}"}
+
+            # Every candidate failing is a systemic fault (commonly a broken
+            # CLIP/`transformers` install), not per-candidate bad luck. Saying
+            # success here writes a 0-row index and defers the error to
+            # whichever retrieval call later reads an empty corpus, so surface
+            # it now. A run that legitimately had nothing to do — no candidates
+            # at all, or everything already present — is still a success.
+            total_failure = bool(candidates_seen) and not added_ids and not skipped
+            if total_failure:
+                sample = "; ".join(
+                    e["error"] for e in errors if e.get("phase") == "process"
+                )[:400]
+                return ToolResult(
+                    success=False,
+                    error=(
+                        f"All {failed} of {candidates_seen} candidates failed to "
+                        f"process; corpus index is empty. This usually means the "
+                        f"CLIP embedding stack is broken (check that `transformers` "
+                        f"and `torch` are installed and mutually compatible). "
+                        f"First errors: {sample or '(none recorded)'}"
+                    ),
+                    data={
+                        "corpus_dir": str(corpus_dir),
+                        "queries_run": len(queries),
+                        "candidates_seen": candidates_seen,
+                        "clips_added": 0,
+                        "clips_skipped_existing": skipped,
+                        "clips_failed": failed,
+                        "total_corpus_size": len(corp),
+                        "errors": errors[:25],
+                    },
+                    duration_seconds=round(elapsed, 2),
+                )
 
             return ToolResult(
                 success=True,


### PR DESCRIPTION
## What

`corpus_builder.execute()` returned `success=True` unconditionally, so a run where **no** candidate survived processing reported success with `clips_added: 0` and saved a 0-row `index.jsonl`.

Closes #357 (part 1 — the silent-success bug; see note on part 2 below).

## Reproduced

At the scale from the report, with `_process_candidate` raising what `transformers>=5` surfaces through `lib/clip_embedder.py`:

```
success        : True
error          : None
candidates_seen: 705
clips_added    : 0
clips_failed   : 705
index rows     : 0
```

The tool exits 0 and the empty corpus only surfaces later as an unexplained retrieval miss in `clip_search` — far from the actual fault, which is what makes this expensive to debug.

## How

Return `success=False` when candidates were found but none were added and none were skipped, naming the likely cause and quoting the first underlying errors:

```
All 705 of 705 candidates failed to process; corpus index is empty. This usually
means the CLIP embedding stack is broken (check that `transformers` and `torch`
are installed and mutually compatible). First errors: AttributeError: ...
```

Diagnostics stay in `data` so a failing run is still debuggable rather than opaque.

The deliberate tolerance documented in the module header — "one flaky URL or one broken codec must not poison the whole run" — is untouched. Only the *total* case flips, on the reasoning that every candidate hitting the same fault is systemic breakage rather than a run of bad luck.

## Guarding against over-firing

The risk in a change like this is turning healthy runs red, so the boundaries are pinned explicitly:

| scenario | result |
|---|---|
| every candidate fails | **fail** (the bug) |
| half the candidates fail | success — unchanged |
| all candidates succeed | success — unchanged |
| search returned no candidates | success — nothing to do is not a failure |
| everything already in corpus (`skip_existing`) | success — `skipped` excluded from the condition |

## Tests

New `tests/tools/test_corpus_builder_total_failure.py` (7 tests), fully offline with a stubbed source and processor.

Against the unfixed source **3 of 7 fail**:

```
FAILED test_total_embedding_failure_is_not_success
FAILED test_total_failure_error_names_the_likely_cause
FAILED test_single_candidate_failure_is_a_total_failure
3 failed, 4 passed
```

The 4 that pass both ways are the over-firing guards above — they exist to prove the fix *doesn't* fire on healthy runs. With the fix: `7 passed`.

Full suite: `12 failed, 821 passed` — the 12 are pre-existing Google-provider contract failures in `test_phase3_contracts.py` (`TestVeoVideo`, `TestGoogleMusic`, `TestGoogleCredentials`), identical on pristine `main` and unrelated to this change. Zero failures outside that set.

## On part 2 of the issue

The issue also asks for a `transformers` version pin. I've left that out deliberately: picking the supported range is a dependency-policy call (pin `<5` vs. adapt `clip_embedder.py` to the 5.x return type), and it belongs with whoever owns that decision rather than being bundled into a correctness fix. Happy to follow up with either once you've called it — this change makes the breakage loud in the meantime.