### PR TITLE
Refresh minimax_video to the official MiniMax API (direct global/CN endpoints, Hailuo 2.3 contract)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,14 @@
 # Copy this to .env and fill in your keys
 
 # --- Image + video gateway ---
-FAL_KEY=                     # FLUX images, Google Veo video, Kling video, MiniMax video, Recraft images
+FAL_KEY=                     # FLUX images, Google Veo video, Kling video, Recraft images
                              # Get one at https://fal.ai/dashboard/keys
 FAL_AI_API_KEY=              # Alias for FAL_KEY (some SDKs/docs use this name); either one is read.
+
+# --- MiniMax direct API ---
+MINIMAX_API_KEY=             # Official MiniMax API key (minimax_video); uses your own MiniMax quota
+MINIMAX_REGION=              # Optional; "global" (default, api.minimax.io) or "cn" (api.minimaxi.com)
+MINIMAX_BASE_URL=            # Optional endpoint override; takes precedence over MINIMAX_REGION
 
 # --- Replicate ---
 REPLICATE_API_TOKEN=         # Replicate-hosted video gen (seedance_replicate). Needed to make the

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -14,7 +14,7 @@ Everything you need to know about every provider in OpenMontage — setup instru
 | 2 | **$0** | Google API key | TTS with 700+ voices (1M chars/month free) + $300 new account credit |
 | 3 | **$0** | ElevenLabs | Premium TTS + music + SFX (10K chars/month free) |
 | 4 | **$0** | Piper (local install) | Fully offline TTS — no API key, no cost, no network |
-| 5 | **~$0.03/image** | fal.ai | FLUX images + Kling/Veo/MiniMax video + Recraft — broad single-key image + video coverage |
+| 5 | **~$0.03/image** | fal.ai | FLUX images + Kling/Veo video + Recraft — broad single-key image + video coverage |
 | 6 | **~$0.05/image** | OpenAI | GPT Image 2 images + OpenAI TTS |
 | 7 | **~$0.04/image** | Google Imagen | Imagen 4 images (shares the Google API key) |
 | 8 | **pay-as-you-go** | Kling Official | Official direct Kling video, image, TTS, avatar, and lip-sync API, separate from fal.ai Kling |
@@ -49,7 +49,12 @@ AZURE_SPEECH_KEY=            # Azure AI Speech — Fast Transcription (word-leve
 AZURE_SPEECH_REGION=         # Speech resource region, e.g. eastus
 
 # MULTI-MODEL GATEWAY (one key, 6+ tools)
-FAL_KEY=                     # FLUX, Recraft, Kling, Veo, MiniMax video
+FAL_KEY=                     # FLUX, Recraft, Kling, Veo
+
+# MINIMAX DIRECT API
+MINIMAX_API_KEY=             # Official MiniMax video (minimax_video)
+MINIMAX_REGION=              # Optional; "global" (default) or "cn"
+MINIMAX_BASE_URL=            # Optional endpoint override
 
 # KLING OFFICIAL DIRECT API
 KLING_API_KEY=               # Official Kling video, image, TTS, avatar, lip sync
@@ -192,7 +197,7 @@ The ASR tool (`qwen3-asr-flash-filetrans`) uses an async submit-poll pattern. Au
 
 > **Broad single-key coverage.** One API key unlocks image and video providers across multiple models.
 
-**Tools unlocked:** `flux_image`, `recraft_image`, `kling_video`, `veo_video`, `minimax_video`
+**Tools unlocked:** `flux_image`, `recraft_image`, `kling_video`, `veo_video`
 **Env var:** `FAL_KEY`
 
 #### Setup
@@ -219,11 +224,42 @@ No subscription — pure pay-as-you-go, no minimum spend.
 | Model | Price | Per $1 |
 |-------|-------|--------|
 | Kling 2.5 Turbo Pro | $0.07/sec | 14 seconds |
-| MiniMax | ~$0.05/sec | 20 seconds |
 | Veo 3 | $0.40/sec | 2.5 seconds |
 | WAN 2.5 | $0.05/sec | 20 seconds |
 
 **Free tier:** None — but $0 to start, you only pay for what you use.
+
+---
+
+### MiniMax — Direct API
+
+> **Official MiniMax path.** `minimax_video` calls the first-party MiniMax video API directly with `Authorization: Bearer <MINIMAX_API_KEY>` and provider name `minimax`, so you consume your own MiniMax quota instead of gateway credits.
+
+**Tools unlocked:** `minimax_video`
+**Env vars:** `MINIMAX_API_KEY`, optional `MINIMAX_REGION`, optional `MINIMAX_BASE_URL`
+
+#### Setup
+
+1. Create a MiniMax account on the global ([platform.minimax.io](https://platform.minimax.io/)) or CN ([platform.minimaxi.com](https://platform.minimaxi.com/)) console.
+2. Generate an API key in the MiniMax console.
+3. Add to `.env`:
+   ```bash
+   MINIMAX_API_KEY=your-key-here
+   # Optional, defaults to the global host (api.minimax.io):
+   MINIMAX_REGION=global   # or "cn" for api.minimaxi.com
+   # Optional explicit override (takes precedence over MINIMAX_REGION):
+   MINIMAX_BASE_URL=https://api.minimax.io
+   ```
+
+#### What It Is Best For
+
+- Text-to-video and image-to-video with the Hailuo 2.3 model family (`MiniMax-Hailuo-2.3`, `MiniMax-Hailuo-2.3-Fast`, `MiniMax-Hailuo-02`, and the `T2V-01`/`I2V-01` families)
+- Prompt-following with camera directions and high-texture footage
+- Direct first-party provenance with regional (global / CN) endpoint selection
+
+#### Flow
+
+`POST /v1/video_generation` → poll `GET /v1/query/video_generation` → `GET /v1/files/retrieve` → download the returned URL.
 
 ---
 
@@ -928,7 +964,8 @@ These tools require only FFmpeg or Python packages — no GPU, no API key.
 | **Piper** | — (install only) | `piper_tts` | Free |
 | **Google** | `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) | `google_tts`, `google_imagen`, `google_music`, `gemini_omni_video`, `veo_video` | Free tier (TTS) + paid |
 | **ElevenLabs** | `ELEVENLABS_API_KEY` | `elevenlabs_tts`, `music_gen` | Free tier + paid |
-| **fal.ai** | `FAL_KEY` | `flux_image`, `recraft_image`, `kling_video`, `veo_video`, `minimax_video` | Pay-as-you-go |
+| **fal.ai** | `FAL_KEY` | `flux_image`, `recraft_image`, `kling_video`, `veo_video` | Pay-as-you-go |
+| **MiniMax** | `MINIMAX_API_KEY` | `minimax_video` | Pay-as-you-go |
 | **Kling Official** | `KLING_API_KEY` | `kling_official_video`, `kling_official_image`, `kling_tts`, `kling_avatar`, `kling_lip_sync` | Pay-as-you-go |
 | **OpenAI** | `OPENAI_API_KEY` | `openai_tts`, `openai_image` | Paid only |
 | **xAI** | `XAI_API_KEY` | `grok_image`, `grok_video` | Paid only |

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -253,13 +253,15 @@ No subscription — pure pay-as-you-go, no minimum spend.
 
 #### What It Is Best For
 
-- Text-to-video and image-to-video with the Hailuo 2.3 model family (`MiniMax-Hailuo-2.3`, `MiniMax-Hailuo-2.3-Fast`, `MiniMax-Hailuo-02`, and the `T2V-01`/`I2V-01` families)
+- 2K text-to-video, image-to-video, first/last-frame, and reference-conditioned generation with the default `MiniMax-H3` model
+- Legacy v1 generation with `MiniMax-Hailuo-2.3`, `MiniMax-Hailuo-2.3-Fast`, `MiniMax-Hailuo-02`, and the `T2V-01`/`I2V-01` families
 - Prompt-following with camera directions and high-texture footage
 - Direct first-party provenance with regional (global / CN) endpoint selection
 
 #### Flow
 
-`POST /v1/video_generation` → poll `GET /v1/query/video_generation` → `GET /v1/files/retrieve` → download the returned URL.
+- MiniMax-H3: `POST /v2/video_generation` → poll `GET /v2/query/video_generation/{task_id}` → download `task.content.url`.
+- Hailuo v1 models: `POST /v1/video_generation` → poll `GET /v1/query/video_generation` → `GET /v1/files/retrieve` → download the returned URL.
 
 ---
 

--- a/tests/tools/test_minimax_video.py
+++ b/tests/tools/test_minimax_video.py
@@ -130,6 +130,62 @@ def test_minimax_video_image_to_video_requires_first_frame(monkeypatch):
     assert "first_frame_image" in result.error
 
 
+def test_video_selector_routes_reference_image_to_minimax(monkeypatch, tmp_path):
+    from tools.video import _shared
+    from tools.video.minimax_video import MiniMaxVideo
+    from tools.video.video_selector import VideoSelector
+
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+    monkeypatch.setattr(
+        _shared,
+        "upload_image_fal",
+        lambda _path: "https://cdn.example/reference.png",
+    )
+
+    calls = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        calls["post_payload"] = json
+        return _FakeResponse(json_data={"task_id": "task-123", "base_resp": {"status_code": 0}})
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        if url.endswith("/v1/query/video_generation"):
+            return _FakeResponse(
+                json_data={"status": "Success", "file_id": "file-9", "base_resp": {"status_code": 0}}
+            )
+        if url.endswith("/v1/files/retrieve"):
+            return _FakeResponse(
+                json_data={"file": {"download_url": "https://cdn.example/out.mp4"}, "base_resp": {"status_code": 0}}
+            )
+        return _FakeResponse(content=b"fake mp4 bytes")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    tool = MiniMaxVideo()
+    selector = VideoSelector()
+    monkeypatch.setattr(selector, "_providers", lambda: [tool])
+    monkeypatch.setattr(
+        selector,
+        "_select_best_tool",
+        lambda _inputs, _candidates, _context: (tool, None),
+    )
+
+    result = selector.execute(
+        {
+            "prompt": "A calm product shot",
+            "operation": "image_to_video",
+            "reference_image_path": str(tmp_path / "reference.png"),
+            "output_path": str(tmp_path / "clip.mp4"),
+        }
+    )
+
+    assert result.success, result.error
+    assert calls["post_payload"]["first_frame_image"] == "https://cdn.example/reference.png"
+    assert result.data["selected_tool"] == "minimax_video"
+
+
 def test_minimax_video_surfaces_base_resp_error(monkeypatch):
     from tools.video.minimax_video import MiniMaxVideo
 

--- a/tests/tools/test_minimax_video.py
+++ b/tests/tools/test_minimax_video.py
@@ -1,11 +1,12 @@
 """Contract coverage for the first-party MiniMax video provider.
 
-These tests mock ``requests`` via ``monkeypatch.setattr`` on the live module
-so the shared ``requests`` import stays intact for every other test.
+These tests patch the live ``requests`` module so the shared import remains
+available to the rest of the test suite.
 """
 
 from __future__ import annotations
 
+import pytest
 import requests
 
 from tools.base_tool import ToolStatus
@@ -23,8 +24,39 @@ class _FakeResponse:
         return self._json
 
 
+@pytest.fixture(autouse=True)
+def _isolate_minimax_environment(monkeypatch):
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    monkeypatch.delenv("MINIMAX_REGION", raising=False)
+    monkeypatch.delenv("MINIMAX_BASE_URL", raising=False)
+
+
+def _h3_success_task(task_id="task-h3"):
+    return {
+        "task": {
+            "id": task_id,
+            "model": "MiniMax-H3",
+            "status": "succeeded",
+            "error": None,
+            "content": {"url": "https://cdn.example/h3.mp4"},
+            "resolution": "2K",
+            "duration": 5,
+            "usage": {
+                "total_seconds": 5,
+                "input_seconds": 0,
+                "output_seconds": 5,
+                "image_count": 0,
+            },
+            "ratio": "16:9",
+            "task_type": "video_generation",
+            "modality": "text_to_video",
+        }
+    }
+
+
 def test_minimax_video_is_discovered_as_direct_provider():
     from tools.tool_registry import ToolRegistry
+    from tools.video.minimax_video import DEFAULT_MODEL, MODELS
 
     registry = ToolRegistry()
     registry.discover()
@@ -34,6 +66,18 @@ def test_minimax_video_is_discovered_as_direct_provider():
     assert tool.provider == "minimax"
     assert tool.capability == "video_generation"
     assert tool.dependencies == ["env:MINIMAX_API_KEY"]
+    assert DEFAULT_MODEL == "MiniMax-H3"
+    assert MODELS == [
+        "MiniMax-H3",
+        "MiniMax-Hailuo-2.3",
+        "MiniMax-Hailuo-2.3-Fast",
+        "MiniMax-Hailuo-02",
+        "T2V-01-Director",
+        "T2V-01",
+        "I2V-01-Director",
+        "I2V-01-live",
+        "I2V-01",
+    ]
 
 
 def test_minimax_video_unavailable_without_key(monkeypatch):
@@ -54,47 +98,224 @@ def test_minimax_video_region_routing(monkeypatch):
     monkeypatch.delenv("MINIMAX_REGION", raising=False)
     assert tool._base_url() == "https://api.minimax.io"
 
-    monkeypatch.setenv("MINIMAX_REGION", "cn")
+    monkeypatch.setenv("MINIMAX_REGION", "global_en")
+    assert tool._base_url() == "https://api.minimax.io"
+
+    monkeypatch.setenv("MINIMAX_REGION", "cn_zh")
     assert tool._base_url() == "https://api.minimaxi.com"
 
     monkeypatch.setenv("MINIMAX_BASE_URL", "https://proxy.example.com/")
     assert tool._base_url() == "https://proxy.example.com"
 
 
-def test_minimax_video_text_to_video_direct_api_contract(monkeypatch, tmp_path):
+def test_minimax_h3_text_to_video_v2_contract(monkeypatch, tmp_path):
     from tools.video.minimax_video import MiniMaxVideo
 
     monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
     monkeypatch.setenv("MINIMAX_REGION", "global")
-    monkeypatch.setattr("time.sleep", lambda _s: None)
-
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
     calls = {}
 
     def fake_post(url, headers=None, json=None, timeout=None):
         calls["post_url"] = url
         calls["post_headers"] = headers
         calls["post_payload"] = json
-        return _FakeResponse(json_data={"task_id": "task-123", "base_resp": {"status_code": 0}})
+        return _FakeResponse(json_data={"task_id": "task-h3"})
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        calls.setdefault("get_urls", []).append(url)
+        if url.endswith("/v2/query/video_generation/task-h3"):
+            return _FakeResponse(json_data=_h3_success_task())
+        return _FakeResponse(content=b"h3 video bytes")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    output_path = tmp_path / "h3.mp4"
+    result = MiniMaxVideo().execute(
+        {
+            "prompt": "A calm product shot, slow dolly-in",
+            "output_path": str(output_path),
+        }
+    )
+
+    assert result.success, result.error
+    assert calls["post_url"] == "https://api.minimax.io/v2/video_generation"
+    assert calls["post_headers"]["Authorization"] == "Bearer test-minimax-key"
+    assert calls["post_payload"] == {
+        "model": "MiniMax-H3",
+        "content": [
+            {"type": "text", "text": "A calm product shot, slow dolly-in"},
+        ],
+        "resolution": "2K",
+        "duration": 5,
+        "ratio": "16:9",
+    }
+    assert (
+        "https://api.minimax.io/v2/query/video_generation/task-h3" in calls["get_urls"]
+    )
+    assert output_path.read_bytes() == b"h3 video bytes"
+    assert result.data["api_version"] == "v2"
+    assert result.data["task"]["status"] == "succeeded"
+    assert result.model == "MiniMax-H3"
+
+
+def test_minimax_h3_reference_content_and_cn_watermark(monkeypatch, tmp_path):
+    from tools.video.minimax_video import MiniMaxVideo
+
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
+    monkeypatch.setenv("MINIMAX_REGION", "cn")
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    calls = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        calls["url"] = url
+        calls["payload"] = json
+        return _FakeResponse(json_data={"task_id": "task-reference"})
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        if url.endswith("/v2/query/video_generation/task-reference"):
+            task = _h3_success_task("task-reference")
+            task["task"]["ratio"] = "adaptive"
+            task["task"]["modality"] = "reference_to_video"
+            return _FakeResponse(json_data=task)
+        return _FakeResponse(content=b"reference video bytes")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    result = MiniMaxVideo().execute(
+        {
+            "prompt": "Keep the character and camera rhythm consistent",
+            "operation": "reference_to_video",
+            "reference_image_urls": ["https://cdn.example/reference.png"],
+            "reference_video_url": "https://cdn.example/reference.mp4",
+            "reference_audio_urls": ["https://cdn.example/reference.wav"],
+            "aigc_watermark": True,
+            "output_path": str(tmp_path / "reference.mp4"),
+        }
+    )
+
+    assert result.success, result.error
+    assert calls["url"] == "https://api.minimaxi.com/v2/video_generation"
+    assert calls["payload"]["aigc_watermark"] is True
+    assert calls["payload"]["ratio"] == "adaptive"
+    assert [
+        (item["type"], item.get("role")) for item in calls["payload"]["content"]
+    ] == [
+        ("text", None),
+        ("image_url", "reference_image"),
+        ("video_url", "reference_video"),
+        ("audio_url", "reference_audio"),
+    ]
+
+
+def test_minimax_h3_validates_frame_and_audio_rules(monkeypatch):
+    from tools.video.minimax_video import MiniMaxVideo
+
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
+    tool = MiniMaxVideo()
+
+    missing_last = tool.execute(
+        {
+            "prompt": "Transition between these frames",
+            "operation": "first_last_frame_to_video",
+            "first_frame_image": "https://cdn.example/first.png",
+        }
+    )
+    assert not missing_last.success
+    assert "last_frame_image" in missing_last.error
+
+    audio_only = tool.execute(
+        {
+            "prompt": "Follow this rhythm",
+            "operation": "reference_to_video",
+            "reference_audio_urls": ["https://cdn.example/reference.wav"],
+        }
+    )
+    assert not audio_only.success
+    assert "requires at least one reference image or video" in audio_only.error
+
+
+def test_minimax_h3_normalizes_selector_duration_and_first_last_frames(monkeypatch):
+    from tools.video.minimax_video import MiniMaxVideo
+
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
+    tool = MiniMaxVideo()
+    payload, error = tool._build_v2_payload(
+        {
+            "prompt": "Move smoothly between these frames",
+            "operation": "first_last_frame_to_video",
+            "first_frame_image": "https://cdn.example/first.png",
+            "last_frame_image": "https://cdn.example/last.png",
+            "duration": "10",
+            "aspect_ratio": "9:16",
+        },
+        "https://api.minimax.io",
+    )
+
+    assert error is None
+    assert payload["duration"] == 10
+    assert payload["ratio"] == "9:16"
+    assert [item.get("role") for item in payload["content"]] == [
+        None,
+        "first_frame",
+        "last_frame",
+    ]
+    assert (
+        tool.estimate_cost(
+            {
+                "duration": "10",
+                "reference_image_urls": [
+                    f"https://cdn.example/{index}.png" for index in range(6)
+                ],
+            }
+        )
+        == 1.33
+    )
+
+
+def test_minimax_hailuo_text_to_video_v1_contract(monkeypatch, tmp_path):
+    from tools.video.minimax_video import MiniMaxVideo
+
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
+    monkeypatch.setenv("MINIMAX_REGION", "global")
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    calls = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        calls["post_url"] = url
+        calls["post_payload"] = json
+        return _FakeResponse(
+            json_data={"task_id": "task-v1", "base_resp": {"status_code": 0}}
+        )
 
     def fake_get(url, headers=None, params=None, timeout=None):
         calls.setdefault("get", []).append((url, params))
         if url.endswith("/v1/query/video_generation"):
             return _FakeResponse(
-                json_data={"status": "Success", "file_id": "file-9", "base_resp": {"status_code": 0}}
+                json_data={
+                    "status": "Success",
+                    "file_id": "file-v1",
+                    "base_resp": {"status_code": 0},
+                }
             )
         if url.endswith("/v1/files/retrieve"):
             return _FakeResponse(
-                json_data={"file": {"download_url": "https://cdn.example/out.mp4"}, "base_resp": {"status_code": 0}}
+                json_data={
+                    "file": {"download_url": "https://cdn.example/v1.mp4"},
+                    "base_resp": {"status_code": 0},
+                }
             )
-        return _FakeResponse(content=b"fake mp4 bytes")
+        return _FakeResponse(content=b"v1 video bytes")
 
     monkeypatch.setattr(requests, "post", fake_post)
     monkeypatch.setattr(requests, "get", fake_get)
 
-    output_path = tmp_path / "clip.mp4"
+    output_path = tmp_path / "v1.mp4"
     result = MiniMaxVideo().execute(
         {
-            "prompt": "A calm product shot, slow dolly-in",
+            "prompt": "A calm product shot",
             "model": "MiniMax-Hailuo-2.3",
             "duration": 6,
             "resolution": "1080P",
@@ -103,62 +324,93 @@ def test_minimax_video_text_to_video_direct_api_contract(monkeypatch, tmp_path):
     )
 
     assert result.success, result.error
-    # Submits to the global direct endpoint with Bearer auth.
     assert calls["post_url"] == "https://api.minimax.io/v1/video_generation"
-    assert calls["post_headers"]["Authorization"] == "Bearer test-minimax-key"
-    # First-party request contract fields.
-    assert calls["post_payload"]["model"] == "MiniMax-Hailuo-2.3"
-    assert calls["post_payload"]["prompt"].startswith("A calm product shot")
-    assert calls["post_payload"]["duration"] == 6
-    assert calls["post_payload"]["resolution"] == "1080P"
-    # Poll then retrieve then download.
-    get_urls = [u for u, _ in calls["get"]]
+    assert calls["post_payload"] == {
+        "model": "MiniMax-Hailuo-2.3",
+        "prompt": "A calm product shot",
+        "duration": 6,
+        "resolution": "1080P",
+    }
+    get_urls = [url for url, _params in calls["get"]]
     assert "https://api.minimax.io/v1/query/video_generation" in get_urls
     assert "https://api.minimax.io/v1/files/retrieve" in get_urls
-    assert output_path.read_bytes() == b"fake mp4 bytes"
-    assert result.data["task_id"] == "task-123"
-    assert result.data["file_id"] == "file-9"
-    assert result.model == "MiniMax-Hailuo-2.3"
+    assert output_path.read_bytes() == b"v1 video bytes"
+    assert result.data["api_version"] == "v1"
+    assert result.data["file_id"] == "file-v1"
 
 
-def test_minimax_video_image_to_video_requires_first_frame(monkeypatch):
+def test_minimax_hailuo_image_to_video_prompt_is_optional(monkeypatch, tmp_path):
     from tools.video.minimax_video import MiniMaxVideo
 
     monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
-    result = MiniMaxVideo().execute({"prompt": "n/a", "operation": "image_to_video"})
-    assert not result.success
-    assert "first_frame_image" in result.error
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    calls = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        calls["payload"] = json
+        return _FakeResponse(
+            json_data={"task_id": "task-v1-image", "base_resp": {"status_code": 0}}
+        )
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        if url.endswith("/v1/query/video_generation"):
+            return _FakeResponse(
+                json_data={
+                    "status": "Success",
+                    "file_id": "file-v1-image",
+                    "base_resp": {"status_code": 0},
+                }
+            )
+        if url.endswith("/v1/files/retrieve"):
+            return _FakeResponse(
+                json_data={
+                    "file": {"download_url": "https://cdn.example/v1-image.mp4"},
+                    "base_resp": {"status_code": 0},
+                }
+            )
+        return _FakeResponse(content=b"v1 image video bytes")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    result = MiniMaxVideo().execute(
+        {
+            "operation": "image_to_video",
+            "model": "I2V-01",
+            "first_frame_image": "https://cdn.example/first.png",
+            "output_path": str(tmp_path / "v1-image.mp4"),
+        }
+    )
+
+    assert result.success, result.error
+    assert calls["payload"] == {
+        "model": "I2V-01",
+        "first_frame_image": "https://cdn.example/first.png",
+    }
 
 
-def test_video_selector_routes_reference_image_to_minimax(monkeypatch, tmp_path):
+def test_video_selector_routes_reference_image_to_minimax_h3(monkeypatch, tmp_path):
     from tools.video import _shared
     from tools.video.minimax_video import MiniMaxVideo
     from tools.video.video_selector import VideoSelector
 
     monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
-    monkeypatch.setattr("time.sleep", lambda _s: None)
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
     monkeypatch.setattr(
         _shared,
         "upload_image_fal",
         lambda _path: "https://cdn.example/reference.png",
     )
-
     calls = {}
 
     def fake_post(url, headers=None, json=None, timeout=None):
-        calls["post_payload"] = json
-        return _FakeResponse(json_data={"task_id": "task-123", "base_resp": {"status_code": 0}})
+        calls["payload"] = json
+        return _FakeResponse(json_data={"task_id": "task-selector"})
 
     def fake_get(url, headers=None, params=None, timeout=None):
-        if url.endswith("/v1/query/video_generation"):
-            return _FakeResponse(
-                json_data={"status": "Success", "file_id": "file-9", "base_resp": {"status_code": 0}}
-            )
-        if url.endswith("/v1/files/retrieve"):
-            return _FakeResponse(
-                json_data={"file": {"download_url": "https://cdn.example/out.mp4"}, "base_resp": {"status_code": 0}}
-            )
-        return _FakeResponse(content=b"fake mp4 bytes")
+        if url.endswith("/v2/query/video_generation/task-selector"):
+            return _FakeResponse(json_data=_h3_success_task("task-selector"))
+        return _FakeResponse(content=b"selector video bytes")
 
     monkeypatch.setattr(requests, "post", fake_post)
     monkeypatch.setattr(requests, "get", fake_get)
@@ -177,22 +429,29 @@ def test_video_selector_routes_reference_image_to_minimax(monkeypatch, tmp_path)
             "prompt": "A calm product shot",
             "operation": "image_to_video",
             "reference_image_path": str(tmp_path / "reference.png"),
-            "output_path": str(tmp_path / "clip.mp4"),
+            "output_path": str(tmp_path / "selector.mp4"),
         }
     )
 
     assert result.success, result.error
-    assert calls["post_payload"]["first_frame_image"] == "https://cdn.example/reference.png"
+    first_frame = calls["payload"]["content"][1]
+    assert first_frame == {
+        "type": "image_url",
+        "image_url": {"url": "https://cdn.example/reference.png"},
+        "role": "first_frame",
+    }
     assert result.data["selected_tool"] == "minimax_video"
 
 
-def test_minimax_video_surfaces_base_resp_error(monkeypatch):
+def test_minimax_video_surfaces_v1_base_resp_error(monkeypatch):
     from tools.video.minimax_video import MiniMaxVideo
 
     monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
 
     def fake_post(url, headers=None, json=None, timeout=None):
-        return _FakeResponse(json_data={"base_resp": {"status_code": 1004, "status_msg": "auth failed"}})
+        return _FakeResponse(
+            json_data={"base_resp": {"status_code": 1004, "status_msg": "auth failed"}}
+        )
 
     monkeypatch.setattr(requests, "post", fake_post)
 

--- a/tests/tools/test_minimax_video.py
+++ b/tests/tools/test_minimax_video.py
@@ -1,0 +1,145 @@
+"""Contract coverage for the first-party MiniMax video provider.
+
+These tests mock ``requests`` via ``monkeypatch.setattr`` on the live module
+so the shared ``requests`` import stays intact for every other test.
+"""
+
+from __future__ import annotations
+
+import requests
+
+from tools.base_tool import ToolStatus
+
+
+class _FakeResponse:
+    def __init__(self, *, json_data=None, content=b""):
+        self._json = json_data or {}
+        self.content = content
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._json
+
+
+def test_minimax_video_is_discovered_as_direct_provider():
+    from tools.tool_registry import ToolRegistry
+
+    registry = ToolRegistry()
+    registry.discover()
+
+    tool = registry.get("minimax_video")
+    assert tool is not None
+    assert tool.provider == "minimax"
+    assert tool.capability == "video_generation"
+    assert tool.dependencies == ["env:MINIMAX_API_KEY"]
+
+
+def test_minimax_video_unavailable_without_key(monkeypatch):
+    from tools.video.minimax_video import MiniMaxVideo
+
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    assert MiniMaxVideo().get_status() == ToolStatus.UNAVAILABLE
+
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
+    assert MiniMaxVideo().get_status() == ToolStatus.AVAILABLE
+
+
+def test_minimax_video_region_routing(monkeypatch):
+    from tools.video.minimax_video import MiniMaxVideo
+
+    tool = MiniMaxVideo()
+    monkeypatch.delenv("MINIMAX_BASE_URL", raising=False)
+    monkeypatch.delenv("MINIMAX_REGION", raising=False)
+    assert tool._base_url() == "https://api.minimax.io"
+
+    monkeypatch.setenv("MINIMAX_REGION", "cn")
+    assert tool._base_url() == "https://api.minimaxi.com"
+
+    monkeypatch.setenv("MINIMAX_BASE_URL", "https://proxy.example.com/")
+    assert tool._base_url() == "https://proxy.example.com"
+
+
+def test_minimax_video_text_to_video_direct_api_contract(monkeypatch, tmp_path):
+    from tools.video.minimax_video import MiniMaxVideo
+
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
+    monkeypatch.setenv("MINIMAX_REGION", "global")
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+
+    calls = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        calls["post_url"] = url
+        calls["post_headers"] = headers
+        calls["post_payload"] = json
+        return _FakeResponse(json_data={"task_id": "task-123", "base_resp": {"status_code": 0}})
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        calls.setdefault("get", []).append((url, params))
+        if url.endswith("/v1/query/video_generation"):
+            return _FakeResponse(
+                json_data={"status": "Success", "file_id": "file-9", "base_resp": {"status_code": 0}}
+            )
+        if url.endswith("/v1/files/retrieve"):
+            return _FakeResponse(
+                json_data={"file": {"download_url": "https://cdn.example/out.mp4"}, "base_resp": {"status_code": 0}}
+            )
+        return _FakeResponse(content=b"fake mp4 bytes")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    output_path = tmp_path / "clip.mp4"
+    result = MiniMaxVideo().execute(
+        {
+            "prompt": "A calm product shot, slow dolly-in",
+            "model": "MiniMax-Hailuo-2.3",
+            "duration": 6,
+            "resolution": "1080P",
+            "output_path": str(output_path),
+        }
+    )
+
+    assert result.success, result.error
+    # Submits to the global direct endpoint with Bearer auth.
+    assert calls["post_url"] == "https://api.minimax.io/v1/video_generation"
+    assert calls["post_headers"]["Authorization"] == "Bearer test-minimax-key"
+    # First-party request contract fields.
+    assert calls["post_payload"]["model"] == "MiniMax-Hailuo-2.3"
+    assert calls["post_payload"]["prompt"].startswith("A calm product shot")
+    assert calls["post_payload"]["duration"] == 6
+    assert calls["post_payload"]["resolution"] == "1080P"
+    # Poll then retrieve then download.
+    get_urls = [u for u, _ in calls["get"]]
+    assert "https://api.minimax.io/v1/query/video_generation" in get_urls
+    assert "https://api.minimax.io/v1/files/retrieve" in get_urls
+    assert output_path.read_bytes() == b"fake mp4 bytes"
+    assert result.data["task_id"] == "task-123"
+    assert result.data["file_id"] == "file-9"
+    assert result.model == "MiniMax-Hailuo-2.3"
+
+
+def test_minimax_video_image_to_video_requires_first_frame(monkeypatch):
+    from tools.video.minimax_video import MiniMaxVideo
+
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
+    result = MiniMaxVideo().execute({"prompt": "n/a", "operation": "image_to_video"})
+    assert not result.success
+    assert "first_frame_image" in result.error
+
+
+def test_minimax_video_surfaces_base_resp_error(monkeypatch):
+    from tools.video.minimax_video import MiniMaxVideo
+
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        return _FakeResponse(json_data={"base_resp": {"status_code": 1004, "status_msg": "auth failed"}})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    result = MiniMaxVideo().execute({"prompt": "hi", "model": "MiniMax-Hailuo-2.3"})
+    assert not result.success
+    assert "1004" in result.error

--- a/tests/tools/test_minimax_video.py
+++ b/tests/tools/test_minimax_video.py
@@ -458,3 +458,48 @@ def test_minimax_video_surfaces_v1_base_resp_error(monkeypatch):
     result = MiniMaxVideo().execute({"prompt": "hi", "model": "MiniMax-Hailuo-2.3"})
     assert not result.success
     assert "1004" in result.error
+
+
+@pytest.mark.parametrize("model", ["MiniMax-H3", "MiniMax-Hailuo-2.3"])
+def test_polling_timeout_is_bounded_and_preserves_task_id(monkeypatch, model):
+    import tools.video.minimax_video as minimax_module
+    from tools.video.minimax_video import MiniMaxVideo
+
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *args, **kwargs: _FakeResponse(
+            json_data={"task_id": "recoverable-task", "base_resp": {"status_code": 0}}
+        ),
+    )
+    monkeypatch.setattr(
+        requests,
+        "get",
+        lambda *args, **kwargs: pytest.fail("deadline must stop polling"),
+    )
+    class _ExpiredClock:
+        def __init__(self):
+            self._ticks = iter([0.0, 2.0])
+
+        @staticmethod
+        def time():
+            return 0.0
+
+        def monotonic(self):
+            return next(self._ticks)
+
+        @staticmethod
+        def sleep(_seconds):
+            return None
+
+    monkeypatch.setattr(minimax_module, "time", _ExpiredClock())
+
+    result = MiniMaxVideo().execute(
+        {"prompt": "A camera move", "model": model, "timeout_seconds": 1}
+    )
+
+    assert not result.success
+    assert "timed out" in (result.error or "")
+    assert result.data["task_id"] == "recoverable-task"
+    assert result.data["status"] == "timed_out"

--- a/tools/video/minimax_video.py
+++ b/tools/video/minimax_video.py
@@ -1,9 +1,8 @@
-"""MiniMax (Hailuo) video generation via the official MiniMax API.
+"""MiniMax video generation via the official first-party API.
 
-Calls the first-party MiniMax video endpoints directly with ``MINIMAX_API_KEY``
-(Bearer auth), covering both the global (``api.minimax.io``) and CN
-(``api.minimaxi.com``) regions. Rewards prompt craft — follows camera
-directions well and produces high-texture footage.
+MiniMax-H3 uses the v2 content-based API. Hailuo 2.3 and earlier models keep
+using the v1 generation, query, and file-retrieval flow. Both API versions
+support the global and mainland China hosts through ``MINIMAX_REGION``.
 """
 
 from __future__ import annotations
@@ -26,16 +25,16 @@ from tools.base_tool import (
     ToolTier,
 )
 
-# Direct MiniMax API hosts per region. The global region is the default; set
-# MINIMAX_REGION=cn to route to the mainland China host.
 REGION_BASE_URLS = {
     "global": "https://api.minimax.io",
+    "global_en": "https://api.minimax.io",
     "cn": "https://api.minimaxi.com",
+    "cn_zh": "https://api.minimaxi.com",
 }
 DEFAULT_REGION = "global"
 
-# Current first-party model slugs (Hailuo 2.3 family plus prior generations).
-MODELS = [
+V2_MODELS = ["MiniMax-H3"]
+V1_MODELS = [
     "MiniMax-Hailuo-2.3",
     "MiniMax-Hailuo-2.3-Fast",
     "MiniMax-Hailuo-02",
@@ -45,17 +44,20 @@ MODELS = [
     "I2V-01-live",
     "I2V-01",
 ]
-DEFAULT_MODEL = "MiniMax-Hailuo-2.3"
+MODELS = V2_MODELS + V1_MODELS
+DEFAULT_MODEL = "MiniMax-H3"
 
-# In-progress poll states returned by the query endpoint. Anything outside the
-# terminal Success/Fail values means the task is still running.
-_TERMINAL_SUCCESS = "Success"
-_TERMINAL_FAIL = "Fail"
+V2_RATIO_VALUES = ["adaptive", "21:9", "16:9", "4:3", "1:1", "3:4", "9:16"]
+_V2_IN_PROGRESS = {"queued", "running"}
+_V2_SUCCESS = "succeeded"
+_V2_FAILURES = {"failed", "cancelled"}
+_V1_SUCCESS = "Success"
+_V1_FAILURE = "Fail"
 
 
 class MiniMaxVideo(BaseTool):
     name = "minimax_video"
-    version = "0.2.0"
+    version = "0.3.0"
     tier = ToolTier.GENERATE
     capability = "video_generation"
     provider = "minimax"
@@ -74,28 +76,47 @@ class MiniMaxVideo(BaseTool):
     )
     agent_skills = ["ai-video-gen"]
 
-    capabilities = ["text_to_video", "image_to_video"]
+    capabilities = [
+        "text_to_video",
+        "image_to_video",
+        "first_last_frame_to_video",
+        "reference_to_video",
+    ]
     supports = {
         "text_to_video": True,
         "image_to_video": True,
+        "first_last_frame_to_video": True,
+        "reference_to_video": True,
+        "reference_image": True,
+        "reference_video": True,
+        "reference_audio": True,
+        "native_audio": True,
         "camera_direction": True,
     }
     best_for = [
-        "prompt-following with camera directions (framing, motion, composition)",
-        "high-texture footage with minimal hallucination",
-        "direct first-party API access with your own MiniMax quota",
+        (
+            "2K text, image, first/last-frame, and reference video generation "
+            "with MiniMax-H3"
+        ),
+        "prompt-following with camera directions and high-texture footage",
+        "direct first-party API access with global and mainland China routing",
     ]
-    not_good_for = ["offline generation", "very long clips"]
+    not_good_for = ["offline generation", "clips longer than 15 seconds"]
     fallback_tools = ["kling_video", "veo_video", "wan_video"]
 
     input_schema = {
         "type": "object",
-        "required": ["prompt"],
+        "required": [],
         "properties": {
-            "prompt": {"type": "string"},
+            "prompt": {"type": "string", "maxLength": 7000},
             "operation": {
                 "type": "string",
-                "enum": ["text_to_video", "image_to_video"],
+                "enum": [
+                    "text_to_video",
+                    "image_to_video",
+                    "first_last_frame_to_video",
+                    "reference_to_video",
+                ],
                 "default": "text_to_video",
             },
             "model": {
@@ -105,10 +126,17 @@ class MiniMaxVideo(BaseTool):
             },
             "first_frame_image": {
                 "type": "string",
+                "description": "Public URL or data URI used as the first frame.",
+            },
+            "last_frame_image": {
+                "type": "string",
                 "description": (
-                    "First-frame image for image_to_video: a public URL or a "
-                    "data URI (data:image/...;base64,<payload>)."
+                    "Public URL or data URI used as the last frame by MiniMax-H3."
                 ),
+            },
+            "end_image_url": {
+                "type": "string",
+                "description": "Alias for last_frame_image.",
             },
             "image_url": {
                 "type": "string",
@@ -116,13 +144,54 @@ class MiniMaxVideo(BaseTool):
             },
             "reference_image_url": {
                 "type": "string",
-                "description": "Alias for first_frame_image.",
+                "description": (
+                    "First-frame alias or a reference image for reference_to_video."
+                ),
+            },
+            "reference_image_urls": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+            "reference_video_url": {
+                "type": "string",
+                "description": "Reference video URL for MiniMax-H3.",
+            },
+            "reference_video_urls": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+            "reference_audio_urls": {
+                "type": "array",
+                "items": {"type": "string"},
             },
             "prompt_optimizer": {"type": "boolean", "default": True},
             "fast_pretreatment": {"type": "boolean"},
-            "duration": {"type": "integer", "description": "Clip length in seconds."},
-            "resolution": {"type": "string", "description": "Output resolution, e.g. 768P or 1080P."},
+            "duration": {
+                "type": "integer",
+                "minimum": 4,
+                "maximum": 15,
+                "description": (
+                    "Clip length in seconds; MiniMax-H3 accepts integers from 4 to 15."
+                ),
+            },
+            "resolution": {
+                "type": "string",
+                "description": (
+                    "MiniMax-H3 requires 2K; v1 models accept their documented "
+                    "resolutions."
+                ),
+            },
+            "ratio": {"type": "string", "enum": V2_RATIO_VALUES},
+            "aspect_ratio": {
+                "type": "string",
+                "enum": V2_RATIO_VALUES,
+                "description": "Selector-compatible alias for ratio.",
+            },
             "callback_url": {"type": "string"},
+            "aigc_watermark": {
+                "type": "boolean",
+                "description": "Mainland China MiniMax-H3 watermark option.",
+            },
             "output_path": {"type": "string"},
         },
     }
@@ -130,24 +199,42 @@ class MiniMaxVideo(BaseTool):
     resource_profile = ResourceProfile(
         cpu_cores=1, ram_mb=512, vram_mb=0, disk_mb=500, network_required=True
     )
-    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
+    retry_policy = RetryPolicy(
+        max_retries=2, retryable_errors=["rate_limit", "timeout"]
+    )
     idempotency_key_fields = [
         "prompt",
         "model",
         "operation",
         "first_frame_image",
+        "last_frame_image",
+        "end_image_url",
         "image_url",
         "reference_image_url",
+        "reference_image_urls",
+        "reference_video_url",
+        "reference_video_urls",
+        "reference_audio_urls",
         "prompt_optimizer",
         "fast_pretreatment",
         "duration",
         "resolution",
+        "ratio",
+        "aspect_ratio",
+        "callback_url",
+        "aigc_watermark",
     ]
     side_effects = ["writes video file to output_path", "calls MiniMax video API"]
-    user_visible_verification = ["Watch generated clip for motion coherence and prompt adherence"]
+    user_visible_verification = [
+        "Watch generated clip for motion coherence and prompt adherence"
+    ]
 
     def _get_api_key(self) -> str | None:
         return os.environ.get("MINIMAX_API_KEY")
+
+    def _region(self) -> str:
+        region = os.environ.get("MINIMAX_REGION", DEFAULT_REGION).strip().lower()
+        return "cn" if region in {"cn", "cn_zh"} else "global"
 
     def _base_url(self) -> str:
         override = os.environ.get("MINIMAX_BASE_URL")
@@ -156,6 +243,9 @@ class MiniMaxVideo(BaseTool):
         region = os.environ.get("MINIMAX_REGION", DEFAULT_REGION).strip().lower()
         return REGION_BASE_URLS.get(region, REGION_BASE_URLS[DEFAULT_REGION])
 
+    def _uses_cn_api(self, base_url: str) -> bool:
+        return self._region() == "cn" or "api.minimaxi.com" in base_url
+
     def get_status(self) -> ToolStatus:
         if self._get_api_key():
             return ToolStatus.AVAILABLE
@@ -163,25 +253,188 @@ class MiniMaxVideo(BaseTool):
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
         model = inputs.get("model", DEFAULT_MODEL)
+        if model == "MiniMax-H3":
+            duration = inputs.get("duration", 5)
+            if isinstance(duration, str) and duration.isdigit():
+                duration = int(duration)
+            seconds = (
+                duration
+                if isinstance(duration, int) and not isinstance(duration, bool)
+                else 5
+            )
+            reference_images = len(inputs.get("reference_image_urls") or [])
+            additional_images = max(0, reference_images - 5)
+            return round((seconds * 0.13) + (additional_images * 0.03), 2)
         if "Fast" in model:
             return 0.08
         return 0.15
 
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         model = inputs.get("model", DEFAULT_MODEL)
+        if model == "MiniMax-H3":
+            return 90.0
         if "Fast" in model:
             return 30.0
         return 60.0
 
     @staticmethod
     def _base_resp_error(payload: dict[str, Any]) -> str | None:
-        """Return an error string when MiniMax base_resp signals failure."""
+        """Return an error string when a v1 base_resp signals failure."""
         base_resp = payload.get("base_resp") or {}
         status_code = base_resp.get("status_code")
         if status_code in (None, 0):
             return None
         status_msg = base_resp.get("status_msg", "")
         return f"MiniMax API error {status_code}: {status_msg}".strip()
+
+    @staticmethod
+    def _media_content(content_type: str, url: str, role: str) -> dict[str, Any]:
+        return {
+            "type": content_type,
+            content_type: {"url": url},
+            "role": role,
+        }
+
+    @staticmethod
+    def _url_values(inputs: dict[str, Any], singular: str, plural: str) -> list[str]:
+        values: list[str] = []
+        if inputs.get(singular):
+            values.append(str(inputs[singular]))
+        values.extend(str(value) for value in (inputs.get(plural) or []) if value)
+        return values
+
+    def _build_v2_payload(
+        self,
+        inputs: dict[str, Any],
+        base_url: str,
+    ) -> tuple[dict[str, Any] | None, str | None]:
+        operation = inputs.get("operation", "text_to_video")
+        prompt = str(inputs.get("prompt") or "")
+        if not prompt:
+            return None, "MiniMax-H3 requires 'prompt'."
+        if len(prompt) > 7000:
+            return None, "MiniMax-H3 prompt must not exceed 7000 characters."
+
+        content: list[dict[str, Any]] = [{"type": "text", "text": prompt}]
+        first_frame = (
+            inputs.get("first_frame_image")
+            or inputs.get("image_url")
+            or inputs.get("reference_image_url")
+        )
+        last_frame = inputs.get("last_frame_image") or inputs.get("end_image_url")
+
+        if operation in {"image_to_video", "first_last_frame_to_video"}:
+            if not first_frame:
+                return None, f"{operation} requires 'first_frame_image'."
+            content.append(
+                self._media_content("image_url", str(first_frame), "first_frame")
+            )
+            if operation == "first_last_frame_to_video" and not last_frame:
+                return None, "first_last_frame_to_video requires 'last_frame_image'."
+            if last_frame:
+                content.append(
+                    self._media_content("image_url", str(last_frame), "last_frame")
+                )
+        elif operation == "reference_to_video":
+            reference_images = self._url_values(
+                inputs, "reference_image_url", "reference_image_urls"
+            )
+            reference_videos = self._url_values(
+                inputs, "reference_video_url", "reference_video_urls"
+            )
+            reference_audio = [
+                str(value)
+                for value in (inputs.get("reference_audio_urls") or [])
+                if value
+            ]
+            if not reference_images and not reference_videos and not reference_audio:
+                return None, "reference_to_video requires at least one reference URL."
+            if reference_audio and not (reference_images or reference_videos):
+                return (
+                    None,
+                    "Reference audio requires at least one reference image or video.",
+                )
+            content.extend(
+                self._media_content("image_url", url, "reference_image")
+                for url in reference_images
+            )
+            content.extend(
+                self._media_content("video_url", url, "reference_video")
+                for url in reference_videos
+            )
+            content.extend(
+                self._media_content("audio_url", url, "reference_audio")
+                for url in reference_audio
+            )
+        elif operation != "text_to_video":
+            return None, f"MiniMax-H3 does not support operation '{operation}'."
+
+        duration = inputs.get("duration", 5)
+        if isinstance(duration, str) and duration.isdigit():
+            duration = int(duration)
+        if (
+            isinstance(duration, bool)
+            or not isinstance(duration, int)
+            or not 4 <= duration <= 15
+        ):
+            return None, "MiniMax-H3 duration must be an integer from 4 to 15 seconds."
+
+        resolution = inputs.get("resolution", "2K")
+        if resolution != "2K":
+            return None, "MiniMax-H3 resolution must be '2K'."
+
+        ratio = inputs.get("ratio") or inputs.get("aspect_ratio")
+        if not ratio:
+            ratio = "16:9" if operation == "text_to_video" else "adaptive"
+        if ratio not in V2_RATIO_VALUES:
+            return None, f"Unsupported MiniMax-H3 ratio '{ratio}'."
+        if operation == "text_to_video" and ratio == "adaptive":
+            return None, "MiniMax-H3 text_to_video does not support the adaptive ratio."
+
+        payload: dict[str, Any] = {
+            "model": "MiniMax-H3",
+            "content": content,
+            "resolution": resolution,
+            "duration": duration,
+            "ratio": ratio,
+        }
+        if inputs.get("callback_url"):
+            payload["callback_url"] = inputs["callback_url"]
+        if self._uses_cn_api(base_url) and "aigc_watermark" in inputs:
+            payload["aigc_watermark"] = inputs["aigc_watermark"]
+        return payload, None
+
+    @staticmethod
+    def _build_v1_payload(
+        inputs: dict[str, Any], model: str
+    ) -> tuple[dict[str, Any] | None, str | None]:
+        operation = inputs.get("operation", "text_to_video")
+        if operation not in {"text_to_video", "image_to_video"}:
+            return None, f"{model} does not support operation '{operation}'."
+
+        payload: dict[str, Any] = {"model": model}
+        if operation == "image_to_video":
+            first_frame = (
+                inputs.get("first_frame_image")
+                or inputs.get("reference_image_url")
+                or inputs.get("image_url")
+            )
+            if not first_frame:
+                return None, "image_to_video requires 'first_frame_image'."
+            payload["first_frame_image"] = first_frame
+            if inputs.get("prompt"):
+                payload["prompt"] = inputs["prompt"]
+        else:
+            if not inputs.get("prompt"):
+                return None, "text_to_video requires 'prompt'."
+            payload["prompt"] = inputs["prompt"]
+
+        if "prompt_optimizer" in inputs:
+            payload["prompt_optimizer"] = inputs["prompt_optimizer"]
+        for field in ("fast_pretreatment", "duration", "resolution", "callback_url"):
+            if inputs.get(field) is not None:
+                payload[field] = inputs[field]
+        return payload, None
 
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
         api_key = self._get_api_key()
@@ -195,38 +448,21 @@ class MiniMaxVideo(BaseTool):
 
         start = time.time()
         base_url = self._base_url()
-        operation = inputs.get("operation", "text_to_video")
         model = inputs.get("model", DEFAULT_MODEL)
-
-        payload: dict[str, Any] = {"model": model}
-        if operation == "image_to_video":
-            first_frame = (
-                inputs.get("first_frame_image")
-                or inputs.get("reference_image_url")
-                or inputs.get("image_url")
+        if model not in MODELS:
+            return ToolResult(
+                success=False, error=f"Unsupported MiniMax model '{model}'."
             )
-            if not first_frame:
-                return ToolResult(
-                    success=False,
-                    error="image_to_video requires 'first_frame_image'.",
-                )
-            payload["first_frame_image"] = first_frame
-            if inputs.get("prompt"):
-                payload["prompt"] = inputs["prompt"]
-        else:
-            if not inputs.get("prompt"):
-                return ToolResult(
-                    success=False,
-                    error="text_to_video requires 'prompt'.",
-                )
-            payload["prompt"] = inputs["prompt"]
 
-        # Optional request fields, passed through only when supplied.
-        if "prompt_optimizer" in inputs:
-            payload["prompt_optimizer"] = inputs["prompt_optimizer"]
-        for field in ("fast_pretreatment", "duration", "resolution", "callback_url"):
-            if inputs.get(field) is not None:
-                payload[field] = inputs[field]
+        if model in V2_MODELS:
+            payload, validation_error = self._build_v2_payload(inputs, base_url)
+            api_version = "v2"
+        else:
+            payload, validation_error = self._build_v1_payload(inputs, model)
+            api_version = "v1"
+        if validation_error:
+            return ToolResult(success=False, error=validation_error)
+        assert payload is not None
 
         headers = {
             "Authorization": f"Bearer {api_key}",
@@ -236,100 +472,130 @@ class MiniMaxVideo(BaseTool):
         def _redact(text: str) -> str:
             return text.replace(api_key, "***") if api_key else text
 
+        task_id: str | None = None
+        file_id: str | None = None
+        task_data: dict[str, Any] = {}
         try:
-            # Submit generation task.
             submit_resp = requests.post(
-                f"{base_url}/v1/video_generation",
+                f"{base_url}/{api_version}/video_generation",
                 headers=headers,
                 json=payload,
                 timeout=30,
             )
             submit_resp.raise_for_status()
             submit_data = submit_resp.json()
-            base_err = self._base_resp_error(submit_data)
-            if base_err:
-                return ToolResult(success=False, error=base_err)
+            if api_version == "v1":
+                base_err = self._base_resp_error(submit_data)
+                if base_err:
+                    return ToolResult(success=False, error=base_err)
             task_id = submit_data.get("task_id")
             if not task_id:
                 return ToolResult(
-                    success=False,
-                    error="MiniMax API did not return a task_id.",
+                    success=False, error="MiniMax API did not return a task_id."
                 )
 
-            # Poll the query endpoint until the task reaches a terminal state.
-            file_id = None
-            while True:
-                time.sleep(5)
-                status_resp = requests.get(
-                    f"{base_url}/v1/query/video_generation",
-                    headers=headers,
-                    params={"task_id": task_id},
-                    timeout=15,
-                )
-                status_resp.raise_for_status()
-                status_data = status_resp.json()
-                base_err = self._base_resp_error(status_data)
-                if base_err:
-                    return ToolResult(success=False, error=base_err)
-                status = status_data.get("status", "")
-                if status == _TERMINAL_SUCCESS:
-                    file_id = status_data.get("file_id")
-                    break
-                if status == _TERMINAL_FAIL:
+            download_url: str | None = None
+            if api_version == "v2":
+                while True:
+                    time.sleep(5)
+                    status_resp = requests.get(
+                        f"{base_url}/v2/query/video_generation/{task_id}",
+                        headers=headers,
+                        timeout=15,
+                    )
+                    status_resp.raise_for_status()
+                    task_data = status_resp.json().get("task") or {}
+                    status = task_data.get("status")
+                    if status == _V2_SUCCESS:
+                        download_url = (task_data.get("content") or {}).get("url")
+                        break
+                    if status in _V2_FAILURES:
+                        error = task_data.get("error") or "unknown error"
+                        return ToolResult(
+                            success=False,
+                            error=f"MiniMax-H3 video generation {status}: {error}",
+                        )
+                    if status not in _V2_IN_PROGRESS:
+                        return ToolResult(
+                            success=False,
+                            error=(
+                                f"MiniMax-H3 returned unknown task status '{status}'."
+                            ),
+                        )
+            else:
+                while True:
+                    time.sleep(5)
+                    status_resp = requests.get(
+                        f"{base_url}/v1/query/video_generation",
+                        headers=headers,
+                        params={"task_id": task_id},
+                        timeout=15,
+                    )
+                    status_resp.raise_for_status()
+                    status_data = status_resp.json()
+                    base_err = self._base_resp_error(status_data)
+                    if base_err:
+                        return ToolResult(success=False, error=base_err)
+                    status = status_data.get("status", "")
+                    if status == _V1_SUCCESS:
+                        file_id = status_data.get("file_id")
+                        break
+                    if status == _V1_FAILURE:
+                        return ToolResult(
+                            success=False, error="MiniMax video generation failed."
+                        )
+
+                if not file_id:
                     return ToolResult(
                         success=False,
-                        error="MiniMax video generation failed.",
+                        error="MiniMax API did not return a file_id on success.",
                     )
-
-            if not file_id:
-                return ToolResult(
-                    success=False,
-                    error="MiniMax API did not return a file_id on success.",
+                file_resp = requests.get(
+                    f"{base_url}/v1/files/retrieve",
+                    headers=headers,
+                    params={"file_id": file_id},
+                    timeout=30,
                 )
+                file_resp.raise_for_status()
+                file_data = file_resp.json()
+                base_err = self._base_resp_error(file_data)
+                if base_err:
+                    return ToolResult(success=False, error=base_err)
+                download_url = (file_data.get("file") or {}).get("download_url")
 
-            # Retrieve the download URL for the generated file.
-            file_resp = requests.get(
-                f"{base_url}/v1/files/retrieve",
-                headers=headers,
-                params={"file_id": file_id},
-                timeout=30,
-            )
-            file_resp.raise_for_status()
-            file_data = file_resp.json()
-            base_err = self._base_resp_error(file_data)
-            if base_err:
-                return ToolResult(success=False, error=base_err)
-            download_url = (file_data.get("file") or {}).get("download_url")
             if not download_url:
                 return ToolResult(
-                    success=False,
-                    error="MiniMax API did not return a download_url.",
+                    success=False, error="MiniMax API did not return a download URL."
                 )
 
             video_response = requests.get(download_url, timeout=120)
             video_response.raise_for_status()
-
             output_path = Path(inputs.get("output_path", "minimax_output.mp4"))
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_bytes(video_response.content)
-
         except Exception as e:  # noqa: BLE001 - surface a redacted error to the caller
             return ToolResult(
                 success=False,
                 error=f"MiniMax video generation failed: {_redact(str(e))}",
             )
 
+        data: dict[str, Any] = {
+            "provider": "minimax",
+            "model": model,
+            "api_version": api_version,
+            "region": base_url,
+            "task_id": task_id,
+            "prompt": inputs.get("prompt", ""),
+            "output": str(output_path),
+        }
+        if file_id:
+            data["file_id"] = file_id
+        if task_data:
+            data["task"] = task_data
+
         return ToolResult(
             success=True,
-            data={
-                "provider": "minimax",
-                "model": model,
-                "region": base_url,
-                "task_id": task_id,
-                "file_id": file_id,
-                "prompt": inputs.get("prompt", ""),
-                "output": str(output_path),
-            },
+            data=data,
             artifacts=[str(output_path)],
             cost_usd=self.estimate_cost(inputs),
             duration_seconds=round(time.time() - start, 2),

--- a/tools/video/minimax_video.py
+++ b/tools/video/minimax_video.py
@@ -110,6 +110,14 @@ class MiniMaxVideo(BaseTool):
                     "data URI (data:image/...;base64,<payload>)."
                 ),
             },
+            "image_url": {
+                "type": "string",
+                "description": "Selector-compatible alias for first_frame_image.",
+            },
+            "reference_image_url": {
+                "type": "string",
+                "description": "Alias for first_frame_image.",
+            },
             "prompt_optimizer": {"type": "boolean", "default": True},
             "fast_pretreatment": {"type": "boolean"},
             "duration": {"type": "integer", "description": "Clip length in seconds."},
@@ -128,6 +136,8 @@ class MiniMaxVideo(BaseTool):
         "model",
         "operation",
         "first_frame_image",
+        "image_url",
+        "reference_image_url",
         "prompt_optimizer",
         "fast_pretreatment",
         "duration",
@@ -190,7 +200,11 @@ class MiniMaxVideo(BaseTool):
 
         payload: dict[str, Any] = {"model": model}
         if operation == "image_to_video":
-            first_frame = inputs.get("first_frame_image")
+            first_frame = (
+                inputs.get("first_frame_image")
+                or inputs.get("reference_image_url")
+                or inputs.get("image_url")
+            )
             if not first_frame:
                 return ToolResult(
                     success=False,

--- a/tools/video/minimax_video.py
+++ b/tools/video/minimax_video.py
@@ -1,6 +1,9 @@
-"""MiniMax (Hailuo AI) video generation via fal.ai API.
+"""MiniMax (Hailuo) video generation via the official MiniMax API.
 
-Rewards prompt craft — follows camera directions well and produces high-texture footage.
+Calls the first-party MiniMax video endpoints directly with ``MINIMAX_API_KEY``
+(Bearer auth), covering both the global (``api.minimax.io``) and CN
+(``api.minimaxi.com``) regions. Rewards prompt craft — follows camera
+directions well and produces high-texture footage.
 """
 
 from __future__ import annotations
@@ -23,10 +26,36 @@ from tools.base_tool import (
     ToolTier,
 )
 
+# Direct MiniMax API hosts per region. The global region is the default; set
+# MINIMAX_REGION=cn to route to the mainland China host.
+REGION_BASE_URLS = {
+    "global": "https://api.minimax.io",
+    "cn": "https://api.minimaxi.com",
+}
+DEFAULT_REGION = "global"
+
+# Current first-party model slugs (Hailuo 2.3 family plus prior generations).
+MODELS = [
+    "MiniMax-Hailuo-2.3",
+    "MiniMax-Hailuo-2.3-Fast",
+    "MiniMax-Hailuo-02",
+    "T2V-01-Director",
+    "T2V-01",
+    "I2V-01-Director",
+    "I2V-01-live",
+    "I2V-01",
+]
+DEFAULT_MODEL = "MiniMax-Hailuo-2.3"
+
+# In-progress poll states returned by the query endpoint. Anything outside the
+# terminal Success/Fail values means the task is still running.
+_TERMINAL_SUCCESS = "Success"
+_TERMINAL_FAIL = "Fail"
+
 
 class MiniMaxVideo(BaseTool):
     name = "minimax_video"
-    version = "0.1.0"
+    version = "0.2.0"
     tier = ToolTier.GENERATE
     capability = "video_generation"
     provider = "minimax"
@@ -35,10 +64,13 @@ class MiniMaxVideo(BaseTool):
     determinism = Determinism.STOCHASTIC
     runtime = ToolRuntime.API
 
-    dependencies = []
+    dependencies = ["env:MINIMAX_API_KEY"]
     install_instructions = (
-        "Set FAL_KEY to your fal.ai API key.\n"
-        "  Get one at https://fal.ai/dashboard/keys"
+        "Set MINIMAX_API_KEY to your MiniMax API key.\n"
+        "  Get one at https://platform.minimax.io/ (global) or "
+        "https://platform.minimaxi.com/ (CN).\n"
+        "  Optionally set MINIMAX_REGION=cn to route to the mainland China host, "
+        "or MINIMAX_BASE_URL to override the endpoint entirely."
     )
     agent_skills = ["ai-video-gen"]
 
@@ -51,7 +83,7 @@ class MiniMaxVideo(BaseTool):
     best_for = [
         "prompt-following with camera directions (framing, motion, composition)",
         "high-texture footage with minimal hallucination",
-        "cost-effective video generation",
+        "direct first-party API access with your own MiniMax quota",
     ]
     not_good_for = ["offline generation", "very long clips"]
     fallback_tools = ["kling_video", "veo_video", "wan_video"]
@@ -66,15 +98,23 @@ class MiniMaxVideo(BaseTool):
                 "enum": ["text_to_video", "image_to_video"],
                 "default": "text_to_video",
             },
-            "model_variant": {
+            "model": {
                 "type": "string",
-                "enum": [
-                    "video-01", "hailuo-02/pro", "hailuo-02/standard",
-                    "hailuo-2.3-fast/pro", "hailuo-2.3-fast/standard",
-                ],
-                "default": "hailuo-02/pro",
+                "enum": MODELS,
+                "default": DEFAULT_MODEL,
             },
-            "image_url": {"type": "string", "description": "Reference image URL for image_to_video"},
+            "first_frame_image": {
+                "type": "string",
+                "description": (
+                    "First-frame image for image_to_video: a public URL or a "
+                    "data URI (data:image/...;base64,<payload>)."
+                ),
+            },
+            "prompt_optimizer": {"type": "boolean", "default": True},
+            "fast_pretreatment": {"type": "boolean"},
+            "duration": {"type": "integer", "description": "Clip length in seconds."},
+            "resolution": {"type": "string", "description": "Output resolution, e.g. 768P or 1080P."},
+            "callback_url": {"type": "string"},
             "output_path": {"type": "string"},
         },
     }
@@ -83,12 +123,28 @@ class MiniMaxVideo(BaseTool):
         cpu_cores=1, ram_mb=512, vram_mb=0, disk_mb=500, network_required=True
     )
     retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
-    idempotency_key_fields = ["prompt", "model_variant", "operation"]
-    side_effects = ["writes video file to output_path", "calls fal.ai API"]
+    idempotency_key_fields = [
+        "prompt",
+        "model",
+        "operation",
+        "first_frame_image",
+        "prompt_optimizer",
+        "fast_pretreatment",
+        "duration",
+        "resolution",
+    ]
+    side_effects = ["writes video file to output_path", "calls MiniMax video API"]
     user_visible_verification = ["Watch generated clip for motion coherence and prompt adherence"]
 
     def _get_api_key(self) -> str | None:
-        return os.environ.get("FAL_KEY") or os.environ.get("FAL_AI_API_KEY")
+        return os.environ.get("MINIMAX_API_KEY")
+
+    def _base_url(self) -> str:
+        override = os.environ.get("MINIMAX_BASE_URL")
+        if override:
+            return override.rstrip("/")
+        region = os.environ.get("MINIMAX_REGION", DEFAULT_REGION).strip().lower()
+        return REGION_BASE_URLS.get(region, REGION_BASE_URLS[DEFAULT_REGION])
 
     def get_status(self) -> ToolStatus:
         if self._get_api_key():
@@ -96,105 +152,172 @@ class MiniMaxVideo(BaseTool):
         return ToolStatus.UNAVAILABLE
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
-        variant = inputs.get("model_variant", "hailuo-02/pro")
-        if "pro" in variant:
-            return 0.15
-        if "fast" in variant:
+        model = inputs.get("model", DEFAULT_MODEL)
+        if "Fast" in model:
             return 0.08
-        return 0.10  # standard
+        return 0.15
 
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
-        variant = inputs.get("model_variant", "hailuo-02/pro")
-        if "fast" in variant:
+        model = inputs.get("model", DEFAULT_MODEL)
+        if "Fast" in model:
             return 30.0
         return 60.0
+
+    @staticmethod
+    def _base_resp_error(payload: dict[str, Any]) -> str | None:
+        """Return an error string when MiniMax base_resp signals failure."""
+        base_resp = payload.get("base_resp") or {}
+        status_code = base_resp.get("status_code")
+        if status_code in (None, 0):
+            return None
+        status_msg = base_resp.get("status_msg", "")
+        return f"MiniMax API error {status_code}: {status_msg}".strip()
 
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
         api_key = self._get_api_key()
         if not api_key:
             return ToolResult(
                 success=False,
-                error="FAL_KEY not set. " + self.install_instructions,
+                error="MINIMAX_API_KEY not set. " + self.install_instructions,
             )
 
         import requests
 
         start = time.time()
+        base_url = self._base_url()
         operation = inputs.get("operation", "text_to_video")
-        variant = inputs.get("model_variant", "hailuo-02/pro")
+        model = inputs.get("model", DEFAULT_MODEL)
 
-        # Build fal.ai model path
-        if operation == "text_to_video":
-            model_path = f"minimax/{variant}/text-to-video"
-            if variant == "video-01":
-                model_path = "minimax/video-01"
+        payload: dict[str, Any] = {"model": model}
+        if operation == "image_to_video":
+            first_frame = inputs.get("first_frame_image")
+            if not first_frame:
+                return ToolResult(
+                    success=False,
+                    error="image_to_video requires 'first_frame_image'.",
+                )
+            payload["first_frame_image"] = first_frame
+            if inputs.get("prompt"):
+                payload["prompt"] = inputs["prompt"]
         else:
-            model_path = f"minimax/{variant}/image-to-video"
-            if variant == "video-01":
-                model_path = "minimax/video-01/image-to-video"
+            if not inputs.get("prompt"):
+                return ToolResult(
+                    success=False,
+                    error="text_to_video requires 'prompt'.",
+                )
+            payload["prompt"] = inputs["prompt"]
 
-        payload: dict[str, Any] = {"prompt": inputs["prompt"]}
-        if operation == "image_to_video" and inputs.get("image_url"):
-            payload["image_url"] = inputs["image_url"]
+        # Optional request fields, passed through only when supplied.
+        if "prompt_optimizer" in inputs:
+            payload["prompt_optimizer"] = inputs["prompt_optimizer"]
+        for field in ("fast_pretreatment", "duration", "resolution", "callback_url"):
+            if inputs.get(field) is not None:
+                payload[field] = inputs[field]
 
         headers = {
-            "Authorization": f"Key {api_key}",
+            "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
         }
 
+        def _redact(text: str) -> str:
+            return text.replace(api_key, "***") if api_key else text
+
         try:
-            # Submit to queue API (async) — sync endpoint times out for video gen
+            # Submit generation task.
             submit_resp = requests.post(
-                f"https://queue.fal.run/fal-ai/{model_path}",
+                f"{base_url}/v1/video_generation",
                 headers=headers,
                 json=payload,
                 timeout=30,
             )
             submit_resp.raise_for_status()
-            queue_data = submit_resp.json()
-            status_url = queue_data["status_url"]
-            response_url = queue_data["response_url"]
+            submit_data = submit_resp.json()
+            base_err = self._base_resp_error(submit_data)
+            if base_err:
+                return ToolResult(success=False, error=base_err)
+            task_id = submit_data.get("task_id")
+            if not task_id:
+                return ToolResult(
+                    success=False,
+                    error="MiniMax API did not return a task_id.",
+                )
 
-            # Poll until complete
+            # Poll the query endpoint until the task reaches a terminal state.
+            file_id = None
             while True:
                 time.sleep(5)
-                status_resp = requests.get(status_url, headers=headers, timeout=15)
+                status_resp = requests.get(
+                    f"{base_url}/v1/query/video_generation",
+                    headers=headers,
+                    params={"task_id": task_id},
+                    timeout=15,
+                )
                 status_resp.raise_for_status()
-                status = status_resp.json().get("status", "UNKNOWN")
-                if status == "COMPLETED":
+                status_data = status_resp.json()
+                base_err = self._base_resp_error(status_data)
+                if base_err:
+                    return ToolResult(success=False, error=base_err)
+                status = status_data.get("status", "")
+                if status == _TERMINAL_SUCCESS:
+                    file_id = status_data.get("file_id")
                     break
-                if status in ("FAILED", "CANCELLED"):
+                if status == _TERMINAL_FAIL:
                     return ToolResult(
                         success=False,
-                        error=f"MiniMax video generation {status.lower()}",
+                        error="MiniMax video generation failed.",
                     )
 
-            # Fetch result
-            result_resp = requests.get(response_url, headers=headers, timeout=30)
-            result_resp.raise_for_status()
-            data = result_resp.json()
+            if not file_id:
+                return ToolResult(
+                    success=False,
+                    error="MiniMax API did not return a file_id on success.",
+                )
 
-            video_url = data["video"]["url"]
-            video_response = requests.get(video_url, timeout=120)
+            # Retrieve the download URL for the generated file.
+            file_resp = requests.get(
+                f"{base_url}/v1/files/retrieve",
+                headers=headers,
+                params={"file_id": file_id},
+                timeout=30,
+            )
+            file_resp.raise_for_status()
+            file_data = file_resp.json()
+            base_err = self._base_resp_error(file_data)
+            if base_err:
+                return ToolResult(success=False, error=base_err)
+            download_url = (file_data.get("file") or {}).get("download_url")
+            if not download_url:
+                return ToolResult(
+                    success=False,
+                    error="MiniMax API did not return a download_url.",
+                )
+
+            video_response = requests.get(download_url, timeout=120)
             video_response.raise_for_status()
 
             output_path = Path(inputs.get("output_path", "minimax_output.mp4"))
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_bytes(video_response.content)
 
-        except Exception as e:
-            return ToolResult(success=False, error=f"MiniMax video generation failed: {e}")
+        except Exception as e:  # noqa: BLE001 - surface a redacted error to the caller
+            return ToolResult(
+                success=False,
+                error=f"MiniMax video generation failed: {_redact(str(e))}",
+            )
 
         return ToolResult(
             success=True,
             data={
                 "provider": "minimax",
-                "model": f"fal-ai/{model_path}",
-                "prompt": inputs["prompt"],
+                "model": model,
+                "region": base_url,
+                "task_id": task_id,
+                "file_id": file_id,
+                "prompt": inputs.get("prompt", ""),
                 "output": str(output_path),
             },
             artifacts=[str(output_path)],
             cost_usd=self.estimate_cost(inputs),
             duration_seconds=round(time.time() - start, 2),
-            model=f"fal-ai/{model_path}",
+            model=model,
         )

--- a/tools/video/minimax_video.py
+++ b/tools/video/minimax_video.py
@@ -192,6 +192,23 @@ class MiniMaxVideo(BaseTool):
                 "type": "boolean",
                 "description": "Mainland China MiniMax-H3 watermark option.",
             },
+            "poll_interval_seconds": {
+                "type": "number",
+                "minimum": 0.1,
+                "maximum": 60,
+                "default": 5,
+                "description": "Seconds between task-status requests.",
+            },
+            "timeout_seconds": {
+                "type": "number",
+                "minimum": 1,
+                "maximum": 3600,
+                "default": 900,
+                "description": (
+                    "Maximum time to wait for remote generation. Timeout errors "
+                    "include task_id so the job can be recovered manually."
+                ),
+            },
             "output_path": {"type": "string"},
         },
     }
@@ -475,6 +492,28 @@ class MiniMaxVideo(BaseTool):
         task_id: str | None = None
         file_id: str | None = None
         task_data: dict[str, Any] = {}
+        poll_interval = max(float(inputs.get("poll_interval_seconds", 5)), 0.1)
+        timeout_seconds = max(float(inputs.get("timeout_seconds", 900)), 1.0)
+        poll_deadline = time.monotonic() + timeout_seconds
+
+        def _timeout_result() -> ToolResult:
+            return ToolResult(
+                success=False,
+                error=(
+                    f"MiniMax video generation timed out after {timeout_seconds:g}s; "
+                    f"the remote task may still complete. Resume or inspect task_id "
+                    f"'{task_id}'."
+                ),
+                data={
+                    "provider": "minimax",
+                    "model": model,
+                    "api_version": api_version,
+                    "task_id": task_id,
+                    "status": "timed_out",
+                },
+                model=model,
+            )
+
         try:
             submit_resp = requests.post(
                 f"{base_url}/{api_version}/video_generation",
@@ -497,7 +536,11 @@ class MiniMaxVideo(BaseTool):
             download_url: str | None = None
             if api_version == "v2":
                 while True:
-                    time.sleep(5)
+                    if time.monotonic() >= poll_deadline:
+                        return _timeout_result()
+                    time.sleep(min(poll_interval, max(poll_deadline - time.monotonic(), 0)))
+                    if time.monotonic() >= poll_deadline:
+                        return _timeout_result()
                     status_resp = requests.get(
                         f"{base_url}/v2/query/video_generation/{task_id}",
                         headers=headers,
@@ -524,7 +567,11 @@ class MiniMaxVideo(BaseTool):
                         )
             else:
                 while True:
-                    time.sleep(5)
+                    if time.monotonic() >= poll_deadline:
+                        return _timeout_result()
+                    time.sleep(min(poll_interval, max(poll_deadline - time.monotonic(), 0)))
+                    if time.monotonic() >= poll_deadline:
+                        return _timeout_result()
                     status_resp = requests.get(
                         f"{base_url}/v1/query/video_generation",
                         headers=headers,
@@ -577,6 +624,13 @@ class MiniMaxVideo(BaseTool):
             return ToolResult(
                 success=False,
                 error=f"MiniMax video generation failed: {_redact(str(e))}",
+                data={
+                    "provider": "minimax",
+                    "model": model,
+                    "api_version": api_version,
+                    "task_id": task_id,
+                } if task_id else {},
+                model=model,
             )
 
         data: dict[str, Any] = {


### PR DESCRIPTION
Reason: Refresh `minimax_video` to the first-party MiniMax video API with direct global and CN endpoints and the current Hailuo 2.3 request/response contract.

`minimax_video` previously routed through a third-party gateway with gateway credentials and gateway-specific model slugs, so it lacked the direct MiniMax endpoints and the current first-party request/response contract. This refreshes the tool to call the official MiniMax video API directly.

## Changes

- **`tools/video/minimax_video.py`**
  - Auth via `MINIMAX_API_KEY` with `Authorization: Bearer <key>` (was gateway credentials).
  - Region selection: `MINIMAX_REGION=global` (default, `https://api.minimax.io`) or `cn` (`https://api.minimaxi.com`), with an optional `MINIMAX_BASE_URL` override.
  - Current model slugs (`MiniMax-Hailuo-2.3`, `MiniMax-Hailuo-2.3-Fast`, `MiniMax-Hailuo-02`, and the `T2V-01`/`I2V-01` families), default `MiniMax-Hailuo-2.3`.
  - Direct request/response contract: `POST /v1/video_generation` → poll `GET /v1/query/video_generation` → `GET /v1/files/retrieve` → download the returned URL. Request fields: `model`, `prompt`, `first_frame_image` (image-to-video), `prompt_optimizer`, `fast_pretreatment`, `duration`, `resolution`, `callback_url`. Errors surface `base_resp.status_code`/`status_msg`, with API-key redaction in error messages.
  - Idempotency key now covers the output-affecting fields (model, operation, first_frame_image, prompt_optimizer, fast_pretreatment, duration, resolution).
- **`.env.example`** and **`docs/PROVIDERS.md`**: document `MINIMAX_API_KEY` / `MINIMAX_REGION` / `MINIMAX_BASE_URL` and move `minimax_video` from the gateway entries to a dedicated direct-API section.
- **`tests/tools/test_minimax_video.py`**: new contract test covering registry discovery, availability, region routing, the text-to-video direct-API request/response flow, the image-to-video first-frame requirement, and `base_resp` error surfacing. HTTP is mocked with `monkeypatch.setattr` on the live `requests` module so the shared `requests` import stays intact for the rest of the suite.

## Checks

- `python -m pytest tests/tools/test_minimax_video.py -v` — 6 passed
- `python -m pytest tests/contracts/test_jimeng_video.py tests/tools/test_provider_model_defaults.py tests/tools/test_video_selector_routing.py -q` — 76 passed (no regressions)
- `python -m py_compile tools/base_tool.py tools/tool_registry.py tools/video/minimax_video.py tests/tools/test_minimax_video.py`
