### PR TITLE
feat(publish): FcpxmlExport — editorial timeline hand-off to DaVinci Resolve

### DIFF
--- a/pipeline_defs/cinematic.yaml
+++ b/pipeline_defs/cinematic.yaml
@@ -262,13 +262,14 @@ stages:
       - script
     produces:
       - publish_log
-    tools_available: []
+    tools_available: [export_bundle, fcpxml_export]
     checkpoint_required: true
     human_approval_default: true
     review_focus:
       - Hero export and derivative exports are clearly labeled
       - Metadata matches the tone and distribution intent
       - Poster-frame or thumbnail concept is coherent
+      - If an editorial hand-off was requested, the FCPXML timeline is exported alongside the flat render
     success_criteria:
       - Schema-valid publish_log artifact
       - Export package contains video and metadata outputs

--- a/skills/pipelines/cinematic/publish-director.md
+++ b/skills/pipelines/cinematic/publish-director.md
@@ -49,11 +49,38 @@ Store in `publish_log.metadata`:
 - metadata fits the tone,
 - the package is usable without manual cleanup.
 
+## Editorial Hand-off (FCPXML)
+
+`export_bundle` packages the **finished render** for platform upload. When the user
+wants to keep cutting — colour grading, finishing, or reworking the edit in DaVinci
+Resolve or Final Cut Pro — also run `fcpxml_export`, which emits an **editable
+timeline** instead of a locked flat file:
+
+```
+registry.get("fcpxml_export").execute({"project_dir": "projects/<project-id>"})
+```
+
+Offer it whenever the brief mentions grading, finishing, or "I'll edit it myself".
+The two are complementary, not alternatives — a hand-off usually ships both.
+
+Things worth telling the user:
+
+- **Grid scenes survive** as multi-track connected clips, so a 2-up or 3-up stays
+  editable per-cell. Only 2-up and 3-up have verified Resolve transforms — wider
+  grids raise rather than emit a silently-wrong timeline.
+- **The sequence format follows the footage** (frame rate and resolution of the
+  first source clip). Pass `fps`/`width`/`height` to override when the deliverable
+  differs from the source.
+- **Check `sdr_substitutions` in the result.** Any clip listed there points at a
+  transcoded SDR copy rather than the original Dolby Vision file — mention it, since
+  the editor will want to relink to the originals before grading.
+
 ## Common Pitfalls
 
 - Mixing teaser and hero outputs without clear naming.
 - Writing generic metadata that ignores the mood.
 - Treating all cutdowns as interchangeable.
+- Shipping only the flat render when the user asked to finish the edit themselves.
 
 ---
 

--- a/tests/tools/test_fcpxml_export.py
+++ b/tests/tools/test_fcpxml_export.py
@@ -1,0 +1,301 @@
+"""Tests for the fcpxml_export publisher tool.
+
+Covers the tool contract, the FCPXML timeline structure for solo and grid
+scenes, and the error paths.
+
+The grid numbers asserted here (positions, crop percentages, the always-"1 1"
+scale) were reverse-engineered from a timeline positioned by hand in DaVinci
+Resolve and exported back out — Resolve's internal position unit space is not
+the 1920x1080 canvas and its conversion isn't publicly documented. They cannot
+be re-derived analytically, so these tests exist to pin them: if someone
+"simplifies" the transform recipe, grid scenes silently stop compositing in
+Resolve and only a manual import would reveal it.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+from tools.base_tool import ToolStatus, ToolTier
+from tools.publishers.fcpxml_export import build_fcpxml, export_project_to_fcpxml
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffprobe") is None or shutil.which("ffmpeg") is None,
+    reason="ffmpeg/ffprobe not available",
+)
+
+
+def _make_clip(path: Path, seconds: int = 2, with_audio: bool = False) -> None:
+    cmd = ["ffmpeg", "-y", "-f", "lavfi", "-i",
+           f"color=c=teal:s=320x240:d={seconds}:r=30"]
+    if with_audio:
+        cmd += ["-f", "lavfi", "-i", f"anullsrc=r=44100:cl=stereo:d={seconds}",
+                "-shortest", "-c:a", "aac"]
+    cmd += ["-c:v", "libx264", "-crf", "40", "-pix_fmt", "yuv420p", str(path)]
+    subprocess.run(cmd, capture_output=True, check=True)
+
+
+@pytest.fixture(scope="module")
+def clips(tmp_path_factory) -> dict[str, str]:
+    """Three real 2-second clips, keyed by the bare filename scene_plan uses."""
+    d = tmp_path_factory.mktemp("clips")
+    paths = {}
+    for name in ("a.mp4", "b.mp4", "c.mp4"):
+        p = d / name
+        _make_clip(p, with_audio=(name == "a.mp4"))
+        paths[name] = str(p)
+    return paths
+
+
+def _scene(scene_id: str, start: float, end: float, *filenames: str) -> dict:
+    return {
+        "id": scene_id,
+        "start_seconds": start,
+        "end_seconds": end,
+        "required_assets": [{"path": f} for f in filenames],
+    }
+
+
+def _make_project(
+    root: Path, fps: int = 30, w: int = 320, h: int = 240, seconds: int = 2
+) -> Path:
+    """A minimal project workspace: one source clip + the two artifacts."""
+    proj = root / "projects" / "demo"
+    (proj / "artifacts").mkdir(parents=True)
+    src = root / "footage" / "shot.mp4"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["ffmpeg", "-y", "-f", "lavfi", "-i",
+         f"color=c=teal:s={w}x{h}:d={seconds}:r={fps}",
+         "-c:v", "libx264", "-crf", "40", "-pix_fmt", "yuv420p", str(src)],
+        capture_output=True, check=True,
+    )
+    (proj / "artifacts" / "scene_plan.json").write_text(json.dumps({
+        "scenes": [_scene("cut-1", 0.0, float(seconds), "shot.mp4")]
+    }))
+    (proj / "artifacts" / "asset_manifest.json").write_text(json.dumps({
+        "assets": [{"type": "video", "path": str(src)}]
+    }))
+    return proj
+
+
+def test_contract_metadata():
+    from tools.publishers.fcpxml_export import FcpxmlExport
+
+    tool = FcpxmlExport()
+    info = tool.get_info()
+    assert info["name"] == "fcpxml_export"
+    assert info["capability"] == "publish"
+    assert info["tier"] == ToolTier.PUBLISH.value
+    assert info["provider"] == "fcpxml"
+    assert info["resource_profile"]["network_required"] is False
+    assert tool.get_status() == ToolStatus.AVAILABLE
+    assert tool.estimate_cost({}) == 0.0
+
+
+def test_registry_discovers_the_tool():
+    from tools.tool_registry import ToolRegistry
+
+    registry = ToolRegistry()
+    registry.discover()
+    names = {t.name for t in registry.get_by_capability("publish")}
+    assert "fcpxml_export" in names
+
+
+def test_cinematic_publish_stage_offers_the_tool():
+    """An agent only uses what the stage's tools_available declares, so a tool
+    absent from every manifest is unreachable through the documented path no
+    matter that the registry can see it."""
+    import yaml
+
+    manifest = yaml.safe_load(
+        (PROJECT_ROOT / "pipeline_defs" / "cinematic.yaml").read_text()
+    )
+    publish = next(s for s in manifest["stages"] if s["name"] == "publish")
+    assert "fcpxml_export" in publish["tools_available"]
+
+
+def test_solo_scene_becomes_a_spine_clip(clips):
+    xml = build_fcpxml(
+        [_scene("cut-1", 0.0, 2.0, "a.mp4")], clips, None, None, "demo"
+    )
+    assert '<format id="r1" name="FFVideoFormat1080p30"' in xml
+    assert 'frameDuration="1/30s" width="1920" height="1080"' in xml
+    # 2 seconds at 30fps == 60 frames
+    assert 'offset="0/30s" duration="60/30s"' in xml
+    assert 'lane=' not in xml
+
+
+def test_fps_and_resolution_are_configurable(clips):
+    """A 25fps vertical project must not be described as 1920x1080@30.
+
+    Every timeline time in FCPXML is a rational over the frame rate, so a
+    hardcoded 30 silently retimes 24/25/50/60fps footage on import.
+    """
+    xml = build_fcpxml(
+        [_scene("cut-1", 0.0, 2.0, "a.mp4")], clips, None, None, "demo",
+        fps=25, width=1080, height=1920,
+    )
+    assert 'frameDuration="1/25s" width="1080" height="1920"' in xml
+    # 2 seconds at 25fps == 50 frames, not 60
+    assert 'duration="50/25s"' in xml
+    assert "/30s" not in xml
+
+
+def test_export_detects_fps_and_resolution_from_the_source(tmp_path):
+    """The sequence format should follow the footage, not a hardcoded default.
+
+    Handing 25fps footage to Resolve inside a 30fps sequence conforms every
+    clip on import, which shifts every downstream cut.
+    """
+    proj = _make_project(tmp_path, fps=25, w=640, h=480)
+    out_path, _, _ = export_project_to_fcpxml(proj)
+    xml = Path(out_path).read_text()
+    assert 'frameDuration="1/25s" width="640" height="480"' in xml
+
+
+def test_execute_accepts_an_explicit_format_override(tmp_path):
+    """Source-derived format is a default, not a mandate — a 4K source may
+    still be finished in a 1080p sequence."""
+    from tools.publishers.fcpxml_export import FcpxmlExport
+
+    proj = _make_project(tmp_path, fps=30, w=640, h=480)
+    result = FcpxmlExport().execute(
+        {"project_dir": str(proj), "fps": 24, "width": 1920, "height": 1080}
+    )
+    assert result.success is True
+    xml = Path(result.data["fcpxml_path"]).read_text()
+    assert 'frameDuration="1/24s" width="1920" height="1080"' in xml
+
+
+def test_missing_ffprobe_returns_a_tool_error(tmp_path, monkeypatch):
+    """The tool declares dependencies=['cmd:ffprobe'], but declaring it doesn't
+    stop the call — a missing binary raised FileNotFoundError straight out of
+    execute() instead of the contract's ToolResult(success=False)."""
+    from tools.publishers.fcpxml_export import FcpxmlExport
+
+    proj = _make_project(tmp_path)
+    monkeypatch.setenv("PATH", "")  # ffprobe is now unresolvable
+    result = FcpxmlExport().execute({"project_dir": str(proj)})
+    assert result.success is False
+    assert "ffprobe" in (result.error or "").lower()
+
+
+def test_unreadable_media_returns_a_tool_error(tmp_path):
+    """A file ffprobe can't parse should name the file, not surface a raw
+    JSON decode error from the probe's empty stdout."""
+    from tools.publishers.fcpxml_export import FcpxmlExport
+
+    proj = _make_project(tmp_path)
+    bogus = proj / "artifacts" / "broken.mp4"
+    bogus.write_text("this is not a video")
+    (proj / "artifacts" / "asset_manifest.json").write_text(json.dumps({
+        "assets": [{"type": "video", "path": str(bogus)}]
+    }))
+    (proj / "artifacts" / "scene_plan.json").write_text(json.dumps({
+        "scenes": [_scene("cut-1", 0.0, 2.0, "broken.mp4")]
+    }))
+
+    result = FcpxmlExport().execute({"project_dir": str(proj)})
+    assert result.success is False
+    assert "broken.mp4" in (result.error or "")
+
+
+def test_sdr_substitutions_are_reported_not_silent(tmp_path):
+    """The Dolby Vision workaround swaps sources behind the user's back.
+
+    If assets/transcoded_sdr/<stem>.mp4 exists the timeline quietly points at
+    it instead of the original. That's the right behaviour — HDR clips don't
+    decode in Resolve on some machines — but an editor comparing the FCPXML
+    against their asset_manifest has no way to know it happened, so the tool
+    has to say so.
+    """
+    from tools.publishers.fcpxml_export import FcpxmlExport
+
+    proj = _make_project(tmp_path)
+    sdr_dir = proj / "assets" / "transcoded_sdr"
+    sdr_dir.mkdir(parents=True)
+    _make_clip(sdr_dir / "shot.mp4")
+
+    result = FcpxmlExport().execute({"project_dir": str(proj)})
+    assert result.success is True
+    assert result.data["sdr_substitutions"] == ["shot.mp4"]
+    # ...and the timeline really does point at the SDR copy.
+    assert "transcoded_sdr" in Path(result.data["fcpxml_path"]).read_text()
+
+
+def test_two_up_grid_uses_verified_resolve_transform(clips):
+    xml = build_fcpxml(
+        [_scene("cut-1", 0.0, 2.0, "a.mp4", "b.mp4")], clips, None, None, "demo"
+    )
+    # Second cell is a connected clip on lane 1, not a second spine item.
+    assert 'lane="1"' in xml
+    # The verified 2-up recipe: no crop, conform-to-fit, scale always 1 1.
+    assert '<adjust-conform type="fit"/>' in xml
+    assert '<adjust-transform position="-99.63 0" anchor="0 0" scale="1 1"/>' in xml
+    assert '<adjust-transform position="99.63 0" anchor="0 0" scale="1 1"/>' in xml
+    assert "adjust-crop" not in xml
+
+
+def test_three_up_grid_crops_and_positions_each_cell(clips):
+    xml = build_fcpxml(
+        [_scene("cut-1", 0.0, 2.0, "a.mp4", "b.mp4", "c.mp4")],
+        clips, None, None, "demo",
+    )
+    assert '<trim-rect right="16.5" left="16.5"/>' in xml
+    for pos in ("-145.6 0", "0.0 0", "145.6 0"):
+        assert f'<adjust-transform position="{pos}" anchor="0 0" scale="1 1"/>' in xml
+    assert 'lane="1"' in xml and 'lane="2"' in xml
+
+
+def test_unsupported_grid_width_is_rejected_not_silently_stacked(clips):
+    """Only 2-up and 3-up have verified Resolve transforms.
+
+    Without a template every cell got no adjustments at all, so all four
+    rendered full-frame stacked on each other and only the top one was
+    visible — a timeline that imports cleanly and is silently wrong. Failing
+    loudly is the only honest option until a 4-up template is measured.
+    """
+    with pytest.raises(ValueError, match="4"):
+        build_fcpxml(
+            [_scene("cut-1", 0.0, 2.0, "a.mp4", "b.mp4", "c.mp4", "a.mp4")],
+            clips, None, None, "demo",
+        )
+
+
+def test_connected_clips_are_relative_to_their_anchor(clips):
+    """Regression: connected-clip offset is relative to the anchor, not the
+    timeline. Using the scene's absolute offset double-counted it and made
+    lanes lag further behind the later a grid fell in the timeline."""
+    xml = build_fcpxml(
+        [
+            _scene("cut-1", 0.0, 2.0, "a.mp4"),
+            _scene("cut-2", 2.0, 4.0, "b.mp4", "c.mp4"),
+        ],
+        clips, None, None, "demo",
+    )
+    # The anchor sits at the absolute timeline position...
+    assert 'offset="60/30s" duration="60/30s"' in xml
+    # ...but its connected cell restarts from zero.
+    assert 'lane="1" offset="0s"' in xml
+
+
+def test_music_lands_on_a_negative_lane(clips, tmp_path):
+    music = tmp_path / "bed.mp3"
+    subprocess.run(
+        ["ffmpeg", "-y", "-f", "lavfi", "-i", "anullsrc=r=44100:cl=stereo:d=4",
+         "-c:a", "libmp3lame", str(music)],
+        capture_output=True, check=True,
+    )
+    xml = build_fcpxml(
+        [_scene("cut-1", 0.0, 2.0, "a.mp4")], clips, str(music), 4.0, "demo"
+    )
+    assert 'lane="-1"' in xml
+    assert 'hasAudio="1" audioSources="1" audioChannels="2" hasVideo="0"' in xml

--- a/tools/publishers/fcpxml_export.py
+++ b/tools/publishers/fcpxml_export.py
@@ -1,0 +1,419 @@
+"""Export a scene_plan/edit_decisions cut to FCPXML for DaVinci Resolve import.
+
+This is a PUBLISH-tier `publish` tool — a second `provider` under the same
+capability as `export_bundle`. Where `export_bundle` packages a *finished
+render* for platform hand-off, this tool emits an *editorial timeline* (FCPXML)
+so the cut can be reopened, colour-graded, and finished in DaVinci Resolve or
+Final Cut Pro instead of being locked to the flat render.
+
+Resolve imports Final Cut Pro XML (FCPXML) timelines reliably; plain EDL
+(CMX3600) has no multi-track or transform support, so side-by-side grid
+scenes couldn't be represented at all. FCPXML's "connected clips" (the
+`lane` attribute) let multiple simultaneous videos stack on one anchor
+clip, which is how grid scenes translate.
+
+Grid cells land on separate connected video tracks (V2, V3, ...) at the
+correct timeline position, each with a per-column-count template applied
+(see GRID_TEMPLATES in build_fcpxml). Two prior attempts guessing generic
+FCPXML <adjust-transform> (position+scale, no crop/conform) failed to
+composite correctly in Resolve. The working recipe — <adjust-crop> (trim,
+percent) + <adjust-conform type="fit"> + <adjust-transform> with scale
+always "1 1" — was reverse-engineered from a timeline the user positioned
+by hand in Resolve and exported back out, since Resolve's internal
+position unit space isn't the 1920x1080 canvas and its exact conversion
+isn't documented anywhere I could find.
+
+Usage (CLI):
+    python -m tools.publishers.fcpxml_export <project_dir> [--limit N] [--out PATH]
+
+Usage (tool / registry):
+    registry.get("fcpxml_export").execute({"project_dir": "projects/<name>"})
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+from xml.sax.saxutils import quoteattr
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolTier,
+)
+
+FPS = 30
+FORMAT_ID = "r1"
+
+
+def _seconds_to_fcp_time(seconds: float) -> str:
+    """Rational time snapped to whole frames at FPS, e.g. '60/30s'."""
+    frames = round(seconds * FPS)
+    return f"{frames}/{FPS}s"
+
+
+def _probe_media(path: Path) -> tuple[float, bool]:
+    """Return (duration_seconds, has_audio_stream)."""
+    proc = subprocess.run(
+        ["ffprobe", "-v", "quiet", "-print_format", "json", "-show_format", "-show_streams", str(path)],
+        capture_output=True, text=True, timeout=15,
+    )
+    data = json.loads(proc.stdout)
+    duration = float(data.get("format", {}).get("duration", 0))
+    has_audio = any(s.get("codec_type") == "audio" for s in data.get("streams", []))
+    return duration, has_audio
+
+
+def build_fcpxml(
+    scenes: list[dict],
+    path_by_filename: dict[str, str],
+    music_path: str | None,
+    music_duration: float | None,
+    project_name: str,
+    clip_rotations: dict[str, float] | None = None,
+    clip_in_overrides: dict[str, dict[str, float]] | None = None,
+) -> str:
+    clip_rotations = clip_rotations or {}
+    clip_in_overrides = clip_in_overrides or {}
+    # --- resources: one asset per unique source file, plus music ---
+    asset_ids: dict[str, str] = {}
+    resource_xml: list[str] = [
+        f'<format id="{FORMAT_ID}" name="FFVideoFormat1080p30" '
+        f'frameDuration="1/{FPS}s" width="1920" height="1080"/>'
+    ]
+
+    def get_or_create_asset(filename: str) -> str:
+        if filename in asset_ids:
+            return asset_ids[filename]
+        rid = f"r{len(asset_ids) + 2}"
+        asset_ids[filename] = rid
+        abs_path = path_by_filename[filename]
+        p = Path(abs_path)
+        dur, has_audio = _probe_media(p)
+        name = p.stem
+        audio_attrs = (
+            'hasAudio="1" audioSources="1" audioChannels="2"' if has_audio else 'hasAudio="0"'
+        )
+        resource_xml.append(
+            f'<asset id="{rid}" name={quoteattr(name)} src={quoteattr(p.as_uri())} '
+            f'start="0s" duration="{_seconds_to_fcp_time(dur)}" hasVideo="1" '
+            f'format="{FORMAT_ID}" {audio_attrs}/>'
+        )
+        return rid
+
+    for s in scenes:
+        for ra in s["required_assets"]:
+            get_or_create_asset(ra["path"])
+
+    music_rid = None
+    if music_path:
+        music_rid = f"r{len(asset_ids) + 2}"
+        p = Path(music_path)
+        resource_xml.append(
+            f'<asset id="{music_rid}" name={quoteattr(p.stem)} src={quoteattr(p.resolve().as_uri())} '
+            f'start="0s" duration="{_seconds_to_fcp_time(music_duration or 0)}" '
+            'hasAudio="1" audioSources="1" audioChannels="2" hasVideo="0"/>'
+        )
+
+    # --- spine: solo scenes as sequential clips, grid scenes as an anchor
+    # clip with the remaining cells attached as connected clips on lanes ---
+    #
+    # Two prior attempts at guessing FCPXML's generic Motion-style
+    # <adjust-transform> (position+scale only) failed to composite in
+    # Resolve — a non-uniform scale skewed the video, and a corrected
+    # uniform scale sat on an opaque background that hid the layers
+    # underneath. The user then positioned one 3-up and one 2-up grid
+    # manually in Resolve and exported the timeline, which revealed
+    # Resolve's actual recipe: <adjust-crop> (trim, percent per side) +
+    # <adjust-conform type="fit"> + <adjust-transform> with scale ALWAYS
+    # "1 1" and position doing the real work, in a unit space that isn't
+    # the 1920x1080 canvas (position values are roughly canvas/13, likely
+    # relative to the conformed/cropped clip's own frame). These are the
+    # two verified per-column-count templates — not derived analytically,
+    # since Resolve's exact unit conversion is opaque from the outside.
+    GRID_TEMPLATES: dict[int, dict[str, object]] = {
+        2: {"crop_pct": 0.0, "positions": [-99.63, 99.63]},
+        3: {"crop_pct": 16.5, "positions": [-145.6, 0.0, 145.6]},
+    }
+
+    spine_items: list[str] = []
+    for s in scenes:
+        dur = _seconds_to_fcp_time(s["end_seconds"] - s["start_seconds"])
+        offset = _seconds_to_fcp_time(s["start_seconds"])
+        assets = s["required_assets"]
+        n = len(assets)
+
+        if n == 1:
+            path = assets[0]["path"]
+            rid = asset_ids[path]
+            name = Path(path).stem
+            start_seconds = clip_in_overrides.get(s["id"], {}).get(path, 0.0)
+            start_time = _seconds_to_fcp_time(start_seconds) if start_seconds else "0s"
+            rotation = clip_rotations.get(s["id"])
+            inner = f'<adjust-transform rotation="{rotation}"/>' if rotation else ""
+            if inner:
+                spine_items.append(
+                    f'<asset-clip ref="{rid}" offset="{offset}" duration="{dur}" '
+                    f'start="{start_time}" name={quoteattr(name)}>{inner}</asset-clip>'
+                )
+            else:
+                spine_items.append(
+                    f'<asset-clip ref="{rid}" offset="{offset}" duration="{dur}" '
+                    f'start="{start_time}" name={quoteattr(name)}/>'
+                )
+        else:
+            template = GRID_TEMPLATES.get(n)
+
+            def cell_adjustments(i: int) -> str:
+                if template is None:
+                    return ""
+                pos = template["positions"][i]
+                crop = template["crop_pct"]
+                crop_xml = (
+                    f'<adjust-crop mode="trim"><trim-rect right="{crop}" left="{crop}"/></adjust-crop>'
+                    if crop else ""
+                )
+                return (
+                    f'{crop_xml}<adjust-conform type="fit"/>'
+                    f'<adjust-transform position="{pos} 0" anchor="0 0" scale="1 1"/>'
+                )
+
+            cell_in_overrides = clip_in_overrides.get(s["id"], {})
+
+            def cell_start(path: str) -> str:
+                secs = cell_in_overrides.get(path, 0.0)
+                return _seconds_to_fcp_time(secs) if secs else "0s"
+
+            anchor_path = assets[0]["path"]
+            anchor_rid = asset_ids[anchor_path]
+            anchor_name = Path(anchor_path).stem
+            connected: list[str] = []
+            for i, ra in enumerate(assets[1:], start=1):
+                rid = asset_ids[ra["path"]]
+                name = Path(ra["path"]).stem
+                # Nested/connected clips' offset is relative to the anchor's
+                # own start, not the absolute timeline position — using the
+                # scene's absolute offset here double-counted it, causing
+                # lanes to lag behind their anchor (worse the later a grid
+                # falls in the timeline). Confirmed against the user's own
+                # manually-positioned export, which used offset="0/1s" for
+                # every connected clip.
+                connected.append(
+                    f'<asset-clip ref="{rid}" lane="{i}" offset="0s" '
+                    f'duration="{dur}" start="{cell_start(ra["path"])}" name={quoteattr(name)}>'
+                    f'{cell_adjustments(i)}'
+                    f'</asset-clip>'
+                )
+            spine_items.append(
+                f'<asset-clip ref="{anchor_rid}" offset="{offset}" duration="{dur}" '
+                f'start="{cell_start(anchor_path)}" name={quoteattr(anchor_name)}>'
+                f'{cell_adjustments(0)}'
+                + "".join(connected)
+                + "</asset-clip>"
+            )
+
+    total_dur = _seconds_to_fcp_time(scenes[-1]["end_seconds"] if scenes else 0)
+
+    music_clip = ""
+    if music_rid:
+        music_clip = (
+            f'<asset-clip ref="{music_rid}" lane="-1" offset="0s" '
+            f'duration="{_seconds_to_fcp_time(music_duration or 0)}" start="0s" name="music"/>'
+        )
+
+    resources = "\n    ".join(resource_xml)
+    spine = "\n        ".join(spine_items)
+
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fcpxml>
+<fcpxml version="1.9">
+  <resources>
+    {resources}
+  </resources>
+  <library>
+    <event name={quoteattr(project_name)}>
+      <project name={quoteattr(project_name)}>
+        <sequence format="{FORMAT_ID}" duration="{total_dur}" tcStart="0s" tcFormat="NDF">
+          <spine>
+            {spine}
+            {music_clip}
+          </spine>
+        </sequence>
+      </project>
+    </event>
+  </library>
+</fcpxml>
+"""
+
+
+def export_project_to_fcpxml(
+    project_dir: str | Path,
+    out: str | Path | None = None,
+    limit: int | None = None,
+) -> tuple[Path, int]:
+    """Load a project's scene_plan + asset_manifest and write an FCPXML timeline.
+
+    Shared core used by both the CLI (`main`) and the `FcpxmlExport` tool.
+    Returns ``(output_path, scene_count)``.
+    """
+    proj = Path(project_dir)
+    scene_plan = json.loads((proj / "artifacts/scene_plan.json").read_text())
+    asset_manifest = json.loads((proj / "artifacts/asset_manifest.json").read_text())
+
+    scenes = scene_plan["scenes"]
+    if limit:
+        scenes = scenes[:limit]
+
+    music_asset = next((a for a in asset_manifest["assets"] if a["type"] == "music"), None)
+    music_path = music_asset["path"] if music_asset else None
+    music_duration = music_asset.get("duration_seconds") if music_asset else None
+
+    # scene_plan stores bare filenames; asset_manifest has the real absolute
+    # paths (the source folder is outside the repo, e.g. ~/Downloads/...).
+    path_by_filename = {
+        Path(a["path"]).name: a["path"] for a in asset_manifest["assets"] if a["type"] == "video"
+    }
+
+    # Dolby Vision (10-bit HEVC profile 8) clips don't decode in Resolve on
+    # some machines — route those specific files to their transcoded 8-bit
+    # Rec.709 H.264 versions instead when present. See assets/transcoded_sdr/.
+    sdr_dir = proj / "assets" / "transcoded_sdr"
+    if sdr_dir.exists():
+        for filename in list(path_by_filename):
+            sdr_path = sdr_dir / f"{Path(filename).stem}.mp4"
+            if sdr_path.exists():
+                path_by_filename[filename] = str(sdr_path.resolve())
+
+    clip_rotations = scene_plan.get("metadata", {}).get("clip_rotations", {})
+    clip_in_overrides = scene_plan.get("metadata", {}).get("clip_in_overrides", {})
+
+    xml = build_fcpxml(
+        scenes, path_by_filename, music_path, music_duration, project_name=proj.name,
+        clip_rotations=clip_rotations, clip_in_overrides=clip_in_overrides,
+    )
+
+    out_path = Path(out) if out else proj / "renders" / f"{proj.name}{'_test' if limit else ''}.fcpxml"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(xml)
+    return out_path, len(scenes)
+
+
+class FcpxmlExport(BaseTool):
+    name = "fcpxml_export"
+    version = "0.1.0"
+    tier = ToolTier.PUBLISH
+    capability = "publish"
+    provider = "fcpxml"
+    stability = ToolStability.BETA
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.DETERMINISTIC
+    runtime = ToolRuntime.LOCAL
+
+    dependencies = ["cmd:ffprobe"]  # reads clip durations / audio streams
+    install_instructions = (
+        "Requires the FFmpeg suite (provides ffprobe). Install via "
+        "'brew install ffmpeg' (macOS) or 'apt-get install ffmpeg' (Linux)."
+    )
+
+    agent_skills = []
+
+    capabilities = ["export_fcpxml", "grid_timeline"]
+    supports = {
+        "local_offline": True,
+        "free": True,
+        "uploads": False,
+        "multi_track_grid": True,
+    }
+    best_for = [
+        "handing a cut to DaVinci Resolve / Final Cut Pro for colour + finishing",
+        "preserving side-by-side grid scenes as multi-track connected clips",
+        "an editable editorial timeline instead of a locked flat render",
+    ]
+    not_good_for = [
+        "packaging a finished render for platform upload (use export_bundle)",
+        "timelines with grid scenes wider than 3 columns (only 2-up/3-up templates verified)",
+    ]
+
+    input_schema = {
+        "type": "object",
+        "required": ["project_dir"],
+        "properties": {
+            "project_dir": {
+                "type": "string",
+                "description": "Project workspace containing artifacts/scene_plan.json and artifacts/asset_manifest.json.",
+            },
+            "out": {
+                "type": "string",
+                "description": "Override the output path. Defaults to <project_dir>/renders/<name>.fcpxml.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Only export the first N scenes (for a quick test import into Resolve).",
+            },
+        },
+    }
+    output_schema = {
+        "type": "object",
+        "properties": {
+            "fcpxml_path": {"type": "string"},
+            "scene_count": {"type": "integer"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=128, vram_mb=0, disk_mb=0, network_required=False
+    )
+    side_effects = ["writes an .fcpxml timeline file to disk"]
+    user_visible_verification = [
+        "Import the .fcpxml into DaVinci Resolve and confirm clips, grid layout, and music land correctly",
+    ]
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        project_dir = Path(inputs["project_dir"]).expanduser()
+        if not project_dir.is_dir():
+            return ToolResult(success=False, error=f"project_dir not found: {project_dir}")
+
+        scene_plan = project_dir / "artifacts" / "scene_plan.json"
+        asset_manifest = project_dir / "artifacts" / "asset_manifest.json"
+        for required in (scene_plan, asset_manifest):
+            if not required.is_file():
+                return ToolResult(
+                    success=False,
+                    error=f"required artifact missing: {required}",
+                )
+
+        try:
+            out_path, scene_count = export_project_to_fcpxml(
+                project_dir, out=inputs.get("out"), limit=inputs.get("limit")
+            )
+        except (KeyError, ValueError, json.JSONDecodeError) as exc:
+            return ToolResult(success=False, error=f"FCPXML export failed: {exc}")
+
+        return ToolResult(
+            success=True,
+            data={"fcpxml_path": str(out_path), "scene_count": scene_count},
+            artifacts=[str(out_path)],
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Export a project cut to FCPXML for DaVinci Resolve.")
+    parser.add_argument("project_dir")
+    parser.add_argument("--limit", type=int, default=None, help="Only export the first N scenes (for a test import)")
+    parser.add_argument("--out", default=None)
+    args = parser.parse_args()
+
+    out_path, n_scenes = export_project_to_fcpxml(args.project_dir, out=args.out, limit=args.limit)
+    print(f"wrote {out_path} ({n_scenes} scenes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/publishers/fcpxml_export.py
+++ b/tools/publishers/fcpxml_export.py
@@ -50,26 +50,77 @@ from tools.base_tool import (
     ToolTier,
 )
 
-FPS = 30
+DEFAULT_FPS = 30
+DEFAULT_WIDTH = 1920
+DEFAULT_HEIGHT = 1080
 FORMAT_ID = "r1"
 
 
-def _seconds_to_fcp_time(seconds: float) -> str:
-    """Rational time snapped to whole frames at FPS, e.g. '60/30s'."""
-    frames = round(seconds * FPS)
-    return f"{frames}/{FPS}s"
+def _seconds_to_fcp_time(seconds: float, fps: int = DEFAULT_FPS) -> str:
+    """Rational time snapped to whole frames at `fps`, e.g. '60/30s'."""
+    frames = round(seconds * fps)
+    return f"{frames}/{fps}s"
+
+
+class FcpxmlExportError(RuntimeError):
+    """The timeline could not be built from the given project."""
+
+
+def _run_ffprobe(path: Path, *args: str) -> dict:
+    """Probe `path`, raising FcpxmlExportError instead of leaking subprocess
+    failures. Declaring dependencies=['cmd:ffprobe'] documents the requirement
+    but doesn't stop the call, so every failure mode is handled here: a missing
+    binary, a hang, and — the quiet one — a non-zero exit, where ffprobe still
+    prints '{}' on stdout and the caller would otherwise carry on with a
+    zero-duration asset and emit a broken timeline that imports cleanly.
+    """
+    cmd = ["ffprobe", "-v", "quiet", "-print_format", "json", *args, str(path)]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+    except FileNotFoundError as exc:
+        raise FcpxmlExportError(
+            "ffprobe not found on PATH — install the FFmpeg suite "
+            "('brew install ffmpeg' on macOS, 'apt-get install ffmpeg' on Linux)."
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise FcpxmlExportError(f"ffprobe timed out reading {path.name}") from exc
+
+    if proc.returncode != 0:
+        raise FcpxmlExportError(
+            f"ffprobe could not read {path.name} (exit {proc.returncode}) — "
+            "the file may be missing, truncated, or not media."
+        )
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise FcpxmlExportError(
+            f"ffprobe returned unreadable output for {path.name}"
+        ) from exc
 
 
 def _probe_media(path: Path) -> tuple[float, bool]:
     """Return (duration_seconds, has_audio_stream)."""
-    proc = subprocess.run(
-        ["ffprobe", "-v", "quiet", "-print_format", "json", "-show_format", "-show_streams", str(path)],
-        capture_output=True, text=True, timeout=15,
-    )
-    data = json.loads(proc.stdout)
+    data = _run_ffprobe(path, "-show_format", "-show_streams")
     duration = float(data.get("format", {}).get("duration", 0))
     has_audio = any(s.get("codec_type") == "audio" for s in data.get("streams", []))
     return duration, has_audio
+
+
+def _probe_video_format(path: Path) -> tuple[int, int, int] | None:
+    """Return (fps, width, height) of the first video stream, or None."""
+    streams = _run_ffprobe(path, "-show_streams", "-select_streams", "v:0").get("streams", [])
+    if not streams:
+        return None
+    s = streams[0]
+    # r_frame_rate is a rational string like "30000/1001" (29.97) or "25/1".
+    num, _, den = s.get("r_frame_rate", "").partition("/")
+    try:
+        fps = round(int(num) / int(den))
+    except (ValueError, ZeroDivisionError):
+        return None
+    if not fps or not s.get("width") or not s.get("height"):
+        return None
+    return fps, int(s["width"]), int(s["height"])
 
 
 def build_fcpxml(
@@ -80,14 +131,24 @@ def build_fcpxml(
     project_name: str,
     clip_rotations: dict[str, float] | None = None,
     clip_in_overrides: dict[str, dict[str, float]] | None = None,
+    fps: int = DEFAULT_FPS,
+    width: int = DEFAULT_WIDTH,
+    height: int = DEFAULT_HEIGHT,
 ) -> str:
     clip_rotations = clip_rotations or {}
     clip_in_overrides = clip_in_overrides or {}
+
+    def fcp_time(seconds: float) -> str:
+        return _seconds_to_fcp_time(seconds, fps)
+
     # --- resources: one asset per unique source file, plus music ---
     asset_ids: dict[str, str] = {}
+    # The format `name` is informational — Resolve reads frameDuration/width/
+    # height. Derived rather than hardcoded so a vertical or non-30fps
+    # sequence isn't mislabelled as 1080p30 in the NLE's format dropdown.
     resource_xml: list[str] = [
-        f'<format id="{FORMAT_ID}" name="FFVideoFormat1080p30" '
-        f'frameDuration="1/{FPS}s" width="1920" height="1080"/>'
+        f'<format id="{FORMAT_ID}" name="FFVideoFormat{height}p{fps}" '
+        f'frameDuration="1/{fps}s" width="{width}" height="{height}"/>'
     ]
 
     def get_or_create_asset(filename: str) -> str:
@@ -104,7 +165,7 @@ def build_fcpxml(
         )
         resource_xml.append(
             f'<asset id="{rid}" name={quoteattr(name)} src={quoteattr(p.as_uri())} '
-            f'start="0s" duration="{_seconds_to_fcp_time(dur)}" hasVideo="1" '
+            f'start="0s" duration="{fcp_time(dur)}" hasVideo="1" '
             f'format="{FORMAT_ID}" {audio_attrs}/>'
         )
         return rid
@@ -119,7 +180,7 @@ def build_fcpxml(
         p = Path(music_path)
         resource_xml.append(
             f'<asset id="{music_rid}" name={quoteattr(p.stem)} src={quoteattr(p.resolve().as_uri())} '
-            f'start="0s" duration="{_seconds_to_fcp_time(music_duration or 0)}" '
+            f'start="0s" duration="{fcp_time(music_duration or 0)}" '
             'hasAudio="1" audioSources="1" audioChannels="2" hasVideo="0"/>'
         )
 
@@ -146,8 +207,8 @@ def build_fcpxml(
 
     spine_items: list[str] = []
     for s in scenes:
-        dur = _seconds_to_fcp_time(s["end_seconds"] - s["start_seconds"])
-        offset = _seconds_to_fcp_time(s["start_seconds"])
+        dur = fcp_time(s["end_seconds"] - s["start_seconds"])
+        offset = fcp_time(s["start_seconds"])
         assets = s["required_assets"]
         n = len(assets)
 
@@ -156,7 +217,7 @@ def build_fcpxml(
             rid = asset_ids[path]
             name = Path(path).stem
             start_seconds = clip_in_overrides.get(s["id"], {}).get(path, 0.0)
-            start_time = _seconds_to_fcp_time(start_seconds) if start_seconds else "0s"
+            start_time = fcp_time(start_seconds) if start_seconds else "0s"
             rotation = clip_rotations.get(s["id"])
             inner = f'<adjust-transform rotation="{rotation}"/>' if rotation else ""
             if inner:
@@ -171,10 +232,18 @@ def build_fcpxml(
                 )
         else:
             template = GRID_TEMPLATES.get(n)
+            if template is None:
+                # Falling through with no template gave every cell zero
+                # adjustments, so all n videos rendered full-frame stacked and
+                # only the topmost was visible. That imports without complaint
+                # and is silently wrong, which is worse than refusing.
+                raise ValueError(
+                    f"scene {s['id']!r} has {n} grid cells, but only "
+                    f"{sorted(GRID_TEMPLATES)}-up layouts have verified Resolve "
+                    "transforms. Split the scene or measure a new template."
+                )
 
             def cell_adjustments(i: int) -> str:
-                if template is None:
-                    return ""
                 pos = template["positions"][i]
                 crop = template["crop_pct"]
                 crop_xml = (
@@ -190,7 +259,7 @@ def build_fcpxml(
 
             def cell_start(path: str) -> str:
                 secs = cell_in_overrides.get(path, 0.0)
-                return _seconds_to_fcp_time(secs) if secs else "0s"
+                return fcp_time(secs) if secs else "0s"
 
             anchor_path = assets[0]["path"]
             anchor_rid = asset_ids[anchor_path]
@@ -220,13 +289,13 @@ def build_fcpxml(
                 + "</asset-clip>"
             )
 
-    total_dur = _seconds_to_fcp_time(scenes[-1]["end_seconds"] if scenes else 0)
+    total_dur = fcp_time(scenes[-1]["end_seconds"] if scenes else 0)
 
     music_clip = ""
     if music_rid:
         music_clip = (
             f'<asset-clip ref="{music_rid}" lane="-1" offset="0s" '
-            f'duration="{_seconds_to_fcp_time(music_duration or 0)}" start="0s" name="music"/>'
+            f'duration="{fcp_time(music_duration or 0)}" start="0s" name="music"/>'
         )
 
     resources = "\n    ".join(resource_xml)
@@ -258,11 +327,15 @@ def export_project_to_fcpxml(
     project_dir: str | Path,
     out: str | Path | None = None,
     limit: int | None = None,
-) -> tuple[Path, int]:
+    fps: int | None = None,
+    width: int | None = None,
+    height: int | None = None,
+) -> tuple[Path, int, list[str]]:
     """Load a project's scene_plan + asset_manifest and write an FCPXML timeline.
 
     Shared core used by both the CLI (`main`) and the `FcpxmlExport` tool.
-    Returns ``(output_path, scene_count)``.
+    Returns ``(output_path, scene_count, sdr_substitutions)``, where the last
+    item names any source files redirected to their transcoded SDR copies.
     """
     proj = Path(project_dir)
     scene_plan = json.loads((proj / "artifacts/scene_plan.json").read_text())
@@ -285,25 +358,50 @@ def export_project_to_fcpxml(
     # Dolby Vision (10-bit HEVC profile 8) clips don't decode in Resolve on
     # some machines — route those specific files to their transcoded 8-bit
     # Rec.709 H.264 versions instead when present. See assets/transcoded_sdr/.
+    # The swap is reported back to the caller rather than made silently: the
+    # emitted timeline otherwise points somewhere the asset_manifest doesn't,
+    # with nothing to explain the mismatch.
+    sdr_substitutions: list[str] = []
     sdr_dir = proj / "assets" / "transcoded_sdr"
     if sdr_dir.exists():
         for filename in list(path_by_filename):
             sdr_path = sdr_dir / f"{Path(filename).stem}.mp4"
             if sdr_path.exists():
                 path_by_filename[filename] = str(sdr_path.resolve())
+                sdr_substitutions.append(filename)
 
     clip_rotations = scene_plan.get("metadata", {}).get("clip_rotations", {})
     clip_in_overrides = scene_plan.get("metadata", {}).get("clip_in_overrides", {})
 
+    # The sequence format follows the footage unless the caller overrides it:
+    # importing 25fps clips into a 30fps sequence makes Resolve conform every
+    # one of them, shifting every cut downstream. Probe the first source clip
+    # the timeline actually references and fall back to 1080p30 if unreadable.
+    if fps is None or width is None or height is None:
+        first = next(
+            (path_by_filename[ra["path"]]
+             for s in scenes for ra in s["required_assets"]
+             if ra["path"] in path_by_filename),
+            None,
+        )
+        probed = _probe_video_format(Path(first)) if first else None
+        if probed:
+            fps = fps if fps is not None else probed[0]
+            width = width if width is not None else probed[1]
+            height = height if height is not None else probed[2]
+
     xml = build_fcpxml(
         scenes, path_by_filename, music_path, music_duration, project_name=proj.name,
         clip_rotations=clip_rotations, clip_in_overrides=clip_in_overrides,
+        fps=fps if fps is not None else DEFAULT_FPS,
+        width=width if width is not None else DEFAULT_WIDTH,
+        height=height if height is not None else DEFAULT_HEIGHT,
     )
 
     out_path = Path(out) if out else proj / "renders" / f"{proj.name}{'_test' if limit else ''}.fcpxml"
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(xml)
-    return out_path, len(scenes)
+    return out_path, len(scenes), sdr_substitutions
 
 
 class FcpxmlExport(BaseTool):
@@ -358,6 +456,18 @@ class FcpxmlExport(BaseTool):
                 "type": "integer",
                 "description": "Only export the first N scenes (for a quick test import into Resolve).",
             },
+            "fps": {
+                "type": "integer",
+                "description": "Sequence frame rate. Defaults to the frame rate of the first source clip.",
+            },
+            "width": {
+                "type": "integer",
+                "description": "Sequence width. Defaults to the first source clip's width.",
+            },
+            "height": {
+                "type": "integer",
+                "description": "Sequence height. Defaults to the first source clip's height.",
+            },
         },
     }
     output_schema = {
@@ -365,6 +475,11 @@ class FcpxmlExport(BaseTool):
         "properties": {
             "fcpxml_path": {"type": "string"},
             "scene_count": {"type": "integer"},
+            "sdr_substitutions": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Source filenames redirected to transcoded SDR copies.",
+            },
         },
     }
 
@@ -391,15 +506,26 @@ class FcpxmlExport(BaseTool):
                 )
 
         try:
-            out_path, scene_count = export_project_to_fcpxml(
-                project_dir, out=inputs.get("out"), limit=inputs.get("limit")
+            out_path, scene_count, sdr_substitutions = export_project_to_fcpxml(
+                project_dir,
+                out=inputs.get("out"),
+                limit=inputs.get("limit"),
+                fps=inputs.get("fps"),
+                width=inputs.get("width"),
+                height=inputs.get("height"),
             )
+        except FcpxmlExportError as exc:
+            return ToolResult(success=False, error=str(exc))
         except (KeyError, ValueError, json.JSONDecodeError) as exc:
             return ToolResult(success=False, error=f"FCPXML export failed: {exc}")
 
         return ToolResult(
             success=True,
-            data={"fcpxml_path": str(out_path), "scene_count": scene_count},
+            data={
+                "fcpxml_path": str(out_path),
+                "scene_count": scene_count,
+                "sdr_substitutions": sdr_substitutions,
+            },
             artifacts=[str(out_path)],
         )
 
@@ -411,8 +537,15 @@ def main() -> None:
     parser.add_argument("--out", default=None)
     args = parser.parse_args()
 
-    out_path, n_scenes = export_project_to_fcpxml(args.project_dir, out=args.out, limit=args.limit)
+    out_path, n_scenes, sdr_substitutions = export_project_to_fcpxml(
+        args.project_dir, out=args.out, limit=args.limit
+    )
     print(f"wrote {out_path} ({n_scenes} scenes)")
+    if sdr_substitutions:
+        print(
+            f"  note: {len(sdr_substitutions)} clip(s) point at transcoded SDR "
+            f"copies instead of the originals: {', '.join(sdr_substitutions)}"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds `fcpxml_export`, a second `publish` provider alongside `export_bundle`. Where `export_bundle` packages a **finished render** for platform upload, this emits an **editable editorial timeline** (FCPXML) so a cut can be reopened, graded, and finished in DaVinci Resolve or Final Cut Pro instead of being locked to a flat file.

Resolve imports FCPXML reliably; plain EDL (CMX3600) has no multi-track or transform support, so side-by-side grid scenes can't be represented at all. FCPXML's connected clips (the `lane` attribute) let simultaneous videos stack on one anchor clip, which is how grid scenes survive the hand-off as separately editable cells.

**On the grid transform constants:** two attempts at generic Motion-style `<adjust-transform>` (position + scale) failed to composite in Resolve — a non-uniform scale skewed the video, and a corrected uniform scale sat on an opaque background hiding the layers beneath. The working recipe (`<adjust-crop>` trim + `<adjust-conform type="fit">` + `<adjust-transform>` with scale **always** `"1 1"`) was reverse-engineered from a timeline positioned by hand in Resolve and exported back out. Resolve's internal position unit space isn't the 1920x1080 canvas and its conversion isn't publicly documented, so those numbers **cannot be re-derived analytically** — hence the tests that pin them.

## Related issue

No linked issue.

## Changes

- `tools/publishers/fcpxml_export.py` — the tool, plus a CLI entry point (`python -m tools.publishers.fcpxml_export <project_dir>`).
- Sequence frame rate and resolution are probed from the first source clip, with `fps`/`width`/`height` overrides on the tool. They were previously hardcoded to 30 and 1920x1080, which silently retimed 24/25/60fps footage on import and mislabelled vertical sequences.
- Grid widths beyond the verified 2-up/3-up now raise. Previously a 4-up got no transform at all, so every cell rendered full-frame stacked and only the top one was visible — a timeline that imports cleanly and is silently wrong.
- All `ffprobe` failure modes return `ToolResult(success=False)`: missing binary, timeout, and non-zero exit. The last one mattered most — ffprobe still prints `{}` on a bad file, so the tool used to build a zero-duration asset and report **success** on a broken timeline.
- Dolby Vision sources redirected to transcoded SDR copies are reported in `ToolResult.data["sdr_substitutions"]` (and by the CLI) instead of being swapped invisibly, so an editor knows to relink before grading.
- Declared in `cinematic.yaml`'s publish stage and documented in the publish-director skill — the registry already discovered the tool, but no manifest offered it, so the documented agent path couldn't reach it.

## Testing

- 15 new tests in `tests/tools/test_fcpxml_export.py`, written test-first — each fix had a test that failed for the right reason before the code existed.
- Tests run against **real** ffmpeg-generated clips (skipped when ffmpeg/ffprobe are unavailable, matching `test_video_compose_vertical.py`), so the ffprobe paths exercise the real binary rather than a mock. The missing-binary case strips `PATH` rather than patching.
- Golden assertions pin the reverse-engineered Resolve constants — positions, crop percentages, `scale="1 1"`, lane structure, and the connected-clip-offset-is-anchor-relative regression.
- Verified end to end through the CLI: a 24fps 720x1280 source produces `frameDuration="1/24s" width="720" height="1280"` and `duration="48/24s"`, and the SDR substitution note prints.
- Full suite: 914 passed, 11 skipped. The 12 failures in `tests/contracts/test_phase3_contracts.py` are pre-existing and environmental (`No module named 'google.genai'` locally); they reproduce identically on unmodified `main`, and CI installs the package via `make install-dev`.

**Known limits, deliberately not hidden:** only 2-up and 3-up grids have measured Resolve transforms (wider raises rather than emitting a wrong timeline), and the tool is marked `BETA`. The publish stage in the other 9 pipeline manifests still has `tools_available: []` — that predates this change and felt like a separate concern, so this PR only wires `cinematic`, where grid scenes live.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [x] I updated docs/README if behavior or usage changed.
- [x] No unrelated files (build artifacts, local config) are included in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
