### PR TITLE
Fix .env.example: move inline comments off empty keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,74 +2,110 @@
 # Copy this to .env and fill in your keys
 
 # --- Image + video gateway ---
-FAL_KEY=                     # FLUX images, Google Veo video, Kling video, MiniMax video, Recraft images
-                             # Get one at https://fal.ai/dashboard/keys
-FAL_AI_API_KEY=              # Alias for FAL_KEY (some SDKs/docs use this name); either one is read.
+# FLUX images, Google Veo video, Kling video, MiniMax video, Recraft images
+# Get one at https://fal.ai/dashboard/keys
+FAL_KEY=
+# Alias for FAL_KEY (some SDKs/docs use this name); either one is read.
+FAL_AI_API_KEY=
 
 # --- Replicate ---
-REPLICATE_API_TOKEN=         # Replicate-hosted video gen (seedance_replicate). Needed to make the
-                             # Replicate-backed Seedance path selectable alongside the fal.ai one.
-                             # Get one at https://replicate.com/account/api-tokens
+# Replicate-hosted video gen (seedance_replicate). Needed to make the
+# Replicate-backed Seedance path selectable alongside the fal.ai one.
+# Get one at https://replicate.com/account/api-tokens
+REPLICATE_API_TOKEN=
 
 # --- Higgsfield ---
-HIGGSFIELD_API_KEY=          # Higgsfield Cloud key (higgsfield_video). Pair with the secret below,
-HIGGSFIELD_API_SECRET=       # or use the combined HIGGSFIELD_KEY="<key>:<secret>" form instead.
-# HIGGSFIELD_KEY=            # Combined key:secret — set this INSTEAD of the _KEY/_SECRET pair if you prefer.
+# Higgsfield Cloud key (higgsfield_video). Pair with the secret below,
+HIGGSFIELD_API_KEY=
+# or use the combined HIGGSFIELD_KEY="<key>:<secret>" form instead.
+HIGGSFIELD_API_SECRET=
+# Combined key:secret — set this INSTEAD of the _KEY/_SECRET pair if you prefer.
+# HIGGSFIELD_KEY=
 
 # --- Kling official direct API ---
-KLING_API_KEY=               # Official Kling API key; enables video, image, TTS, avatar, lip sync
-KLING_API_BASE_URL=          # Optional endpoint override; leave blank for default https://api-singapore.klingai.com
-                             # Mainland China accounts can use https://api-beijing.klingai.com
+# Official Kling API key; enables video, image, TTS, avatar, lip sync
+KLING_API_KEY=
+# Optional endpoint override; leave blank for default https://api-singapore.klingai.com
+# Mainland China accounts can use https://api-beijing.klingai.com
+KLING_API_BASE_URL=
 
 # --- Google (one key unlocks image gen + TTS + video) ---
-GOOGLE_API_KEY=              # Google Imagen images, Google Cloud TTS (700+ voices, 50+ languages),
-                             # Gemini Omni video (generation + conversational editing, paid tier)
-                             # Get one at https://aistudio.google.com/apikey
-# GEMINI_API_KEY=            # Alias for GOOGLE_API_KEY (takes precedence when both are set)
+# Google Imagen images, Google Cloud TTS (700+ voices, 50+ languages),
+# Gemini Omni video (generation + conversational editing, paid tier)
+# Get one at https://aistudio.google.com/apikey
+GOOGLE_API_KEY=
+# Alias for GOOGLE_API_KEY (takes precedence when both are set)
+# GEMINI_API_KEY=
 # Alternative to the API key: service-account JSON auth.
 # TTS uses Cloud Text-to-Speech; Imagen routes to Vertex AI.
-GOOGLE_APPLICATION_CREDENTIALS=   # path to a service-account JSON key file
-GOOGLE_CLOUD_PROJECT=             # GCP project id (required for Imagen via Vertex AI)
-GOOGLE_CLOUD_LOCATION=            # Vertex AI region, default us-central1
+# path to a service-account JSON key file
+GOOGLE_APPLICATION_CREDENTIALS=
+# GCP project id (required for Imagen via Vertex AI)
+GOOGLE_CLOUD_PROJECT=
+# Vertex AI region, default us-central1
+GOOGLE_CLOUD_LOCATION=
 
 # --- Voice ---
-ELEVENLABS_API_KEY=          # TTS narration, music generation, sound effects
-OPENAI_API_KEY=              # OpenAI TTS fallback and GPT Image 2 image generation
-XAI_API_KEY=                 # Grok image generation/editing and Grok video generation
-DOUBAO_SPEECH_API_KEY=       # Volcengine Doubao Speech TTS (new console API Key)
-DOUBAO_SPEECH_VOICE_TYPE=    # Default Doubao speaker/voice type, e.g. zh_female_vv_uranus_bigtts
+# TTS narration, music generation, sound effects
+ELEVENLABS_API_KEY=
+# OpenAI TTS fallback and GPT Image 2 image generation
+OPENAI_API_KEY=
+# Grok image generation/editing and Grok video generation
+XAI_API_KEY=
+# Volcengine Doubao Speech TTS (new console API Key)
+DOUBAO_SPEECH_API_KEY=
+# Default Doubao speaker/voice type, e.g. zh_female_vv_uranus_bigtts
+DOUBAO_SPEECH_VOICE_TYPE=
 # Piper local voices do not require env vars; install `piper-tts` via pip
 
 # --- DashScope (Alibaba Cloud Bailian) ---
-DASHSCOPE_API_KEY=           # Qwen image gen (qwen-image-2.0-pro), TTS (qwen3-tts-flash), ASR with word timestamps (qwen3-asr-flash-filetrans)
-                              # Get one at https://dashscope.aliyun.com/
+# Qwen image gen (qwen-image-2.0-pro), TTS (qwen3-tts-flash), ASR with word timestamps (qwen3-asr-flash-filetrans)
+# Get one at https://dashscope.aliyun.com/
+DASHSCOPE_API_KEY=
 
 # --- Music ---
-SUNO_API_KEY=                # Suno AI music generation (full songs, instrumentals, any genre)
+# Suno AI music generation (full songs, instrumentals, any genre)
+SUNO_API_KEY=
 
 # --- Video Generation ---
-HEYGEN_API_KEY=              # HeyGen API (VEO, Sora, Runway, Kling, Seedance via single key)
-RUNWAY_API_KEY=              # Runway Gen-4 (direct API, alternative to fal.ai routing)
-VOLC_ACCESSKEY=              # Volcengine Jimeng (即梦 AI) video generation via official API (HMAC-SHA256 V4 signing)
-VOLC_SECRETKEY=             # Secret Access Key paired with VOLC_ACCESSKEY. Get both at https://console.volcengine.com/iam/keymanage
-VIDEO_GEN_LOCAL_ENABLED=     # Set to "true" for local video gen (needs GPU + diffusers)
-VIDEO_GEN_LOCAL_MODEL=       # Local model: wan2.1-1.3b, wan2.1-14b, hunyuan-1.5, ltx2-local, cogvideo-5b
-MODAL_LTX2_ENDPOINT_URL=    # Modal self-hosted LTX-2 endpoint (optional)
+# HeyGen API (VEO, Sora, Runway, Kling, Seedance via single key)
+HEYGEN_API_KEY=
+# Runway Gen-4 (direct API, alternative to fal.ai routing)
+RUNWAY_API_KEY=
+# Volcengine Jimeng (即梦 AI) video generation via official API (HMAC-SHA256 V4 signing)
+VOLC_ACCESSKEY=
+# Secret Access Key paired with VOLC_ACCESSKEY. Get both at https://console.volcengine.com/iam/keymanage
+VOLC_SECRETKEY=
+# Set to "true" for local video gen (needs GPU + diffusers)
+VIDEO_GEN_LOCAL_ENABLED=
+# Local model: wan2.1-1.3b, wan2.1-14b, hunyuan-1.5, ltx2-local, cogvideo-5b
+VIDEO_GEN_LOCAL_MODEL=
+# Modal self-hosted LTX-2 endpoint (optional)
+MODAL_LTX2_ENDPOINT_URL=
 
 # --- Stock Media ---
-PEXELS_API_KEY=              # Pexels stock footage/images (free)
-PIXABAY_API_KEY=             # Pixabay stock footage/images (free)
-UNSPLASH_ACCESS_KEY=         # Unsplash stock images (free developer key)
+# Pexels stock footage/images (free)
+PEXELS_API_KEY=
+# Pixabay stock footage/images (free)
+PIXABAY_API_KEY=
+# Unsplash stock images (free developer key)
+UNSPLASH_ACCESS_KEY=
 
 # --- Analysis ---
-HF_TOKEN=                    # HuggingFace token — enables speaker diarization in transcriber
+# HuggingFace token — enables speaker diarization in transcriber
+HF_TOKEN=
 # Speech-to-text: optional Azure AI Speech (Fast Transcription). When set, the
 # agent prefers azure_stt for cloud STT; the local faster-whisper transcriber
 # remains the default offline path.
-AZURE_SPEECH_KEY=            # Azure AI Speech resource key ('Keys and Endpoint' page)
-AZURE_SPEECH_REGION=         # Speech resource region, e.g. eastus
-# AZURE_SPEECH_ENDPOINT=     # Optional: full custom endpoint URL (overrides region)
+# Azure AI Speech resource key ('Keys and Endpoint' page)
+AZURE_SPEECH_KEY=
+# Speech resource region, e.g. eastus
+AZURE_SPEECH_REGION=
+# Optional: full custom endpoint URL (overrides region)
+# AZURE_SPEECH_ENDPOINT=
 
 # --- Avatar (local installs) ---
-# WAV2LIP_PATH=              # Path to cloned Wav2Lip repo (for lip sync)
-# SADTALKER_PATH=            # Path to cloned SadTalker repo (for talking head avatars)
+# Path to cloned Wav2Lip repo (for lip sync)
+# WAV2LIP_PATH=
+# Path to cloned SadTalker repo (for talking head avatars)
+# SADTALKER_PATH=


### PR DESCRIPTION
## Summary

`python-dotenv` only strips a trailing `#` comment when a key already has a value. For an **empty** key — which is the state of every line in a freshly copied `.env` — the comment text itself becomes the value.

For example, on a fresh install with no keys filled in:

```
FAL_KEY -> '# FLUX images, Google Veo video, Kling video, MiniMax video, Recraft images'
```

Any tool that gates availability on "is this env var non-empty" then reports itself **available**, and fails at call time with a 400/401 instead of being cleanly reported as unconfigured. Per the issue, this affected ~26 keys and inflated the tool-registry's "available" count from a true ~60 to 89 of 101.

## Fix

Move each inline comment onto its own line above the key it documents, so a copied-but-unfilled `.env` parses every key as truly empty:

```diff
-FAL_KEY=                     # FLUX images, Google Veo video, Kling video, MiniMax video
+# FLUX images, Google Veo video, Kling video, MiniMax video
+FAL_KEY=
```

This also incidentally fixes the "glued" case mentioned in the issue, where a value pasted immediately before `#` (easy to do, cursor lands right after `=`) got the `#` appended to the credential.

Fixes #431

## Test plan

- Verified with the issue's own repro: after this change, `dotenv_values(".env")` on a copy of the updated `.env.example` reports **0** keys holding comment text (previously 26).
- Ran `tests/contracts/test_kling_official_core.py`, which asserts on the presence of `KLING_API_KEY=` / `KLING_API_BASE_URL=` in `.env.example` — still passes.
- No code changes, only reformatting of `.env.example` comments/whitespace; every key name and default (empty) value is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)