### PR TITLE
fix(video_compose): derive the Remotion theme from real playbook keys

### DIFF
--- a/tests/contracts/test_remotion_theme_playbook_keys.py
+++ b/tests/contracts/test_remotion_theme_playbook_keys.py
@@ -1,0 +1,88 @@
+"""The Remotion theme must be derived from the playbook's real schema keys.
+
+`VideoCompose._build_theme_from_playbook` says it reads "a playbook's actual
+color values [...] not picked from a preset menu", but it read three keys the
+playbook schema does not define, so each silently fell back to a hardcoded
+default for every playbook:
+
+    typo.get("heading")        schema key is `headings`
+    palette.get("muted_text")  schema key is `muted`
+    motion.get("pace")         `pace` is an identity field, not a motion one
+
+Expectations come from the playbook YAML rather than a hardcoded table, so a
+playbook that changes its typeface keeps this honest.
+
+This is the Remotion counterpart of the HyperFrames style-bridge defect in
+issue #306; that bridge lives in lib/hyperframes_style_bridge.py and is not
+touched here.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from styles.playbook_loader import list_playbooks
+from tools.video.video_compose import VideoCompose
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STYLES_DIR = REPO_ROOT / "styles"
+
+PLAYBOOK_NAMES = sorted(list_playbooks())
+
+
+def _raw(name: str) -> dict:
+    return yaml.safe_load((STYLES_DIR / f"{name}.yaml").read_text(encoding="utf-8"))
+
+
+def _theme(name: str) -> dict:
+    theme = VideoCompose()._build_theme_from_playbook(name, {})
+    if not theme:
+        pytest.skip(f"{name} does not currently yield a theme")
+    return theme
+
+
+@pytest.mark.parametrize("name", PLAYBOOK_NAMES)
+def test_heading_font_comes_from_the_playbook(name: str) -> None:
+    """Regression: read from `heading`, so every playbook rendered in Inter."""
+    expected = _raw(name)["typography"]["headings"]["font"]
+    assert _theme(name)["headingFont"] == expected
+
+
+@pytest.mark.parametrize("name", PLAYBOOK_NAMES)
+def test_muted_text_color_comes_from_the_playbook(name: str) -> None:
+    """Regression: read from `muted_text`, so this was always #6B7280."""
+    palette = _raw(name)["visual_language"]["color_palette"]
+    if "muted" not in palette:
+        pytest.skip(f"{name} declares no muted color")
+    assert _theme(name)["mutedTextColor"] == palette["muted"]
+
+
+def test_identity_pace_drives_the_motion_feel() -> None:
+    """Regression: read `pace` off motion, where the schema has no such key,
+    so the spring never left its moderate default."""
+    fast = [n for n in PLAYBOOK_NAMES if _raw(n)["identity"]["pace"] == "fast"]
+    if not fast:
+        pytest.skip("no playbook declares a fast pace")
+
+    moderate_default = {"damping": 20, "stiffness": 120, "mass": 1}
+    for name in fast:
+        theme = _theme(name)
+        assert theme["springConfig"] != moderate_default, (
+            f"{name} declares pace=fast but still got the moderate spring"
+        )
+        assert theme["transitionDuration"] < 0.4
+
+
+@pytest.mark.parametrize("name", PLAYBOOK_NAMES)
+def test_derived_theme_only_reads_documented_palette_keys(name: str) -> None:
+    """The derived colors must be values the playbook can actually express."""
+    palette = _raw(name)["visual_language"]["color_palette"]
+    theme = _theme(name)
+
+    primary = palette["primary"]
+    accent = palette["accent"]
+    assert theme["primaryColor"] == (primary[0] if isinstance(primary, list) else primary)
+    assert theme["accentColor"] == (accent[0] if isinstance(accent, list) else accent)
+    assert theme["backgroundColor"] == palette["background"]
+    assert theme["textColor"] == palette["text"]

--- a/tools/video/video_compose.py
+++ b/tools/video/video_compose.py
@@ -1253,7 +1253,7 @@ class VideoCompose(BaseTool):
             bg = palette.get("background", "#FFFFFF")
             text = palette.get("text", "#1F2937")
             surface = palette.get("surface", bg)
-            muted = palette.get("muted_text", "#6B7280")
+            muted = palette.get("muted", "#6B7280")
 
             # Build chart colors from all palette entries
             chart_colors = []
@@ -1271,7 +1271,7 @@ class VideoCompose(BaseTool):
                 "surfaceColor": surface,
                 "textColor": text,
                 "mutedTextColor": muted,
-                "headingFont": typo.get("heading", {}).get("font", "Inter"),
+                "headingFont": typo.get("headings", {}).get("font", "Inter"),
                 "bodyFont": typo.get("body", {}).get("font", "Inter"),
                 "monoFont": typo.get("code", {}).get("font", "JetBrains Mono"),
                 "chartColors": chart_colors[:6],
@@ -1287,9 +1287,9 @@ class VideoCompose(BaseTool):
                 else f"rgba(15, 23, 42, 0.75)"
             )
 
-            # Motion style from playbook
-            motion = playbook.get("motion", {})
-            pace = motion.get("pace", "moderate")
+            # Motion style from playbook. `pace` is an identity field in the
+            # playbook schema; motion carries pacing_rules, not a pace enum.
+            pace = playbook.get("identity", {}).get("pace", "moderate")
             if pace == "fast":
                 theme["springConfig"] = {"damping": 12, "stiffness": 80, "mass": 1}
                 theme["transitionDuration"] = 0.3


### PR DESCRIPTION
## The defect

`VideoCompose._build_theme_from_playbook` documents itself as:

> Derive a Remotion ThemeConfig from a playbook's actual color values. Instead of passing a playbook name and hoping Remotion has a matching preset, we read the playbook YAML and extract concrete colors/fonts.

Three of the keys it reads are not in `schemas/styles/playbook.schema.json`, so each silently fell back to a hardcoded default for **every** playbook:

| Read | Schema key | Consequence |
|---|---|---|
| `typo.get("heading")` | `headings` | every playbook rendered its headings in `Inter` |
| `palette.get("muted_text")` | `muted` | `mutedTextColor` was always `#6B7280` |
| `motion.get("pace")` | `identity.pace` | no playbook's declared pace ever reached the spring config |

Before → after:

```
flat-motion-graphics  headingFont  Inter    -> Space Grotesk
                      muted        #6B7280  -> #64748B
                      spring       20/120 @0.4s -> 12/80 @0.3s   (pace: fast)
minimalist-diagram    headingFont  Inter    -> IBM Plex Sans
anime-ghibli          headingFont  Inter    -> Noto Serif JP
```

This is the **Remotion counterpart** of the HyperFrames style-bridge defect in #306. That bridge lives in `lib/hyperframes_style_bridge.py` and is untouched here, as are the open PRs against it (#296, #307).

## Note on ordering

`Root.tsx`'s `resolveTheme` currently prefers a named preset over `themeConfig`, and four of the five playbook names collide with Remotion preset names. So the derived theme was being **discarded** exactly where these defaults would have shown — which masked this bug.

Fixing `resolveTheme` first would have made every video lose its heading typeface, muted color and motion pacing in one step. This PR has to land first.

## Deliberately left alone

- `palette.get("surface", bg)` also names a key the schema does not define, but the fallback to the background color is an explicit, sensible default rather than a dropped value. Giving playbooks a real surface color would be a schema addition, not a bug fix.
- The pace branch still handles only `fast` and `slow`, so `deliberate` and `rapid` land on the moderate default. Extending that mapping is a motion tuning decision, not part of reading the right key.

## Coverage

`tests/contracts/test_remotion_theme_playbook_keys.py` takes its expectations from the playbook YAML rather than a hardcoded table, so a playbook that changes its typeface keeps the test honest rather than making it stale.

## Verification

- 4 cases fail on the unfixed tree; all pass after.
- Full suite: **964 → 977 passed**, 13 skipped, no regressions.
- `make lint`: passed.

The 3 skips are `anime-ghibli`, which cannot yield a theme on current `main` for the reason #468 fixes; they start running once that lands.

Independent of #468, #469, #472 and #473 — no overlapping files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)