### PR TITLE
fix(pipelines): make the screen-demo manifest load

### DIFF
--- a/schemas/pipelines/pipeline_manifest.schema.json
+++ b/schemas/pipelines/pipeline_manifest.schema.json
@@ -38,6 +38,41 @@
       "type": "array",
       "items": { "type": "string" }
     },
+    "production_modes": {
+      "type": "array",
+      "description": "Mutually exclusive ways this pipeline can be produced. The agent picks one at the idea stage and records it in the brief; the stage director skill reads it to constrain later choices (see skills/pipelines/screen-demo/idea-director.md).",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "required_tools": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Tools that must be available for this mode to be viable"
+          },
+          "optional_tools": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "scene_type": {
+            "type": "string",
+            "description": "Remotion cut.type this mode composes, when it synthesizes rather than captures"
+          },
+          "agent_skills": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Layer 3 skills to read before producing in this mode"
+          },
+          "best_for": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
     "stages": {
       "type": "array",
       "items": {

--- a/tests/contracts/test_pipeline_catalog.py
+++ b/tests/contracts/test_pipeline_catalog.py
@@ -1,0 +1,75 @@
+"""Every shipped pipeline manifest must actually load.
+
+`lib.checkpoint` degrades gracefully when a manifest cannot be parsed:
+`get_pipeline_stages()` falls back to the canonical STAGES list and
+`_stage_requires_approval()` returns None so the caller's own flag wins. That
+is the right behaviour for a corrupt user manifest, but it means a manifest
+shipped *in this repo* that fails its schema is silently ignored rather than
+loudly rejected — the pipeline then runs against the wrong stage order and
+without its declared approval gates.
+
+Existing manifest coverage names individual pipelines (talking-head,
+framework-smoke, animated-explainer, documentary-montage), so a manifest that
+no test happens to name is never loaded. These tests iterate the directory.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from lib.checkpoint import _stage_requires_approval, get_pipeline_stages
+from lib.pipeline_loader import load_pipeline
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PIPELINE_DEFS = REPO_ROOT / "pipeline_defs"
+
+PIPELINE_NAMES = sorted(p.stem for p in PIPELINE_DEFS.glob("*.yaml"))
+
+
+def _declared_stages(name: str) -> list[str]:
+    raw = yaml.safe_load((PIPELINE_DEFS / f"{name}.yaml").read_text(encoding="utf-8"))
+    return [stage["name"] for stage in raw["stages"]]
+
+
+def test_catalog_is_not_empty() -> None:
+    assert PIPELINE_NAMES, "no pipeline manifests found"
+
+
+@pytest.mark.parametrize("name", PIPELINE_NAMES)
+def test_shipped_manifest_validates(name: str) -> None:
+    """Regression: screen-demo.yaml carried a `production_modes` block the
+    manifest schema did not allow, so the whole manifest failed to load."""
+    manifest = load_pipeline(name)
+    assert manifest["stages"]
+
+
+@pytest.mark.parametrize("name", PIPELINE_NAMES)
+def test_effective_stage_order_is_the_declared_one(name: str) -> None:
+    """A manifest that silently falls back gets the canonical stage list.
+
+    For screen-demo that inserted `research` and `proposal` ahead of its real
+    first stage, so the prerequisite check rejected the opening checkpoint of
+    every run with PREREQUISITE VIOLATION.
+    """
+    assert get_pipeline_stages(name) == _declared_stages(name)
+
+
+@pytest.mark.parametrize("name", PIPELINE_NAMES)
+def test_declared_approval_gates_are_enforceable(name: str) -> None:
+    """AGENT_GUIDE.md: the manifest's human_approval_default is binding.
+
+    `_stage_requires_approval` returning None means the caller's own flag wins,
+    which is exactly the fail-open the gate is supposed to prevent.
+    """
+    raw = yaml.safe_load((PIPELINE_DEFS / f"{name}.yaml").read_text(encoding="utf-8"))
+
+    for stage in raw["stages"]:
+        if "human_approval_default" not in stage:
+            continue
+        resolved = _stage_requires_approval(name, stage["name"])
+        assert resolved == stage["human_approval_default"], (
+            f"{name}.{stage['name']}: manifest declares "
+            f"{stage['human_approval_default']} but the checkpoint writer "
+            f"resolves {resolved}"
+        )


### PR DESCRIPTION
## The defect

`pipeline_defs/screen-demo.yaml` carries a top-level `production_modes` block the manifest schema does not allow, so `load_pipeline("screen-demo")` raises. The pipeline is marked **production** stability in AGENT_GUIDE.md's table.

`lib/checkpoint.py` degrades gracefully when a manifest cannot be parsed. That is right for a corrupt *user* manifest, but it means a manifest shipped **in this repo** is silently ignored rather than loudly rejected — and both fallbacks then misfire.

### 1. The pipeline cannot start

The stage-order fallback returns the canonical list, which inserts `research` and `proposal` ahead of screen-demo's real first stage:

```
get_pipeline_stages("screen-demo")
  ->  [research, proposal, idea, script, scene_plan, assets, edit, compose, publish]
manifest declares
  ->  [idea, script, scene_plan, assets, edit, compose, publish]
```

So the opening checkpoint of every screen-demo run is rejected:

```python
write_checkpoint(..., stage="idea", status="completed", human_approved=True)
```
```
CheckpointValidationError: PREREQUISITE VIOLATION: stage 'idea' cannot advance;
  incomplete or missing: ['research', 'proposal']
```

The other five `idea`-first pipelines (`talking-head`, `hybrid`, `clip-factory`, …) clear that same check, which isolates the cause to the unloadable manifest rather than the prerequisite rule.

### 2. Its approval gates fail open

```
_stage_requires_approval("screen-demo", "idea")  ->  None      # manifest declares True
```

`None` means the caller's own `human_approval_required` flag wins. All five declared gates — `idea`, `script`, `scene_plan`, `assets`, `publish` — stop being binding, against AGENT_GUIDE.md:

> Read `human_approval_default` from the pipeline manifest per stage. **The manifest value is binding** — never re-judge it.

## The repair

`production_modes` is a documented, first-class feature rather than stray YAML:

- `skills/pipelines/screen-demo/idea-director.md` builds its entire `real_capture` vs `synthetic_terminal` decision table on it, down to which render runtimes each mode permits.
- AGENT_GUIDE.md routes agents to this manifest to make that choice: *"Picking a screen-recording mode (real capture vs synthetic terminal)? → `pipeline_defs/screen-demo.yaml` + `skills/pipelines/screen-demo/idea-director.md`."*
- Nothing in Python reads it — it is agent-facing declarative content, like `best_for` and `agent_skills` elsewhere in the manifest.

So the schema is what is stale, and it gains a typed definition for the block, following the shape of the existing `stages` entries.

`extensions` was considered as a home and rejected: it is a fixed set of four capability booleans (`custom_scripts`, `custom_playbooks`, `custom_skills`, `custom_tools`), not a free-form bucket.

## Coverage

Existing manifest tests load `talking-head`, `framework-smoke`, `animated-explainer` and `documentary-montage` **by name**, so the one broken manifest was never touched — the same gap that hides this class of bug elsewhere in the repo.

`tests/contracts/test_pipeline_catalog.py` iterates `pipeline_defs/` and asserts three things, one per symptom above:

- every shipped manifest validates
- the stage order the checkpoint writer actually uses equals the one the manifest declares
- every declared `human_approval_default` is what `_stage_requires_approval` resolves

## Verification

- The 3 `screen-demo` cases fail on the unfixed tree; all 40 pass after.
- Full suite: **964 → 1004 passed**, 10 skipped, no regressions.
- `make lint`: passed.

Independent of #468 and #469 — no overlapping files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)