### PR TITLE
fix(styles): make the anime-ghibli playbook loadable again

### DIFF
--- a/schemas/styles/playbook.schema.json
+++ b/schemas/styles/playbook.schema.json
@@ -141,16 +141,50 @@
           "type": "array",
           "items": { "type": "string" },
           "minItems": 1
+        },
+        "scene_type": {
+          "type": "string",
+          "description": "Default Remotion cut.type this style composes scenes as, e.g. 'anime_scene'. See remotion-composer/SCENE_TYPES.md."
+        },
+        "multi_image_per_scene": {
+          "type": "boolean",
+          "description": "Whether a scene is built from several stills that crossfade (the anime_scene grammar) rather than a single image."
+        },
+        "images_per_scene": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "How many stills to generate per scene when multi_image_per_scene is set."
+        },
+        "image_variation_guidance": {
+          "type": "string",
+          "description": "How the per-scene stills should differ from each other so the crossfade reads as motion."
+        },
+        "default_particles": {
+          "type": "string",
+          "description": "Default particle overlay for scenes in this style (maps to the renderer's particles prop)."
+        },
+        "default_particle_color": {
+          "type": "string",
+          "description": "Default particle color (maps to the renderer's particleColor prop)."
+        },
+        "default_vignette": {
+          "type": "boolean",
+          "description": "Whether scenes in this style get a vignette by default (maps to the renderer's vignette prop)."
         }
       },
       "additionalProperties": false
     },
     "overlays": {
+      "description": "Per-overlay styling. Covers the in-scene overlay boxes plus the timed overlay types the Explainer composition renders (see remotion-composer/src/Explainer.tsx, `Overlay.type`).",
       "type": "object",
       "properties": {
         "stat_card": { "$ref": "#/$defs/overlay_style" },
         "key_term": { "$ref": "#/$defs/overlay_style" },
-        "code_block": { "$ref": "#/$defs/overlay_style" }
+        "code_block": { "$ref": "#/$defs/overlay_style" },
+        "section_title": { "$ref": "#/$defs/overlay_style" },
+        "stat_reveal": { "$ref": "#/$defs/overlay_style" },
+        "hero_title": { "$ref": "#/$defs/overlay_style" },
+        "provider_chip": { "$ref": "#/$defs/overlay_style" }
       },
       "additionalProperties": false
     },
@@ -236,7 +270,11 @@
         "text": { "type": "string" },
         "radius": { "type": "number" },
         "shadow": { "type": "string" },
-        "highlight": { "type": "string" }
+        "highlight": { "type": "string" },
+        "accent": {
+          "type": "string",
+          "description": "Accent color for overlay types that render one (maps to the renderer's accentColor prop)."
+        }
       },
       "additionalProperties": false
     },

--- a/styles/anime-ghibli.yaml
+++ b/styles/anime-ghibli.yaml
@@ -1,19 +1,19 @@
 identity:
   name: "Anime Ghibli"
-  category: anime-illustration
+  category: custom
   mood: warm, whimsical, contemplative, magical
-  pace: gentle
+  pace: slow
   best_for: "Narrative animations, nature-themed stories, emotional storytelling, fantasy visuals, educational content with wonder"
 
 visual_language:
   color_palette:
     primary: ["#2D5016", "#1B4332"]       # Deep forest greens
-    accent: ["#FFB347", "#FF6B9D"]        # Warm golden, soft cherry blossom pink
+    # Warm golden, soft cherry blossom pink, spirit glow (magical elements),
+    # golden-hour light. The last two are referenced by name in consistency_anchors.
+    accent: ["#FFB347", "#FF6B9D", "#A8E6CF", "#FFF3B0"]
     background: "#0A0A1A"                  # Deep night sky
     text: "#F5F0E8"                        # Warm parchment white
     muted: "#8B9A7E"                       # Mossy sage
-    spirit_glow: "#A8E6CF"                 # Soft teal glow for magical elements
-    golden_hour: "#FFF3B0"                 # Warm golden hour light
   composition: centered subjects, rule of thirds for landscapes, generous negative space, layered depth
   texture: soft watercolor edges, painterly brushstrokes, organic shapes, no hard geometric lines
 

--- a/tests/styles/test_playbook_catalog.py
+++ b/tests/styles/test_playbook_catalog.py
@@ -1,0 +1,80 @@
+"""Every shipped style playbook must actually load.
+
+`list_playbooks()` advertises a playbook as selectable, `pipeline_defs/*.yaml`
+offer them by name, and `lib.checkpoint._validate_style_playbook` fails closed
+on anything `load_playbook()` rejects. So a playbook that is listed but does not
+validate is not a cosmetic problem — it blocks `init_project()`/`write_checkpoint()`
+outright, taking the whole pipeline down for that style.
+
+These tests iterate the catalog rather than a hardcoded list, which is how
+`anime-ghibli` and `premium-minimalist` slipped through: the pre-existing
+coverage in tests/qa/test_07_playbook_intelligence.py names three playbooks
+that were the only ones in the repo when it was written.
+"""
+
+import pytest
+
+from lib.checkpoint import init_project
+from styles.playbook_loader import list_playbooks, load_playbook
+
+PLAYBOOK_NAMES = sorted(list_playbooks())
+
+# The overlay types remotion-composer actually renders, from the `Overlay`
+# union in remotion-composer/src/Explainer.tsx. A playbook must be able to
+# style any of them.
+RENDERER_OVERLAY_TYPES = (
+    "section_title",
+    "stat_reveal",
+    "hero_title",
+    "provider_chip",
+)
+
+
+def test_catalog_is_not_empty() -> None:
+    assert PLAYBOOK_NAMES, "list_playbooks() found no playbooks at all"
+
+
+@pytest.mark.parametrize("name", PLAYBOOK_NAMES)
+def test_listed_playbook_loads_and_validates(name: str) -> None:
+    """A playbook offered by the catalog must pass its own schema."""
+    playbook = load_playbook(name)
+    assert playbook["identity"]["name"]
+
+
+@pytest.mark.parametrize("name", PLAYBOOK_NAMES)
+def test_listed_playbook_is_accepted_by_init_project(name: str, tmp_path) -> None:
+    """The checkpoint writer validates style_playbook fail-closed.
+
+    Regression: `anime-ghibli` was listed and offered by pipeline_defs/animation.yaml
+    but raised CheckpointValidationError here, so no run using that style could
+    write a checkpoint.
+    """
+    init_project(
+        f"catalog-{name}",
+        title="Catalog probe",
+        pipeline_type="animation",
+        pipeline_dir=tmp_path,
+        style_playbook=name,
+    )
+
+
+@pytest.mark.parametrize("overlay_type", RENDERER_OVERLAY_TYPES)
+def test_schema_allows_every_renderer_overlay_type(overlay_type: str) -> None:
+    """The playbook schema's overlay vocabulary must track the renderer's.
+
+    Regression: the schema allowed only stat_card/key_term/code_block — none of
+    the four overlay types Explainer renders — so styling `section_title` made
+    the whole playbook invalid.
+    """
+    import json
+    from pathlib import Path
+
+    schema_path = (
+        Path(__file__).resolve().parents[2]
+        / "schemas"
+        / "styles"
+        / "playbook.schema.json"
+    )
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    allowed = schema["properties"]["overlays"]["properties"]
+    assert overlay_type in allowed


### PR DESCRIPTION
## The defect

`load_playbook("anime-ghibli")` raises a `ValidationError` on current `main`. Because `lib/checkpoint.py::_validate_style_playbook` fails closed, that takes down every run using the style:

```python
from lib.checkpoint import init_project
init_project("demo", title="Demo", pipeline_type="animation",
             pipeline_dir=tmp, style_playbook="anime-ghibli")
```

```
clean-professional     init_project OK
anime-ghibli           init_project FAILED: CheckpointValidationError
    Unknown or invalid style_playbook 'anime-ghibli'.
    Available playbooks: ['clean-professional', 'flat-motion-graphics',
                          'premium-minimalist', 'anime-ghibli', 'minimalist-diagram'].
```

The playbook is returned by `list_playbooks()` and offered by name in `pipeline_defs/animation.yaml`, so the error names it as an available alternative to itself. A run that selects it cannot write a checkpoint at all.

There is a quieter half too: `VideoCompose._build_theme_from_playbook("anime-ghibli")` swallows the load error and returns `{}`, so no `themeConfig` reaches Remotion and the style silently falls back to the default dark theme at render time.

## The repair

Four distinct schema violations. Each was repaired on the side the evidence pointed to — **widen the schema where a shipped renderer feature backs the key, conform the playbook where it is only vocabulary drift**:

| Violation | Side repaired | Evidence |
|---|---|---|
| `overlays.section_title` | schema | The `Overlay` union in `remotion-composer/src/Explainer.tsx` renders `section_title`/`stat_reveal`/`hero_title`/`provider_chip`. The schema allowed `stat_card`/`key_term`/`code_block` — **not one** of the types the renderer supports. Added all four, plus `accent` on `overlay_style` to match the renderer's `accentColor` prop. |
| `asset_generation` extras | schema | `scene_type`, `multi_image_per_scene`, `images_per_scene`, `image_variation_guidance`, `default_particles`, `default_particle_color`, `default_vignette` map onto real `AnimeScene` props (`images`, `particles`, `particleColor`, `vignette`). |
| `identity.category: anime-illustration`, `pace: gentle` | playbook | No code reads either field for behavior — `identity.category` is only ever written by `lib/playbook_generator.py`, and `hyperframes_style_bridge` reads `motion.pace`, not `identity.pace`. Using the canonical `custom`/`slow` beats expanding a public enum for one style. |
| `color_palette.spirit_glow`, `golden_hour` | playbook | Ad-hoc named colors with no consumer. Folded into the `accent` array; both hexes are preserved and still referenced by name in `consistency_anchors`. |

After the fix, `_build_theme_from_playbook("anime-ghibli")` returns the Ghibli palette (`primaryColor: "#2D5016"`, `accentColor: "#FFB347"`, `backgroundColor: "#0A0A1A"`, …) instead of `{}`.

## Why it slipped, and the coverage that stops it recurring

`tests/qa/test_07_playbook_intelligence.py:50` loads a **hardcoded list of three** playbook names — the three that existed when it was written. `anime-ghibli` and `premium-minimalist` were added later and never got load coverage.

`tests/styles/test_playbook_catalog.py` iterates the catalog instead, asserting the invariant that makes this class of bug impossible to ship:

- every name `list_playbooks()` advertises also passes `load_playbook()`
- every advertised playbook is accepted by `init_project()` — guarding the fail-closed checkpoint path specifically
- the schema's overlay vocabulary covers every overlay type the renderer declares

## Verification

- 6 of the 15 new tests fail on the unfixed tree (`anime-ghibli` load, `anime-ghibli` init_project, and all four overlay types); all pass after.
- Full suite: **964 → 979 passed**, 10 skipped, no regressions.
- `make lint`: passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)