### PR TITLE
fix(corpus): key the total-failure guard on failures, not on skips

### DIFF
--- a/tests/tools/test_corpus_builder_total_failure.py
+++ b/tests/tools/test_corpus_builder_total_failure.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 import pytest
 
 import tools.video.stock_sources as stock_sources
+from lib.corpus import Corpus
 from tools.video.corpus_builder import CorpusBuilder
 
 
@@ -26,10 +27,11 @@ class _Source:
 
 @pytest.fixture
 def run_builder(monkeypatch, tmp_path):
-    def run(count: int, processor):
+    def run(count: int, processor, existing: tuple[str, ...] = ()):
         monkeypatch.setattr(stock_sources, "available_sources", lambda: [_Source(count)])
         monkeypatch.setattr(stock_sources, "source_summary", lambda: {})
         monkeypatch.setattr(CorpusBuilder, "_process_candidate", processor)
+        monkeypatch.setattr(Corpus, "has", lambda self, clip_id: clip_id in existing)
         return CorpusBuilder().execute({
             "corpus_dir": str(tmp_path / f"corpus-{count}"),
             "queries": [{"query": "city at night"}],
@@ -50,6 +52,42 @@ def test_all_candidate_failures_fail_closed_with_diagnostics(run_builder) -> Non
     assert result.data["clips_failed"] == 4
     assert "corpus index is empty" in result.error
     assert "BaseModelOutput" in result.error
+
+
+def test_total_failure_is_reported_even_when_some_clips_were_skipped(run_builder) -> None:
+    """One already-present clip must not mask a total processing failure.
+
+    `skipped` counts clips that were already in the corpus, so it says nothing
+    about whether the candidates we actually processed succeeded. Exempting
+    every run that contains a skip means a broken decoder or CLIP stack reports
+    success as soon as a single prior clip happens to be present, which is the
+    same silent-empty-index failure this guard exists to prevent.
+    """
+
+    def broken_clip_stack(*args, **kwargs):
+        raise AttributeError("BaseModelOutput has no attribute norm")
+
+    result = run_builder(5, broken_clip_stack, existing=("clip-0", "clip-1"))
+
+    assert result.data["clips_skipped_existing"] == 2
+    assert result.data["clips_failed"] == 3
+    assert result.data["clips_added"] == 0
+    assert result.success is False
+    assert "2 already present" in result.error
+    assert "BaseModelOutput" in result.error
+
+
+def test_skip_only_run_stays_successful(run_builder) -> None:
+    """Nothing processed means nothing failed, so the run is still valid."""
+
+    def never_called(*args, **kwargs):  # pragma: no cover - must not run
+        raise AssertionError("_process_candidate should not run for skipped clips")
+
+    result = run_builder(3, never_called, existing=("clip-0", "clip-1", "clip-2"))
+
+    assert result.success is True
+    assert result.data["clips_skipped_existing"] == 3
+    assert result.data["clips_failed"] == 0
 
 
 def test_no_candidates_is_a_valid_empty_search(run_builder) -> None:

--- a/tools/video/corpus_builder.py
+++ b/tools/video/corpus_builder.py
@@ -393,22 +393,30 @@ class CorpusBuilder(BaseTool):
                 cache_snapshot = {"error": f"{type(e).__name__}: {e}"}
 
             # Per-candidate tolerance is useful only while at least one item
-            # survives. If every discovered candidate fails, reporting success
-            # persists an empty index and hides a systemic codec/CLIP failure
-            # until retrieval. A no-result or skip-only run remains valid.
-            total_failure = bool(candidates_seen) and not added_ids and not skipped
+            # survives. If every candidate we processed fails, reporting success
+            # persists an index with no new rows and hides a systemic codec/CLIP
+            # failure until retrieval. Keyed on `failed`, not on `skipped`:
+            # already-present clips say nothing about whether processing worked,
+            # so a run that skips one clip and fails the other nine is still a
+            # total failure. A no-result or skip-only run (failed == 0) is valid.
+            total_failure = bool(candidates_seen) and not added_ids and failed > 0
             if total_failure:
                 first_errors = "; ".join(
                     item["error"]
                     for item in errors
                     if item.get("phase") == "process"
                 )[:400]
+                index_state = (
+                    "corpus index is empty"
+                    if not skipped
+                    else f"no clips added ({skipped} already present)"
+                )
                 return ToolResult(
                     success=False,
                     error=(
-                        f"All {failed} of {candidates_seen} candidates failed to "
-                        "process; corpus index is empty. Check the media decoder "
-                        "and the CLIP `transformers`/`torch` compatibility. "
+                        f"All {failed} processed candidate(s) failed, of "
+                        f"{candidates_seen} seen; {index_state}. Check the media "
+                        "decoder and the CLIP `transformers`/`torch` compatibility. "
                         f"First errors: {first_errors or '(none recorded)'}"
                     ),
                     data={


### PR DESCRIPTION
## Summary

Follow-up to #466. That PR added a fail-closed guard so a corpus build that processes candidates and embeds none of them stops reporting success. The guard is right, but it is keyed on `skipped`, which disables it as soon as a single already-present clip shows up in the run.

```python
total_failure = bool(candidates_seen) and not added_ids and not skipped
```

`skipped` counts clips that were already in the corpus. It says nothing about whether the candidates we actually processed succeeded. So a run that skips one already-present clip and then fails the other nine on a broken decoder or CLIP stack returns `success=True`, `clips_added: 0`, `error: None`, which is exactly the silent-empty-index failure the guard was added to prevent.

The existing comment already describes the intended rule: *"a no-result or skip-only run remains valid."* A skip-only run is one where `failed == 0`. This keys the condition on that instead.

## Related issue

Refs #466, #424

## Changes

- `tools/video/corpus_builder.py`: key the guard on `failed > 0` rather than `not skipped`, so already-present clips no longer suppress a total processing failure.
- `tools/video/corpus_builder.py`: make the diagnostic accurate when prior clips exist. `"corpus index is empty"` is false in that case, so the message now reports `no clips added (N already present)`. The original wording is unchanged when `skipped == 0`.
- `tests/tools/test_corpus_builder_total_failure.py`: extend the `run_builder` fixture with an optional `existing` argument that marks clip ids as already present, and add two regression tests.

Behavior is unchanged for every case #466 already covered.

## Testing

Verified the new test fails on current `main` before the fix, with the exact silent success described above:

```
assert result.success is False
E  AssertionError: assert True is False
   ToolResult(success=True, ..., 'clips_added': 0, 'clips_skipped_existing': 2,
              'clips_failed': 3, ..., error=None)
```

After the fix:

```
python -m pytest tests/tools/test_corpus_builder_total_failure.py -v
4 passed

python -m pytest tests/ -k corpus
12 passed, 1 skipped
```

Both tests added by #466 pass unchanged. Nothing else in the tree asserts on the old error wording.

Platform: Windows, Python 3.13.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [x] I updated docs/README if behavior or usage changed.
- [x] No unrelated files (build artifacts, local config) are included in the diff.
