### PR TITLE
fix(tests): stop diagram_gen contract test overwriting the tracked diagram.png

### DIFF
--- a/tests/contracts/test_phase2_contracts.py
+++ b/tests/contracts/test_phase2_contracts.py
@@ -174,10 +174,17 @@ class TestPhase2ErrorHandling:
         # Either succeeds (provider available) or fails gracefully
         assert isinstance(r, ToolResult)
 
-    def test_diagram_gen_empty_boxes(self):
+    def test_diagram_gen_empty_boxes(self, tmp_path):
         tool = DiagramGen()
         if tool.get_status() == ToolStatus.AVAILABLE:
-            r = tool.execute({"diagram_type": "boxes", "boxes": []})
+            # Must pass output_path: DiagramGen defaults to a bare "diagram.png",
+            # which resolves against cwd and overwrites the tracked diagram.png
+            # at the repo root on every test run.
+            r = tool.execute({
+                "diagram_type": "boxes",
+                "boxes": [],
+                "output_path": str(tmp_path / "empty.png"),
+            })
             assert isinstance(r, ToolResult)
 
 


### PR DESCRIPTION
## Summary

`TestDiagramGenUnit.test_diagram_gen_empty_boxes` calls `DiagramGen.execute()` without an `output_path`. The tool defaults to a bare `"diagram.png"` (`tools/graphics/diagram_gen.py:143`), which resolves against the current working directory — the repo root. So every full test run silently rewrites the tracked `diagram.png` and leaves the working tree dirty.

Sibling tests in the same class already pass `tmp_path`; this one was missed.

## Related issue

No existing issue — found while running `make test` on a clean checkout.

## Changes

- `test_diagram_gen_empty_boxes` now takes the `tmp_path` fixture and passes `output_path`, like every other test in `TestDiagramGenUnit`.
- Added a comment explaining the default-path trap so the next person doesn't drop it again.

## Testing

On a clean checkout of `main`:

```
$ git status --short          # clean
$ pytest tests/ --ignore=tests/qa -q
932 passed, 9 skipped
$ git status --short
 M diagram.png                # <-- polluted by the test run
```

With this patch, the same sequence leaves `git status --short` empty.

Full suite after the change: `932 passed, 9 skipped`.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`pytest tests/ --ignore=tests/qa`).
- [ ] I updated docs/README if behavior or usage changed. — n/a, test-only fix.
- [x] No unrelated files (build artifacts, local config) are included in the diff.