### PR TITLE
fix(clip_embedder): unwrap CLIP features on transformers 5.x

### DIFF
--- a/lib/clip_embedder.py
+++ b/lib/clip_embedder.py
@@ -61,6 +61,22 @@ def model_info() -> dict:
     }
 
 
+def _as_feature_tensor(features):
+    """Return CLIP features as a plain tensor, across transformers versions.
+
+    transformers < 5 returned a tensor directly from ``get_text_features()``
+    and ``get_image_features()``. 5.x wraps the result in a
+    ``BaseModelOutputWithPooling`` whose ``pooler_output`` already holds the
+    projected, shared-space embedding — the projection must NOT be applied
+    again (on the vision tower ``visual_projection`` expects 768 inputs and
+    would raise on the 512-d pooled output).
+
+    Accept either shape so the embedder works on both.
+    """
+    pooled = getattr(features, "pooler_output", None)
+    return features if pooled is None else pooled
+
+
 def embed_images(image_paths: Sequence[Union[str, Path]]) -> np.ndarray:
     """Embed a list of image files into a (N, 512) float32 matrix.
 
@@ -82,7 +98,7 @@ def embed_images(image_paths: Sequence[Union[str, Path]]) -> np.ndarray:
 
     inputs = _PROCESSOR(images=images, return_tensors="pt").to(_DEVICE)
     with torch.no_grad():
-        features = _MODEL.get_image_features(**inputs)
+        features = _as_feature_tensor(_MODEL.get_image_features(**inputs))
     features = features / features.norm(dim=-1, keepdim=True).clamp_min(1e-8)
     arr = features.cpu().numpy().astype(np.float32, copy=False)
     # Close PIL handles to avoid leaking file handles on Windows
@@ -116,7 +132,7 @@ def embed_texts(texts: Sequence[str]) -> np.ndarray:
         max_length=77,
     ).to(_DEVICE)
     with torch.no_grad():
-        features = _MODEL.get_text_features(**inputs)
+        features = _as_feature_tensor(_MODEL.get_text_features(**inputs))
     features = features / features.norm(dim=-1, keepdim=True).clamp_min(1e-8)
     return features.cpu().numpy().astype(np.float32, copy=False)
 

--- a/tests/lib/test_clip_embedder_transformers_compat.py
+++ b/tests/lib/test_clip_embedder_transformers_compat.py
@@ -1,0 +1,71 @@
+"""Regression tests for CLIP feature unwrapping across transformers versions.
+
+transformers < 5 returned a plain tensor from ``get_text_features()`` and
+``get_image_features()``. 5.x returns a ``BaseModelOutputWithPooling`` whose
+``pooler_output`` already holds the projected, shared-space embedding. The
+embedder called ``.norm()`` directly on the result, so on 5.x every embed
+raised::
+
+    AttributeError: 'BaseModelOutputWithPooling' object has no attribute 'norm'
+
+That failure is silent at the pipeline level — `corpus_builder` counts each
+candidate as merely "failed" and keeps downloading — so it is worth pinning.
+
+These tests exercise the pure-Python unwrap helper and need neither torch nor
+a downloaded model.
+"""
+
+from __future__ import annotations
+
+from lib.clip_embedder import _as_feature_tensor
+
+
+class _FakeTensor:
+    """Stands in for a torch tensor: notably has no ``pooler_output``."""
+
+    def __init__(self, tag: str = "tensor") -> None:
+        self.tag = tag
+
+
+class _FakeModelOutput:
+    """Stands in for transformers' BaseModelOutputWithPooling."""
+
+    def __init__(self, pooler_output, last_hidden_state=None) -> None:
+        self.pooler_output = pooler_output
+        self.last_hidden_state = last_hidden_state
+
+
+def test_plain_tensor_passes_through_unchanged():
+    """transformers 4.x path: a bare tensor must be returned as-is."""
+    t = _FakeTensor()
+    assert _as_feature_tensor(t) is t
+
+
+def test_model_output_is_unwrapped_to_pooler_output():
+    """transformers 5.x path: unwrap to pooler_output, the projected embedding."""
+    pooled = _FakeTensor("pooled")
+    out = _FakeModelOutput(pooler_output=pooled, last_hidden_state=_FakeTensor("hidden"))
+    assert _as_feature_tensor(out) is pooled
+
+
+def test_last_hidden_state_is_not_used():
+    """last_hidden_state is per-token and the wrong rank — never select it."""
+    hidden = _FakeTensor("hidden")
+    out = _FakeModelOutput(pooler_output=_FakeTensor("pooled"), last_hidden_state=hidden)
+    assert _as_feature_tensor(out) is not hidden
+
+
+def test_output_without_pooler_output_falls_back_to_itself():
+    """Unknown wrapper shapes must not raise; degrade to the object itself."""
+
+    class _Bare:
+        pass
+
+    obj = _Bare()
+    assert _as_feature_tensor(obj) is obj
+
+
+def test_none_pooler_output_falls_back_to_the_object():
+    """A present-but-None pooler_output must not be returned as the features."""
+    out = _FakeModelOutput(pooler_output=None)
+    assert _as_feature_tensor(out) is out


### PR DESCRIPTION
## Summary

Fixes #429. On transformers 5.x, `CLIPModel.get_text_features()` and `get_image_features()` return a `BaseModelOutputWithPooling` instead of a plain tensor, so `lib/clip_embedder.py` raises on every call:

```
AttributeError: 'BaseModelOutputWithPooling' object has no attribute 'norm'
```

This takes down the whole real-footage corpus pipeline, and it fails in a way that is worse than a crash: `corpus_builder` catches the per-candidate exception, counts it as `failed`, and moves on — but `max_new_clips` gates on rows *added to the index*, so the cap never fires and downloads run unbounded. A run requested with `max_new_clips: 3` pulled **553 MB across 24+ clips** before I killed it, leaving no `index.jsonl` because `corp.save()` only runs after all queries complete.

## Related issue

Fixes #429

## Changes

- Add `_as_feature_tensor()`, which accepts either the 4.x tensor or the 5.x output object, and use it at both call sites in `embed_texts` and `embed_images`.
- Add `tests/lib/test_clip_embedder_transformers_compat.py` covering both version paths.

**Why `pooler_output` rather than `text_projection(pooler_output)`** — this was the part worth getting right, because the wrong choice fails silently rather than loudly:

On the text tower both candidates are 512-d, so shape alone cannot distinguish them. The vision tower settles it: `get_image_features()` returns a **512-d** `pooler_output` while `visual_projection` expects **768** inputs, so re-applying the projection raises `mat1 and mat2 shapes cannot be multiplied (1x512 and 768x512)`. The pooled output is already in the shared space.

I did not want to rely on that inference alone, since a wrong-but-plausible accessor would produce vectors that still normalise fine and still return results — silently poisoning every similarity search in the corpus. So I checked it semantically as well (below).

## Testing

Windows 11, Python 3.12, `transformers 5.14.1`, `torch 2.13.0+cpu`.

**Semantic validation** — a real gym photo embedded against three captions:

```
+0.2948  "a man lifting dumbbells in a gym"     <- correct
+0.1808  "a bowl of spaghetti on a table"
+0.1436  "a snowy mountain landscape"
```

Text and image genuinely share a space and the ranking is correct.

**Contract check** — `embed_texts` returns `(2, 512)` float32 and `embed_images` `(1, 512)` float32, all rows with L2 norm exactly 1.0, matching the documented `(N, 512)` L2-normalised contract.

**Unit tests** — 5 new tests, no torch or model download required, since the helper is pure Python. They pin that a bare tensor passes through unchanged, that a model output unwraps to `pooler_output`, that `last_hidden_state` is never selected (per-token, wrong rank — the subtle way this could regress), and that unknown or `None`-pooler shapes degrade instead of raising.

**Full suite: 867 passed, 11 skipped, 1 failed.** In the interest of not overstating: the one failure is `tests/backlot/test_server.py::TestBacklotPerformanceBudgets::test_projects_and_state_stay_within_loose_budgets`, a wall-clock budget assertion unrelated to this change. It **passes in isolation in 2.43s** and failed only under load on a memory-constrained machine. Happy to be told otherwise if it is not a known flake for you.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test`).
- [ ] I updated docs/README if behavior or usage changed.
  - No user-facing behavior change; restores documented behavior.
- [x] No unrelated files (build artifacts, local config) are included in the diff.

---

Two suggestions from #429 that this PR deliberately does **not** address, since they are design calls rather than bug fixes:

1. **Bound the corpus download loop on attempts, not just successes.** Any future per-candidate failure reintroduces unbounded downloading. A `max_candidates` cap or consecutive-failure circuit breaker would make this class of bug non-catastrophic.
2. **Pin or range-check `transformers`.** It is not in `requirements.txt`, so a fresh install resolves to 5.x, which this code predated.
