### PR TITLE
fix(audio_mixer): let full_mix pin the exact composition length (target_duration)

### DIFF
--- a/tests/tools/test_audio_mixer_target_duration.py
+++ b/tests/tools/test_audio_mixer_target_duration.py
@@ -1,0 +1,122 @@
+"""Regression tests for audio_mixer full_mix target_duration (issue #361).
+
+full_mix builds its final stage with amix=...:duration=longest, but the
+ducked-music branch is gated behind the speech sidechain, so "longest" tracks
+the speech bus and the music tail past the last narration is dropped. A caller
+that knows its video length had no way to state it, so the mixed audio ended
+early (a 6s music bed under 2s of narration produced a 2s mix). target_duration
+pads with silence and hard-trims so the output is exactly the composition
+length, while an unset target keeps the historical behavior.
+"""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.audio.audio_mixer import AudioMixer  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None,
+    reason="ffmpeg/ffprobe required for full_mix duration tests",
+)
+
+
+def _sine(path: Path, freq: int, dur: int) -> None:
+    subprocess.run(
+        ["ffmpeg", "-y", "-f", "lavfi", "-i", f"sine=frequency={freq}:duration={dur}", str(path)],
+        capture_output=True,
+        check=True,
+        timeout=30,
+    )
+
+
+def _duration(path: Path) -> float:
+    out = subprocess.run(
+        ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+         "-of", "csv=p=0", str(path)],
+        capture_output=True, text=True, timeout=30,
+    )
+    return float(out.stdout.strip())
+
+
+def _tracks(tmp_path: Path):
+    speech, music = tmp_path / "speech.wav", tmp_path / "music.wav"
+    _sine(speech, 440, 2)  # narration ends at 2s
+    _sine(music, 220, 6)   # music bed runs to 6s
+    return [
+        {"path": str(speech), "role": "speech"},
+        {"path": str(music), "role": "music"},
+    ]
+
+
+def test_target_duration_preserves_music_tail_past_speech(tmp_path):
+    # Without target_duration the ducking graph truncates to the 2s speech bus.
+    # Stating the 6s composition length must keep the full music tail.
+    out = tmp_path / "mixed.wav"
+    result = AudioMixer().execute(
+        {
+            "operation": "full_mix",
+            "tracks": _tracks(tmp_path),
+            "ducking": {"enabled": True},
+            "target_duration": 6,
+            "output_path": str(out),
+        }
+    )
+    assert result.success is True, result.error
+    assert result.data["target_duration"] == 6
+    assert _duration(out) == pytest.approx(6.0, abs=0.15)
+
+
+def test_target_duration_pads_when_longer_than_all_tracks(tmp_path):
+    # Target beyond every input must pad with silence, not clamp to the longest.
+    out = tmp_path / "padded.wav"
+    result = AudioMixer().execute(
+        {
+            "operation": "full_mix",
+            "tracks": _tracks(tmp_path),
+            "ducking": {"enabled": True},
+            "target_duration": 9,
+            "output_path": str(out),
+        }
+    )
+    assert result.success is True, result.error
+    assert _duration(out) == pytest.approx(9.0, abs=0.15)
+
+
+def test_unset_target_duration_keeps_legacy_length(tmp_path):
+    # Backward compatibility: with no target the output still follows the
+    # surviving bus (2s here), and the reported target_duration is None.
+    out = tmp_path / "legacy.wav"
+    result = AudioMixer().execute(
+        {
+            "operation": "full_mix",
+            "tracks": _tracks(tmp_path),
+            "ducking": {"enabled": True},
+            "output_path": str(out),
+        }
+    )
+    assert result.success is True, result.error
+    assert result.data["target_duration"] is None
+    assert _duration(out) == pytest.approx(2.0, abs=0.15)
+
+
+def test_target_duration_without_ducking(tmp_path):
+    # The non-ducking amix path must honor target_duration too.
+    out = tmp_path / "noduck.wav"
+    result = AudioMixer().execute(
+        {
+            "operation": "full_mix",
+            "tracks": _tracks(tmp_path),
+            "ducking": {"enabled": False},
+            "target_duration": 6,
+            "output_path": str(out),
+        }
+    )
+    assert result.success is True, result.error
+    assert _duration(out) == pytest.approx(6.0, abs=0.15)

--- a/tools/audio/audio_mixer.py
+++ b/tools/audio/audio_mixer.py
@@ -184,6 +184,17 @@ class AudioMixer(BaseTool):
                 "default": 0.5,
                 "description": "Duration of fade in/out at segment boundaries (seconds).",
             },
+            "target_duration": {
+                "type": "number",
+                "minimum": 0,
+                "description": (
+                    "full_mix only. Exact output length in seconds. When set, the "
+                    "mix is padded with silence and trimmed to this duration, so the "
+                    "output matches the video cut regardless of which bus survives "
+                    "the ducking graph. When omitted, output length follows the "
+                    "longest surviving bus, which sidechain ducking can shorten."
+                ),
+            },
         },
     }
 
@@ -596,12 +607,28 @@ class AudioMixer(BaseTool):
                 f"{all_labels}amix=inputs={len(all_tracks)}:duration=longest:dropout_transition=2[premix]"
             )
 
+        # Enforce an exact composition length when the caller states one. The
+        # ducking graph's final amix uses duration=longest, but the ducked-music
+        # branch is gated behind the speech sidechain, so "longest" tracks the
+        # speech bus and the music tail past the last narration is dropped. Pad
+        # with silence then hard-trim so the output is exactly target_duration —
+        # apad extends a short mix, atrim caps a long one. Done before loudnorm
+        # so the trailing silence is shaped by the same normalization pass.
+        premix_label = "premix"
+        target_duration = inputs.get("target_duration")
+        if target_duration is not None:
+            target = float(target_duration)
+            filter_parts.append(
+                f"[premix]apad,atrim=0:{target},asetpts=PTS-STARTPTS[premix_dur]"
+            )
+            premix_label = "premix_dur"
+
         # Normalize
         if normalize:
-            filter_parts.append(self._loudnorm_filter(inputs, "premix", "out"))
+            filter_parts.append(self._loudnorm_filter(inputs, premix_label, "out"))
             out_label = "[out]"
         else:
-            out_label = "[premix]"
+            out_label = f"[{premix_label}]"
 
         filter_complex = ";".join(p for p in filter_parts if p)
 
@@ -621,6 +648,7 @@ class AudioMixer(BaseTool):
                 "sfx_tracks": len(sfx_tracks),
                 "ducking_enabled": duck_enabled,
                 "normalized": normalize,
+                "target_duration": target_duration,
                 "output": str(output_path),
             },
             artifacts=[str(output_path)],


### PR DESCRIPTION
## What

`full_mix` builds every stage with `amix=...:duration=longest`, but the ducked-music branch is gated behind the speech sidechain (`asplit` → `sidechaincompress`). So the final mix's "longest" tracks the **speech** bus, and the music tail past the last narration is dropped — the mix ends early and the rest of the video is silent. There was no way to state the composition's length; output was an emergent property of the mix graph.

Reproduced on `main` (2s narration under a 6s music bed, ducking on):

```
full_mix → output duration 2.000s   # music tail 2s→6s lost
```

## Fix

Add an optional `target_duration` (seconds) to `full_mix`. When set, the premix is padded with silence and hard-trimmed to that length before loudnorm:

```
[premix]apad,atrim=0:<target>,asetpts=PTS-STARTPTS[premix_dur]
```

- `apad` extends a mix that ends early; `atrim` caps one that runs long — output is *exactly* `target_duration` either way.
- Applied **before** loudnorm so the trailing silence is shaped by the same normalization pass.
- Honored on both the ducking and non-ducking paths.
- **Unset target keeps the historical behavior** (length follows the longest surviving bus) — fully backward compatible. The schema note documents that ducking can shorten that length.

After the fix, same inputs:

| call | output |
|------|--------|
| `target_duration: 6`, ducking | 6.0s (music tail preserved) |
| `target_duration: 9` (> all inputs) | 9.0s (padded) |
| unset | 2.0s (unchanged) |
| `target_duration: 6`, no ducking | 6.0s |

## Tests

`tests/tools/test_audio_mixer_target_duration.py` — real ffmpeg/ffprobe, gated on their presence like the sibling suites. Covers tail-preservation, pad-up-when-longer, the non-ducking path, and the unset legacy length. Reverting the source drops the three target assertions to red; restoring returns them green. Full audio_mixer suite (16 tests) passes.

Closes #361