### PR TITLE
fix(video_compose): render cuts through CinematicRenderer instead of 30s of black

### DIFF
--- a/tests/tools/test_cinematic_cuts_to_scenes.py
+++ b/tests/tools/test_cinematic_cuts_to_scenes.py
@@ -1,0 +1,245 @@
+"""Regression tests for the CinematicRenderer cut-schema adapter (#358).
+
+CinematicRenderer renders from ``props.scenes``. The canonical edit_decisions
+artifact stores its timeline as ``cuts[]``. Before the adapter existed, the
+cinematic families fell through to ``defaultProps.scenes = []`` and produced a
+fixed 30s black video while reporting success.
+
+These tests exercise the pure adapter plus the props assembly in
+``_remotion_render`` — no Remotion CLI, no rendering.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.video.video_compose import VideoCompose
+
+
+def _cut(cut_id, source, start, end, **extra):
+    cut = {
+        "id": cut_id,
+        "source": source,
+        "in_seconds": start,
+        "out_seconds": end,
+    }
+    cut.update(extra)
+    return cut
+
+
+# ------------------------------------------------------------------
+# _cuts_to_cinematic_scenes — pure adapter
+# ------------------------------------------------------------------
+
+def test_cuts_map_to_back_to_back_scenes():
+    scenes = VideoCompose._cuts_to_cinematic_scenes([
+        _cut("a", "one.mp4", 0.0, 4.0),
+        _cut("b", "two.mp4", 2.0, 5.5),
+    ])
+
+    assert [s["id"] for s in scenes] == ["a", "b"]
+    assert [s["kind"] for s in scenes] == ["video", "video"]
+    assert [s["src"] for s in scenes] == ["one.mp4", "two.mp4"]
+
+    # Laid end to end on the timeline...
+    assert scenes[0]["startSeconds"] == 0.0
+    assert scenes[0]["durationSeconds"] == 4.0
+    assert scenes[1]["startSeconds"] == 4.0
+    assert scenes[1]["durationSeconds"] == 3.5
+
+    # ...each trimmed to its own in-point.
+    assert scenes[0]["trimBeforeSeconds"] == 0.0
+    assert scenes[1]["trimBeforeSeconds"] == 2.0
+
+
+def test_fade_transitions_become_fade_frames():
+    scenes = VideoCompose._cuts_to_cinematic_scenes([
+        _cut("a", "one.mp4", 0, 2, transition_in="fade", transition_out="cut"),
+        _cut("b", "two.mp4", 0, 2, transition_in="cut", transition_out="slow dissolve"),
+    ])
+
+    assert scenes[0]["fadeInFrames"] > 0
+    assert scenes[0]["fadeOutFrames"] == 0
+    assert scenes[1]["fadeInFrames"] == 0
+    assert scenes[1]["fadeOutFrames"] > 0
+
+
+def test_tone_defaults_to_neutral_and_is_forwarded():
+    scenes = VideoCompose._cuts_to_cinematic_scenes([
+        _cut("a", "one.mp4", 0, 2),
+        _cut("b", "two.mp4", 0, 2, tone="cold"),
+    ])
+
+    assert scenes[0]["tone"] == "neutral"
+    assert scenes[1]["tone"] == "cold"
+
+
+@pytest.mark.parametrize("bad_cut", [
+    {"id": "no-source", "in_seconds": 0, "out_seconds": 2},
+    {"id": "zero-length", "source": "x.mp4", "in_seconds": 2, "out_seconds": 2},
+    {"id": "negative", "source": "x.mp4", "in_seconds": 5, "out_seconds": 1},
+    {"id": "unparseable", "source": "x.mp4", "in_seconds": "abc", "out_seconds": 3},
+])
+def test_unrenderable_cuts_are_dropped(bad_cut):
+    assert VideoCompose._cuts_to_cinematic_scenes([bad_cut]) == []
+
+
+def test_ids_are_synthesised_when_missing():
+    scenes = VideoCompose._cuts_to_cinematic_scenes([
+        {"source": "one.mp4", "in_seconds": 0, "out_seconds": 2},
+        {"source": "two.mp4", "in_seconds": 0, "out_seconds": 2},
+    ])
+    assert [s["id"] for s in scenes] == ["scene-1", "scene-2"]
+
+
+# ------------------------------------------------------------------
+# _remotion_render — props assembly
+# ------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPOSER_PUBLIC = REPO_ROOT / "remotion-composer" / "public"
+
+
+@pytest.fixture(autouse=True)
+def staged_cleanup():
+    """Yield remotion-composer/public/ and remove anything the test staged into it.
+
+    Staging writes into the real composer public dir (that is the point — it is
+    what Remotion serves), so tests must not leave assets behind.
+    """
+    before = set(COMPOSER_PUBLIC.rglob("*")) if COMPOSER_PUBLIC.exists() else set()
+    yield COMPOSER_PUBLIC
+    if not COMPOSER_PUBLIC.exists():
+        return
+    created = sorted(set(COMPOSER_PUBLIC.rglob("*")) - before, reverse=True)
+    for path in created:
+        if path.is_file() or path.is_symlink():
+            path.unlink()
+        elif path.is_dir():
+            path.rmdir()
+
+
+@pytest.fixture()
+def props_capture(monkeypatch, tmp_path):
+    """Run _remotion_render up to the CLI call and hand back the props written."""
+    captured = {}
+
+    def fake_run_command(self, cmd, **kwargs):
+        for arg in cmd:
+            if arg.startswith("--props="):
+                captured["props"] = json.loads(Path(arg.split("=", 1)[1]).read_text())
+        # Materialise the expected output so _remotion_render's existence check passes.
+        Path(captured["output_path"]).write_bytes(b"fake mp4")
+        return None
+
+    monkeypatch.setattr(VideoCompose, "run_command", fake_run_command, raising=False)
+
+    def run(edit_decisions):
+        out = tmp_path / "out.mp4"
+        captured["output_path"] = str(out)
+        tool = VideoCompose()
+        tool._remotion_render({
+            "edit_decisions": edit_decisions,
+            "output_path": str(out),
+        })
+        return captured.get("props", {})
+
+    return run
+
+
+@pytest.mark.parametrize("family", sorted(VideoCompose.CUT_SCHEMA_CINEMATIC_FAMILIES))
+def test_cinematic_families_get_scenes_from_cuts(props_capture, tmp_path, family):
+    """#358: cut-schema props alone rendered 30s of black. Scenes must be derived."""
+    clip = tmp_path / "clip.mp4"
+    clip.write_bytes(b"fake mp4")
+
+    props = props_capture({
+        "renderer_family": family,
+        "render_runtime": "remotion",
+        "cuts": [_cut("sc1", str(clip), 0, 3)],
+    })
+
+    assert props.get("scenes"), f"{family} produced no scenes — would render black"
+    assert props["scenes"][0]["durationSeconds"] == 3
+    assert props["scenes"][0]["kind"] == "video"
+
+
+def test_explicit_scenes_are_not_overwritten(props_capture, tmp_path):
+    clip = tmp_path / "clip.mp4"
+    clip.write_bytes(b"fake mp4")
+    supplied = [{
+        "id": "hand-authored",
+        "kind": "video",
+        "src": "already-staged.mp4",
+        "startSeconds": 0,
+        "durationSeconds": 1,
+    }]
+
+    props = props_capture({
+        "renderer_family": "cinematic-trailer",
+        "cuts": [_cut("sc1", str(clip), 0, 3)],
+        "scenes": supplied,
+    })
+
+    assert props["scenes"] == supplied
+
+
+def test_non_cinematic_families_get_no_scenes(props_capture, tmp_path):
+    clip = tmp_path / "clip.mp4"
+    clip.write_bytes(b"fake mp4")
+
+    props = props_capture({
+        "renderer_family": "explainer-data",
+        "cuts": [_cut("sc1", str(clip), 0, 3)],
+    })
+
+    assert "scenes" not in props
+
+
+# ------------------------------------------------------------------
+# _remotion_render — local media staging
+# ------------------------------------------------------------------
+
+def test_local_sources_are_staged_not_file_uris(props_capture, tmp_path, staged_cleanup):
+    """OffthreadVideo's compositor proxy rejects file://; props must stay relative."""
+    clip = tmp_path / "clip.mp4"
+    clip.write_bytes(b"fake mp4")
+
+    props = props_capture({
+        "renderer_family": "cinematic-trailer",
+        "cuts": [_cut("sc1", str(clip), 0, 3)],
+    })
+
+    staged = props["cuts"][0]["source"]
+    assert not staged.startswith("file://"), "file:// is rejected by the compositor proxy"
+    assert not Path(staged).is_absolute()
+    assert staged.startswith("openmontage_assets/")
+    assert (staged_cleanup / staged).exists()
+
+
+def test_remote_and_data_sources_pass_through(props_capture):
+    props = props_capture({
+        "renderer_family": "cinematic-trailer",
+        "cuts": [
+            _cut("a", "https://example.com/a.mp4", 0, 2),
+            _cut("b", "data:video/mp4;base64,AAAA", 0, 2),
+        ],
+    })
+
+    assert props["cuts"][0]["source"] == "https://example.com/a.mp4"
+    assert props["cuts"][1]["source"] == "data:video/mp4;base64,AAAA"
+
+
+def test_missing_local_file_is_left_untouched(props_capture, tmp_path):
+    """Unresolvable sources belong to the validation gate, not the staging helper."""
+    missing = tmp_path / "nope.mp4"
+
+    props = props_capture({
+        "renderer_family": "cinematic-trailer",
+        "cuts": [_cut("sc1", str(missing), 0, 3)],
+    })
+
+    assert props["cuts"][0]["source"] == str(missing)

--- a/tools/video/video_compose.py
+++ b/tools/video/video_compose.py
@@ -698,6 +698,57 @@ class VideoCompose(BaseTool):
         "animation-first": "Explainer",
     }
 
+    # Families whose composition is CinematicRenderer, which renders from
+    # scenes[] rather than the cut schema the edit_decisions artifact stores.
+    CUT_SCHEMA_CINEMATIC_FAMILIES = frozenset({"cinematic-trailer", "documentary-montage"})
+
+    # Cut transitions that should become a fade on the adapted scene.
+    _CINEMATIC_FADE_TRANSITIONS = frozenset({"fade", "dissolve", "slow dissolve"})
+
+    # Frames of fade applied per side when a cut requests one, at the 30fps
+    # CinematicRenderer timebase (0.4s — matches the schema's default
+    # transition_duration).
+    _CINEMATIC_FADE_FRAMES = 12
+
+    @classmethod
+    def _cuts_to_cinematic_scenes(cls, cuts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Adapt cut-schema timeline entries to CinematicVideoScene[].
+
+        CinematicRenderer reads ``props.scenes``; the canonical edit_decisions
+        artifact stores its timeline as ``cuts[]``. Scenes are laid end to end
+        on the timeline, each trimmed to its cut's in/out window.
+
+        Cuts without a source or without a positive duration are dropped —
+        they cannot produce a renderable scene.
+        """
+        scenes: list[dict[str, Any]] = []
+        cursor = 0.0
+        for cut in cuts:
+            source = cut.get("source")
+            if not source:
+                continue
+            try:
+                in_seconds = float(cut.get("in_seconds", 0))
+                duration = float(cut.get("out_seconds", 0)) - in_seconds
+            except (TypeError, ValueError):
+                continue
+            if duration <= 0:
+                continue
+            fade = cls._CINEMATIC_FADE_FRAMES
+            scenes.append({
+                "id": cut.get("id") or f"scene-{len(scenes) + 1}",
+                "kind": "video",
+                "src": source,
+                "startSeconds": cursor,
+                "durationSeconds": duration,
+                "trimBeforeSeconds": in_seconds,
+                "tone": cut.get("tone") or "neutral",
+                "fadeInFrames": fade if cut.get("transition_in") in cls._CINEMATIC_FADE_TRANSITIONS else 0,
+                "fadeOutFrames": fade if cut.get("transition_out") in cls._CINEMATIC_FADE_TRANSITIONS else 0,
+            })
+            cursor += duration
+        return scenes
+
     @classmethod
     def _get_composition_id(cls, renderer_family: str) -> str:
         """Resolve renderer_family to Remotion composition ID.
@@ -1700,15 +1751,52 @@ class VideoCompose(BaseTool):
         # Deep-copy props so we don't mutate the original
         props = json.loads(json.dumps(composition_data))
 
-        # Convert absolute file paths to file:// URIs for Remotion's
-        # Img and OffthreadVideo components
+        # Local media must be staged into remotion-composer/public/ rather than
+        # handed to Remotion as file:// URIs. OffthreadVideo routes frame
+        # extraction through the compositor proxy, which hard-rejects anything
+        # that is not http(s):
+        #
+        #   Can only download URLs starting with http:// or https://,
+        #   got "file:///.../clip.mp4"
+        #
+        # (reproduced on Remotion 4.0.484). <Img> does accept file://, which is
+        # why the previous conversion looked correct for still-image
+        # compositions while breaking every video-backed one. Staging yields
+        # staticFile()-compatible relative paths, which both components accept.
+        composer_dir = Path(__file__).resolve().parent.parent.parent / "remotion-composer"
+        public_dir = composer_dir / "public"
+        staged_root = public_dir / "openmontage_assets" / output_path.stem
+
+        def _stage_for_remotion(value: Any) -> str:
+            src = str(value)
+            if src.startswith(("http://", "https://", "data:")):
+                return src
+            local = Path(src[len("file://"):] if src.startswith("file://") else src)
+            if not local.is_absolute():
+                local = local.resolve()
+            if not local.exists():
+                # Leave unresolvable sources untouched so the pre-compose
+                # validation gate reports them instead of this helper.
+                return src
+            staged_root.mkdir(parents=True, exist_ok=True)
+            target = staged_root / local.name
+            if target.exists() or target.is_symlink():
+                target.unlink()
+            shutil.copy2(local, target)
+            return target.relative_to(public_dir).as_posix()
+
         for cut in props.get("cuts", []):
             source = cut.get("source", "")
-            if source and not source.startswith(("http://", "https://", "file://")):
-                resolved = Path(source).resolve()
-                if resolved.exists():
-                    posix = resolved.as_posix()
-                    cut["source"] = f"file:///{posix}" if not posix.startswith("/") else f"file://{posix}"
+            if source:
+                cut["source"] = _stage_for_remotion(source)
+
+        # CinematicRenderer renders from props.scenes, but the canonical
+        # edit_decisions artifact stores its timeline as cuts[]. Without this
+        # adapter the composition falls back to defaultProps.scenes = [] and
+        # emits a fixed 30s black video while still reporting success (#358).
+        renderer_family = (composition_data or {}).get("renderer_family")
+        if renderer_family in self.CUT_SCHEMA_CINEMATIC_FAMILIES and not props.get("scenes"):
+            props["scenes"] = self._cuts_to_cinematic_scenes(props.get("cuts", []))
 
         # Build a custom themeConfig from the playbook's actual colors.
         # This ensures every video gets a unique visual identity derived


### PR DESCRIPTION
## Summary

Fixes the silent black render described in #358, and a second defect that surfaced once the first was fixed.

**1. No `cuts` → `scenes` adapter.** `CinematicRenderer` renders from `props.scenes`; the canonical `edit_decisions` artifact stores its timeline as `cuts[]`. `_remotion_render` passed the cut schema through verbatim, so `cinematic-trailer` and `documentary-montage` both fell back to `defaultProps.scenes = []` and emitted a fixed 30s black video — while returning `success: true`.

**2. `file://` sources are unusable for video.** Fixing the adapter alone still rendered nothing. `OffthreadVideo` routes frame extraction through the compositor proxy, which hard-rejects non-http(s) input:

```
Can only download URLs starting with http:// or https://,
got "file:///.../sc1_rural_classroom_opening.mp4"
```

`<Img>` *does* accept `file://`, which is why the conversion looked correct for still-image compositions while breaking every video-backed one. Local media is now staged into `remotion-composer/public/` and passed as `staticFile()`-compatible relative paths, which both components accept.

This is distinct from the four-slash bug fixed in 9c9b1be — that corrected how the URI was spelled; this is the proxy refusing the scheme outright.

## Related issue

Closes #358

## Changes

- Add `VideoCompose._cuts_to_cinematic_scenes()`, applied for `CUT_SCHEMA_CINEMATIC_FAMILIES` when props carry no explicit `scenes[]`. Scenes are laid end to end, each trimmed to its cut's in/out window; `fade`/`dissolve` transitions become fade frames; `tone` is forwarded and defaults to `neutral`.
- Cuts with no source, a non-positive duration, or unparseable timings are dropped — they cannot produce a renderable scene.
- Replace the `file://` conversion with staging into `remotion-composer/public/`. Remote and `data:` sources pass through untouched; unresolvable local paths are left as-is so the existing pre-compose validation gate reports them rather than this helper swallowing them.
- Hand-authored `scenes[]` are never overwritten, and non-cinematic families are unaffected.

## Testing

**Repro, on `main` @ c36e412** — `cinematic-trailer` `edit_decisions` with two 2s cuts, rendered via `_remotion_render`, then measured with `ffmpeg signalstats`:

| | frames | duration | mean luma | max luma | result |
|---|---|---|---|---|---|
| before | 900 | 30.06s | 0.0 | 0.0 | all black, `success: true` |
| after | 120 | 4.05s | 66.1 | 97.0 | renders the cuts |

The 30.06s/all-black row is exactly the symptom #358 reports.

**Unit tests** — new `tests/tools/test_cinematic_cuts_to_scenes.py` (15 tests) covers the adapter (timeline layout, trimming, fades, tone, dropped cuts, synthesised ids) and props assembly (both cinematic families, explicit scenes preserved, non-cinematic families untouched, staging vs. `file://`, remote/`data:` passthrough, missing files). No Remotion CLI required — `run_command` is stubbed.

Tests that stage into the composer public dir remove what they wrote, verified with `git status` and a directory diff.

Full suite: `937 passed, 9 skipped` (`pytest tests/ --ignore=tests/qa`). Verified against Remotion 4.0.484 on Linux.

## Checklist

- [x] The change is focused on a single logical concern. — one user-visible defect (this render path produces black video); the adapter alone does not fix it, so both parts ship together.
- [x] I ran the relevant tests locally (`pytest tests/ --ignore=tests/qa`).
- [ ] I updated docs/README if behavior or usage changed. — no user-facing API change.
- [x] No unrelated files (build artifacts, local config) are included in the diff.