### PR TITLE
fix(transcriber): detect CUDA via CTranslate2, not torch

### DIFF
--- a/tools/analysis/transcriber.py
+++ b/tools/analysis/transcriber.py
@@ -135,50 +135,78 @@ class Transcriber(BaseTool):
 
         start = time.time()
 
-        # Load model (CPU by default, CUDA if available)
+        # Load model (CPU by default, CUDA if available).
+        # faster-whisper runs on CTranslate2, not torch, so CTranslate2 is the
+        # authority on whether a usable CUDA device exists. Probing torch here
+        # silently forced CPU on any machine with a GPU but no torch installed.
+        device = "cpu"
+        compute_type = "int8"
         try:
-            import torch
-            device = "cuda" if torch.cuda.is_available() else "cpu"
-            compute_type = "float16" if device == "cuda" else "int8"
-        except ImportError:
+            import ctranslate2
+
+            if ctranslate2.get_cuda_device_count() > 0:
+                supported = ctranslate2.get_supported_compute_types("cuda")
+                for candidate in ("float16", "int8_float16", "float32"):
+                    if candidate in supported:
+                        device = "cuda"
+                        compute_type = candidate
+                        break
+        except Exception:
+            pass
+
+        def _transcribe_on(dev: str, ctype: str):
+            """Build the model and fully drain the segment iterator.
+
+            Draining here is deliberate: faster-whisper is lazy, so a CUDA
+            install that is advertised but broken (driver present, cuBLAS/cuDNN
+            missing) raises during iteration rather than at construction.
+            """
+            mdl = WhisperModel(model_size, device=dev, compute_type=ctype)
+            seg_iter, inf = mdl.transcribe(
+                str(input_path),
+                language=language,
+                word_timestamps=True,
+                vad_filter=True,
+            )
+
+            segs: list[dict[str, Any]] = []
+            words_flat: list[dict[str, Any]] = []
+
+            for seg in seg_iter:
+                seg_data = {
+                    "id": seg.id,
+                    "start": round(seg.start, 3),
+                    "end": round(seg.end, 3),
+                    "text": seg.text.strip(),
+                }
+
+                if seg.words:
+                    words = []
+                    for w in seg.words:
+                        word_entry = {
+                            "word": w.word,
+                            "start": round(w.start, 3),
+                            "end": round(w.end, 3),
+                            "probability": round(w.probability, 3),
+                        }
+                        words.append(word_entry)
+                        words_flat.append(word_entry)
+                    seg_data["words"] = words
+
+                segs.append(seg_data)
+
+            return segs, words_flat, inf
+
+        gpu_fallback_reason = None
+        try:
+            segments, word_timestamps, info = _transcribe_on(device, compute_type)
+        except Exception as exc:
+            if device == "cpu":
+                raise
+            gpu_fallback_reason = f"{type(exc).__name__}: {exc}"
             device = "cpu"
             compute_type = "int8"
-
-        model = WhisperModel(model_size, device=device, compute_type=compute_type)
-
-        # Transcribe
-        segments_iter, info = model.transcribe(
-            str(input_path),
-            language=language,
-            word_timestamps=True,
-            vad_filter=True,
-        )
-
-        segments = []
-        word_timestamps = []
-
-        for seg in segments_iter:
-            seg_data = {
-                "id": seg.id,
-                "start": round(seg.start, 3),
-                "end": round(seg.end, 3),
-                "text": seg.text.strip(),
-            }
-
-            if seg.words:
-                words = []
-                for w in seg.words:
-                    word_entry = {
-                        "word": w.word,
-                        "start": round(w.start, 3),
-                        "end": round(w.end, 3),
-                        "probability": round(w.probability, 3),
-                    }
-                    words.append(word_entry)
-                    word_timestamps.append(word_entry)
-                seg_data["words"] = words
-
-            segments.append(seg_data)
+            segments, word_timestamps, info = _transcribe_on(device, compute_type)
 
         detected_language = language or info.language
         duration = info.duration
@@ -198,6 +226,7 @@ class Transcriber(BaseTool):
             "duration_seconds": round(duration, 3),
             "model_size": model_size,
             "device": device,
+            "gpu_fallback_reason": gpu_fallback_reason,
         }
 
         # Write transcript JSON


### PR DESCRIPTION
## Problem

`transcriber` picks its execution device by asking **torch**:

```python
try:
    import torch
    device = "cuda" if torch.cuda.is_available() else "cpu"
    compute_type = "float16" if device == "cuda" else "int8"
except ImportError:
    device = "cpu"
    compute_type = "int8"
```

But the tool's only declared dependency is `python:faster_whisper`, and faster-whisper runs on **CTranslate2**, not torch. Torch is never installed by the project and plays no part in the inference.

So on a machine with a perfectly good GPU but no torch, `import torch` raises `ImportError` and the tool pins itself to CPU `int8` — roughly a 10x slowdown. It happens silently: no warning is logged, and the returned `device` field is the only hint, which reads like a deliberate choice rather than a failed probe.

I hit this on a box with an RTX 5070 where `ctranslate2.get_cuda_device_count()` returns `1` and `get_supported_compute_types("cuda")` includes `float16`, yet every transcription ran on CPU. Whisper `large-v3` had even been pre-downloaded in an earlier attempt to improve accuracy — it just kept running on the CPU regardless of model size.

## Fix

Ask CTranslate2, since it is the engine doing the work, and select the best compute type it reports as supported.

## Second, subtler problem

A CUDA device can be advertised by the driver while the CUDA **runtime libraries** are missing — a very common Windows state where the driver is installed but cuBLAS is not. Guarding only the model constructor does not catch this, because faster-whisper's segment iterator is lazy: `WhisperModel(...)` succeeds, and the failure only surfaces once iteration triggers `model.encode()`.

Naively switching the probe to CTranslate2 therefore turns a silent slowdown into a hard crash on those machines — strictly worse. So transcription now runs inside a helper that fully drains the iterator, and any GPU failure retries on CPU, recording the cause in a new `gpu_fallback_reason` output field. Degradation stays visible instead of silent.

## Verification

On a machine where the driver reports one CUDA device but cuBLAS is absent:

**Before** — CPU, no explanation:
```
device: cpu
```

**After** — attempts CUDA, falls back, reports why:
```
device usato : cpu
fallback     : RuntimeError: Library cublas64_12.dll is not found or cannot be loaded
```

On a machine with a complete CUDA runtime, the same code path selects `cuda` / `float16` and `gpu_fallback_reason` stays `None`.

Existing contract tests pass (87 in `tests/contracts/test_phase1_contracts.py` and `tests/tools/test_azure_stt.py`, the two suites referencing this tool).

## Notes

- No new dependency: `ctranslate2` is already a transitive requirement of `faster-whisper`.
- The probe is wrapped in `try/except` so a missing or unusual CTranslate2 build degrades to CPU rather than raising.
- Out of scope, but flagging it: the WhisperX alignment and diarization passes further down are still hardcoded to `device="cpu"`. Happy to open a separate PR if that is wanted.
