### PR TITLE
fix(checkpoint): enforce pipeline stage prerequisites at write time

### DIFF
--- a/lib/checkpoint.py
+++ b/lib/checkpoint.py
@@ -227,6 +227,64 @@ def init_project(
     return project_dir
 
 
+def _check_stage_prerequisites(
+    pipeline_dir: Path,
+    project_id: str,
+    stage: str,
+    status: str,
+    pipeline_type: Optional[str],
+) -> None:
+    """Raise CheckpointValidationError if prerequisite stages are not completed.
+
+    Enforced when status is 'awaiting_human' or 'completed' — the two states
+    that indicate a stage is actually executing. 'in_progress' writes are
+    exempt so incremental heartbeats don't require all prior stages to finish.
+
+    Only enforced when pipeline_type is known (so the manifest-driven stage
+    order is available). If the manifest cannot be loaded the check is skipped
+    rather than blocking a valid run — degradation must be visible via the
+    existing load-failure warning in get_pipeline_stages().
+    """
+    if status == "in_progress":
+        return
+    if not pipeline_type or pipeline_type == "unknown":
+        return
+
+    try:
+        stages = get_pipeline_stages(pipeline_type)
+    except Exception:
+        return  # Manifest unavailable — skip silently (warning already logged)
+
+    if stage not in stages:
+        return  # Unknown stage for this pipeline — let later validation catch it
+
+    stage_index = stages.index(stage)
+    if stage_index == 0:
+        return  # First stage has no prerequisites
+
+    missing = []
+    for prior_stage in stages[:stage_index]:
+        path = _checkpoint_path(pipeline_dir, project_id, prior_stage)
+        if not path.exists():
+            missing.append(prior_stage)
+            continue
+        try:
+            with open(path) as f:
+                prior = json.load(f)
+            if prior.get("status") != "completed":
+                missing.append(prior_stage)
+        except (json.JSONDecodeError, OSError):
+            missing.append(prior_stage)
+
+    if missing:
+        raise CheckpointValidationError(
+            f"PREREQUISITE VIOLATION: stage {stage!r} cannot proceed — "
+            f"the following stages must be completed first: {missing}. "
+            f"Pipeline order for {pipeline_type!r}: {stages}. "
+            f"Complete the missing stages in order before writing {stage!r}."
+        )
+
+
 def _stage_requires_approval(pipeline_type: Optional[str], stage: str) -> Optional[bool]:
     """Read human_approval_default for a stage from its pipeline manifest.
 
@@ -374,6 +432,12 @@ def write_checkpoint(
             f"Invalid stage: {stage!r} for pipeline {pipeline_type!r}. "
             f"Valid stages: {sorted(valid_stages)}"
         )
+
+    # --- Prerequisite stage enforcement ---
+    # Ensures stages run in declared pipeline order. A stage cannot be written
+    # as awaiting_human or completed unless all prior stages have completed
+    # checkpoints. in_progress writes are exempt (heartbeats/partial progress).
+    _check_stage_prerequisites(pipeline_dir, project_id, stage, status, pipeline_type)
 
     # --- Gate enforcement (GI-4) ---
     # The pipeline manifest is the binding source of truth for whether a stage


### PR DESCRIPTION
## Problem

`write_checkpoint()` validated artifact schemas and gate approval, but had no check that prior pipeline stages were actually completed. This allowed agents to skip stages silently — for example, jumping straight from init to `proposal` without running `research`, even though `proposal` declares `required_artifacts_in: [research_brief]` in the pipeline manifest.

The governance contract existed in the YAML but was not enforced at the persistence layer.

## What this PR does

Adds `_check_stage_prerequisites()`, called inside `write_checkpoint()` before gate enforcement. When a stage attempts to write an `awaiting_human` or `completed` checkpoint, it:

1. Loads the pipeline's stage order from the manifest via `get_pipeline_stages()`
2. Walks every stage that precedes the current one
3. Checks each has an existing checkpoint file with `status: completed`
4. If any are missing, raises `CheckpointValidationError` with the exact list

**Error message example:**
```
PREREQUISITE VIOLATION: stage 'proposal' cannot proceed —
the following stages must be completed first: ['research'].
Pipeline order for 'cinematic': ['research', 'proposal', ...].
```

## Behaviour boundaries

| Situation | Behaviour |
|-----------|-----------|
| `status="in_progress"` | Exempt — heartbeats / partial progress should not be blocked |
| `pipeline_type` missing or `"unknown"` | Skip check (fail-open, same pattern as gate enforcement) |
| Manifest fails to load | Skip check (warning already surfaced by `get_pipeline_stages()`) |
| `read_checkpoint()` | Unaffected — prerequisite check is write-only |
| Existing projects with pre-existing checkpoints | Unaffected — check only fires on new writes |

## Testing

Verified three cases:
- `proposal` with no `research` checkpoint → blocked ✅  
- `research` completed, then `proposal` → allowed ✅  
- `script` with `research` but no `proposal` → blocked on `proposal` ✅

Existing project checkpoints continue to read and validate without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)