### PR TITLE
Fix artifact schema drift and the Remotion render path

### DIFF
--- a/remotion-composer/SCENE_TYPES.md
+++ b/remotion-composer/SCENE_TYPES.md
@@ -50,7 +50,22 @@ When you add a new component, append it here and in `src/components/index.ts`.
      return maybeWrapWithBg(<MyScene ... />);
    }
    ```
-5. Document it in this file. That's what makes it discoverable to the next agent.
+5. Add the `type` to **`schemas/artifacts/edit_decisions.schema.json`** — the
+   `$defs.scene_type` enum — and declare any new prop fields on `cuts[]`. The
+   schema sets `additionalProperties: false`, so a type or prop that is missing
+   there is rejected at checkpoint time even though the renderer handles it.
+6. Add the `type` to **`VideoCompose._REMOTION_SCENE_TYPES`** in
+   `tools/video/video_compose.py`.
+7. Document it in this file. That's what makes it discoverable to the next agent.
+
+Steps 3–7 are enforced by `tests/contracts/test_artifact_schema_drift.py`, which
+fails if the dispatch cases, this table, the schema enum, and the Python set ever
+disagree.
+
+> If a media-bearing prop is added (something that points at a file on disk),
+> also add it to `VideoCompose._REMOTION_MEDIA_FIELDS` so `_stage_remotion_assets`
+> copies it into `public/` before the render. Assets outside `public/` cannot be
+> reached by `staticFile()` and 404 silently.
 
 ## Existing synthetic-UI components
 

--- a/remotion-composer/src/CinematicRenderer.tsx
+++ b/remotion-composer/src/CinematicRenderer.tsx
@@ -456,11 +456,16 @@ const Soundtrack: React.FC<{
 
 export const calculateCinematicMetadata: CalculateMetadataFunction<CinematicRendererProps> =
   async ({ props }) => {
+    // `scenes` may be absent when a caller passes props shaped for a different
+    // composition. Default rather than throwing, so the failure surfaces as a
+    // blank render with a readable message instead of a TypeError inside
+    // Remotion's metadata phase.
+    const sceneList = props.scenes ?? [];
     const totalSeconds =
-      props.scenes.length === 0
+      sceneList.length === 0
         ? 30
         : Math.max(
-            ...props.scenes.map((scene) => scene.startSeconds + scene.durationSeconds),
+            ...sceneList.map((scene) => scene.startSeconds + scene.durationSeconds),
           );
 
     return {
@@ -472,7 +477,7 @@ export const calculateCinematicMetadata: CalculateMetadataFunction<CinematicRend
   };
 
 export const CinematicRenderer: React.FC<CinematicRendererProps> = ({
-  scenes,
+  scenes = [],
   titleFontSize = 78,
   titleWidth = 1320,
   signalLineCount = 18,

--- a/remotion-composer/src/cinematic/types.ts
+++ b/remotion-composer/src/cinematic/types.ts
@@ -56,7 +56,9 @@ export interface CinematicCaptionConfig {
 
 export interface CinematicRendererProps {
   [key: string]: unknown;
-  scenes: CinematicScene[];
+  /** Optional so a caller passing props for a different composition renders
+   *  blank rather than throwing inside calculateMetadata. */
+  scenes?: CinematicScene[];
   titleFontSize?: number;
   titleWidth?: number;
   signalLineCount?: number;

--- a/schemas/artifacts/asset_manifest.schema.json
+++ b/schemas/artifacts/asset_manifest.schema.json
@@ -11,7 +11,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["id", "type", "path", "source_tool", "scene_id"],
+        "required": ["id", "type", "path", "source_tool"],
         "properties": {
           "id": { "type": "string" },
           "type": {
@@ -20,7 +20,10 @@
           },
           "path": { "type": "string", "description": "Relative path within the pipeline project directory" },
           "source_tool": { "type": "string" },
-          "scene_id": { "type": "string" },
+          "scene_id": {
+            "type": "string",
+            "description": "Scene this asset belongs to. REQUIRED for every scene-bound asset — the reviewer treats a missing scene_id on an image/video/narration entry as a finding. Omitted only for project-global assets that have no scene: background music, fonts, LUTs, a whole-video subtitle track."
+          },
           "prompt": { "type": "string", "description": "Generation prompt if AI-generated" },
           "seed": { "type": "integer", "description": "Seed if applicable" },
           "model": { "type": "string", "description": "Model used for generation" },

--- a/schemas/artifacts/edit_decisions.schema.json
+++ b/schemas/artifacts/edit_decisions.schema.json
@@ -14,20 +14,40 @@
         "required": ["id", "source", "in_seconds", "out_seconds"],
         "properties": {
           "id": { "type": "string" },
-          "source": { "type": "string", "description": "Source file path or asset-manifest ID" },
+          "source": { "type": "string", "description": "Source file path or asset-manifest ID. Empty string for pure component scenes (cut.type set, no media)." },
           "in_seconds": { "type": "number", "minimum": 0 },
           "out_seconds": { "type": "number", "minimum": 0 },
+          "source_in_seconds": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Seek offset INTO the source media before playback. Distinct from in_seconds (timeline position). Read by remotion-composer/src/Explainer.tsx."
+          },
           "speed": { "type": "number", "minimum": 0.1, "default": 1.0 },
           "layer": {
             "type": "string",
             "enum": ["primary", "overlay", "background"],
             "default": "primary"
           },
+          "type": {
+            "$ref": "#/$defs/scene_type",
+            "description": "Remotion scene-component type. Absent = plain media cut (image via <Img>, video via <OffthreadVideo>). See remotion-composer/SCENE_TYPES.md — that file and this enum must be updated together."
+          },
           "transform": {
             "type": "object",
             "properties": {
               "scale": { "type": "number", "minimum": 0, "default": 1.0 },
-              "position": { "type": "string", "default": "center" },
+              "position": {
+                "oneOf": [
+                  { "type": "string" },
+                  {
+                    "type": "object",
+                    "required": ["x", "y"],
+                    "properties": { "x": { "type": "number" }, "y": { "type": "number" } },
+                    "additionalProperties": false
+                  }
+                ],
+                "default": "center"
+              },
               "animation": {
                 "type": "string",
                 "description": "Motion applied to still images (e.g. ken-burns-slow-zoom, pan-left, static)"
@@ -44,6 +64,10 @@
             },
             "additionalProperties": false
           },
+          "animation": {
+            "type": "string",
+            "description": "Cut-level motion (zoom-in, ken-burns, pan-left, drift-up, parallax, static). Read directly by Explainer.tsx and by video_compose._needs_remotion; transform.animation is the older nested spelling."
+          },
           "transition_in": {
             "type": "string",
             "description": "Transition type entering this cut (e.g. fade, dissolve, cut, wipe)"
@@ -57,43 +81,191 @@
             "minimum": 0,
             "description": "Duration of transition in seconds"
           },
-          "reason": { "type": "string" }
+          "reason": { "type": "string" },
+
+          "text": { "type": "string", "description": "text_card / callout / hero_title body copy" },
+          "title": { "type": "string", "description": "callout / comparison / kpi_grid heading" },
+          "subtitle": { "type": "string", "description": "stat_card secondary line" },
+          "caption": { "type": "string", "description": "HyperFrames scene caption (tools/video/hyperframes_compose.py)" },
+          "stat": { "type": "string", "description": "stat_card headline number" },
+          "callout_type": { "type": "string", "enum": ["info", "warning", "tip", "quote"] },
+          "heroSubtitle": { "type": "string", "description": "hero_title secondary line" },
+
+          "leftLabel": { "type": "string" },
+          "rightLabel": { "type": "string" },
+          "leftValue": { "type": "string" },
+          "rightValue": { "type": "string" },
+
+          "chartData": { "type": "array", "items": { "type": "object" }, "description": "bar_chart / pie_chart / kpi_grid data rows" },
+          "chartSeries": { "type": "array", "items": { "type": "object" }, "description": "line_chart series" },
+          "chartColors": { "type": "array", "items": { "type": "string" } },
+          "chartAnimation": { "type": "string" },
+          "donut": { "type": "boolean" },
+          "centerLabel": { "type": "string" },
+          "centerValue": { "type": "string" },
+          "showGrid": { "type": "boolean" },
+          "showValues": { "type": "boolean" },
+          "showLegend": { "type": "boolean" },
+          "showMarkers": { "type": "boolean" },
+          "xLabel": { "type": "string" },
+          "yLabel": { "type": "string" },
+          "columns": { "type": "integer", "enum": [2, 3, 4] },
+
+          "progress": { "type": "number" },
+          "progressLabel": { "type": "string" },
+          "progressColor": { "type": "string" },
+          "progressAnimation": { "type": "string" },
+          "progressSegments": { "type": "array", "items": { "type": "object" } },
+
+          "backgroundColor": { "type": "string" },
+          "backgroundImage": { "type": "string", "description": "Still rendered behind the component (also the screenshot_scene plate)" },
+          "backgroundVideo": { "type": "string", "description": "Clip rendered behind the component; takes priority over backgroundImage" },
+          "backgroundVideoStart": { "type": "number", "minimum": 0 },
+          "backgroundOverlay": { "type": "number", "minimum": 0, "maximum": 1 },
+          "color": { "type": "string" },
+          "accentColor": { "type": "string" },
+          "fontSize": { "type": "number", "minimum": 1 },
+
+          "images": { "type": "array", "items": { "type": "string" }, "description": "anime_scene stills" },
+          "particles": { "type": "string" },
+          "particleColor": { "type": "string" },
+          "particleCount": { "type": "number", "minimum": 0 },
+          "particleIntensity": { "type": "number", "minimum": 0 },
+          "vignette": { "type": "boolean" },
+          "lightingFrom": { "type": "string" },
+          "lightingTo": { "type": "string" },
+
+          "steps": { "type": "array", "items": { "type": "object" }, "description": "terminal_scene timeline primitives" },
+          "terminalTitle": { "type": "string" },
+          "prompt": { "type": "string", "description": "terminal_scene shell prompt string" },
+
+          "screenshotSteps": { "type": "array", "items": { "type": "object" } },
+          "screenshotSize": {
+            "type": "object",
+            "properties": { "width": { "type": "number" }, "height": { "type": "number" } },
+            "additionalProperties": false
+          },
+          "cursorStartAt": {
+            "type": "array",
+            "items": { "type": "number" },
+            "minItems": 2,
+            "maxItems": 2
+          },
+
+          "shot_language": { "type": "object", "description": "Cinematography vocabulary carried over from scene_plan. Read by lib/slideshow_risk.py via video_compose._pre_compose_validation." },
+          "shot_intent": { "type": "string" },
+          "narrative_role": { "type": "string" },
+          "information_role": { "type": "string" },
+          "hero_moment": { "type": "boolean", "default": false }
+        },
+        "additionalProperties": false
+      }
+    },
+    "captions": {
+      "type": "array",
+      "description": "Word-level captions burned in by the Remotion CaptionOverlay component (ExplainerProps.captions / TalkingHeadProps.captions). Distinct from `subtitles`, which configures the FFmpeg file-based burn.",
+      "items": {
+        "type": "object",
+        "required": ["word", "startMs", "endMs"],
+        "properties": {
+          "word": { "type": "string" },
+          "startMs": { "type": "number", "minimum": 0 },
+          "endMs": { "type": "number", "minimum": 0 }
         },
         "additionalProperties": false
       }
     },
     "overlays": {
       "type": "array",
+      "description": "Timed overlays composited above the primary layer. Two shapes are valid: (a) an asset-backed overlay (asset_id + start_seconds/end_seconds + geometric position), used by the FFmpeg path; (b) a Remotion component overlay (type + in_seconds/out_seconds + component props, position as a named slot), consumed by Explainer.tsx and TalkingHead.tsx. See remotion-composer/SCENE_TYPES.md → 'Overlay types'.",
       "items": {
         "type": "object",
-        "required": ["asset_id", "start_seconds", "end_seconds", "position"],
+        "anyOf": [
+          { "required": ["asset_id", "start_seconds", "end_seconds", "position"] },
+          { "required": ["type", "in_seconds", "out_seconds"] }
+        ],
         "properties": {
+          "id": { "type": "string" },
           "asset_id": { "type": "string" },
           "start_seconds": { "type": "number", "minimum": 0 },
           "end_seconds": { "type": "number", "minimum": 0 },
+          "in_seconds": { "type": "number", "minimum": 0 },
+          "out_seconds": { "type": "number", "minimum": 0 },
+          "type": {
+            "oneOf": [
+              {
+                "type": "string",
+                "enum": ["section_title", "stat_reveal", "hero_title", "provider_chip"],
+                "description": "Explainer overlay types"
+              },
+              {
+                "$ref": "#/$defs/scene_type",
+                "description": "TalkingHead reuses the scene-component catalog as positioned overlays"
+              }
+            ]
+          },
           "position": {
-            "type": "object",
-            "properties": {
-              "x": { "type": "number" },
-              "y": { "type": "number" },
-              "width": { "type": "number" },
-              "height": { "type": "number" }
-            },
-            "required": ["x", "y"]
+            "oneOf": [
+              {
+                "type": "string",
+                "description": "Named slot: lower_third, upper_third, left_panel, right_panel, full_overlay, top-left, …"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "x": { "type": "number" },
+                  "y": { "type": "number" },
+                  "width": { "type": "number" },
+                  "height": { "type": "number" }
+                },
+                "required": ["x", "y"]
+              }
+            ]
           },
           "animation": { "type": "string" },
-          "opacity": { "type": "number", "minimum": 0, "maximum": 1 }
+          "opacity": { "type": "number", "minimum": 0, "maximum": 1 },
+
+          "text": { "type": "string" },
+          "title": { "type": "string" },
+          "subtitle": { "type": "string" },
+          "stat": { "type": "string" },
+          "callout_type": { "type": "string", "enum": ["info", "warning", "tip", "quote"] },
+          "leftLabel": { "type": "string" },
+          "rightLabel": { "type": "string" },
+          "leftValue": { "type": "string" },
+          "rightValue": { "type": "string" },
+          "chartData": { "type": "array", "items": { "type": "object" } },
+          "chartSeries": { "type": "array", "items": { "type": "object" } },
+          "chartColors": { "type": "array", "items": { "type": "string" } },
+          "chartAnimation": { "type": "string" },
+          "donut": { "type": "boolean" },
+          "centerLabel": { "type": "string" },
+          "centerValue": { "type": "string" },
+          "showGrid": { "type": "boolean" },
+          "showValues": { "type": "boolean" },
+          "showLegend": { "type": "boolean" },
+          "showMarkers": { "type": "boolean" },
+          "columns": { "type": "integer", "enum": [2, 3, 4] },
+          "backgroundColor": { "type": "string" },
+          "accentColor": { "type": "string" },
+          "fontSize": { "type": "number", "minimum": 1 },
+
+          "providers": { "type": "array", "items": { "type": "string" }, "description": "provider_chip rotation list" },
+          "cycleSeconds": { "type": "number", "minimum": 0 },
+          "label": { "type": "string" }
         },
         "additionalProperties": false
       }
     },
     "audio": {
       "type": "object",
-      "description": "Audio configuration for narration, music, and SFX.",
+      "description": "Audio configuration for narration, music, and SFX. Two shapes are valid and both are in use: the asset-id shape (`segments[].asset_id`, `music.asset_id`, snake_case fades) resolved by tools/video/hyperframes_compose.py and the FFmpeg path; and the Remotion shape (`narration.src`, `music.src`, camelCase `fadeInSeconds`/`fadeOutSeconds`/`offsetSeconds`/`loop`) passed straight through to <Audio> by remotion-composer. The narration/music objects are intentionally open so both survive validation.",
       "properties": {
         "narration": {
           "type": "object",
           "properties": {
+            "src": { "type": "string", "description": "Remotion shape — direct path to the narration file" },
+            "volume": { "type": "number", "minimum": 0 },
             "segments": {
               "type": "array",
               "items": {
@@ -113,9 +285,14 @@
           "type": "object",
           "properties": {
             "asset_id": { "type": "string" },
+            "src": { "type": "string", "description": "Remotion shape — direct path to the music file" },
             "volume": { "type": "number", "minimum": 0, "maximum": 1 },
             "fade_in_seconds": { "type": "number", "minimum": 0 },
             "fade_out_seconds": { "type": "number", "minimum": 0 },
+            "fadeInSeconds": { "type": "number", "minimum": 0, "description": "Remotion spelling of fade_in_seconds" },
+            "fadeOutSeconds": { "type": "number", "minimum": 0, "description": "Remotion spelling of fade_out_seconds" },
+            "offsetSeconds": { "type": "number", "minimum": 0, "description": "Start playback this far into the track (skip quiet intros)" },
+            "loop": { "type": "boolean", "description": "Loop the track when it is shorter than the video" },
             "ducking": {
               "oneOf": [
                 { "type": "boolean" },
@@ -227,7 +404,55 @@
         "verdict": { "type": "string", "enum": ["strong", "acceptable", "revise", "fail"] }
       }
     },
+    "theme": {
+      "type": "string",
+      "description": "Named Remotion theme preset. Resolved by resolveTheme() in remotion-composer/src/Root.tsx; falls back to `playbook`, then `themeConfig`, then DEFAULT_THEME."
+    },
+    "playbook": {
+      "type": "string",
+      "description": "Style playbook name. Doubles as a theme preset key in resolveTheme(), and is the lookup key video_compose._build_theme_from_playbook uses to derive themeConfig from the playbook YAML's real colors."
+    },
+    "themeConfig": {
+      "type": "object",
+      "description": "Fully-specified Remotion ThemeConfig (colors, fonts, spring config). Overrides the preset lookup. Normally synthesized by video_compose._build_theme_from_playbook rather than hand-authored.",
+      "additionalProperties": true
+    },
+    "delivery_promise": {
+      "type": "object",
+      "description": "Copy of proposal_packet.production_plan.delivery_promise, carried onto edit_decisions so video_compose._pre_compose_validation can enforce it at compose time. May also be nested under metadata.delivery_promise — the tool checks both.",
+      "additionalProperties": true
+    },
+    "end_tag": {
+      "type": "object",
+      "description": "Documentary-montage end-tag placement. Written by the edit director, read by the compose director (edit_decisions.end_tag.offset_seconds) when brief.metadata.end_tag_plan.mode == 'overlay'.",
+      "properties": {
+        "offset_seconds": { "type": "number", "minimum": 0, "description": "When the tag overlay starts, normally body_duration - tag_duration" },
+        "notes": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
     "metadata": { "type": "object" }
+  },
+  "$defs": {
+    "scene_type": {
+      "type": "string",
+      "enum": [
+        "text_card",
+        "hero_title",
+        "stat_card",
+        "callout",
+        "comparison",
+        "bar_chart",
+        "line_chart",
+        "pie_chart",
+        "kpi_grid",
+        "progress_bar",
+        "anime_scene",
+        "terminal_scene",
+        "screenshot_scene"
+      ],
+      "description": "Scene components dispatched by remotion-composer/src/Explainer.tsx. Keep in lockstep with remotion-composer/SCENE_TYPES.md."
+    }
   },
   "additionalProperties": false
 }

--- a/schemas/artifacts/final_review.schema.json
+++ b/schemas/artifacts/final_review.schema.json
@@ -47,7 +47,11 @@
           "type": "object",
           "description": "Sample frames inspected from opening, middle, climax, ending",
           "properties": {
-            "frames_sampled": { "type": "integer", "minimum": 4 },
+            "frames_sampled": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "How many frames were actually extracted. The target is 4 (opening/middle/climax/ending); video_compose._run_final_review records under-sampling as an issue rather than failing, so this is a count of what happened and must not be constrained to >= 4."
+            },
             "frame_paths": {
               "type": "array",
               "items": { "type": "string" }

--- a/schemas/artifacts/render_report.schema.json
+++ b/schemas/artifacts/render_report.schema.json
@@ -21,6 +21,7 @@
           "fps": { "type": "number" },
           "duration_seconds": { "type": "number", "minimum": 0 },
           "file_size_bytes": { "type": "integer" },
+          "audio_channels": { "type": "integer", "minimum": 0 },
           "platform_target": { "type": "string" }
         },
         "additionalProperties": false
@@ -40,6 +41,21 @@
       "type": "string",
       "description": "Which renderer family was used for this render",
       "enum": ["explainer-data", "explainer-teacher", "cinematic-trailer", "documentary-montage", "product-reveal", "screen-demo", "presenter", "animation-first"]
+    },
+    "render_runtime": {
+      "type": "string",
+      "enum": ["remotion", "hyperframes", "ffmpeg"],
+      "description": "Technical runtime that actually executed this render. Records the governance fact 'what ran'; compare against proposal_packet.production_plan.render_runtime to detect a silent swap."
+    },
+    "composition_mode": {
+      "type": "string",
+      "enum": ["templated", "atelier"],
+      "description": "Authoring mode that produced the composition, carried through from edit_decisions."
+    },
+    "render_summary": {
+      "type": "object",
+      "description": "Free-form rollup of what the render actually did (cuts rendered, subtitle burn, audio tracks mixed, planned vs actual duration).",
+      "additionalProperties": true
     },
     "slideshow_risk_score": {
       "type": "object",

--- a/schemas/artifacts/scene_plan.schema.json
+++ b/schemas/artifacts/scene_plan.schema.json
@@ -17,7 +17,20 @@
           "id": { "type": "string" },
           "type": {
             "type": "string",
-            "enum": ["talking_head", "broll", "animation", "character_scene", "diagram", "text_card", "transition", "generated", "screen_recording"]
+            "enum": ["talking_head", "broll", "animation", "character_scene", "diagram", "text_card", "transition", "generated", "screen_recording", "overlay"]
+          },
+          "overlay_type": {
+            "type": "string",
+            "description": "Only for type='overlay' — which component renders in the slot (text_card, stat_card, bar_chart, callout, comparison, …). Carried into edit_decisions.overlays[].type at the edit stage."
+          },
+          "content": {
+            "type": "object",
+            "description": "Only for type='overlay' — the component props for overlay_type (text, subtext, stat, chartData, backgroundColor, accentColor, …).",
+            "additionalProperties": true
+          },
+          "position": {
+            "type": "string",
+            "description": "Only for type='overlay' — named slot: lower_third, upper_third, side_panel, left_panel, right_panel, full_overlay."
           },
           "description": { "type": "string" },
           "start_seconds": { "type": "number", "minimum": 0 },

--- a/skills/pipelines/documentary-montage/asset-director.md
+++ b/skills/pipelines/documentary-montage/asset-director.md
@@ -363,7 +363,7 @@ visually identical. Re-rank the slot whose clip got dropped with
 
 ### 8. Handle The Music Plan
 
-Read `brief.music_plan`. Execute exactly the plan the idea director
+Read `brief.metadata.music_plan`. Execute exactly the plan the idea director
 recorded — do not invent a new source here:
 
 - **`source=library`**: Verify the file at `music_plan.path` exists.

--- a/skills/pipelines/documentary-montage/edit-director.md
+++ b/skills/pipelines/documentary-montage/edit-director.md
@@ -259,6 +259,7 @@ Canonical shape for this pipeline:
 {
   "version": "1.0",
   "renderer_family": "documentary-montage",
+  "render_runtime": "remotion",
   "cuts": [
     {
       "id": "cut_01",

--- a/skills/pipelines/documentary-montage/idea-director.md
+++ b/skills/pipelines/documentary-montage/idea-director.md
@@ -153,32 +153,42 @@ there's no narration — don't leave the field missing.
 
 ### 7. Record The Brief
 
-Minimum fields the brief must carry:
+Minimum fields the brief must carry. The `brief` schema sets
+`additionalProperties: false`, so every documentary-specific field lives
+under `metadata` — which is also exactly where the downstream directors
+read them from (`brief.metadata.end_tag_plan`, `brief.metadata.music_plan`):
 
 ```json
 {
-  "topic": "A minute in the rain",
-  "thematic_question": "What does rain show you about a city?",
+  "version": "1.0",
+  "title": "A minute in the rain",
+  "hook": "What does rain show you about a city?",
+  "key_points": ["The city keeps its own vigil in the rain"],
   "tone": "elegiac",
-  "duration_seconds": 90,
-  "shape": "list",
-  "sources_allowed": ["pexels", "pixabay_video", "coverr", "mixkit", "archive_org", "nara", "nasa"],
-  "generated_clips_allowed": false,
-  "narration": "none",
-  "music_plan": {
-    "source": "generated",
-    "provider": "elevenlabs",
-    "prompt_seed": "slow ambient drone in A minor, no percussion, 60s sustained swell, Max Richter register"
-  },
-  "end_tag_plan": {
-    "text": "THE CITY KEEPS ITS OWN VIGIL.",
-    "palette": "cool_offwhite_on_black",
-    "duration_seconds": 5.5,
-    "render_engine": "remotion",
-    "component": "EndTag"
-  },
-  "era_mix": "any",
-  "target_platform": "social_short"
+  "style": "documentary-montage",
+  "target_platform": "generic",
+  "target_duration_seconds": 90,
+  "metadata": {
+    "thematic_question": "What does rain show you about a city?",
+    "shape": "list",
+    "sources_allowed": ["pexels", "pixabay_video", "coverr", "mixkit", "archive_org", "nara", "nasa"],
+    "generated_clips_allowed": false,
+    "narration": "none",
+    "music_plan": {
+      "source": "generated",
+      "provider": "elevenlabs",
+      "prompt_seed": "slow ambient drone in A minor, no percussion, 60s sustained swell, Max Richter register"
+    },
+    "end_tag_plan": {
+      "text": "THE CITY KEEPS ITS OWN VIGIL.",
+      "palette": "cool_offwhite_on_black",
+      "duration_seconds": 5.5,
+      "render_engine": "remotion",
+      "component": "EndTag"
+    },
+    "era_mix": "any",
+    "delivery_target": "social_short"
+  }
 }
 ```
 

--- a/skills/pipelines/documentary-montage/scene-director.md
+++ b/skills/pipelines/documentary-montage/scene-director.md
@@ -139,7 +139,7 @@ each. No filler words.
 
 ### 5. Target Sources Per Slot (Era-Aware)
 
-Read `brief.era_mix`. Assign each slot one or more `preferred_sources`
+Read `brief.metadata.era_mix`. Assign each slot one or more `preferred_sources`
 based on what footage lives where:
 
 | Source | Strengths | Use when |

--- a/skills/pipelines/explainer/asset-director.md
+++ b/skills/pipelines/explainer/asset-director.md
@@ -137,7 +137,7 @@ Process asset tasks grouped by tool for efficiency:
    - **User-selected library track**: If the proposal specified a track from `music_library/`, copy it to `projects/<project>/assets/music/background_music.mp3`
    - **User music library (`music_library/`)**: If the folder exists and has tracks, pick the best match for the playbook's `audio.music_mood`. List candidates by filename and let the EP decide.
    - **Music generation API**: Use `music_gen` (ElevenLabs) or `suno_music` if available. Check status via registry first — if the tool is unavailable or quota-exhausted, skip immediately (do NOT attempt and fail silently).
-   - **No music available**: Log this clearly in the asset manifest as `"music_status": "unavailable"` with the reason. Do NOT silently produce a video without music — the EP and user should know.
+   - **No music available**: Log this clearly in the asset manifest as `metadata.music_status: "unavailable"` with the reason (the manifest sets `additionalProperties: false` at the top level, so free-form status flags belong under `metadata`). Do NOT silently produce a video without music — the EP and user should know.
 4. Duration should be at least as long as total video duration. If shorter, it can be looped by the compose stage.
 5. Verify the audio file exists at `projects/<project>/assets/music/background_music.mp3`
 
@@ -180,11 +180,14 @@ Assemble all generated assets into the manifest:
     }
   ],
   "total_cost_usd": 0.053,
-  "generation_summary": {
-    "narration_sections": 5,
-    "images_generated": 8,
-    "diagrams_generated": 2,
-    "music_tracks": 1
+  "metadata": {
+    "generation_summary": {
+      "narration_sections": 5,
+      "images_generated": 8,
+      "diagrams_generated": 2,
+      "music_tracks": 1
+    },
+    "music_status": "generated"
   }
 }
 ```

--- a/skills/pipelines/explainer/compose-director.md
+++ b/skills/pipelines/explainer/compose-director.md
@@ -401,13 +401,15 @@ result = Transcriber().execute({
       "resolution": "1920x1080",
       "fps": 30,
       "duration_seconds": 62.4,
-      "file_size_mb": 45.2,
+      "file_size_bytes": 47395635,
       "audio_codec": "aac",
       "audio_channels": 2,
-      "render_strategy": "ffmpeg",
-      "render_time_seconds": 180
+      "platform_target": "youtube"
     }
   ],
+  "render_time_seconds": 180,
+  "render_grammar": "explainer-data",
+  "render_runtime": "remotion",
   "render_summary": {
     "total_cuts_rendered": 12,
     "subtitles_burned": true,

--- a/skills/pipelines/talking-head/scene-director.md
+++ b/skills/pipelines/talking-head/scene-director.md
@@ -187,8 +187,9 @@ For each approved overlay from Step 3, create an overlay scene entry:
   "id": "overlay_1",
   "type": "overlay",
   "overlay_type": "text_card",
+  "description": "Define 'Agentic AI' while the speaker first says it",
   "start_seconds": 22.0,
-  "duration_seconds": 4.0,
+  "end_seconds": 26.0,
   "content": {
     "text": "Agentic AI",
     "subtext": "Software that acts autonomously toward goals",

--- a/tests/contracts/test_artifact_schema_drift.py
+++ b/tests/contracts/test_artifact_schema_drift.py
@@ -1,0 +1,868 @@
+"""Artifact-schema drift contracts.
+
+The canonical artifacts are the contract between pipeline stages, and every
+schema in `schemas/artifacts/` sets `additionalProperties: false`. That makes
+drift silent and expensive: `video_compose` never validates `edit_decisions`,
+so a field the renderer happily consumes can be rejected much later by
+`lib/checkpoint.py`, after the render already succeeded.
+
+These tests round-trip representative artifacts — the shapes the director
+skills actually tell the agent to write, and the shapes the Remotion
+compositions actually read — through `validate_artifact()`, so the drift fails
+here rather than at checkpoint time.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from schemas.artifacts import load_schema, validate_artifact
+from tools.video.video_compose import VideoCompose
+
+COMPOSER_DIR = PROJECT_ROOT / "remotion-composer"
+
+
+# ---------------------------------------------------------------------------
+# edit_decisions — the Remotion (templated) shape
+# ---------------------------------------------------------------------------
+
+
+def _remotion_edit_decisions() -> dict:
+    """A composition exercising every field family the Explainer reads.
+
+    Mirrors what `skills/pipelines/explainer/compose-director.md` instructs the
+    agent to assemble: scene-type cuts, word-level captions, the Remotion audio
+    shape, component overlays, and a playbook-derived theme.
+    """
+    return {
+        "version": "1.0",
+        "renderer_family": "explainer-data",
+        "render_runtime": "remotion",
+        "composition_mode": "templated",
+        "playbook": "flat-motion-graphics",
+        "theme": "flat-motion-graphics",
+        "themeConfig": {
+            "primaryColor": "#22D3EE",
+            "backgroundColor": "#0F172A",
+            "chartColors": ["#22D3EE", "#A78BFA"],
+            "springConfig": {"damping": 12, "stiffness": 80, "mass": 1},
+        },
+        "delivery_promise": {
+            "promise_type": "data_explainer",
+            "motion_required": False,
+            "tone_mode": "educational",
+            "quality_floor": "presentable",
+        },
+        "cuts": [
+            {
+                "id": "cut-1",
+                "source": "",
+                "in_seconds": 0,
+                "out_seconds": 4,
+                "type": "hero_title",
+                "text": "Vector Databases",
+                "heroSubtitle": "Explained in 60 seconds",
+                "animation": "zoom-in",
+                "transition_out": "fade",
+                "transition_duration": 0.4,
+            },
+            {
+                "id": "cut-2",
+                "source": "",
+                "in_seconds": 4,
+                "out_seconds": 9,
+                "type": "text_card",
+                "text": "Similarity, not equality",
+                "fontSize": 96,
+                "color": "#F8FAFC",
+                "backgroundColor": "#0F172A",
+                # Planning provenance carried from scene_plan — read back by
+                # video_compose._pre_compose_validation for slideshow scoring.
+                "shot_intent": "State the core reframe before any mechanism",
+                "narrative_role": "deliver_payload",
+                "information_role": "The one idea the viewer keeps",
+                "hero_moment": True,
+                "shot_language": {"shot_size": "medium", "camera_movement": "static"},
+            },
+            {
+                "id": "cut-3",
+                "source": "",
+                "in_seconds": 9,
+                "out_seconds": 14,
+                "type": "stat_card",
+                "stat": "4.8B",
+                "subtitle": "Vectors indexed daily",
+                "accentColor": "#A78BFA",
+                "backgroundVideo": "assets/video/loop.mp4",
+                "backgroundVideoStart": 2.5,
+                "backgroundOverlay": 0.55,
+            },
+            {
+                "id": "cut-4",
+                "source": "",
+                "in_seconds": 14,
+                "out_seconds": 20,
+                "type": "bar_chart",
+                "chartData": [{"label": "2024", "value": 2.1}, {"label": "2025", "value": 3.5}],
+                "chartColors": ["#22D3EE"],
+                "chartAnimation": "grow",
+                "showValues": True,
+                "showGrid": True,
+                "title": "Adoption",
+            },
+            {
+                "id": "cut-5",
+                "source": "",
+                "in_seconds": 20,
+                "out_seconds": 26,
+                "type": "line_chart",
+                "chartSeries": [{"name": "latency", "points": [{"x": 1, "y": 4}]}],
+                "xLabel": "Index size",
+                "yLabel": "ms",
+                "showMarkers": True,
+            },
+            {
+                "id": "cut-6",
+                "source": "",
+                "in_seconds": 26,
+                "out_seconds": 31,
+                "type": "pie_chart",
+                "chartData": [{"label": "hits", "value": 82}],
+                "donut": True,
+                "centerLabel": "Recall",
+                "centerValue": "82%",
+                "showLegend": True,
+            },
+            {
+                "id": "cut-7",
+                "source": "",
+                "in_seconds": 31,
+                "out_seconds": 36,
+                "type": "kpi_grid",
+                "chartData": [{"label": "p95", "value": "18ms"}],
+                "columns": 3,
+            },
+            {
+                "id": "cut-8",
+                "source": "",
+                "in_seconds": 36,
+                "out_seconds": 40,
+                "type": "progress_bar",
+                "progress": 0.82,
+                "progressLabel": "Index rebuilt",
+                "progressColor": "#22D3EE",
+                "progressSegments": [{"label": "shard-1", "value": 0.4}],
+            },
+            {
+                "id": "cut-9",
+                "source": "",
+                "in_seconds": 40,
+                "out_seconds": 46,
+                "type": "comparison",
+                "leftLabel": "Keyword",
+                "leftValue": "exact",
+                "rightLabel": "Vector",
+                "rightValue": "semantic",
+                "title": "Two ways to search",
+            },
+            {
+                "id": "cut-10",
+                "source": "",
+                "in_seconds": 46,
+                "out_seconds": 51,
+                "type": "callout",
+                "text": "Embeddings are lossy — verify before you trust",
+                "callout_type": "warning",
+            },
+            {
+                "id": "cut-11",
+                "source": "",
+                "in_seconds": 51,
+                "out_seconds": 58,
+                "type": "terminal_scene",
+                "steps": [{"kind": "cmd", "text": "pip install openmontage"}],
+                "terminalTitle": "install",
+                "prompt": "$",
+                "accentColor": "#22D3EE",
+            },
+            {
+                "id": "cut-12",
+                "source": "",
+                "in_seconds": 58,
+                "out_seconds": 64,
+                "type": "screenshot_scene",
+                "backgroundImage": "screens/dashboard.png",
+                "screenshotSteps": [{"kind": "cursor", "at": [0.5, 0.5]}],
+                "screenshotSize": {"width": 2880, "height": 1800},
+                "cursorStartAt": [0.1, 0.9],
+            },
+            {
+                "id": "cut-13",
+                "source": "",
+                "in_seconds": 64,
+                "out_seconds": 70,
+                "type": "anime_scene",
+                "images": ["assets/images/a.png", "assets/images/b.png"],
+                "animation": "ken-burns",
+                "particles": "fireflies",
+                "particleColor": "#FDE68A",
+                "particleCount": 20,
+                "particleIntensity": 0.5,
+                "vignette": True,
+                "lightingFrom": "rgba(255,220,150,0.3)",
+                "lightingTo": "transparent",
+            },
+            {
+                # Plain media cut — no `type`, seeks into the source.
+                "id": "cut-14",
+                "source": "assets/video/broll.mp4",
+                "in_seconds": 70,
+                "out_seconds": 76,
+                "source_in_seconds": 12.5,
+                "speed": 1.0,
+                "layer": "primary",
+                "transform": {"scale": 1.0, "position": "center", "animation": "ken-burns-slow-zoom"},
+                "reason": "Establishing shot under the closing narration",
+            },
+        ],
+        "overlays": [
+            {
+                "type": "section_title",
+                "in_seconds": 4,
+                "out_seconds": 8,
+                "text": "How it works",
+                "position": "top-left",
+                "accentColor": "#22D3EE",
+            },
+            {
+                "type": "provider_chip",
+                "in_seconds": 64,
+                "out_seconds": 70,
+                "providers": ["seedance", "veo"],
+                "cycleSeconds": 2,
+                "label": "Generated with",
+            },
+        ],
+        "captions": [
+            {"word": "Vector", "startMs": 0, "endMs": 340},
+            {"word": "databases", "startMs": 340, "endMs": 820},
+        ],
+        "audio": {
+            "narration": {"src": "assets/audio/narration.mp3", "volume": 1},
+            "music": {
+                "src": "assets/music/bed.mp3",
+                "volume": 0.1,
+                "fadeInSeconds": 2,
+                "fadeOutSeconds": 3,
+                "offsetSeconds": 55,
+                "loop": False,
+            },
+        },
+        "metadata": {"playbook": "flat-motion-graphics"},
+    }
+
+
+def _hyperframes_edit_decisions() -> dict:
+    """The asset-id shape: HyperFrames / FFmpeg runtimes and documentary-montage."""
+    return {
+        "version": "1.0",
+        "renderer_family": "documentary-montage",
+        "render_runtime": "hyperframes",
+        "cuts": [
+            {
+                "id": "cut_01",
+                "source": "asset_slot_01",
+                "in_seconds": 1.2,
+                "out_seconds": 5.2,
+                "layer": "primary",
+                "type": "text_card",
+                "text": "A minute in the rain",
+                "caption": "opening plate",
+                "transform": {"scale": 1.0, "position": "center"},
+                "transition_in": "fade_in",
+                "transition_out": "cut",
+                "transition_duration": 0.8,
+                "reason": "opening hero — raindrop on asphalt",
+            }
+        ],
+        "overlays": [
+            {
+                "asset_id": "logo-lockup",
+                "start_seconds": 80,
+                "end_seconds": 84,
+                "position": {"x": 100, "y": 900, "width": 320, "height": 80},
+                "opacity": 0.9,
+            }
+        ],
+        "audio": {
+            "narration": {"segments": [{"asset_id": "narration-s1", "start_seconds": 0}]},
+            "music": {
+                "asset_id": "asset_music_bed",
+                "volume": 0.7,
+                "fade_in_seconds": 1.0,
+                "fade_out_seconds": 4.0,
+                "ducking": False,
+            },
+            "sfx": [{"asset_id": "sfx-thunder", "start_seconds": 12.0, "volume": 0.4}],
+        },
+        "subtitles": {
+            "enabled": True,
+            "style": "word-by-word",
+            "source": "assets/subtitles.srt",
+            "font": "Inter",
+            "font_size": 48,
+            "position": "bottom-center",
+        },
+        "end_tag": {
+            "offset_seconds": 84.5,
+            "notes": "Aligns tag fade-out with the final cut's fade-out.",
+        },
+        "metadata": {"pipeline": "documentary-montage"},
+    }
+
+
+def test_remotion_edit_decisions_round_trips():
+    """A full templated-Remotion composition must survive validate_artifact()."""
+    validate_artifact("edit_decisions", _remotion_edit_decisions())
+
+
+def test_hyperframes_edit_decisions_round_trips():
+    validate_artifact("edit_decisions", _hyperframes_edit_decisions())
+
+
+@pytest.mark.parametrize("scene_type", sorted(VideoCompose._REMOTION_SCENE_TYPES))
+def test_every_remotion_scene_type_is_accepted_on_a_cut(scene_type):
+    """Every type the tool routes to Remotion must be expressible in the artifact.
+
+    This is the exact bug class that made `type: "text_card"` invisible: the
+    renderer dispatched on it, the tool branched on it, and the schema rejected
+    it.
+    """
+    artifact = {
+        "version": "1.0",
+        "render_runtime": "remotion",
+        "cuts": [{"id": "c1", "source": "", "in_seconds": 0, "out_seconds": 3, "type": scene_type}],
+    }
+    validate_artifact("edit_decisions", artifact)
+
+
+def test_unknown_scene_type_is_still_rejected():
+    """Widening the schema must not turn `type` into a free-for-all."""
+    artifact = {
+        "version": "1.0",
+        "render_runtime": "remotion",
+        "cuts": [{"id": "c1", "source": "", "in_seconds": 0, "out_seconds": 3, "type": "txt_card"}],
+    }
+    with pytest.raises(Exception):
+        validate_artifact("edit_decisions", artifact)
+
+
+# ---------------------------------------------------------------------------
+# Scene-type registry: four sources that must agree
+# ---------------------------------------------------------------------------
+
+
+def _scene_types_from_explainer() -> set[str]:
+    src = (COMPOSER_DIR / "src" / "Explainer.tsx").read_text(encoding="utf-8")
+    return set(re.findall(r'cut\.type === "([a-z_]+)"', src))
+
+
+def _scene_types_from_doc() -> set[str]:
+    doc = (COMPOSER_DIR / "SCENE_TYPES.md").read_text(encoding="utf-8")
+    # Only the "Cut types" table, which ends at the next `---` rule.
+    section = doc.split("## Cut types (`cut.type`)", 1)[1].split("\n---", 1)[0]
+    rows = set(re.findall(r"^\|\s*\*{0,2}`([a-z_]+)`\*{0,2}\s*\|", section, re.MULTILINE))
+    return rows - {"type"}  # the table's own header cell
+
+
+def _scene_types_from_schema() -> set[str]:
+    return set(load_schema("edit_decisions")["$defs"]["scene_type"]["enum"])
+
+
+def test_scene_type_registry_agrees_across_sources():
+    """Explainer dispatch, SCENE_TYPES.md, the schema enum, and the Python set.
+
+    If these four ever diverge, a scene type is either undocumented, unroutable,
+    or unrepresentable in the artifact. Keeping them pinned together is what
+    stops the drift from recurring.
+    """
+    from_code = _scene_types_from_explainer()
+    from_doc = _scene_types_from_doc()
+    from_schema = _scene_types_from_schema()
+    from_tool = set(VideoCompose._REMOTION_SCENE_TYPES)
+
+    assert from_code, "no `cut.type === ...` dispatch cases found in Explainer.tsx"
+    assert from_doc == from_code, (
+        "SCENE_TYPES.md and Explainer.tsx disagree; "
+        f"doc-only={sorted(from_doc - from_code)} code-only={sorted(from_code - from_doc)}"
+    )
+    assert from_schema == from_code, (
+        "edit_decisions.schema.json $defs.scene_type and Explainer.tsx disagree; "
+        f"schema-only={sorted(from_schema - from_code)} code-only={sorted(from_code - from_schema)}"
+    )
+    assert from_tool == from_code, (
+        "VideoCompose._REMOTION_SCENE_TYPES and Explainer.tsx disagree; "
+        f"tool-only={sorted(from_tool - from_code)} code-only={sorted(from_code - from_tool)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The other canonical artifacts
+# ---------------------------------------------------------------------------
+
+
+def test_asset_manifest_allows_project_global_assets_without_a_scene():
+    """Background music belongs to the video, not to a scene.
+
+    `scene_id` used to be required on every asset, so the manifest the
+    asset-director documents could never validate.
+    """
+    validate_artifact(
+        "asset_manifest",
+        {
+            "version": "1.0",
+            "assets": [
+                {
+                    "id": "narration-s1",
+                    "type": "audio",
+                    "subtype": "narration",
+                    "path": "assets/narration/s1.mp3",
+                    "source_tool": "tts_selector",
+                    "scene_id": "scene-1",
+                    "duration_seconds": 8.2,
+                    "cost_usd": 0.003,
+                },
+                {
+                    "id": "music-bg",
+                    "type": "audio",
+                    "subtype": "music",
+                    "path": "assets/music/background.mp3",
+                    "source_tool": "music_gen",
+                    "duration_seconds": 62,
+                    "cost_usd": 0.05,
+                },
+            ],
+            "total_cost_usd": 0.053,
+            "metadata": {"generation_summary": {"images_generated": 8}, "music_status": "generated"},
+        },
+    )
+
+
+def test_render_report_records_the_runtime_that_ran():
+    validate_artifact(
+        "render_report",
+        {
+            "version": "1.0",
+            "outputs": [
+                {
+                    "path": "renders/output.mp4",
+                    "format": "mp4",
+                    "codec": "h264",
+                    "audio_codec": "aac",
+                    "audio_channels": 2,
+                    "resolution": "1920x1080",
+                    "fps": 30,
+                    "duration_seconds": 62.4,
+                    "file_size_bytes": 47395635,
+                    "platform_target": "youtube",
+                }
+            ],
+            "render_time_seconds": 180,
+            "render_grammar": "explainer-data",
+            "render_runtime": "remotion",
+            "composition_mode": "templated",
+            "render_summary": {"total_cuts_rendered": 12, "subtitles_burned": True},
+            "verification_notes": ["Duration within +0.2s of planned"],
+        },
+    )
+
+
+def test_scene_plan_accepts_talking_head_overlay_scenes():
+    validate_artifact(
+        "scene_plan",
+        {
+            "version": "1.0",
+            "scenes": [
+                {
+                    "id": "section_1",
+                    "type": "talking_head",
+                    "description": "Speaker introduces agentic AI",
+                    "start_seconds": 0,
+                    "end_seconds": 22,
+                },
+                {
+                    "id": "overlay_1",
+                    "type": "overlay",
+                    "overlay_type": "text_card",
+                    "description": "Define 'Agentic AI' while the speaker first says it",
+                    "start_seconds": 22.0,
+                    "end_seconds": 26.0,
+                    "content": {"text": "Agentic AI", "subtext": "Acts autonomously toward goals"},
+                    "position": "lower_third",
+                },
+            ],
+        },
+    )
+
+
+def test_final_review_accepts_an_under_sampled_visual_spotcheck():
+    """`_run_final_review` records under-sampling as an issue; it must validate.
+
+    The schema demanded `frames_sampled >= 4`, so a partially-failed ffmpeg
+    extraction produced a review the checkpoint writer then refused.
+    """
+    validate_artifact(
+        "final_review",
+        {
+            "version": "1.0",
+            "output_path": "renders/output.mp4",
+            "status": "pass",
+            "checks": {
+                "technical_probe": {"valid_container": True, "has_audio": True},
+                "visual_spotcheck": {
+                    "frames_sampled": 2,
+                    "frame_paths": ["/tmp/f0.png", "/tmp/f1.png"],
+                    "issues": ["Only 2/4 frames extracted — some timestamps may be out of range"],
+                },
+                "audio_spotcheck": {"narration_present": True, "music_present": True},
+                "promise_preservation": {"delivery_promise_honored": True, "render_runtime_used": "remotion"},
+                "subtitle_check": {"subtitles_expected": True, "subtitles_present": True},
+            },
+            "issues_found": [],
+            "recommended_action": "present_to_user",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# cuts -> CinematicRendererProps
+# ---------------------------------------------------------------------------
+
+
+def _cinematic_prop_names() -> dict[str, set[str]]:
+    """Field names declared by remotion-composer/src/cinematic/types.ts.
+
+    Parsed rather than hardcoded so the adapter's output is checked against the
+    interfaces it actually has to satisfy.
+    """
+    src = (COMPOSER_DIR / "src" / "cinematic" / "types.ts").read_text(encoding="utf-8")
+    blocks: dict[str, set[str]] = {}
+    for name, body in re.findall(r"export interface (\w+)[^{]*\{(.*?)\n\}", src, re.DOTALL):
+        blocks[name] = set(re.findall(r"^\s{2}(\w+)\??:", body, re.MULTILINE))
+    return blocks
+
+
+def _documentary_edit_decisions() -> dict:
+    """The shape skills/pipelines/documentary-montage/edit-director.md emits."""
+    return {
+        "version": "1.0",
+        "renderer_family": "documentary-montage",
+        "render_runtime": "remotion",
+        "cuts": [
+            {
+                "id": "cut_01",
+                "source": "assets/video/rain.mp4",
+                "in_seconds": 0,
+                "out_seconds": 4.0,
+                "source_in_seconds": 1.2,
+                "transition_in": "fade_in",
+                "transition_out": "cut",
+                "transition_duration": 0.8,
+                "reason": "opening hero",
+            },
+            {
+                "id": "cut_02",
+                "source": "assets/video/umbrella.mp4",
+                "in_seconds": 4.0,
+                "out_seconds": 7.5,
+                "transition_in": "cut",
+                "transition_out": "cut",
+            },
+            {
+                "id": "cut_03",
+                "source": "",
+                "in_seconds": 7.5,
+                "out_seconds": 12.0,
+                "type": "hero_title",
+                "text": "THE CITY KEEPS ITS OWN VIGIL.",
+                "accentColor": "#86d8ff",
+            },
+        ],
+        "audio": {
+            "narration": {"src": "assets/audio/vo.mp3", "volume": 1},
+            "music": {
+                "asset_id": "asset_music_bed",
+                "src": "assets/music/bed.mp3",
+                "volume": 0.7,
+                "fade_in_seconds": 1.0,
+                "fade_out_seconds": 4.0,
+            },
+        },
+        "captions": [{"word": "Rain", "startMs": 0, "endMs": 300}],
+        "metadata": {"pipeline": "documentary-montage", "cinematic_tone": "void"},
+    }
+
+
+def test_cuts_adapt_to_cinematic_renderer_props():
+    """documentary-montage must actually render, not crash on `props.scenes`."""
+    props, error = VideoCompose._to_cinematic_props(_documentary_edit_decisions())
+    assert error is None, error
+
+    interfaces = _cinematic_prop_names()
+    video_fields = interfaces["CinematicBaseScene"] | interfaces["CinematicVideoScene"]
+    title_fields = interfaces["CinematicBaseScene"] | interfaces["CinematicTitleScene"]
+
+    scenes = props["scenes"]
+    assert [s["kind"] for s in scenes] == ["video", "video", "title"]
+
+    # Timeline position and length, not in/out points.
+    assert scenes[0]["startSeconds"] == 0 and scenes[0]["durationSeconds"] == 4.0
+    assert scenes[1]["startSeconds"] == 4.0 and scenes[1]["durationSeconds"] == 3.5
+
+    # source_in_seconds is a seek INTO the source -> trimBeforeSeconds.
+    assert scenes[0]["trimBeforeSeconds"] == 1.2
+    # "fade_in" over 0.8s at 30fps ramps; "cut" must not.
+    assert scenes[0]["fadeInFrames"] == 24
+    assert scenes[0]["fadeOutFrames"] == 0
+    assert scenes[1]["fadeInFrames"] == 0
+
+    assert scenes[2]["text"] == "THE CITY KEEPS ITS OWN VIGIL."
+    assert scenes[2]["accent"] == "#86d8ff"
+
+    for scene in scenes:
+        allowed = title_fields if scene["kind"] == "title" else video_fields
+        unknown = set(scene) - allowed
+        assert not unknown, f"{scene['id']} carries fields the interface has no slot for: {unknown}"
+
+    assert props["soundtrack"]["src"] == "assets/audio/vo.mp3"
+    assert props["music"] == {
+        "src": "assets/music/bed.mp3",
+        "volume": 0.7,
+        "fadeInSeconds": 1.0,
+        "fadeOutSeconds": 4.0,
+    }
+    assert set(props["music"]) <= interfaces["CinematicSoundtrack"]
+    assert props["captions"]["words"] == [{"word": "Rain", "startMs": 0, "endMs": 300}]
+    assert props["renderer_family"] == "documentary-montage"
+
+
+def test_cinematic_tone_only_applied_when_valid():
+    ed = _documentary_edit_decisions()
+    ed["metadata"]["cinematic_tone"] = "elegiac"  # a brief tone, not a CinematicTone
+    props, error = VideoCompose._to_cinematic_props(ed)
+    assert error is None
+    assert all("tone" not in s for s in props["scenes"]), "invalid tone must not be passed through"
+
+
+def test_cinematic_refuses_scene_types_it_cannot_render():
+    """Dropping a chart cut would silently change the deliverable."""
+    ed = _documentary_edit_decisions()
+    ed["cuts"].append(
+        {
+            "id": "cut_04",
+            "source": "",
+            "in_seconds": 12.0,
+            "out_seconds": 16.0,
+            "type": "bar_chart",
+            "chartData": [{"label": "2024", "value": 2.1}],
+        }
+    )
+    props, error = VideoCompose._to_cinematic_props(ed)
+    assert props is None
+    assert "cut_04" in error and "bar_chart" in error
+    assert "explainer-" in error, "the error should name the way out"
+
+
+def test_audio_asset_ids_resolve_to_remotion_src():
+    """The asset-id spelling had no resolver on the Remotion path — silent video."""
+    lookup = {
+        "music-bg": {"id": "music-bg", "path": "assets/music/bed.mp3"},
+        "narration-s1": {"id": "narration-s1", "path": "assets/audio/s1.mp3"},
+    }
+    audio = {
+        "music": {"asset_id": "music-bg", "volume": 0.7},
+        "narration": {"segments": [{"asset_id": "narration-s1", "start_seconds": 0}]},
+    }
+    resolved, error = VideoCompose._resolve_audio_sources(audio, lookup)
+    assert error is None
+    assert resolved["music"]["src"] == "assets/music/bed.mp3"
+    assert resolved["narration"]["src"] == "assets/audio/s1.mp3"
+    # The original must be untouched — the FFmpeg/HyperFrames paths still read it.
+    assert "src" not in audio["music"]
+
+
+def test_remotion_render_routes_documentary_to_cinematic_props(tmp_path, monkeypatch):
+    """End-to-end wiring: the props file handed to the CLI must be adapted.
+
+    Covers the seam the unit test cannot — that _remotion_render picks
+    CinematicRenderer for this family AND converts before writing props.
+    """
+    import shutil as _shutil
+
+    monkeypatch.setattr(_shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    tool = VideoCompose()
+    output_path = tmp_path / "renders" / "final.mp4"
+    captured: dict = {}
+
+    def fake_run_command(cmd, **kwargs):
+        captured["cmd"] = cmd
+        props_arg = next(a for a in cmd if a.startswith("--props="))
+        captured["props"] = json.loads(Path(props_arg.split("=", 1)[1]).read_text())
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(b"fake-mp4")
+        return None
+
+    monkeypatch.setattr(tool, "run_command", fake_run_command)
+
+    result = tool._remotion_render(
+        {
+            "edit_decisions": _documentary_edit_decisions(),
+            "output_path": str(output_path),
+        }
+    )
+
+    assert result.success, result.error
+    assert captured["cmd"][4] == "CinematicRenderer"
+    props = captured["props"]
+    assert "scenes" in props and "cuts" not in props, "props were not adapted"
+    assert props["scenes"][0]["kind"] == "video"
+    assert props["soundtrack"]["src"] == "assets/audio/vo.mp3"
+
+
+def test_multi_segment_narration_is_refused_not_truncated():
+    lookup = {f"n{i}": {"id": f"n{i}", "path": f"a/{i}.mp3"} for i in range(3)}
+    audio = {"narration": {"segments": [{"asset_id": f"n{i}", "start_seconds": i * 5} for i in range(3)]}}
+    resolved, error = VideoCompose._resolve_audio_sources(audio, lookup)
+    assert resolved is None
+    assert "3 segments" in error and "audio_mixer" in error
+
+
+# ---------------------------------------------------------------------------
+# Remotion asset staging
+# ---------------------------------------------------------------------------
+
+
+def test_remotion_assets_are_staged_public_relative(tmp_path):
+    """Assets must land under public/ and be referenced relative to it.
+
+    `staticFile()` prefixes whatever it is given with the public URL, so an
+    absolute path or a `file://` URI becomes `/public/Users/...` and 404s. The
+    only reference form the components can resolve is public-relative.
+    """
+    import shutil
+
+    src_a = tmp_path / "a"
+    src_b = tmp_path / "b"
+    src_a.mkdir()
+    src_b.mkdir()
+    # Same basename in two different directories — must not collide.
+    (src_a / "shot.png").write_bytes(b"a")
+    (src_b / "shot.png").write_bytes(b"b")
+    (tmp_path / "narration.mp3").write_bytes(b"n")
+    (tmp_path / "subs.srt").write_bytes(b"s")
+
+    props = {
+        "cuts": [
+            {"id": "c1", "source": str(src_a / "shot.png"), "in_seconds": 0, "out_seconds": 2},
+            {"id": "c2", "source": f"file://{src_b / 'shot.png'}", "in_seconds": 2, "out_seconds": 4},
+            {
+                "id": "c3",
+                "source": "",
+                "type": "anime_scene",
+                "images": [str(src_a / "shot.png")],
+                "in_seconds": 4,
+                "out_seconds": 6,
+            },
+            {"id": "c4", "source": "https://example.com/x.mp4", "in_seconds": 6, "out_seconds": 8},
+        ],
+        "audio": {"narration": {"src": str(tmp_path / "narration.mp3"), "volume": 1}},
+        # An .srt for the FFmpeg burn — Remotion never loads it, so it must be
+        # left alone despite the key also being named "source".
+        "subtitles": {"enabled": True, "source": str(tmp_path / "subs.srt")},
+    }
+
+    stage_dir = VideoCompose._stage_remotion_assets(
+        props, COMPOSER_DIR, tmp_path / "renders" / "final.mp4"
+    )
+    try:
+        public = COMPOSER_DIR / "public"
+        sources = [c["source"] for c in props["cuts"]]
+
+        assert not any(s.startswith(("file://", "/")) for s in sources[:3]), sources
+        assert sources[0] != sources[1], "same-basename assets collided in public/"
+        assert sources[3] == "https://example.com/x.mp4", "remote URLs must pass through"
+        assert props["cuts"][2]["images"][0] == sources[0], "identical files copied twice"
+        assert props["subtitles"]["source"] == str(tmp_path / "subs.srt")
+
+        for rel in (sources[0], sources[1], props["audio"]["narration"]["src"]):
+            assert (public / rel).is_file(), f"{rel} was not staged into public/"
+
+        assert stage_dir is not None and stage_dir.is_relative_to(public)
+    finally:
+        if stage_dir is not None:
+            shutil.rmtree(stage_dir, ignore_errors=True)
+            try:
+                stage_dir.parent.rmdir()  # leave public/ exactly as we found it
+            except OSError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Director-skill examples must be valid artifacts
+# ---------------------------------------------------------------------------
+
+# The canonical artifact each `<stage>-director.md` teaches the agent to emit.
+# Only stages whose examples are complete artifacts (not fragments) are listed.
+_DIRECTOR_ARTIFACTS = {
+    "edit": "edit_decisions",
+    "compose": "render_report",
+    "assets": "asset_manifest",
+}
+
+_JSON_FENCE = re.compile(r"```json\s*\n(.*?)```", re.DOTALL)
+
+
+def _complete_examples() -> list[tuple[Path, str, dict]]:
+    """Every fenced JSON block in a director skill that is a whole artifact."""
+    found: list[tuple[Path, str, dict]] = []
+    for stage, artifact in _DIRECTOR_ARTIFACTS.items():
+        for md in sorted((PROJECT_ROOT / "skills" / "pipelines").glob(f"*/{stage}-director.md")):
+            for block in _JSON_FENCE.findall(md.read_text(encoding="utf-8")):
+                try:
+                    obj = json.loads(block)
+                except json.JSONDecodeError:
+                    continue  # fragments with <placeholders> are not parseable
+                # A whole artifact carries the version marker; anything else is
+                # an illustrative fragment and is out of scope here.
+                if isinstance(obj, dict) and obj.get("version") == "1.0":
+                    found.append((md.relative_to(PROJECT_ROOT), artifact, obj))
+    return found
+
+
+def test_director_skill_examples_are_valid_artifacts():
+    """The JSON a director skill shows is the JSON the agent will copy.
+
+    An example that cannot validate produces a stage that cannot checkpoint —
+    which is how the render_report and documentary-montage edit_decisions
+    examples silently rotted.
+    """
+    examples = _complete_examples()
+    assert examples, "no complete artifact examples found in the director skills"
+
+    failures = []
+    for path, artifact, obj in examples:
+        try:
+            validate_artifact(artifact, obj)
+        except Exception as exc:  # noqa: BLE001 — surfacing every failure at once
+            failures.append(f"{path} ({artifact}): {str(exc).splitlines()[0]}")
+
+    assert not failures, "director-skill examples do not match their schema:\n" + "\n".join(failures)

--- a/tools/video/video_compose.py
+++ b/tools/video/video_compose.py
@@ -30,8 +30,10 @@ the agent to re-ask the user rather than substituting a different engine.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
+import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -678,8 +680,15 @@ class VideoCompose(BaseTool):
                 except OSError:
                     pass
 
+    # Scene components the Explainer composition dispatches on `cut.type`.
+    # Source of truth: remotion-composer/SCENE_TYPES.md and the `cut.type ===`
+    # branches in remotion-composer/src/Explainer.tsx. The older version of this
+    # set listed "progress"/"chart", which no component ever matched, and was
+    # missing every chart and synthetic-UI type added since.
     _REMOTION_SCENE_TYPES = {
-        "text_card", "stat_card", "callout", "comparison", "progress", "chart",
+        "text_card", "hero_title", "stat_card", "callout", "comparison",
+        "bar_chart", "line_chart", "pie_chart", "kpi_grid", "progress_bar",
+        "anime_scene", "terminal_scene", "screenshot_scene",
     }
 
     # Maps renderer_family (set at proposal stage) to Remotion composition ID.
@@ -1407,8 +1416,18 @@ class VideoCompose(BaseTool):
             )
         # --- Explicit Remotion path (render_runtime == 'remotion') ---
         if self._needs_remotion(resolved_cuts):
+            resolved_audio, audio_error = self._resolve_audio_sources(
+                edit_decisions.get("audio") or {}, asset_lookup
+            )
+            if audio_error:
+                return ToolResult(success=False, error=audio_error)
+
+            remotion_edit_decisions = dict(edit_decisions, cuts=resolved_cuts)
+            if resolved_audio:
+                remotion_edit_decisions["audio"] = resolved_audio
+
             remotion_inputs: dict[str, Any] = {
-                "edit_decisions": dict(edit_decisions, cuts=resolved_cuts),
+                "edit_decisions": remotion_edit_decisions,
                 "output_path": str(output_path),
             }
             if profile:
@@ -1670,6 +1689,358 @@ class VideoCompose(BaseTool):
 
         return render_result
 
+    @staticmethod
+    def _resolve_audio_sources(
+        audio: dict[str, Any],
+        asset_lookup: dict[str, Any],
+    ) -> tuple[dict[str, Any] | None, str | None]:
+        """Fill in Remotion's `src` from the asset-id audio spelling.
+
+        The Remotion compositions read `audio.narration.src` and
+        `audio.music.src` directly. The asset-id spelling
+        (`music.asset_id`, `narration.segments[].asset_id`) that the edit
+        directors document for the FFmpeg and HyperFrames runtimes had no
+        resolver on this path, so a documentary-montage edit — which is
+        required to run on Remotion — rendered silent.
+
+        Resolving here keeps both spellings working without asking the edit
+        stage to know which runtime it will land on. Returns
+        (resolved_audio_or_None, error_message_or_None).
+        """
+        if not audio:
+            return None, None
+
+        resolved = json.loads(json.dumps(audio))
+
+        music = resolved.get("music")
+        if isinstance(music, dict) and not music.get("src"):
+            asset = asset_lookup.get(music.get("asset_id"))
+            if asset and asset.get("path"):
+                music["src"] = asset["path"]
+
+        narration = resolved.get("narration")
+        if isinstance(narration, dict) and not narration.get("src"):
+            segments = narration.get("segments") or []
+            if len(segments) == 1:
+                asset = asset_lookup.get(segments[0].get("asset_id"))
+                if asset and asset.get("path"):
+                    narration["src"] = asset["path"]
+            elif len(segments) > 1:
+                # Explainer's AudioConfig carries ONE narration track. Picking
+                # the first segment would ship a video with a fraction of the
+                # narration and no warning, which the governance contract
+                # forbids — make the agent choose instead.
+                return None, (
+                    f"edit_decisions.audio.narration has {len(segments)} segments, but the "
+                    "Remotion compositions accept a single narration track. Either mix the "
+                    "segments into one file first (audio_mixer) and set "
+                    "audio.narration.src to the mixed file, or render this composition on a "
+                    "runtime that lays out segments individually (hyperframes/ffmpeg)."
+                )
+
+        return resolved, None
+
+    # Cut types the CinematicRenderer can express as a title card. Every other
+    # scene component (charts, KPI grids, terminals) has no counterpart there.
+    _CINEMATIC_TITLE_TYPES = {"text_card", "hero_title"}
+    _CINEMATIC_TONES = {"cold", "steel", "void", "neutral"}
+    # Transition names that mean "ramp the opacity" rather than "hard cut".
+    _FADE_TRANSITIONS = {"fade", "fade_in", "fade_out", "fadein", "fadeout", "dissolve", "crossfade"}
+    _CINEMATIC_FPS = 30  # CinematicRenderer hardcodes FPS = 30
+
+    @classmethod
+    def _to_cinematic_props(
+        cls,
+        props: dict[str, Any],
+    ) -> tuple[dict[str, Any] | None, str | None]:
+        """Adapt the canonical `cuts` artifact to CinematicRendererProps.
+
+        `renderer_family` of "cinematic-trailer" or "documentary-montage" routes
+        to the CinematicRenderer composition, whose props are a different shape
+        entirely: `scenes[]` of {kind, id, startSeconds, durationSeconds}, plus
+        `soundtrack`/`music`/`captions.words`. Handing it raw edit_decisions
+        crashed in calculateCinematicMetadata (`props.scenes.length` on
+        undefined), so this render path never worked.
+
+        The adaptation lives here rather than in the artifact because `cuts` is
+        the cross-stage contract — every edit director writes it, and
+        backlot/state.py, lib/slideshow_risk.py, and _pre_compose_validation all
+        read it. HyperFrames already adapts the same artifact for its runtime
+        (hyperframes_compose._resolve_audio_refs); Explainer needs no adapter
+        only because its prop names happen to match.
+
+        Returns (cinematic_props, None) or (None, error_message).
+        """
+        cuts = props.get("cuts") or []
+        metadata = props.get("metadata") or {}
+
+        tone = metadata.get("cinematic_tone")
+        if tone not in cls._CINEMATIC_TONES:
+            tone = None  # let the component's own default apply
+
+        scenes: list[dict[str, Any]] = []
+        unsupported: list[str] = []
+
+        for index, cut in enumerate(cuts):
+            in_s = float(cut.get("in_seconds", 0) or 0)
+            out_s = float(cut.get("out_seconds", 0) or 0)
+            duration = out_s - in_s
+            if duration <= 0:
+                continue
+
+            scene: dict[str, Any] = {
+                "id": cut.get("id") or f"cut-{index + 1}",
+                "startSeconds": in_s,
+                "durationSeconds": duration,
+            }
+
+            cut_type = cut.get("type")
+            if cut_type in cls._CINEMATIC_TITLE_TYPES:
+                text = cut.get("text")
+                if not text:
+                    unsupported.append(f"{scene['id']} (type={cut_type!r} with no `text`)")
+                    continue
+                scene["kind"] = "title"
+                scene["text"] = text
+                if cut.get("accentColor"):
+                    scene["accent"] = cut["accentColor"]
+                if cut.get("backgroundImage") or cut.get("backgroundVideo"):
+                    scene["backgroundSrc"] = cut.get("backgroundVideo") or cut["backgroundImage"]
+                    if cut.get("backgroundVideoStart") is not None:
+                        scene["backgroundTrimBeforeSeconds"] = cut["backgroundVideoStart"]
+                    scene["variant"] = "overlay"
+                scenes.append(scene)
+                continue
+
+            if cut_type is not None:
+                # A chart / terminal / anime scene has no CinematicRenderer
+                # counterpart. Dropping it would silently change the
+                # deliverable, so refuse and let the agent decide.
+                unsupported.append(f"{scene['id']} (type={cut_type!r})")
+                continue
+
+            source = cut.get("source")
+            if not source:
+                unsupported.append(f"{scene['id']} (no `source` and no `type`)")
+                continue
+
+            scene["kind"] = "video"
+            scene["src"] = source
+            if cut.get("source_in_seconds") is not None:
+                scene["trimBeforeSeconds"] = cut["source_in_seconds"]
+            if tone:
+                scene["tone"] = tone
+
+            fade_frames = round(
+                float(cut.get("transition_duration", 0) or 0) * cls._CINEMATIC_FPS
+            )
+            for prop, key in (("fadeInFrames", "transition_in"), ("fadeOutFrames", "transition_out")):
+                transition = cut.get(key)
+                if transition is None:
+                    continue  # omit → the component's default ramp applies
+                scene[prop] = fade_frames if str(transition).lower() in cls._FADE_TRANSITIONS else 0
+
+            scenes.append(scene)
+
+        if unsupported:
+            return None, (
+                "These cuts cannot be rendered by the CinematicRenderer composition "
+                f"(renderer_family={props.get('renderer_family')!r}): "
+                + ", ".join(unsupported)
+                + ".\nCinematicRenderer renders video scenes and title cards only. Options:\n"
+                "  1. Re-cut them as plain media cuts, or as text_card/hero_title titles\n"
+                "  2. Switch renderer_family to an explainer-* family (Explainer composition "
+                "handles the full scene-type catalog) — this changes the creative grammar, so "
+                "it needs user approval and a logged decision\n"
+                "  3. Hand-author the composition via composition_mode='atelier'"
+            )
+
+        if not scenes:
+            return None, (
+                "No renderable cuts for the CinematicRenderer composition — every cut had a "
+                "zero or negative duration (out_seconds must be greater than in_seconds)."
+            )
+
+        cinematic: dict[str, Any] = {"scenes": scenes}
+
+        audio = props.get("audio") or {}
+        narration = audio.get("narration") or {}
+        if narration.get("src"):
+            cinematic["soundtrack"] = {
+                "src": narration["src"],
+                **({"volume": narration["volume"]} if narration.get("volume") is not None else {}),
+            }
+        music = audio.get("music") or {}
+        if music.get("src"):
+            track: dict[str, Any] = {"src": music["src"]}
+            if music.get("volume") is not None:
+                track["volume"] = music["volume"]
+            # Accept either spelling of the fades.
+            fade_in = music.get("fadeInSeconds", music.get("fade_in_seconds"))
+            fade_out = music.get("fadeOutSeconds", music.get("fade_out_seconds"))
+            if fade_in is not None:
+                track["fadeInSeconds"] = fade_in
+            if fade_out is not None:
+                track["fadeOutSeconds"] = fade_out
+            if music.get("offsetSeconds") is not None:
+                track["trimBeforeSeconds"] = music["offsetSeconds"]
+            cinematic["music"] = track
+
+        captions = props.get("captions")
+        if captions:
+            cinematic["captions"] = {"words": captions}
+
+        # Carry the governance fields through so the props file stays auditable.
+        for key in ("renderer_family", "render_runtime", "composition_mode", "metadata"):
+            if key in props:
+                cinematic[key] = props[key]
+
+        return cinematic, None
+
+    # Props fields that hold a media path handed to a component's
+    # resolveAsset(). Scoped per container rather than matched anywhere in the
+    # tree, because key names collide with non-asset fields — `subtitles.source`
+    # is an .srt for the FFmpeg burn, not something Remotion ever loads.
+    # Adding a media-bearing scene prop is a one-line change here; miss it and
+    # the asset 404s silently at render time.
+    _REMOTION_MEDIA_FIELDS: dict[str, tuple[str, ...]] = {
+        # Explainer cuts + TalkingHead/Explainer overlays
+        "cuts": ("source", "backgroundImage", "backgroundVideo"),
+        "overlays": ("backgroundImage", "backgroundVideo"),
+        # CinematicRenderer scenes
+        "scenes": ("src", "backgroundSrc"),
+    }
+    # Lists of bare media paths on a cut (anime_scene stills).
+    _REMOTION_MEDIA_LIST_FIELDS = ("images",)
+    # Single-media props hanging off the root of a composition.
+    _REMOTION_ROOT_MEDIA_PATHS = (
+        ("videoSrc",),                 # TalkingHead
+        ("audio", "narration", "src"),
+        ("audio", "music", "src"),
+        ("soundtrack", "src"),         # CinematicRenderer
+        ("music", "src"),
+    )
+
+    @staticmethod
+    def _stage_remotion_assets(
+        props: dict[str, Any],
+        composer_dir: Path,
+        output_path: Path,
+    ) -> Path | None:
+        """Copy on-disk assets into remotion-composer/public/ and rewrite paths.
+
+        Remotion serves the composition from a dev server rooted at
+        `remotion-composer/`, and every component resolves its media through a
+        local `resolveAsset()` that ultimately calls Remotion's `staticFile()`.
+        `staticFile()` only understands paths *relative to public/* — it
+        prefixes whatever it is given with the public URL. Handing it an
+        absolute path or a `file://` URI produces requests like
+        `http://localhost:3000/public/Users/...`, which 404. (AnimeScene's copy
+        of resolveAsset() does not even special-case absolute paths, so it
+        fails this way for every local file.)
+
+        The reliable path is therefore to stage the assets: copy each referenced
+        file into a per-render directory under `public/` and rewrite the prop to
+        the public-relative location. Returns the staging dir so the caller can
+        remove it after the render, or None if nothing needed staging.
+        """
+        log = logging.getLogger("video_compose")
+        public_dir = composer_dir / "public"
+
+        # One dir per output file — deterministic (no clock/RNG), so a retry of
+        # the same render reuses the same location, and two different renders
+        # never collide.
+        digest = hashlib.sha1(str(output_path).encode("utf-8")).hexdigest()[:10]
+        stage_dir = public_dir / "om-staged" / f"{output_path.stem}-{digest}"
+
+        # abs source path -> public-relative posix path (copy each file once)
+        staged: dict[str, str] = {}
+        used = False
+
+        def stage_one(value: Any) -> Any:
+            nonlocal used
+            if not isinstance(value, str) or not value:
+                return value
+            if value.startswith(("http://", "https://", "data:")):
+                return value
+
+            raw = value
+            if raw.startswith("file://"):
+                raw = raw[len("file://"):]
+                # file:///C:/x -> C:/x ; file:///x -> /x
+                if len(raw) > 2 and raw[0] == "/" and raw[2] == ":":
+                    raw = raw[1:]
+
+            candidate = Path(raw)
+            if not candidate.is_absolute():
+                # A bare relative path is ambiguous: it may already be
+                # public-relative (the convention for hand-authored props), or
+                # relative to cwd. Prefer the public/ reading and leave it be.
+                if (public_dir / raw).exists():
+                    return raw
+                candidate = Path.cwd() / raw
+
+            try:
+                resolved = candidate.resolve()
+            except OSError:
+                return value
+            if not resolved.is_file():
+                # Not something we can stage — leave it untouched so Remotion
+                # reports the missing asset rather than us silently rewriting.
+                return value
+
+            # Already inside public/: just make it public-relative.
+            try:
+                return resolved.relative_to(public_dir.resolve()).as_posix()
+            except ValueError:
+                pass
+
+            key = str(resolved)
+            if key in staged:
+                return staged[key]
+
+            # Namespace by the source directory so two files with the same
+            # basename from different asset dirs cannot overwrite each other.
+            bucket = hashlib.sha1(str(resolved.parent).encode("utf-8")).hexdigest()[:8]
+            dest_dir = stage_dir / bucket
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            dest = dest_dir / resolved.name
+            try:
+                shutil.copy2(resolved, dest)
+            except OSError as exc:
+                log.warning("Could not stage %s into public/: %s", resolved, exc)
+                return value
+
+            rel = dest.relative_to(public_dir).as_posix()
+            staged[key] = rel
+            used = True
+            return rel
+
+        for container, fields in VideoCompose._REMOTION_MEDIA_FIELDS.items():
+            for item in props.get(container) or []:
+                if not isinstance(item, dict):
+                    continue
+                for field in fields:
+                    if isinstance(item.get(field), str):
+                        item[field] = stage_one(item[field])
+                for field in VideoCompose._REMOTION_MEDIA_LIST_FIELDS:
+                    if isinstance(item.get(field), list):
+                        item[field] = [stage_one(v) for v in item[field]]
+
+        for path in VideoCompose._REMOTION_ROOT_MEDIA_PATHS:
+            node: Any = props
+            for key in path[:-1]:
+                node = node.get(key) if isinstance(node, dict) else None
+                if node is None:
+                    break
+            if isinstance(node, dict) and isinstance(node.get(path[-1]), str):
+                node[path[-1]] = stage_one(node[path[-1]])
+
+        if used:
+            log.info("Staged %d asset(s) into %s", len(staged), stage_dir)
+            return stage_dir
+        return None
+
     def _remotion_render(self, inputs: dict[str, Any]) -> ToolResult:
         """Render via Remotion (requires Node.js + npx).
 
@@ -1677,8 +2048,6 @@ class VideoCompose(BaseTool):
         types, and transitions using React-based frame-accurate rendering.
         Accepts edit_decisions (with resolved file paths) or raw composition_data.
         """
-        import shutil
-
         if not shutil.which("npx"):
             return ToolResult(
                 success=False,
@@ -1697,18 +2066,33 @@ class VideoCompose(BaseTool):
         # Absolutise so the CLI can resolve the output regardless of cwd.
         output_path = output_path.resolve()
 
+        # remotion-composer lives at project root
+        composer_dir = Path(__file__).resolve().parent.parent.parent / "remotion-composer"
+        if not composer_dir.exists():
+            return ToolResult(
+                success=False,
+                error=f"Remotion composer project not found at {composer_dir}",
+            )
+
+        # Route to the correct Remotion composition based on renderer_family.
+        # This prevents all pipelines from collapsing into the Explainer visual
+        # grammar. Resolved before props are built because CinematicRenderer
+        # takes a different prop shape entirely.
+        renderer_family = (composition_data or {}).get("renderer_family", "explainer-data")
+        composition_id = self._get_composition_id(renderer_family)
+
         # Deep-copy props so we don't mutate the original
         props = json.loads(json.dumps(composition_data))
 
-        # Convert absolute file paths to file:// URIs for Remotion's
-        # Img and OffthreadVideo components
-        for cut in props.get("cuts", []):
-            source = cut.get("source", "")
-            if source and not source.startswith(("http://", "https://", "file://")):
-                resolved = Path(source).resolve()
-                if resolved.exists():
-                    posix = resolved.as_posix()
-                    cut["source"] = f"file:///{posix}" if not posix.startswith("/") else f"file://{posix}"
+        if composition_id == "CinematicRenderer":
+            props, adapt_error = self._to_cinematic_props(props)
+            if adapt_error:
+                return ToolResult(success=False, error=adapt_error)
+
+        # Stage every on-disk asset into remotion-composer/public/ and rewrite
+        # the reference public-relative. See _stage_remotion_assets for why
+        # file:// URIs do not work with the components' resolveAsset().
+        stage_dir = self._stage_remotion_assets(props, composer_dir, output_path)
 
         # Build a custom themeConfig from the playbook's actual colors.
         # This ensures every video gets a unique visual identity derived
@@ -1727,19 +2111,6 @@ class VideoCompose(BaseTool):
         props_path = output_path.parent / ".remotion_props.json"
         with open(props_path, "w", encoding="utf-8") as f:
             json.dump(props, f)
-
-        # remotion-composer lives at project root
-        composer_dir = Path(__file__).resolve().parent.parent.parent / "remotion-composer"
-        if not composer_dir.exists():
-            return ToolResult(
-                success=False,
-                error=f"Remotion composer project not found at {composer_dir}",
-            )
-
-        # Route to the correct Remotion composition based on renderer_family.
-        # This prevents all pipelines from collapsing into the Explainer visual grammar.
-        renderer_family = (composition_data or {}).get("renderer_family", "explainer-data")
-        composition_id = self._get_composition_id(renderer_family)
 
         cmd = [
             "npx", "remotion", "render",
@@ -1808,6 +2179,16 @@ class VideoCompose(BaseTool):
         finally:
             if props_path.exists():
                 props_path.unlink()
+            # Staged copies exist only for the duration of this render — the
+            # shared public/ dir would otherwise grow by the full asset set of
+            # every render ever run. The dir is unique per output path, so
+            # concurrent renders never clean up each other's assets.
+            if stage_dir is not None and stage_dir.exists():
+                shutil.rmtree(stage_dir, ignore_errors=True)
+                try:
+                    stage_dir.parent.rmdir()  # only succeeds while no other render holds a dir
+                except OSError:
+                    pass
 
         if not output_path.exists():
             return ToolResult(


### PR DESCRIPTION
## Summary

Two related fixes. The artifact schemas had drifted from what the pipeline actually writes and reads, and the Remotion render path had three bugs that meant some of it had never worked at all.

The drift was invisible for a structural reason: every schema in `schemas/artifacts/` sets `additionalProperties: false`, but `video_compose` never validates `edit_decisions` — only `lib/checkpoint.py` does, at checkpoint time. So a field the renderer happily consumed could be rejected long after the render already succeeded, and no test caught it because the tool tests call `video_compose` directly without validating the artifact.

## Schema drift (`33f48db`)

`edit_decisions` was worst affected. Beyond `cuts[].type` and the per-scene payload fields, the schema also rejected:

- `cuts[].shot_language` / `shot_intent` / `narrative_role` / `information_role` / `hero_moment` — read by `_pre_compose_validation` to feed `slideshow_risk`, so the pre-compose quality gate was scoring on fields the schema forbade
- `captions` (word-level, `ExplainerProps.captions`), distinct from `subtitles`, which is the separate FFmpeg file-based burn config
- `theme` / `playbook` / `themeConfig`, read by `resolveTheme()` in `Root.tsx`
- **`overlays[]` entirely** — the schema wanted `asset_id` + `start_seconds` + a geometric position, while `Explainer` and `TalkingHead` read `type` + `in_seconds`/`out_seconds` + component props + a named slot. Both shapes validate now.
- `end_tag`, written by documentary-montage's edit-director and read by its compose-director — a pure cross-stage contract

Other schemas:

- **`asset_manifest`** required `scene_id` on every asset, so background music could never validate. Now optional, documented as required for scene-bound assets.
- **`final_review`** enforced `frames_sampled >= 4` while the producer explicitly handles fewer and records it as an issue — a partially-failed frame extraction produced a review the checkpoint writer then refused.
- **`render_report`** gained `render_runtime`, `composition_mode`, `render_summary`, `audio_channels`.
- **`scene_plan`** gained the overlay-scene shape talking-head uses across stages.

Stale director-skill examples were fixed to match their schemas: the explainer `render_report` used `file_size_mb` and a per-output `render_time_seconds`; the asset manifest put `generation_summary` and `music_status` at the root instead of under `metadata`; documentary-montage's brief was written flat when every downstream director reads `brief.metadata.*`.

`proposal_packet` was clean.

## Remotion render path (`a7af02d`)

**Asset resolution.** `_remotion_render` rewrote on-disk cut sources into `file://` URLs, but every component resolves media through a local `resolveAsset()` ending in `staticFile()`, which only understands paths relative to `public/` — it prefixes whatever it is given, producing `http://localhost:3000/public/Users/...` and a 404. `AnimeScene`'s copy doesn't even special-case absolute paths, so it failed that way for every local file. Replaced with `_stage_remotion_assets`, which copies referenced assets into a per-render dir under `public/`, rewrites public-relative, and cleans up in `finally`. Traversal is scoped per container rather than matching key names anywhere in the tree, because `subtitles.source` is an `.srt` for the FFmpeg burn and must not be touched.

**CinematicRenderer.** `renderer_family` of `cinematic-trailer` or `documentary-montage` routes to a composition whose props are a different shape entirely — `scenes[]` of `{kind, startSeconds, durationSeconds}` plus `soundtrack`/`music`/`captions.words` — but `edit_decisions` was passed straight through, so `calculateMetadata` threw on `props.scenes.length` and this path had never worked. `_to_cinematic_props` adapts `cuts` to it. The adapter lives in the tool rather than the artifact because `cuts` is the cross-stage contract that `backlot/state.py`, `slideshow_risk` and `_pre_compose_validation` all read; HyperFrames already adapts the same artifact for its runtime. Cut types the composition can't express fail loudly with the ways out, since dropping them would silently change the deliverable.

**Audio.** The asset-id spelling documented for FFmpeg and HyperFrames had no resolver on the Remotion path, so documentary-montage — which is *required* to run on Remotion — rendered silent. Multi-segment narration is refused with a pointer to `audio_mixer` rather than shipping the first segment of five.

Also corrects `_REMOTION_SCENE_TYPES`, which listed `"progress"` and `"chart"` that no component ever matched, while missing all nine chart and synthetic-UI types added since.

## Verification

- **Real render**, not just a typecheck: a documentary-montage `edit_decisions` produced a 9.0s 1920x1080 h264 file with an **aac stream present** — the tell that asset-id audio resolution works. Sampled frames confirm the correct clip per cut, the tone treatment, word-level captions, and the title card.
- `npx tsc --noEmit` before vs. after: byte-identical error lists. The 15 pre-existing errors live in `Root.tsx`/`Explainer.tsx`/`ProviderChip.tsx`/`TitledVideo.tsx`; the two files touched here are clean.
- **831 passed**, 9 skipped. The first commit was checked out on its own and is green (802 passed) — no broken intermediate state.
- The new tests were verified to go **red** against the old schema (17 failures), so they genuinely catch this.

## Regression guard

`tests/contracts/test_artifact_schema_drift.py` pins the scene-type registry across four sources — `Explainer.tsx`'s dispatch cases, `SCENE_TYPES.md`, the schema enum, and `_REMOTION_SCENE_TYPES` — so a type can never again be routable but unrepresentable. It also asserts every complete artifact example in the director skills validates, which is how the `render_report` and documentary-montage examples silently rotted. `SCENE_TYPES.md`'s "adding a new scene type" checklist now includes the schema and the Python set.

## Reviewer notes

- Schema changes are purely **additive widening** plus doc corrections — nothing that previously validated stops validating. `cuts[].type` is a closed enum, not a free string, so typos like `text-card` are still rejected.
- One judgement call worth a second opinion: unsupported cut types on the cinematic path **fail the render** rather than being skipped. That's the governance-correct reading (silently dropping a cut changes the deliverable), but it is stricter than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
