### PR TITLE
fix(enhancement): repair bg_remove rembg call and upscale OOM crash

### DIFF
--- a/tests/tools/test_bg_remove_rembg_api.py
+++ b/tests/tools/test_bg_remove_rembg_api.py
@@ -1,0 +1,73 @@
+"""Regression tests for the rembg call signature used by the bg_remove tool.
+
+rembg's ``remove()`` selects a model via ``session=``, not ``model_name=``.
+Passing ``model_name=`` lands in ``**kwargs``, which rembg forwards to
+``new_session(*args, **kwargs)`` — where it collides with that function's own
+first positional parameter and raises::
+
+    TypeError: new_session() got multiple values for argument 'model_name'
+
+These tests pin the calling convention so the tool cannot regress to the
+broken form.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture()
+def fake_rembg(monkeypatch):
+    """Inject a fake rembg exposing remove() and new_session()."""
+    fake = MagicMock()
+    fake.new_session.return_value = "fake-session"
+    monkeypatch.setitem(sys.modules, "rembg", fake)
+    return fake
+
+
+@pytest.fixture()
+def source_image(tmp_path):
+    """A real on-disk image, so only rembg is faked."""
+    from PIL import Image
+
+    path = tmp_path / "input.png"
+    Image.new("RGB", (8, 8), (10, 20, 30)).save(path)
+    return path
+
+
+def _run(fake_rembg, source_image, tmp_path, **extra):
+    from tools.enhancement.bg_remove import BgRemove
+
+    inputs = {"input_path": str(source_image), "output_path": str(tmp_path / "out.png")}
+    inputs.update(extra)
+    return BgRemove().execute(inputs)
+
+
+def test_bg_remove_passes_session_not_model_name(fake_rembg, source_image, tmp_path):
+    """remove() must receive session=; model_name= would raise inside rembg."""
+    result = _run(fake_rembg, source_image, tmp_path)
+
+    assert result.success is True, result.error
+    fake_rembg.remove.assert_called_once()
+    kwargs = fake_rembg.remove.call_args.kwargs
+    assert "model_name" not in kwargs, (
+        "model_name= falls through to new_session() and raises TypeError"
+    )
+    assert kwargs["session"] == "fake-session"
+
+
+def test_bg_remove_builds_session_from_requested_model(fake_rembg, source_image, tmp_path):
+    """The chosen model must reach new_session(), not be silently dropped."""
+    _run(fake_rembg, source_image, tmp_path, model="isnet-general-use")
+
+    fake_rembg.new_session.assert_called_once_with("isnet-general-use")
+
+
+def test_bg_remove_defaults_to_u2net(fake_rembg, source_image, tmp_path):
+    """Default model is u2net when none is requested."""
+    _run(fake_rembg, source_image, tmp_path)
+
+    fake_rembg.new_session.assert_called_once_with("u2net")

--- a/tests/tools/test_mps_device.py
+++ b/tests/tools/test_mps_device.py
@@ -213,8 +213,9 @@ def test_upscale_build_upsampler_uses_signature_guard(monkeypatch):
 
     # Build a fake RealESRGANer whose __init__ DOES accept device=
     class FakeRealESRGANer:
-        def __init__(self, *, scale, model_path, model, dni_weight, half, device=None):
+        def __init__(self, *, scale, model_path, model, dni_weight, half, tile=0, tile_pad=10, device=None):
             self.called_with_device = device
+            self.called_with_tile = tile
     fake_realesrganer_cls = FakeRealESRGANer
 
     monkeypatch.setitem(sys.modules, "torch", fake_torch)
@@ -252,8 +253,9 @@ def test_upscale_build_upsampler_skips_device_when_unsupported(monkeypatch):
 
     # Build a fake RealESRGANer whose __init__ does NOT accept device=
     class FakeRealESRGANerNoDevice:
-        def __init__(self, *, scale, model_path, model, dni_weight, half):
+        def __init__(self, *, scale, model_path, model, dni_weight, half, tile=0, tile_pad=10):
             self.called_with_device = None  # no device param
+            self.called_with_tile = tile
     fake_realesrganer_cls = FakeRealESRGANerNoDevice
 
     monkeypatch.setitem(sys.modules, "torch", fake_torch)
@@ -279,6 +281,60 @@ def test_upscale_build_upsampler_skips_device_when_unsupported(monkeypatch):
     # Should NOT raise TypeError about unexpected keyword argument 'device'
     result = tool._build_upsampler(scale=4, model_name="RealESRGAN_x4plus", denoise_strength=0.5, face_enhance=False)
     assert result.called_with_device is None
+
+
+# ------------------------------------------------------------------
+# upscale.py — tiling guard for low-memory (non-CUDA) devices
+# ------------------------------------------------------------------
+
+def _build_upsampler_on_device(monkeypatch, device: str):
+    """Helper: build an upsampler with a faked backend on the given device."""
+    import importlib
+
+    fake_torch = MagicMock()
+    fake_torch.device = lambda x: f"device({x})"
+
+    class FakeRealESRGANer:
+        def __init__(self, *, scale, model_path, model, dni_weight, half, tile=0, tile_pad=10, device=None):
+            self.called_with_tile = tile
+
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    basicsr_mock = MagicMock()
+    monkeypatch.setitem(sys.modules, "basicsr", basicsr_mock)
+    monkeypatch.setitem(sys.modules, "basicsr.archs", basicsr_mock.archs)
+    monkeypatch.setitem(sys.modules, "basicsr.archs.rrdbnet_arch", basicsr_mock.archs.rrdbnet_arch)
+
+    realesrgan_mock = MagicMock()
+    realesrgan_mock.RealESRGANer = FakeRealESRGANer
+    monkeypatch.setitem(sys.modules, "realesrgan", realesrgan_mock)
+
+    fake_shared = MagicMock()
+    fake_shared.get_torch_device.return_value = device
+    monkeypatch.setitem(sys.modules, "tools.video._shared", fake_shared)
+
+    from tools.enhancement import upscale
+    importlib.reload(upscale)
+
+    return upscale.Upscale()._build_upsampler(
+        scale=4, model_name="RealESRGAN_x4plus", denoise_strength=0.5, face_enhance=False
+    )
+
+
+@pytest.mark.parametrize("device", ["cpu", "mps"])
+def test_upscale_tiles_on_non_cuda_devices(monkeypatch, device):
+    """A full-frame pass allocates the whole x4 tensor and segfaults on low-RAM
+    CPU/MPS machines, so tiling must be on for every non-CUDA device."""
+    result = _build_upsampler_on_device(monkeypatch, device)
+    assert result.called_with_tile > 0, (
+        f"tiling disabled on {device}: large images will exhaust memory and crash"
+    )
+
+
+def test_upscale_does_not_tile_on_cuda(monkeypatch):
+    """CUDA has the headroom for a single pass, which is faster — keep it untiled."""
+    result = _build_upsampler_on_device(monkeypatch, "cuda")
+    assert result.called_with_tile == 0
 
 
 # ------------------------------------------------------------------

--- a/tools/enhancement/bg_remove.py
+++ b/tools/enhancement/bg_remove.py
@@ -130,7 +130,7 @@ class BgRemove(BaseTool):
 
         result_image = rembg.remove(
             input_image,
-            model_name=model_name,
+            session=rembg.new_session(model_name),
             alpha_matting=alpha_matting,
         )
 

--- a/tools/enhancement/upscale.py
+++ b/tools/enhancement/upscale.py
@@ -297,6 +297,11 @@ class Upscale(BaseTool):
             "model": model,
             "dni_weight": denoise_strength,
             "half": half,
+            # Tile on CPU/MPS: a full-frame pass allocates the whole x4 tensor at
+            # once and hard-crashes (access violation) on low-RAM machines. CUDA
+            # keeps the faster single-pass path.
+            "tile": 0 if _device == "cuda" else 256,
+            "tile_pad": 10,
         }
         # Guard: only pass device= if the installed version accepts it
         if "device" in inspect.signature(RealESRGANer.__init__).parameters:


### PR DESCRIPTION
## Summary

Two independent defects that make `tools/enhancement` unusable on current dependency versions and on CPU-only machines. Both surfaced while setting up a fresh clone on Windows with a CPU-only PyTorch install, and neither is reachable from the existing test suite.

## Related issue

None — I searched open issues for `rembg` / `bg_remove` / `upscale` / `realesrgan` and found no existing report. Happy to file issues first if you prefer that order.

## Changes

- **`bg_remove` passed an unsupported kwarg to rembg.** It called `rembg.remove(img, model_name=...)`, but `remove()` selects a model via `session=`. The stray kwarg lands in `**kwargs`, which rembg forwards to `new_session()`, where it collides with that function's own first positional parameter:

  ```
  TypeError: new_session() got multiple values for argument 'model_name'
  ```

  Now builds the session explicitly via `rembg.new_session(model_name)`.

- **`upscale` crashed the interpreter on large images.** `RealESRGANer` was constructed without `tile`, so the whole x4 tensor is allocated in a single pass. On a low-RAM CPU machine this is not a Python exception but a hard native crash — access violation `0xC0000005`, process dies with no traceback. Tiling is now enabled for non-CUDA devices (`tile=256, tile_pad=10`); CUDA keeps the faster untiled path.

- Regression tests for both.

## Testing

Windows 11, Python 3.12, `torch 2.13.0+cpu`, `rembg 2.0.77`, `realesrgan 0.3.0`.

- **Full suite: 869 passed, 11 skipped** (`python -m pytest tests/ -q`).
- New `tests/tools/test_bg_remove_rembg_api.py` pins the `session=` convention. I verified it actually catches the bug rather than passing vacuously: reverted `bg_remove.py` to the current `main` version, confirmed all 3 tests fail with the real `TypeError`, then restored the fix and confirmed they pass.
- `tests/tools/test_mps_device.py` gains parametrized coverage asserting tiling is on for `cpu`/`mps` and off for `cuda`.
- **Heads-up on an existing test:** that file's `RealESRGANer` fakes have hardcoded constructor signatures with no `tile`, so `test_upscale_build_upsampler_uses_signature_guard` and `test_upscale_build_upsampler_skips_device_when_unsupported` both failed against the fix until the fakes were updated to match the real constructor. Updated here.
- Manual end-to-end on real images:
  - `bg_remove` — succeeds with u2net.
  - `upscale` — 1920x720 -> 3840x1440 completes in 24 tiles (~11 min on 4 CPU cores). Before the fix the same input killed the process; a 128x128 input survived, which is what pointed at allocation size rather than an API problem.

## Checklist

- [ ] The change is focused on a single logical concern.
  - Not strictly. This is two fixes. Both are one-line-scale changes in `tools/enhancement/`, found in the same session and sharing a root cause of "doesn't run on CPU with current deps", so I bundled them rather than open two near-identical PRs. **Happy to split into two if you'd prefer.**
- [x] I ran the relevant tests locally (`make test`).
- [ ] I updated docs/README if behavior or usage changed.
  - No user-facing behavior or usage change — both are crash fixes.
- [x] No unrelated files (build artifacts, local config) are included in the diff.

---

**Unrelated, flagging but not fixing here:** `face_restore`'s default `model="CodeFormer"` fails with `'GFPGANer' object has no attribute 'gfpgan'` on a plain `pip install gfpgan`, because that package doesn't register the CodeFormer arch. `model="GFPGAN"` works. I left it alone since changing a default is a maintainer call — glad to open a separate issue or PR if useful.
