### PR TITLE
chore(gitignore): ignore per-run pipeline checkpoints at the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,17 @@ htmlcov/
 # Pipeline outputs (regenerable — never commit large media)
 output/
 pipeline/
+# Per-run checkpoints + decision logs written by the checkpoint protocol to
+# pipelines/<project_id>/ (see AGENT_GUIDE "Human Checkpoint Protocol"). These
+# are regenerable run state, not source — the singular pipeline/ rule above
+# does not match this plural path.
+#
+# Anchored to the repo root on purpose: an unanchored `pipelines/` matches a
+# directory of that name at ANY depth, which also swallowed skills/pipelines/
+# (every stage director skill) and tests/pipelines/. Tracked files there stay
+# tracked, so nothing breaks visibly — but a NEW director skill would be
+# silently unstageable, which is a bad way to lose work.
+/pipelines/
 tests/qa/output/
 
 # Project workspaces (generated assets, renders — all regenerable)


### PR DESCRIPTION
## Summary

The checkpoint protocol writes per-run checkpoints and decision logs to `pipelines/<project_id>/` (AGENT_GUIDE, "Human Checkpoint Protocol"). That path isn't ignored — the existing `pipeline/` rule is singular and doesn't match it — so every production run leaves regenerable run state in `git status`.

The rule is **anchored** (`/pipelines/`) rather than bare. An unanchored `pipelines/` matches a directory of that name at *any* depth, which would also swallow `skills/pipelines/` (all 103 tracked stage director skills) and `tests/pipelines/`. Already-tracked files there keep working normally, so nothing looks broken — but a **newly added director skill would be silently unstageable**, which is an easy way to lose work without noticing.

## Related issue

No linked issue.

## Changes

- Ignore `/pipelines/` — per-run checkpoint state at the repo root only.
- Comment explaining why the rule is anchored, so it doesn't get "simplified" back to `pipelines/` later.

## Testing

- Verified both directions empirically: a file created at `pipelines/<run>/checkpoint.json` is ignored, while new files at `skills/pipelines/cinematic/` and `tests/pipelines/` still show up as untracked.
- `git check-ignore -v` confirmed the bare rule matched `skills/pipelines/...` before the fix and no longer does.
- Full suite: 899 passed, 11 skipped. The 12 failures in `tests/contracts/test_phase3_contracts.py` are pre-existing and environmental (`No module named 'google.genai'` locally); they reproduce identically on unmodified `main`, and CI installs the package via `make install-dev`.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [x] I updated docs/README if behavior or usage changed.
- [x] No unrelated files (build artifacts, local config) are included in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
