### PR TITLE
Improve Seedance integration, Remotion public_dir handling, and documentary pipeline support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ python-dotenv>=1.0
 Pillow>=10.0
 numpy>=1.24
 requests>=2.31
+fal-client==1.0.0    # official fal.ai upload + queue client
 google-auth>=2.0       # service-account auth for Google TTS + Imagen (Vertex AI)
 openai>=2.44.0         # Videos API support for Sora 2
 

--- a/schemas/pipelines/pipeline_manifest.schema.json
+++ b/schemas/pipelines/pipeline_manifest.schema.json
@@ -11,7 +11,7 @@
     "description": { "type": "string" },
     "category": {
       "type": "string",
-      "enum": ["talking_head", "generated", "hybrid", "screen_recording", "animation", "cinematic", "custom"]
+      "enum": ["talking_head", "generated", "hybrid", "screen_recording", "animation", "cinematic", "documentary", "custom"]
     },
     "stability": {
       "type": "string",

--- a/tests/tools/test_fal_upload_helper.py
+++ b/tests/tools/test_fal_upload_helper.py
@@ -1,0 +1,39 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from tools.video._shared import upload_image_fal
+
+
+class FalUploadHelperTests(unittest.TestCase):
+    def test_uses_official_client_and_returns_trimmed_url(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            image = Path(directory) / "reference.png"
+            image.write_bytes(b"not-a-real-png-but-upload-is-mocked")
+            with patch(
+                "fal_client.upload_file",
+                return_value="  https://v3b.fal.media/files/reference.png  ",
+            ) as upload:
+                result = upload_image_fal(str(image))
+
+        upload.assert_called_once_with(image)
+        self.assertEqual(result, "https://v3b.fal.media/files/reference.png")
+
+    def test_rejects_empty_client_result(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            image = Path(directory) / "reference.jpeg"
+            image.write_bytes(b"reference")
+            with patch("fal_client.upload_file", return_value=""):
+                with self.assertRaisesRegex(RuntimeError, "returned no URL"):
+                    upload_image_fal(str(image))
+
+    def test_missing_file_fails_before_client_call(self) -> None:
+        with patch("fal_client.upload_file") as upload:
+            with self.assertRaises(FileNotFoundError):
+                upload_image_fal("/definitely/missing/reference.png")
+        upload.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_seedance_video_diagnostics.py
+++ b/tests/tools/test_seedance_video_diagnostics.py
@@ -1,0 +1,182 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import fal_client
+import httpx
+
+from tools.video.seedance_video import SeedanceVideo
+
+
+class _DownloadResponse:
+    content = b"mock-video"
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _Handle:
+    def __init__(self, statuses, result=None, result_error=None):
+        self.request_id = "fal-request-123"
+        self._statuses = iter(statuses)
+        self._result = result or {"video": {"url": "https://files.example/video.mp4"}, "seed": 41001}
+        self._result_error = result_error
+        self.status_calls = 0
+        self.get_calls = 0
+
+    def status(self, *, with_logs=False):
+        self.status_calls += 1
+        status = next(self._statuses)
+        if isinstance(status, Exception):
+            raise status
+        return status
+
+    def get(self):
+        self.get_calls += 1
+        if self._result_error:
+            raise self._result_error
+        return self._result
+
+
+def _http_error(status_code=422, body=None):
+    body = body or {"detail": [{"loc": ["body", "image_urls"], "msg": "invalid reference"}]}
+    request = httpx.Request("GET", "https://queue.fal.run/model/requests/id")
+    response = httpx.Response(
+        status_code,
+        content=json.dumps(body).encode(),
+        headers={
+            "x-fal-request-id": "fal-request-123",
+            "x-request-id": "trace-456",
+            "content-type": "application/json",
+        },
+        request=request,
+    )
+    return fal_client.FalClientHTTPError(
+        message="unprocessable entity",
+        status_code=status_code,
+        response_headers=dict(response.headers),
+        response=response,
+        error_type="unprocessable_entity",
+    )
+
+
+def _inputs(output_path):
+    return {
+        "scene_id": "shot-01",
+        "prompt": "@Image1 and @Image2 in one continuous shot",
+        "preferred_provider": "seedance",
+        "preferred_provider_gap": 1.0,
+        "allowed_providers": ["seedance"],
+        "operation": "reference_to_video",
+        "model_variant": "standard",
+        "duration": "4",
+        "aspect_ratio": "16:9",
+        "resolution": "720p",
+        "generate_audio": True,
+        "seed": 41001,
+        "output_path": str(output_path),
+        "reference_image_urls": ["https://files.example/a.jpeg", "https://files.example/b.png"],
+    }
+
+
+class SeedanceVideoDiagnosticTests(unittest.TestCase):
+    def setUp(self):
+        os.environ["FAL_KEY"] = "test-id:test-secret"
+
+    def test_outbound_payload_contains_only_provider_fields(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "video.mp4"
+            handle = _Handle([fal_client.Completed(logs=[], metrics={})])
+            with (
+                patch("fal_client.submit", return_value=handle) as submit,
+                patch("requests.get", return_value=_DownloadResponse()),
+                patch("tools.video._shared.probe_output", return_value={"duration_seconds": 4.0}),
+            ):
+                result = SeedanceVideo().execute(_inputs(output))
+
+        self.assertTrue(result.success)
+        submit.assert_called_once()
+        application, payload = submit.call_args.args
+        self.assertEqual(application, "bytedance/seedance-2.0/reference-to-video")
+        self.assertEqual(
+            set(payload),
+            {"prompt", "duration", "aspect_ratio", "resolution", "generate_audio", "seed", "image_urls"},
+        )
+        self.assertEqual(payload["image_urls"], ["https://files.example/a.jpeg", "https://files.example/b.png"])
+        self.assertNotIn("reference_image_urls", payload)
+        for field in (
+            "scene_id",
+            "preferred_provider",
+            "preferred_provider_gap",
+            "allowed_providers",
+            "operation",
+            "model_variant",
+            "output_path",
+        ):
+            self.assertNotIn(field, payload)
+
+    def test_polling_422_preserves_complete_diagnostics(self):
+        error = _http_error()
+        handle = _Handle([fal_client.InProgress(logs=[]), error])
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            patch("fal_client.submit", return_value=handle) as submit,
+            patch("time.sleep"),
+        ):
+            result = SeedanceVideo().execute(_inputs(Path(directory) / "video.mp4"))
+
+        self.assertFalse(result.success)
+        self.assertEqual(submit.call_count, 1)
+        self.assertEqual(result.data["http_status"], 422)
+        self.assertEqual(result.data["fal_request_id"], "fal-request-123")
+        self.assertEqual(result.data["terminal_queue_status"], "INPROGRESS")
+        self.assertEqual(
+            json.loads(result.data["response_body"]),
+            {"detail": [{"loc": ["body", "image_urls"], "msg": "invalid reference"}]},
+        )
+        self.assertEqual(result.data["response_headers"]["x-fal-request-id"], "fal-request-123")
+        self.assertEqual(result.data["response_headers"]["x-request-id"], "trace-456")
+        self.assertGreaterEqual(result.data["elapsed_processing_seconds"], 0)
+
+    def test_result_422_preserves_response_body(self):
+        error = _http_error(body={"detail": "terminal result validation failed"})
+        handle = _Handle(
+            [fal_client.Completed(logs=[], metrics={})],
+            result_error=error,
+        )
+        with tempfile.TemporaryDirectory() as directory, patch("fal_client.submit", return_value=handle):
+            result = SeedanceVideo().execute(_inputs(Path(directory) / "video.mp4"))
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.data["phase"], "result")
+        self.assertEqual(result.data["http_status"], 422)
+        self.assertEqual(json.loads(result.data["response_body"]), {"detail": "terminal result validation failed"})
+
+    def test_polling_never_submits_twice(self):
+        handle = _Handle(
+            [
+                fal_client.Queued(position=1),
+                fal_client.InProgress(logs=[]),
+                fal_client.Completed(logs=[], metrics={}),
+            ]
+        )
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            patch("fal_client.submit", return_value=handle) as submit,
+            patch("time.sleep"),
+            patch("requests.get", return_value=_DownloadResponse()),
+            patch("tools.video._shared.probe_output", return_value={"duration_seconds": 4.0}),
+        ):
+            result = SeedanceVideo().execute(_inputs(Path(directory) / "video.mp4"))
+
+        self.assertTrue(result.success)
+        self.assertEqual(submit.call_count, 1)
+        self.assertEqual(handle.status_calls, 3)
+        self.assertEqual(handle.get_calls, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/video/_shared.py
+++ b/tools/video/_shared.py
@@ -416,42 +416,19 @@ def poll_heygen(execution_id: str, api_key: str, timeout: int = 600) -> str:
 
 
 def upload_image_fal(image_path: str) -> str:
-    """Upload a local image to fal.ai storage and return a public URL."""
-    import requests
-
-    api_key = os.environ.get("FAL_KEY") or os.environ.get("FAL_AI_API_KEY")
-    if not api_key:
-        raise RuntimeError("FAL_KEY or FAL_AI_API_KEY required for image upload")
+    """Upload a local image with the official fal client and return its URL."""
+    import fal_client
 
     path = Path(image_path)
     if not path.exists():
         raise FileNotFoundError(f"Image not found: {image_path}")
+    if not path.is_file():
+        raise ValueError(f"Image path is not a file: {image_path}")
 
-    suffix = path.suffix.lower()
-    content_type = {"png": "image/png", "jpg": "image/jpeg", "jpeg": "image/jpeg", "webp": "image/webp"}.get(
-        suffix.lstrip("."), "image/png"
-    )
-
-    # Initiate upload
-    init_resp = requests.post(
-        "https://rest.alpha.fal.ai/storage/upload/initiate",
-        headers={"Authorization": f"Key {api_key}", "Content-Type": "application/json"},
-        json={"content_type": content_type, "file_name": path.name},
-        timeout=30,
-    )
-    init_resp.raise_for_status()
-    data = init_resp.json()
-
-    # Upload file content
-    put_resp = requests.put(
-        data["upload_url"],
-        headers={"Content-Type": content_type},
-        data=path.read_bytes(),
-        timeout=60,
-    )
-    put_resp.raise_for_status()
-
-    return data["file_url"]
+    url = fal_client.upload_file(path)
+    if not isinstance(url, str) or not url.strip():
+        raise RuntimeError(f"fal_client.upload_file returned no URL for {image_path}")
+    return url.strip()
 
 
 def upload_image_heygen(image_path: str, api_key: str) -> str:

--- a/tools/video/seedance_video.py
+++ b/tools/video/seedance_video.py
@@ -159,6 +159,30 @@ class SeedanceVideo(BaseTool):
         "Watch generated clip for motion coherence, audio sync, and visual quality"
     ]
 
+    REFERENCE_OUTBOUND_FIELDS = (
+        "prompt",
+        "duration",
+        "aspect_ratio",
+        "resolution",
+        "generate_audio",
+        "seed",
+        "image_urls",
+        "video_urls",
+        "audio_urls",
+    )
+    TRACE_HEADER_NAMES = frozenset(
+        {
+            "cf-ray",
+            "date",
+            "server-timing",
+            "traceparent",
+            "x-amzn-trace-id",
+            "x-cloud-trace-context",
+            "x-fal-request-id",
+            "x-request-id",
+        }
+    )
+
     def _get_api_key(self) -> str | None:
         return os.environ.get("FAL_KEY") or os.environ.get("FAL_AI_API_KEY")
 
@@ -178,6 +202,67 @@ class SeedanceVideo(BaseTool):
         variant = inputs.get("model_variant", "standard")
         return 60.0 if variant == "fast" else 120.0
 
+    @classmethod
+    def _trace_headers(cls, headers: Any) -> dict[str, str]:
+        return {
+            str(key): str(value)
+            for key, value in dict(headers or {}).items()
+            if str(key).lower() in cls.TRACE_HEADER_NAMES
+            or "request-id" in str(key).lower()
+            or "trace" in str(key).lower()
+        }
+
+    @classmethod
+    def _http_failure_result(
+        cls,
+        *,
+        exc: Exception,
+        phase: str,
+        model_path: str,
+        request_id: str | None,
+        terminal_queue_status: str,
+        started: float,
+        outbound_payload: dict[str, Any],
+    ) -> ToolResult:
+        response = getattr(exc, "response", None)
+        status_code = getattr(exc, "status_code", None)
+        if status_code is None and response is not None:
+            status_code = getattr(response, "status_code", None)
+        response_body = ""
+        if response is not None:
+            try:
+                response_body = response.text
+            except Exception:
+                response_body = repr(getattr(response, "content", b""))
+        response_headers = cls._trace_headers(
+            getattr(exc, "response_headers", None)
+            or getattr(response, "headers", None)
+        )
+        elapsed = round(time.monotonic() - started, 2)
+        diagnostics = {
+            "provider": "seedance",
+            "model": model_path,
+            "phase": phase,
+            "http_status": status_code,
+            "response_body": response_body,
+            "response_headers": response_headers,
+            "fal_request_id": request_id,
+            "terminal_queue_status": terminal_queue_status,
+            "elapsed_processing_seconds": elapsed,
+            "outbound_payload": outbound_payload,
+        }
+        return ToolResult(
+            success=False,
+            data=diagnostics,
+            error=(
+                f"Seedance 2.0 {phase} failed"
+                f" with HTTP {status_code}: {response_body}"
+            ),
+            cost_usd=0.0,
+            duration_seconds=elapsed,
+            model=model_path,
+        )
+
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
         api_key = self._get_api_key()
         if not api_key:
@@ -186,9 +271,10 @@ class SeedanceVideo(BaseTool):
                 error="FAL_KEY not set. " + self.install_instructions,
             )
 
+        import fal_client
         import requests
 
-        start = time.time()
+        started = time.monotonic()
         operation = inputs.get("operation", "text_to_video")
         variant = inputs.get("model_variant", "standard")
         operation_path = operation.replace("_", "-")
@@ -222,9 +308,15 @@ class SeedanceVideo(BaseTool):
 
         if operation == "reference_to_video":
             ref_image_urls = list(inputs.get("reference_image_urls") or [])
-            for local_path in inputs.get("reference_image_paths") or []:
-                from tools.video._shared import upload_image_fal
-                ref_image_urls.append(upload_image_fal(local_path))
+            try:
+                for local_path in inputs.get("reference_image_paths") or []:
+                    from tools.video._shared import upload_image_fal
+                    ref_image_urls.append(upload_image_fal(local_path))
+            except Exception as exc:
+                return ToolResult(
+                    success=False,
+                    error=f"Seedance 2.0 reference preparation failed: {exc}",
+                )
             # Seedance 2.0 reference-to-video ceilings: 9 images + 3 video + 3 audio.
             if len(ref_image_urls) > 9:
                 return ToolResult(
@@ -244,46 +336,112 @@ class SeedanceVideo(BaseTool):
                     error=f"Seedance 2.0 reference_to_video accepts at most 3 reference audio clips; got {len(ref_audio_urls)}",
                 )
             if ref_image_urls:
-                payload["reference_image_urls"] = ref_image_urls
+                payload["image_urls"] = ref_image_urls
             if ref_video_urls:
-                payload["reference_video_urls"] = ref_video_urls
+                payload["video_urls"] = ref_video_urls
             if ref_audio_urls:
-                payload["reference_audio_urls"] = ref_audio_urls
+                payload["audio_urls"] = ref_audio_urls
 
-        headers = {
-            "Authorization": f"Key {api_key}",
-            "Content-Type": "application/json",
-        }
+            # Provider boundary: selector/repository inputs and deprecated
+            # aliases must never cross into the Seedance request body.
+            payload = {
+                field: payload[field]
+                for field in self.REFERENCE_OUTBOUND_FIELDS
+                if field in payload
+            }
+
+        handle = None
+        request_id = None
+        terminal_queue_status = "NOT_SUBMITTED"
+        try:
+            handle = fal_client.submit(model_path, payload)
+            request_id = getattr(handle, "request_id", None)
+            terminal_queue_status = "SUBMITTED"
+        except fal_client.FalClientHTTPError as exc:
+            return self._http_failure_result(
+                exc=exc,
+                phase="submission",
+                model_path=model_path,
+                request_id=request_id,
+                terminal_queue_status=terminal_queue_status,
+                started=started,
+                outbound_payload=payload,
+            )
+        except Exception as exc:
+            elapsed = round(time.monotonic() - started, 2)
+            return ToolResult(
+                success=False,
+                data={
+                    "provider": "seedance",
+                    "model": model_path,
+                    "phase": "submission",
+                    "fal_request_id": request_id,
+                    "terminal_queue_status": terminal_queue_status,
+                    "elapsed_processing_seconds": elapsed,
+                    "outbound_payload": payload,
+                },
+                error=f"Seedance 2.0 submission failed: {exc}",
+                cost_usd=0.0,
+                duration_seconds=elapsed,
+                model=model_path,
+            )
 
         try:
-            submit_resp = requests.post(
-                f"https://queue.fal.run/{model_path}",
-                headers=headers,
-                json=payload,
-                timeout=30,
-            )
-            submit_resp.raise_for_status()
-            queue_data = submit_resp.json()
-            status_url = queue_data["status_url"]
-            response_url = queue_data["response_url"]
-
             while True:
-                time.sleep(5)
-                status_resp = requests.get(status_url, headers=headers, timeout=15)
-                status_resp.raise_for_status()
-                status = status_resp.json().get("status", "UNKNOWN")
-                if status == "COMPLETED":
+                status = handle.status(with_logs=True)
+                terminal_queue_status = type(status).__name__.upper()
+                if isinstance(status, fal_client.Completed):
+                    status_error = getattr(status, "error", None)
+                    if status_error:
+                        error_type = getattr(status, "error_type", None)
+                        elapsed = round(time.monotonic() - started, 2)
+                        return ToolResult(
+                            success=False,
+                            data={
+                                "provider": "seedance",
+                                "model": model_path,
+                                "phase": "polling",
+                                "http_status": None,
+                                "response_body": status_error,
+                                "response_headers": {},
+                                "fal_request_id": request_id,
+                                "terminal_queue_status": "COMPLETED_WITH_ERROR",
+                                "elapsed_processing_seconds": elapsed,
+                                "outbound_payload": payload,
+                                "error_type": error_type,
+                            },
+                            error=f"Seedance 2.0 completed with error: {status_error}",
+                            cost_usd=0.0,
+                            duration_seconds=elapsed,
+                            model=model_path,
+                        )
                     break
-                if status in ("FAILED", "CANCELLED"):
-                    return ToolResult(
-                        success=False,
-                        error=f"Seedance 2.0 video generation {status.lower()}",
-                    )
+                time.sleep(5)
+        except fal_client.FalClientHTTPError as exc:
+            return self._http_failure_result(
+                exc=exc,
+                phase="polling",
+                model_path=model_path,
+                request_id=request_id,
+                terminal_queue_status=terminal_queue_status,
+                started=started,
+                outbound_payload=payload,
+            )
 
-            result_resp = requests.get(response_url, headers=headers, timeout=30)
-            result_resp.raise_for_status()
-            data = result_resp.json()
+        try:
+            data = handle.get()
+        except fal_client.FalClientHTTPError as exc:
+            return self._http_failure_result(
+                exc=exc,
+                phase="result",
+                model_path=model_path,
+                request_id=request_id,
+                terminal_queue_status=terminal_queue_status,
+                started=started,
+                outbound_payload=payload,
+            )
 
+        try:
             video_url = data["video"]["url"]
             video_response = requests.get(video_url, timeout=120)
             video_response.raise_for_status()
@@ -292,10 +450,23 @@ class SeedanceVideo(BaseTool):
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_bytes(video_response.content)
 
-        except Exception as e:
+        except Exception as exc:
+            elapsed = round(time.monotonic() - started, 2)
             return ToolResult(
                 success=False,
-                error=f"Seedance 2.0 video generation failed: {e}",
+                data={
+                    "provider": "seedance",
+                    "model": model_path,
+                    "phase": "download",
+                    "fal_request_id": request_id,
+                    "terminal_queue_status": terminal_queue_status,
+                    "elapsed_processing_seconds": elapsed,
+                    "outbound_payload": payload,
+                },
+                error=f"Seedance 2.0 result download failed: {exc}",
+                cost_usd=0.0,
+                duration_seconds=elapsed,
+                model=model_path,
             )
 
         from tools.video._shared import probe_output
@@ -320,6 +491,6 @@ class SeedanceVideo(BaseTool):
             },
             artifacts=[str(output_path)],
             cost_usd=self.estimate_cost(inputs),
-            duration_seconds=round(time.time() - start, 2),
+            duration_seconds=round(time.monotonic() - started, 2),
             model=model_path,
         )

--- a/tools/video/video_compose.py
+++ b/tools/video/video_compose.py
@@ -91,6 +91,14 @@ class VideoCompose(BaseTool):
             },
             "input_path": {"type": "string"},
             "output_path": {"type": "string"},
+            "public_dir": {
+                "type": "string",
+                "description": (
+                    "Project-local Remotion public directory. For atelier renders, "
+                    "this is used when edit_decisions.bespoke.public_dir is absent, "
+                    "so render wiring does not require mutating approved edit decisions."
+                ),
+            },
             "edit_decisions": {
                 "type": "object",
                 "description": "Full edit_decisions artifact (required for compose/render)",
@@ -814,7 +822,10 @@ class VideoCompose(BaseTool):
             # Equals form is required for cross-platform path parsing (see _remotion_render).
             cmd.append(f"--props={pp}")
 
-        public_dir = bespoke.get("public_dir")
+        # The public directory is render wiring, not a creative Edit decision.
+        # Accept it as an explicit tool input so an approved edit artifact does
+        # not need to be mutated merely to expose project-local static assets.
+        public_dir = bespoke.get("public_dir") or inputs.get("public_dir")
         if public_dir:
             pd = Path(public_dir).resolve()
             if pd.exists():


### PR DESCRIPTION
<!--
Thanks for contributing to OpenMontage! Please fill in the sections below.
Keep PRs focused — one logical change per PR is easier to review and merge.
-->

<!--
Thanks for contributing to OpenMontage! Please fill in the sections below.
Keep PRs focused — one logical change per PR is easier to review and merge.
-->

## Summary

- Replace the manual fal.ai upload flow with the official `fal-client`.
- Improve Seedance diagnostics and test coverage.
- Allow `VideoCompose` to accept a project-local `public_dir` without modifying approved edit decisions.
- Add `documentary` as a supported pipeline category.

## Related issue

None.

## Changes

- Added official `fal-client` integration.
- Added Seedance diagnostic tests.
- Added `public_dir` render-input support.
- Added the `documentary` pipeline category.

## Testing

- [x] `python -m py_compile tools/video/_shared.py tools/video/seedance_video.py`
- [x] `pytest -q tests/tools/test_fal_upload_helper.py tests/tools/test_seedance_video_diagnostics.py`
  - 7 passed
- [x] `pytest -q tests/tools -k "compose or remotion"`
  - 57 passed, 153 deselected

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [ ] I updated docs/README if behavior or usage changed.
- [x] No unrelated files (build artifacts, local config) are included in the diff.