### PR TITLE
fix: route Lyria 3 requests to the global Vertex location

### DIFF
--- a/tests/tools/test_google_music_global_location.py
+++ b/tests/tools/test_google_music_global_location.py
@@ -1,0 +1,44 @@
+"""Regression test: google_music must request the global Vertex location.
+
+Lyria 3 is only served from the "global" Vertex location. When the genai
+client was built with the default region (e.g. us-central1 from
+GOOGLE_CLOUD_LOCATION), every Vertex-authenticated generation failed with
+`400 Lyria 3 is only supported in the global location.` The tool must pass
+an explicit location override so the region env var cannot break music
+generation.
+"""
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def test_google_music_builds_client_with_global_location(monkeypatch, tmp_path):
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+
+    import tools.google_credentials as gc
+
+    captured: dict = {}
+
+    class _Boom(Exception):
+        pass
+
+    def _fake_get_genai_client(http_options=None, location=None):
+        captured["location"] = location
+        raise _Boom("stop before any network call")
+
+    monkeypatch.setattr(gc, "get_genai_client", _fake_get_genai_client)
+
+    from tools.audio.google_music import GoogleMusic
+
+    result = GoogleMusic().execute(
+        {"prompt": "solo piano", "output_path": str(tmp_path / "m.mp3")}
+    )
+
+    # The client factory must be asked for the global location regardless of
+    # GOOGLE_CLOUD_LOCATION; the stub then aborts before any network call.
+    assert captured["location"] == "global"
+    assert not result.success

--- a/tools/audio/google_music.py
+++ b/tools/audio/google_music.py
@@ -146,7 +146,8 @@ class GoogleMusic(BaseTool):
             from tools.google_credentials import get_genai_client, GOOGLE_API_TIMEOUT_MS
 
             http_options = types.HttpOptions(timeout=GOOGLE_API_TIMEOUT_MS)
-            client = get_genai_client(http_options=http_options)
+            # Lyria 3 is only served from the "global" Vertex location.
+            client = get_genai_client(http_options=http_options, location="global")
         except ImportError as e:
             return ToolResult(
                 success=False,

--- a/tools/google_credentials.py
+++ b/tools/google_credentials.py
@@ -38,8 +38,13 @@ def has_google_credentials() -> bool:
     )
 
 
-def get_genai_client(http_options: Any | None = None) -> Any:
-    """Lazily import and initialize the Google GenAI Client based on configured credentials."""
+def get_genai_client(http_options: Any | None = None, location: str | None = None) -> Any:
+    """Lazily import and initialize the Google GenAI Client based on configured credentials.
+
+    ``location`` overrides the Vertex region for models that are only served
+    from a specific location (e.g. Lyria 3 requires ``global``). It is ignored
+    on the API-key path, which has no region concept.
+    """
     from google import genai
 
     api_key = os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")
@@ -51,7 +56,8 @@ def get_genai_client(http_options: Any | None = None) -> Any:
     if use_vertex or (not api_key and service_account_configured()):
         kwargs = {
             "vertexai": True,
-            "location": os.environ.get("GOOGLE_CLOUD_LOCATION", "us-central1"),
+            "location": location
+            or os.environ.get("GOOGLE_CLOUD_LOCATION", "us-central1"),
             "http_options": http_options,
         }
         project_id = resolve_project_id()


### PR DESCRIPTION
Lyria 3 is only served from the `global` Vertex location. With the client built from `GOOGLE_CLOUD_LOCATION` (e.g. `us-central1`), every Vertex-authenticated generation failed with `400 Lyria 3 is only supported in the global location.`

- Add an optional `location` override to `get_genai_client` (ignored on the API-key path)
- `google_music` now always requests `location="global"`
- Verified live against `lyria-3-pro-preview` on Vertex; offline unit test included

🤖 Generated with [Claude Code](https://claude.com/claude-code)