### PR TITLE
Music plan: check all three music capabilities, not just music_generation

### DIFF
--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -526,17 +526,29 @@ If a user prefers a specific vendor and that tool is available, surface it direc
 
 Music is a critical part of any video. **Surface the music situation to the user at proposal/idea time** — do not silently defer it to the asset stage where a failure becomes expensive.
 
-Check music availability in this order and present the options:
+Music tools span **three** capability names. Checking only one is the most common
+mistake here, and it makes music look far more constrained than it is:
 
-1. **User music library (`music_library/`):** Check if this folder exists and contains tracks. If so, list available tracks with durations and let the user pick one.
-2. **Music generation APIs:** Check which music tools are available via the registry (`registry.get_by_capability("music_generation")`). Report their status honestly — include quota status if known.
-3. **Royalty-free sources:** Note if the user can provide their own track (e.g., from YouTube Audio Library, Jamendo, or other free sources). Offer the `music_library/` drop path.
+| Capability | Tools | Cost |
+|---|---|---|
+| `music_library` | `music_library` | free, user's own files |
+| `music_search` | `pixabay_music`, `freesound_music` | free (`pixabay_music` needs **no API key at all**) |
+| `music_generation` | `music_gen` (ElevenLabs), `google_music` (Lyria) | paid API key |
+
+Check all three and present the options:
+
+1. **User music library (`music_library/`):** Check `registry.get_by_capability("music_library")`, or the folder directly. If it has tracks, list them with durations and let the user pick one.
+2. **Stock music search:** Check `registry.get_by_capability("music_search")`. `pixabay_music` requires no key and is royalty-free for commercial use, so it is usually available even on a bare install. Offer it before anything that costs money.
+3. **Music generation APIs:** Check `registry.get_by_capability("music_generation")`. Report status honestly — include quota status if known, and name the cost.
 
 **Always present the user with explicit choices:**
 - Use a track from their library (which one?)
+- Search free stock music (`pixabay_music` / `freesound_music`)
 - Provide a different track (drop it in `music_library/`)
 - Generate one via API (if available — name the provider and cost)
 - Proceed without music
+
+**Prefer free sources first.** An empty `music_library/` is not "no music available" — stock search is still there, and it costs nothing.
 
 **If no music source is available:** Tell the user explicitly. Do NOT let this surface as a surprise at the asset stage.
 

--- a/skills/INDEX.md
+++ b/skills/INDEX.md
@@ -60,7 +60,9 @@ Key capability families to look for in the output:
 | `analysis` | — | Mixed providers |
 | `character_animation` | — | Local character specs, SVG rigs, pose libraries, action timelines, previews, and QA |
 | `graphics` | — | Local rendering tools |
-| `music_generation` | — | Single-provider |
+| `music_generation` | — | `music_gen` (ElevenLabs), `google_music` (Lyria) |
+| `music_search` | — | `pixabay_music` (no API key), `freesound_music` |
+| `music_library` | — | Local user files in `music_library/` |
 | `subtitle` | — | Pure Python |
 | `avatar` | — | Local GPU models |
 | `video_post` | — | FFmpeg-based local tools |

--- a/skills/pipelines/cinematic/idea-director.md
+++ b/skills/pipelines/cinematic/idea-director.md
@@ -88,23 +88,29 @@ Cinematic videos live and die by their audio. **Surface the music situation befo
 
 Check availability in this order:
 
-1. **User music library (`music_library/`):** Check if this folder exists and contains tracks. List available tracks with durations and moods. Let the user choose.
-2. **Music generation APIs:** Check `registry.get_by_capability("music_generation")`. Report status, quota, and cost per track.
-3. **Royalty-free sources:** Note that the user can provide a track from YouTube Audio Library, Jamendo, or other free sources by dropping it in `music_library/`.
+Music spans **three** capabilities. Check all of them — querying only
+`music_generation` hides the free stock sources and makes music look unavailable
+when it isn't.
+
+1. **User music library:** Check `registry.get_by_capability("music_library")`, or the folder directly. List available tracks with durations and moods. Let the user choose.
+2. **Stock music search:** Check `registry.get_by_capability("music_search")`. `pixabay_music` needs **no API key** and is royalty-free for commercial use. Offer it before anything paid.
+3. **Music generation APIs:** Check `registry.get_by_capability("music_generation")`. Report status, quota, and cost per track.
 
 Present explicit options:
 
 ```
 MUSIC PLAN
 ├── Your music library: [N tracks / empty]
+├── Free stock search: [pixabay_music / freesound_music] — [AVAILABLE/UNAVAILABLE]
 ├── AI generation: [provider] — [AVAILABLE/UNAVAILABLE] [cost]
 └── Bring your own: Drop a track in music_library/ before asset stage
 
 Options:
   (a) Use a library track (which one?)
-  (b) Provide your own track
-  (c) Generate via API (if available)
-  (d) Proceed without music (not recommended for cinematic)
+  (b) Search free stock music
+  (c) Provide your own track
+  (d) Generate via API (if available)
+  (e) Proceed without music (not recommended for cinematic)
 ```
 
 Record the decision in `brief.metadata.music_strategy` with the chosen source and path/prompt.

--- a/skills/pipelines/cinematic/proposal-director.md
+++ b/skills/pipelines/cinematic/proposal-director.md
@@ -221,15 +221,18 @@ Let the user select, combine, modify, or redirect entirely.
 
 Cinematic videos live and die by their audio. Surface the music situation before the user approves.
 
-Check availability in this order:
-1. **User music library (`music_library/`)** — list available tracks
-2. **Music generation APIs** — report status, cost, and quality honestly
-3. **Bring-your-own path** — user can drop a track in `music_library/`
+Check availability in this order. Music spans **three** capabilities — checking
+only `music_generation` hides the free stock sources:
+1. **User music library** (`registry.get_by_capability("music_library")`) — list available tracks
+2. **Stock music search** (`registry.get_by_capability("music_search")`) — `pixabay_music` needs **no API key**; offer it before anything paid
+3. **Music generation APIs** (`registry.get_by_capability("music_generation")`) — report status, cost, and quality honestly
+4. **Bring-your-own path** — user can drop a track in `music_library/`
 
 Present explicit options:
 ```
 MUSIC PLAN
 ├── Your music library: [N tracks / empty]
+├── Free stock search: [pixabay_music / freesound_music] — [AVAILABLE/UNAVAILABLE]
 ├── AI generation: [provider] — [AVAILABLE/UNAVAILABLE] [cost]
 └── Bring your own: Drop a track in music_library/ before asset stage
 

--- a/skills/pipelines/documentary-montage/idea-director.md
+++ b/skills/pipelines/documentary-montage/idea-director.md
@@ -90,11 +90,15 @@ itself. If the user has not mentioned music, ASSUME THEY WANT IT and pick:
 
 - user-provided track (put path in `music_plan.source_path`),
 - music library pick (list what's in `music_library/`),
+- free stock search (`registry.get_by_capability("music_search")` — `pixabay_music` needs no API key),
 - generated (name the tool and prompt seed with register),
 - explicit opt-out (`source: "none"` + `opt_out_reason`).
 
 **Warn the user if no music source is available.** Do not silently
-defer this — it becomes an expensive surprise at the asset stage.
+defer this — it becomes an expensive surprise at the asset stage. Check all
+three music capabilities before concluding nothing is available: `music_library`,
+`music_search`, and `music_generation`. An empty `music_library/` on its own is
+not "no music" — free stock search is usually still there.
 
 ### 5. Note End-Tag Intent (MANDATORY)
 

--- a/skills/pipelines/explainer/proposal-director.md
+++ b/skills/pipelines/explainer/proposal-director.md
@@ -369,9 +369,12 @@ Music is a critical part of the video's feel. **Surface the music situation to t
 
 **Check music availability in this order:**
 
-1. **User music library (`music_library/`):** Check if this folder exists and contains tracks. If so, list available tracks with durations and let the user pick one.
-2. **Music generation APIs:** Check which music tools are available via the registry (`registry.get_by_capability("music_generation")`). Report their status honestly.
-3. **Stock music sources:** Note if stock music is available via any provider.
+Music spans **three** capabilities. Check all of them — querying only
+`music_generation` hides the free stock sources.
+
+1. **User music library:** Check `registry.get_by_capability("music_library")`, or the folder directly. If it has tracks, list them with durations and let the user pick one.
+2. **Stock music search:** Check `registry.get_by_capability("music_search")`. `pixabay_music` needs **no API key** and is royalty-free for commercial use. Offer it before anything paid.
+3. **Music generation APIs:** Check `registry.get_by_capability("music_generation")`. Report their status honestly, and name the cost.
 
 **Present to the user:**
 
@@ -381,21 +384,24 @@ MUSIC PLAN
 │   ├── cosmic_interstellar_space.mp3 (3:13) — ambient, cosmic
 │   ├── cinematic_epic.mp3 (2:45) — dramatic, building
 │   └── lofi_beat.mp3 (4:00) — chill, electronic
+├── Free stock search: pixabay_music — AVAILABLE (no API key needed)
 ├── AI generation: music_gen (ElevenLabs) — UNAVAILABLE (plan limit)
 └── Recommendation: Use "cosmic_interstellar_space.mp3" from your library
     OR provide a different track before asset generation
 
 Would you like to:
   (a) Use a track from your library (which one?)
-  (b) Provide a different track (drop it in music_library/)
-  (c) Generate one via API (if available)
-  (d) Proceed without music
+  (b) Search free stock music
+  (c) Provide a different track (drop it in music_library/)
+  (d) Generate one via API (if available)
+  (e) Proceed without music
 ```
 
-**If no music source is available:** Tell the user explicitly. Do NOT let this surface as a surprise at the asset stage. Offer the `music_library/` path so they can add a track before production starts.
+**If no music source is available:** Tell the user explicitly. Do NOT let this surface as a surprise at the asset stage. Offer the `music_library/` path so they can add a track before production starts. Note that an empty `music_library/` is **not** the same as no music available — stock search is still there and costs nothing.
 
 **Rules:**
 - Always check `music_library/` first — user-provided music is free and intentional
+- Free sources (library, then stock search) come before anything that bills
 - Always report music API status (available, unavailable, quota remaining if checkable)
 - Record the music decision in `proposal_packet.production_plan.music_source`
 - If the user picks a library track, record its path for the asset director


### PR DESCRIPTION
## Problem

Music tools are split across three capability names:

| Capability | Tools | Cost |
|---|---|---|
| `music_library` | `music_library` | free, user's own files |
| `music_search` | `pixabay_music`, `freesound_music` | free (`pixabay_music` needs **no API key**) |
| `music_generation` | `music_gen`, `google_music`, `suno_music` | paid API key |

But every music instruction in the repo queries only one of them:

- `AGENT_GUIDE.md` — "Check which music tools are available via the registry (`registry.get_by_capability("music_generation")`)"
- `skills/pipelines/cinematic/idea-director.md`
- `skills/pipelines/cinematic/proposal-director.md`
- `skills/pipelines/explainer/proposal-director.md`
- `skills/pipelines/documentary-montage/idea-director.md`

That query cannot see `pixabay_music` or `freesound_music`, because their capability is `music_search`.

The practical effect shows up hardest on a fresh install with no API keys, which is the first-run experience. The mandated Music Plan offers exactly two paths: pick from `music_library/`, or pay for generation. So the agent reports that no music is available and falls back to reusing whatever is in `music_library/` — or finds nothing at all, since that folder does not exist by default. Meanwhile `pixabay_music` is sitting right there, royalty-free, needing no key.

## Change

Docs only. No tool or registry code is touched.

- The Music Plan in `AGENT_GUIDE.md` now checks all three capabilities and carries a table showing which sources cost money.
- The four director skills do the same, ordered free-sources-first so the agent reaches for the library and stock search before anything that bills.
- Added an explicit note that an empty `music_library/` is **not** the same as "no music available" — that assumption is what causes the fallback.
- `skills/INDEX.md` listed `music_generation` as "Single-provider" and omitted `music_search` and `music_library` entirely. Corrected to list all three families and their tools.

## Notes

`pixabay_music` scrapes the Pixabay site rather than using an API, and its own `install_instructions` warn it may break. While testing this I did hit an HTTP 502 from it. That is a pre-existing fragility in that tool and out of scope here; `freesound_music` is already declared as its fallback. Even with that caveat, making the free tier visible is strictly better than the current behavior of not knowing it exists.

Kept focused per CONTRIBUTING.md. Behavior of the tools themselves is unchanged, so there is nothing new to unit test.
