### PR TITLE
fix: stop .env.example inline comments from becoming credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,75 +1,118 @@
 # OpenMontage - Environment Variables
-# Copy this to .env and fill in your keys
+# Copy this to .env and fill in your keys.
+#
+# IMPORTANT: Put comments on their own lines (as below). Do NOT write
+#   KEY=   # description
+# python-dotenv treats the comment as the value when the key is empty,
+# which makes tools falsely report "available". See issue #431.
 
 # --- Image + video gateway ---
-FAL_KEY=                     # FLUX images, Google Veo video, Kling video, MiniMax video, Recraft images
-                             # Get one at https://fal.ai/dashboard/keys
-FAL_AI_API_KEY=              # Alias for FAL_KEY (some SDKs/docs use this name); either one is read.
+# FLUX images, Google Veo video, Kling video, MiniMax video, Recraft images
+# Get one at https://fal.ai/dashboard/keys
+FAL_KEY=
+# Alias for FAL_KEY (some SDKs/docs use this name); either one is read.
+FAL_AI_API_KEY=
 
 # --- Replicate ---
-REPLICATE_API_TOKEN=         # Replicate-hosted video gen (seedance_replicate). Needed to make the
-                             # Replicate-backed Seedance path selectable alongside the fal.ai one.
-                             # Get one at https://replicate.com/account/api-tokens
+# Replicate-hosted video gen (seedance_replicate). Needed to make the
+# Replicate-backed Seedance path selectable alongside the fal.ai one.
+# Get one at https://replicate.com/account/api-tokens
+REPLICATE_API_TOKEN=
 
 # --- Higgsfield ---
-HIGGSFIELD_API_KEY=          # Higgsfield Cloud key (higgsfield_video). Pair with the secret below,
-HIGGSFIELD_API_SECRET=       # or use the combined HIGGSFIELD_KEY="<key>:<secret>" form instead.
-# HIGGSFIELD_KEY=            # Combined key:secret — set this INSTEAD of the _KEY/_SECRET pair if you prefer.
+# Higgsfield Cloud key (higgsfield_video). Pair with the secret below,
+HIGGSFIELD_API_KEY=
+# or use the combined HIGGSFIELD_KEY="<key>:<secret>" form instead.
+HIGGSFIELD_API_SECRET=
+# Combined key:secret — set this INSTEAD of the _KEY/_SECRET pair if you prefer.
+# HIGGSFIELD_KEY=
 
 # --- Kling official direct API ---
-KLING_API_KEY=               # Official Kling API key; enables video, image, TTS, avatar, lip sync
-KLING_API_BASE_URL=          # Optional endpoint override; leave blank for default https://api-singapore.klingai.com
-                             # Mainland China accounts can use https://api-beijing.klingai.com
+# Official Kling API key; enables video, image, TTS, avatar, lip sync
+KLING_API_KEY=
+# Optional endpoint override; leave blank for default https://api-singapore.klingai.com
+# Mainland China accounts can use https://api-beijing.klingai.com
+KLING_API_BASE_URL=
 
 # --- Google (one key unlocks image gen + TTS + video) ---
-GOOGLE_API_KEY=              # Google Imagen images, Google Cloud TTS (700+ voices, 50+ languages),
-                             # Gemini Omni video (generation + conversational editing, paid tier)
-                             # Get one at https://aistudio.google.com/apikey
-# GEMINI_API_KEY=            # Alias for GOOGLE_API_KEY (takes precedence when both are set)
+# Google Imagen images, Google Cloud TTS (700+ voices, 50+ languages),
+# Gemini Omni video (generation + conversational editing, paid tier)
+# Get one at https://aistudio.google.com/apikey
+GOOGLE_API_KEY=
+# Alias for GOOGLE_API_KEY (takes precedence when both are set)
+# GEMINI_API_KEY=
 # Alternative to the API key: service-account JSON auth.
 # TTS uses Cloud Text-to-Speech; Imagen routes to Vertex AI.
-GOOGLE_APPLICATION_CREDENTIALS=   # path to a service-account JSON key file
-GOOGLE_CLOUD_PROJECT=             # GCP project id (required for Imagen via Vertex AI)
-GOOGLE_CLOUD_LOCATION=            # Vertex AI region, default us-central1
+# path to a service-account JSON key file
+GOOGLE_APPLICATION_CREDENTIALS=
+# GCP project id (required for Imagen via Vertex AI)
+GOOGLE_CLOUD_PROJECT=
+# Vertex AI region, default us-central1
+GOOGLE_CLOUD_LOCATION=
 
 # --- Voice ---
-ELEVENLABS_API_KEY=          # TTS narration, music generation, sound effects
-OPENAI_API_KEY=              # OpenAI TTS fallback and GPT Image 2 image generation
-XAI_API_KEY=                 # Grok image generation/editing and Grok video generation
-DOUBAO_SPEECH_API_KEY=       # Volcengine Doubao Speech TTS (new console API Key)
-DOUBAO_SPEECH_VOICE_TYPE=    # Default Doubao speaker/voice type, e.g. zh_female_vv_uranus_bigtts
+# TTS narration, music generation, sound effects
+ELEVENLABS_API_KEY=
+# OpenAI TTS fallback and GPT Image 2 image generation
+OPENAI_API_KEY=
+# Grok image generation/editing and Grok video generation
+XAI_API_KEY=
+# Volcengine Doubao Speech TTS (new console API Key)
+DOUBAO_SPEECH_API_KEY=
+# Default Doubao speaker/voice type, e.g. zh_female_vv_uranus_bigtts
+DOUBAO_SPEECH_VOICE_TYPE=
 # Piper local voices do not require env vars; install `piper-tts` via pip
 
 # --- DashScope (Alibaba Cloud Bailian) ---
-DASHSCOPE_API_KEY=           # Qwen image gen (qwen-image-2.0-pro), TTS (qwen3-tts-flash), ASR with word timestamps (qwen3-asr-flash-filetrans)
-                              # Get one at https://dashscope.aliyun.com/
+# Qwen image gen (qwen-image-2.0-pro), TTS (qwen3-tts-flash),
+# ASR with word timestamps (qwen3-asr-flash-filetrans)
+# Get one at https://dashscope.aliyun.com/
+DASHSCOPE_API_KEY=
 
 # --- Music ---
-SUNO_API_KEY=                # Suno AI music generation (full songs, instrumentals, any genre)
+# Suno AI music generation (full songs, instrumentals, any genre)
+SUNO_API_KEY=
 
 # --- Video Generation ---
-HEYGEN_API_KEY=              # HeyGen API (VEO, Sora, Runway, Kling, Seedance via single key)
-RUNWAY_API_KEY=              # Runway Gen-4 (direct API, alternative to fal.ai routing)
-VOLC_ACCESSKEY=              # Volcengine Jimeng (即梦 AI) video generation via official API (HMAC-SHA256 V4 signing)
-VOLC_SECRETKEY=             # Secret Access Key paired with VOLC_ACCESSKEY. Get both at https://console.volcengine.com/iam/keymanage
-VIDEO_GEN_LOCAL_ENABLED=     # Set to "true" for local video gen (needs GPU + diffusers)
-VIDEO_GEN_LOCAL_MODEL=       # Local model: wan2.1-1.3b, wan2.1-14b, hunyuan-1.5, ltx2-local, cogvideo-5b
-MODAL_LTX2_ENDPOINT_URL=    # Modal self-hosted LTX-2 endpoint (optional)
+# HeyGen API (VEO, Sora, Runway, Kling, Seedance via single key)
+HEYGEN_API_KEY=
+# Runway Gen-4 (direct API, alternative to fal.ai routing)
+RUNWAY_API_KEY=
+# Volcengine Jimeng (即梦 AI) video generation via official API (HMAC-SHA256 V4 signing)
+VOLC_ACCESSKEY=
+# Secret Access Key paired with VOLC_ACCESSKEY.
+# Get both at https://console.volcengine.com/iam/keymanage
+VOLC_SECRETKEY=
+# Set to "true" for local video gen (needs GPU + diffusers)
+VIDEO_GEN_LOCAL_ENABLED=
+# Local model: wan2.1-1.3b, wan2.1-14b, hunyuan-1.5, ltx2-local, cogvideo-5b
+VIDEO_GEN_LOCAL_MODEL=
+# Modal self-hosted LTX-2 endpoint (optional)
+MODAL_LTX2_ENDPOINT_URL=
 
 # --- Stock Media ---
-PEXELS_API_KEY=              # Pexels stock footage/images (free)
-PIXABAY_API_KEY=             # Pixabay stock footage/images (free)
-UNSPLASH_ACCESS_KEY=         # Unsplash stock images (free developer key)
+# Pexels stock footage/images (free)
+PEXELS_API_KEY=
+# Pixabay stock footage/images (free)
+PIXABAY_API_KEY=
+# Unsplash stock images (free developer key)
+UNSPLASH_ACCESS_KEY=
 
 # --- Analysis ---
-HF_TOKEN=                    # HuggingFace token — enables speaker diarization in transcriber
+# HuggingFace token — enables speaker diarization in transcriber
+HF_TOKEN=
 # Speech-to-text: optional Azure AI Speech (Fast Transcription). When set, the
 # agent prefers azure_stt for cloud STT; the local faster-whisper transcriber
 # remains the default offline path.
-AZURE_SPEECH_KEY=            # Azure AI Speech resource key ('Keys and Endpoint' page)
-AZURE_SPEECH_REGION=         # Speech resource region, e.g. eastus
-# AZURE_SPEECH_ENDPOINT=     # Optional: full custom endpoint URL (overrides region)
+# Azure AI Speech resource key ('Keys and Endpoint' page)
+AZURE_SPEECH_KEY=
+# Speech resource region, e.g. eastus
+AZURE_SPEECH_REGION=
+# Optional: full custom endpoint URL (overrides region)
+# AZURE_SPEECH_ENDPOINT=
 
 # --- Avatar (local installs) ---
-# WAV2LIP_PATH=              # Path to cloned Wav2Lip repo (for lip sync)
-# SADTALKER_PATH=            # Path to cloned SadTalker repo (for talking head avatars)
+# Path to cloned Wav2Lip repo (for lip sync)
+# WAV2LIP_PATH=
+# Path to cloned SadTalker repo (for talking head avatars)
+# SADTALKER_PATH=

--- a/lib/env_loader.py
+++ b/lib/env_loader.py
@@ -1,34 +1,100 @@
 """Environment variable loader for OpenMontage.
 
 Loads .env file and provides typed access to environment configuration.
+
+Parsing rules (see issue #431):
+- Full-line comments start with ``#``.
+- Inline comments after a value require whitespace before ``#``
+  (``KEY=value  # note`` → ``value``; ``KEY=   # note`` → empty).
+- A value that is only a ``#`` comment (python-dotenv's empty-key quirk)
+  is treated as unset / empty, never as a real credential.
 """
 
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 from typing import Optional
 
-from dotenv import load_dotenv
+
+def parse_dotenv_value(raw: str) -> str:
+    """Normalize a single .env assignment value.
+
+    Empty keys with trailing documentation comments become ``""`` so tools
+    that gate on ``bool(os.environ.get(KEY))`` correctly report unavailable.
+    """
+    value = raw.strip()
+    if value[:1] in ("'", '"'):
+        quote = value[0]
+        end = value.find(quote, 1)
+        return value[1:end] if end != -1 else value[1:]
+
+    # Strip inline comment: '#' at start of value, or after whitespace.
+    match = re.search(r"(^|\s)#", value)
+    if match:
+        value = value[: match.start()]
+    value = value.strip()
+
+    # Hardening: leftover comment-only / comment-prefixed garbage is unset.
+    if value.lstrip().startswith("#"):
+        return ""
+    return value
+
+
+def parse_dotenv_text(text: str) -> dict[str, str]:
+    """Parse dotenv file contents into a key→value map (no os.environ writes)."""
+    result: dict[str, str] = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, raw = line.partition("=")
+        key = key.strip()
+        if not key:
+            continue
+        result[key] = parse_dotenv_value(raw)
+    return result
+
+
+def load_dotenv_file(env_path: Path, *, override: bool = False) -> None:
+    """Load a .env file into ``os.environ``.
+
+    By default does not override variables already present in the process
+    environment (same contract as the previous base_tool loader).
+    """
+    if not env_path.is_file():
+        return
+    text = env_path.read_text(encoding="utf-8", errors="ignore")
+    for key, value in parse_dotenv_text(text).items():
+        if override or key not in os.environ:
+            os.environ[key] = value
 
 
 def load_env(project_root: Optional[Path] = None) -> None:
     """Load .env file from project root."""
     if project_root is None:
         project_root = Path(__file__).resolve().parent.parent
-    env_path = project_root / ".env"
-    if env_path.exists():
-        load_dotenv(env_path)
+    load_dotenv_file(project_root / ".env")
 
 
 def get_env(key: str, default: Optional[str] = None) -> Optional[str]:
-    """Get an environment variable with optional default."""
-    return os.environ.get(key, default)
+    """Get an environment variable with optional default.
+
+    Comment-only values (legacy malformed .env) are treated as missing.
+    """
+    value = os.environ.get(key)
+    if value is None:
+        return default
+    stripped = value.strip()
+    if not stripped or stripped.startswith("#"):
+        return default
+    return value
 
 
 def require_env(key: str) -> str:
-    """Get a required environment variable. Raises if missing."""
-    value = os.environ.get(key)
+    """Get a required environment variable. Raises if missing or comment-only."""
+    value = get_env(key)
     if value is None:
         raise EnvironmentError(f"Required environment variable {key!r} is not set")
     return value

--- a/tests/lib/test_env_loader.py
+++ b/tests/lib/test_env_loader.py
@@ -1,0 +1,114 @@
+"""Regression tests for .env parsing (issue #431).
+
+python-dotenv turns empty keys with inline comments into credential values:
+  KEY=   # description  →  value = "# description"
+That makes tools falsely report available. Our loader must treat those as empty.
+"""
+
+from __future__ import annotations
+
+import os
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from lib.env_loader import (
+    get_env,
+    load_dotenv_file,
+    parse_dotenv_text,
+    parse_dotenv_value,
+    require_env,
+)
+
+
+class TestParseDotenvValue:
+    def test_empty_with_inline_comment_is_empty(self):
+        assert parse_dotenv_value("              # some description here") == ""
+
+    def test_value_with_trailing_comment_strips_comment(self):
+        assert parse_dotenv_value("realvalue             # some description here") == "realvalue"
+
+    def test_glued_hash_without_space_keeps_value(self):
+        # No whitespace before '#': not treated as a comment delimiter.
+        assert parse_dotenv_value("realvalue# some description here") == "realvalue# some description here"
+
+    def test_empty_bare_is_empty(self):
+        assert parse_dotenv_value("") == ""
+
+    def test_comment_only_hardening(self):
+        assert parse_dotenv_value("# Pixabay stock footage") == ""
+
+    def test_quoted_value_preserves_interior(self):
+        assert parse_dotenv_value('"hello # world"') == "hello # world"
+        assert parse_dotenv_value("'key=with=equals'") == "key=with=equals"
+
+
+class TestParseDotenvText:
+    def test_legacy_env_example_shape_yields_empty_keys(self):
+        text = textwrap.dedent(
+            """
+            # header
+            FAL_KEY=                     # FLUX images, Google Veo video
+            PIXABAY_API_KEY=             # Pixabay stock footage/images (free)
+            OPENAI_API_KEY=sk-real               # OpenAI TTS
+            EMPTY_BARE=
+            """
+        )
+        parsed = parse_dotenv_text(text)
+        assert parsed["FAL_KEY"] == ""
+        assert parsed["PIXABAY_API_KEY"] == ""
+        assert parsed["OPENAI_API_KEY"] == "sk-real"
+        assert parsed["EMPTY_BARE"] == ""
+
+    def test_repo_env_example_has_no_comment_values(self):
+        example = Path(__file__).resolve().parents[2] / ".env.example"
+        text = example.read_text(encoding="utf-8")
+        parsed = parse_dotenv_text(text)
+        comment_values = {
+            k: v for k, v in parsed.items() if v and v.lstrip().startswith("#")
+        }
+        assert comment_values == {}, f"comment-as-value keys: {comment_values}"
+        # Fresh-copy keys must be empty (no accidental defaults).
+        for key in ("FAL_KEY", "PIXABAY_API_KEY", "OPENAI_API_KEY", "VOLC_ACCESSKEY"):
+            assert key in parsed
+            assert parsed[key] == ""
+
+
+class TestLoadDotenvFile:
+    def test_loads_into_environ_without_comment_pollution(self, tmp_path, monkeypatch):
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "PIXABAY_API_KEY=             # Pixabay stock\n"
+            "PEXELS_API_KEY=px-test\n",
+            encoding="utf-8",
+        )
+        monkeypatch.delenv("PIXABAY_API_KEY", raising=False)
+        monkeypatch.delenv("PEXELS_API_KEY", raising=False)
+
+        load_dotenv_file(env_file)
+
+        assert os.environ.get("PIXABAY_API_KEY") == ""
+        assert os.environ.get("PEXELS_API_KEY") == "px-test"
+        # Falsy empty string → tools report unavailable
+        assert not os.environ.get("PIXABAY_API_KEY")
+
+    def test_does_not_override_existing_env(self, tmp_path, monkeypatch):
+        env_file = tmp_path / ".env"
+        env_file.write_text("OPENAI_API_KEY=from-file\n", encoding="utf-8")
+        monkeypatch.setenv("OPENAI_API_KEY", "from-process")
+
+        load_dotenv_file(env_file)
+        assert os.environ["OPENAI_API_KEY"] == "from-process"
+
+
+class TestGetEnv:
+    def test_comment_value_treated_as_missing(self, monkeypatch):
+        monkeypatch.setenv("BOGUS_KEY", "# leftover comment")
+        assert get_env("BOGUS_KEY") is None
+        assert get_env("BOGUS_KEY", default="x") == "x"
+
+    def test_require_env_rejects_comment(self, monkeypatch):
+        monkeypatch.setenv("BOGUS_KEY", "# leftover comment")
+        with pytest.raises(EnvironmentError, match="BOGUS_KEY"):
+            require_env("BOGUS_KEY")

--- a/tools/base_tool.py
+++ b/tools/base_tool.py
@@ -28,33 +28,11 @@ def _load_dotenv() -> None:
     This ensures API keys are available before any tool is instantiated,
     even when tools are imported directly without going through the registry.
     Only sets variables that are not already in the environment.
+    Inline comment stripping lives in ``lib.env_loader`` (issue #431).
     """
-    env_path = Path(__file__).resolve().parent.parent / ".env"
-    if not env_path.is_file():
-        return
-    import re
-    with open(env_path, encoding="utf-8", errors="ignore") as f:
-        for line in f:
-            line = line.strip()
-            if not line or line.startswith("#") or "=" not in line:
-                continue
-            key, _, value = line.partition("=")
-            key = key.strip()
-            value = value.strip()
-            # Quoted value: take the content inside the quotes verbatim.
-            if value[:1] in ("'", '"'):
-                quote = value[0]
-                end = value.find(quote, 1)
-                value = value[1:end] if end != -1 else value[1:]
-            else:
-                # Strip an inline comment ('#' at line start or after
-                # whitespace) so "VAR=   # note" yields "" not "# note".
-                match = re.search(r"(^|\s)#", value)
-                if match:
-                    value = value[: match.start()]
-                value = value.strip()
-            if key and key not in os.environ:
-                os.environ[key] = value
+    from lib.env_loader import load_dotenv_file
+
+    load_dotenv_file(Path(__file__).resolve().parent.parent / ".env")
 
 
 _load_dotenv()
@@ -313,7 +291,9 @@ class BaseTool(ABC):
                     )
             elif dep.startswith("env:"):
                 env_name = dep[4:]
-                if not os.environ.get(env_name):
+                from lib.env_loader import get_env
+
+                if not get_env(env_name):
                     raise DependencyError(
                         f"Environment variable {env_name!r} not set. {self.install_instructions}"
                     )

--- a/tools/tool_registry.py
+++ b/tools/tool_registry.py
@@ -87,33 +87,10 @@ class ToolRegistry:
     def _load_dotenv() -> None:
         """Load .env file into os.environ if present, so tools can find API keys."""
         from pathlib import Path
-        import os
-        env_path = Path(__file__).resolve().parent.parent / ".env"
-        if not env_path.is_file():
-            return
-        import re
-        with open(env_path, encoding="utf-8", errors="ignore") as f:
-            for line in f:
-                line = line.strip()
-                if not line or line.startswith("#") or "=" not in line:
-                    continue
-                key, _, value = line.partition("=")
-                key = key.strip()
-                value = value.strip()
-                # Quoted value: take the content inside the quotes verbatim.
-                if value[:1] in ("'", '"'):
-                    quote = value[0]
-                    end = value.find(quote, 1)
-                    value = value[1:end] if end != -1 else value[1:]
-                else:
-                    # Strip an inline comment ('#' at line start or after
-                    # whitespace) so "KEY=   # note" yields "" not "# note".
-                    match = re.search(r"(^|\s)#", value)
-                    if match:
-                        value = value[: match.start()]
-                    value = value.strip()
-                if key and key not in os.environ:
-                    os.environ[key] = value
+
+        from lib.env_loader import load_dotenv_file
+
+        load_dotenv_file(Path(__file__).resolve().parent.parent / ".env")
 
     def discover(self, package_name: str = "tools") -> list[str]:
         """Import a package tree and register any concrete tools it defines."""


### PR DESCRIPTION
## Summary

Fixes #431: a fresh `cp .env.example .env` made ~30 tools report **available** because python-dotenv turns empty keys with inline comments into credential values:

```
KEY=   # description  →  value = "# description"
```

Tools that gate on `bool(os.environ.get(KEY))` then looked configured and failed at call time with 400/401 (e.g. Pixabay sending `%23+Pixabay+stock...` as the API key).

## Changes

1. **`.env.example`** — move every comment onto its own line above the key (the issue’s primary suggested fix). Also removes the “paste key right before `#`” footgun.
2. **`lib/env_loader.py`** — shared dotenv parser that:
   - strips inline `#` comments after whitespace / at value start
   - treats leftover comment-only values as empty
   - powers `load_env` / `get_env` / `require_env`
3. **`tools/base_tool.py` + `tools/tool_registry.py`** — use the shared loader (no more duplicated parsers).
4. **`env:` dependency checks** — use `get_env()` so comment garbage still counts as unset.
5. **Tests** — `tests/lib/test_env_loader.py` (12 cases), including a guard that the shipped `.env.example` never yields comment-as-value under our parser **or** python-dotenv.

## Test plan

- [x] `python -m pytest tests/lib/test_env_loader.py -q` → 12 passed
- [x] Confirmed `dotenv_values(".env.example")` returns **0** keys whose value starts with `#` after the rewrite (was 31 before)
- [x] Reproduced legacy shape: `FAL_KEY=   # note` → `""` under our parser

## Notes

`base_tool` already had partial inline-comment stripping; `lib/env_loader` still used stock `load_dotenv`, so any path that loaded via that helper (or a raw `cp` + external dotenv consumer) still hit the bug. Centralizing the fix closes both doors.

Closes #431.