### PR TITLE
fix(remotion): correct four defects in render-scoped asset staging

### DIFF
--- a/tests/tools/test_remotion_media_staging.py
+++ b/tests/tools/test_remotion_media_staging.py
@@ -1,0 +1,129 @@
+"""Regression coverage for Remotion media staging (`_stage_remotion_media`).
+
+Two defects this locks down:
+
+1. ``file://C:\\Users\\...`` — the naive ``f"file://{path}"`` form Windows
+   tooling produces — parsed as a UNC authority and never resolved, so the
+   asset was silently skipped.
+2. ``--public-dir`` REPLACES Remotion's default public dir, so assets staged
+   into ``remotion-composer/public/`` by earlier pipeline stages 404 once a
+   render points at its own staging dir.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.video.video_compose import VideoCompose
+
+
+# --- file:// URI parsing ---------------------------------------------------
+# Parsing is asserted on the string form (not the filesystem) so the Windows
+# cases are meaningful when the suite runs on POSIX.
+
+@pytest.mark.parametrize(
+    ("label", "uri", "expected"),
+    [
+        ("posix", "file:///Users/me/voice.mp3", "/Users/me/voice.mp3"),
+        ("windows_rfc", "file:///C:/Users/me/voice.mp3", "C:/Users/me/voice.mp3"),
+        ("windows_authority", "file://C:/Users/me/voice.mp3", "C:/Users/me/voice.mp3"),
+        # The regression: no slash after the scheme, so urlsplit puts the whole
+        # drive path in netloc and leaves path empty.
+        ("windows_naive", "file://C:\\Users\\me\\voice.mp3", "C:\\Users\\me\\voice.mp3"),
+        ("percent_encoded", "file:///Users/me/my%20voice.mp3", "/Users/me/my voice.mp3"),
+        ("localhost", "file://localhost/Users/me/voice.mp3", "/Users/me/voice.mp3"),
+    ],
+)
+def test_file_uri_to_raw_path(label, uri, expected):
+    assert VideoCompose._file_uri_to_raw_path(uri) == expected
+
+
+def test_unc_authority_still_treated_as_network_path():
+    """A genuine UNC host must not be mistaken for a drive path."""
+    assert (
+        VideoCompose._file_uri_to_raw_path("file://server/share/voice.mp3")
+        == "//server/share/voice.mp3"
+    )
+
+
+def test_stage_resolves_bare_concat_file_uri(tmp_path):
+    """End-to-end: a bare f"file://{path}" concat round-trips through staging.
+
+    On POSIX this exercises the ``file:///...`` shape, which already worked —
+    the Windows drive forms cannot be exercised end-to-end off Windows because
+    the path has to exist on disk. Parsing for those is asserted directly in
+    ``test_file_uri_to_raw_path`` above; this covers the copy/rewrite half.
+    """
+    src = tmp_path / "voice.mp3"
+    src.write_bytes(b"ID3")
+    public_dir = tmp_path / "public"
+
+    # Simulate the naive f"file://{path}" concat using the real temp path.
+    props = {"audio": {"narration": {"src": f"file://{src}"}}}
+    staged = VideoCompose._stage_remotion_media(props, public_dir)
+
+    assert staged == 1
+    rewritten = props["audio"]["narration"]["src"]
+    assert not rewritten.startswith("file://")
+    assert (public_dir / rewritten).is_file()
+
+
+# --- public/ mirroring -----------------------------------------------------
+
+def test_mirror_public_dir_exposes_prestaged_assets(tmp_path):
+    """anime_scene.images[] / screenshot_scene.backgroundImage are staticFile()
+    refs resolved against the real public/ dir and staged there by the
+    asset-director stage — not by _stage_remotion_media. They must survive a
+    render that overrides --public-dir.
+    """
+    composer_public = tmp_path / "remotion-composer" / "public"
+    (composer_public / "demo-project").mkdir(parents=True)
+    (composer_public / "demo-project" / "scene1-a.png").write_bytes(b"\x89PNG")
+    (composer_public / "logo.svg").write_bytes(b"<svg/>")
+
+    staging = tmp_path / "renders" / ".remotion-public-final"
+    VideoCompose._mirror_public_dir(composer_public, staging)
+
+    mirrored = staging / "demo-project" / "scene1-a.png"
+    assert mirrored.is_file()
+    assert mirrored.read_bytes() == b"\x89PNG"
+    assert (staging / "logo.svg").is_file()
+
+
+def test_mirror_never_clobbers_staged_media(tmp_path):
+    """Staged render media wins over a same-named entry in public/."""
+    composer_public = tmp_path / "public"
+    composer_public.mkdir()
+    (composer_public / "voice.mp3").write_bytes(b"FROM_PUBLIC")
+
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    (staging / "voice.mp3").write_bytes(b"FROM_RENDER")
+
+    VideoCompose._mirror_public_dir(composer_public, staging)
+
+    assert (staging / "voice.mp3").read_bytes() == b"FROM_RENDER"
+
+
+def test_mirror_is_read_only_toward_source(tmp_path):
+    """Cleanup deletes the staging dir; the real public/ must survive."""
+    import shutil
+
+    composer_public = tmp_path / "public"
+    (composer_public / "assets").mkdir(parents=True)
+    (composer_public / "assets" / "keep.png").write_bytes(b"\x89PNG")
+
+    staging = tmp_path / "staging"
+    VideoCompose._mirror_public_dir(composer_public, staging)
+    # Mirrors what _remotion_render's finally block does.
+    shutil.rmtree(staging, ignore_errors=True)
+
+    assert (composer_public / "assets" / "keep.png").is_file()
+
+
+def test_mirror_missing_source_is_noop(tmp_path):
+    staging = tmp_path / "staging"
+    VideoCompose._mirror_public_dir(tmp_path / "does-not-exist", staging)
+    assert not staging.exists()

--- a/tests/tools/test_remotion_staging_lifecycle.py
+++ b/tests/tools/test_remotion_staging_lifecycle.py
@@ -1,0 +1,127 @@
+"""Lifecycle guarantees for the Remotion render-scoped public dir.
+
+Two defects this locks down:
+
+1. A public dir named only after the output stem is shared by every render of
+   that output — concurrent renders overwrite each other's staged media, the
+   first to finish deletes the other's inputs, and cleanup can erase a
+   pre-existing directory that happens to match the name.
+2. Staging that runs *before* the try/finally leaves staged user media on disk
+   when setup fails after the directory was created but before the render.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from tools.video.video_compose import VideoCompose
+
+
+def _mp4(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\x00\x00\x00\x18ftypmp42")
+    return path
+
+
+def _inputs(tmp_path: Path, source: Path) -> dict:
+    return {
+        "output_path": str(tmp_path / "renders" / "final.mp4"),
+        "composition_data": {
+            "renderer_family": "explainer-data",
+            "cuts": [
+                {"id": "c1", "source": str(source), "in_seconds": 0, "out_seconds": 2}
+            ],
+        },
+    }
+
+
+@pytest.fixture
+def render(monkeypatch):
+    """Drive _remotion_render with the Remotion CLI stubbed out.
+
+    Returns (tool, calls) where calls collects each argv the render would run.
+    """
+    monkeypatch.setattr(shutil, "which", lambda name: f"/usr/bin/{name}")
+    tool = VideoCompose()
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+
+    monkeypatch.setattr(tool, "run_command", fake_run)
+    return tool, calls
+
+
+def _public_dir_arg(argv: list[str]) -> str | None:
+    for arg in argv:
+        if arg.startswith("--public-dir="):
+            return arg.split("=", 1)[1]
+    return None
+
+
+def _staging_dirs(tmp_path: Path) -> list[Path]:
+    return list((tmp_path / "renders").glob(".remotion-public-*"))
+
+
+def test_public_dir_is_unique_per_render(tmp_path, render):
+    """Two renders of the same output must not share a staging dir."""
+    tool, calls = render
+    source = _mp4(tmp_path / "assets" / "clip.mp4")
+
+    tool._remotion_render(_inputs(tmp_path, source))
+    tool._remotion_render(_inputs(tmp_path, source))
+
+    dirs = [_public_dir_arg(c) for c in calls]
+    assert len(calls) == 2
+    assert all(d is not None for d in dirs), "staged media but no --public-dir passed"
+    assert dirs[0] != dirs[1], f"concurrent renders would collide on {dirs[0]}"
+
+
+def test_staged_media_cleaned_up_after_render(tmp_path, render):
+    tool, _ = render
+    source = _mp4(tmp_path / "assets" / "clip.mp4")
+
+    tool._remotion_render(_inputs(tmp_path, source))
+
+    assert _staging_dirs(tmp_path) == []
+    assert source.is_file(), "cleanup must not touch the original media"
+
+
+def test_pre_render_failure_still_cleans_staged_media(tmp_path, monkeypatch, render):
+    """The regression: failure *after* staging but *before* the render.
+
+    Staging created the directory and copied user media into it; if the guard
+    only wraps run_command, that media is left behind.
+    """
+    tool, _ = render
+    source = _mp4(tmp_path / "assets" / "clip.mp4")
+
+    real_open = open
+
+    def exploding_open(file, mode="r", *args, **kwargs):
+        if str(file).endswith(".remotion_props.json") and "w" in mode:
+            raise OSError("disk full")
+        return real_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", exploding_open)
+
+    result = tool._remotion_render(_inputs(tmp_path, source))
+
+    assert not result.success
+    assert _staging_dirs(tmp_path) == [], "staged user media leaked after setup failure"
+
+
+def test_cleanup_leaves_preexisting_dirs_alone(tmp_path, render):
+    """A dir matching the old stem-only name is not ours to delete."""
+    tool, _ = render
+    source = _mp4(tmp_path / "assets" / "clip.mp4")
+    squatter = tmp_path / "renders" / ".remotion-public-final"
+    squatter.mkdir(parents=True)
+    (squatter / "keep.txt").write_text("not ours")
+
+    tool._remotion_render(_inputs(tmp_path, source))
+
+    assert (squatter / "keep.txt").read_text() == "not ours"

--- a/tools/video/video_compose.py
+++ b/tools/video/video_compose.py
@@ -30,9 +30,11 @@ the agent to re-ask the user rather than substituting a different engine.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import hashlib
 import logging
+import secrets
 import shutil
 import subprocess
 import time
@@ -824,6 +826,67 @@ class VideoCompose(BaseTool):
         return scenes
 
     @staticmethod
+    def _file_uri_to_raw_path(uri: str) -> str:
+        """Convert a ``file:`` URI to a raw filesystem path string.
+
+        Handles the forms agents and tooling actually produce:
+
+        - POSIX:                  ``file:///Users/me/voice.mp3``
+        - Windows RFC:            ``file:///C:/Users/me/voice.mp3``
+        - Windows drive authority:``file://C:/Users/me/voice.mp3``
+        - Windows naive concat:   ``file://C:\\Users\\me\\voice.mp3``
+
+        The naive form is what a bare ``f"file://{path}"`` produces on Windows.
+        It has no ``/`` after the scheme, so urlsplit puts the *entire* drive
+        path in ``netloc`` and leaves ``path`` empty — treating that as a UNC
+        authority (``//C:\\Users\\...``) yields a path that never resolves, so
+        the asset is silently skipped.
+        """
+        parsed = urlsplit(uri)
+        decoded_path = unquote(parsed.path)
+        netloc = unquote(parsed.netloc)
+        # Both "C:" (drive as authority) and "C:\Users\..." (naive concat)
+        # start with "<letter>:" — neither is a real network authority.
+        if len(netloc) >= 2 and netloc[0].isalpha() and netloc[1] == ":":
+            raw_path = f"{netloc}{decoded_path}"
+        elif netloc and netloc.lower() != "localhost":
+            raw_path = f"//{netloc}{decoded_path}"
+        else:
+            raw_path = decoded_path
+        # Standard Windows file URIs use file:///C:/...; pathlib on
+        # Windows needs the drive path without the URI's leading slash.
+        if len(raw_path) >= 3 and raw_path[0] == "/" and raw_path[2] == ":":
+            raw_path = raw_path[1:]
+        return raw_path
+
+    @staticmethod
+    def _mirror_public_dir(source_root: Path, staging_root: Path) -> None:
+        """Link the real ``public/`` tree into a render-scoped ``--public-dir``.
+
+        ``--public-dir`` REPLACES Remotion's default public dir for the render.
+        Assets that earlier pipeline stages already staged into
+        ``remotion-composer/public/`` — ``anime_scene.images[]``,
+        ``screenshot_scene.backgroundImage``, demo-props fixtures, all
+        documented as public/-relative ``staticFile()`` paths — would therefore
+        404 as soon as we point the render at our own dir. Symlink each
+        top-level entry in (read-only; nothing is written back to
+        *source_root*), falling back to a copy where symlinks aren't permitted
+        (e.g. Windows without developer mode).
+        """
+        if not source_root.is_dir():
+            return
+        staging_root.mkdir(parents=True, exist_ok=True)
+        for entry in source_root.iterdir():
+            link = staging_root / entry.name
+            if link.exists() or link.is_symlink():
+                continue
+            try:
+                link.symlink_to(entry, target_is_directory=entry.is_dir())
+            except OSError:
+                with contextlib.suppress(OSError):
+                    (shutil.copytree if entry.is_dir() else shutil.copy2)(entry, link)
+
+    @staticmethod
     def _stage_remotion_media(value: Any, public_dir: Path) -> int:
         """Copy local media references into a Remotion public dir in-place.
 
@@ -850,18 +913,7 @@ class VideoCompose(BaseTool):
                 return node
 
             if node.lower().startswith("file://"):
-                parsed = urlsplit(node)
-                decoded_path = unquote(parsed.path)
-                if len(parsed.netloc) == 2 and parsed.netloc[1] == ":":
-                    raw_path = f"{parsed.netloc}{decoded_path}"
-                elif parsed.netloc and parsed.netloc.lower() != "localhost":
-                    raw_path = f"//{parsed.netloc}{decoded_path}"
-                else:
-                    raw_path = decoded_path
-                # Standard Windows file URIs use file:///C:/...; pathlib on
-                # Windows needs the drive path without the URI's leading slash.
-                if len(raw_path) >= 3 and raw_path[0] == "/" and raw_path[2] == ":":
-                    raw_path = raw_path[1:]
+                raw_path = VideoCompose._file_uri_to_raw_path(node)
             else:
                 raw_path = node
             source = Path(raw_path).resolve()
@@ -1930,60 +1982,77 @@ class VideoCompose(BaseTool):
                     error=f"Remotion public_dir does not exist or is not a directory: {public_dir}",
                 )
         else:
-            public_dir = output_path.parent / f".remotion-public-{output_path.stem}"
+            # Unique per render. A name derived only from the output stem is
+            # shared by every render of that output: concurrent renders
+            # overwrite each other's staged media and the first to finish
+            # deletes the other's inputs, and cleanup would also erase a
+            # pre-existing directory that happened to match. The random suffix
+            # means the dir we delete is always one this invocation created.
+            public_dir = output_path.parent / f".remotion-public-{output_path.stem}-{secrets.token_hex(4)}"
             cleanup_public_dir = True
 
-        staged_count = self._stage_remotion_media(props, public_dir)
-        if not staged_count and cleanup_public_dir:
-            public_dir = None
-
-        # Write the fully adapted/staged props, never the original cut payload.
+        # Everything from staging onward is guarded, so a failure during props
+        # writing or command setup — not just during the render — still removes
+        # the staged user media instead of leaving it on disk.
         props_path = output_path.parent / ".remotion_props.json"
-        with open(props_path, "w", encoding="utf-8") as f:
-            json.dump(props, f)
-
-        cmd = [
-            "npx", "remotion", "render",
-            str(composer_dir / "src" / "index.tsx"),
-            composition_id,
-            str(output_path),
-            # Use the `--props=<path>` equals form rather than two separate
-            # args. On Windows, passing `--props` and the path separately makes
-            # Remotion mis-parse the value (quote escaping differs), failing
-            # with "neither valid JSON nor a file path". The equals form is the
-            # API Remotion recommends for file paths and is cross-platform safe.
-            f"--props={props_path}",
-        ]
-        if public_dir is not None:
-            cmd.append(f"--public-dir={public_dir}")
-
-        # Apply media profile dimensions
+        staged_count = 0
         profile_name = inputs.get("profile")
-        if profile_name:
-            try:
-                from lib.media_profiles import get_profile
-                p = get_profile(profile_name)
-                cmd.extend(["--width", str(p.width), "--height", str(p.height)])
-            except (ImportError, ValueError):
-                pass
-
-        # Optional creator-facing render timeout. Remotion's `--timeout` (ms)
-        # governs headless-browser setup and delayRender(); on slow machines or
-        # restricted networks the default 30s browser setup times out with an
-        # opaque failure. Pass it through and give the subprocess enough headroom
-        # so run_command() does not kill Remotion before its own timeout fires.
-        remotion_timeout_ms = inputs.get("remotion_timeout_ms")
-        scene_count = len(props.get("scenes") or props.get("cuts") or [])
-        subprocess_timeout = max(600, scene_count * 15)
-        if remotion_timeout_ms:
-            try:
-                ms = int(remotion_timeout_ms)
-                cmd.append(f"--timeout={ms}")
-                subprocess_timeout = max(subprocess_timeout, ms // 1000 + 60)
-            except (TypeError, ValueError):
-                pass
-
         try:
+            staged_count = self._stage_remotion_media(props, public_dir)
+            if not staged_count and cleanup_public_dir:
+                public_dir = None
+            elif cleanup_public_dir:
+                # We are about to override Remotion's public dir with our own, so
+                # mirror the real one in — otherwise assets already staged into
+                # remotion-composer/public/ by earlier pipeline stages 404.
+                # Only for the dir we created and will delete; a caller-supplied
+                # public_dir is their contract to populate, so leave it untouched.
+                self._mirror_public_dir(composer_dir / "public", public_dir)
+
+            # Write the fully adapted/staged props, never the original cut payload.
+            with open(props_path, "w", encoding="utf-8") as f:
+                json.dump(props, f)
+
+            cmd = [
+                "npx", "remotion", "render",
+                str(composer_dir / "src" / "index.tsx"),
+                composition_id,
+                str(output_path),
+                # Use the `--props=<path>` equals form rather than two separate
+                # args. On Windows, passing `--props` and the path separately makes
+                # Remotion mis-parse the value (quote escaping differs), failing
+                # with "neither valid JSON nor a file path". The equals form is the
+                # API Remotion recommends for file paths and is cross-platform safe.
+                f"--props={props_path}",
+            ]
+            if public_dir is not None:
+                cmd.append(f"--public-dir={public_dir}")
+
+            # Apply media profile dimensions
+            if profile_name:
+                try:
+                    from lib.media_profiles import get_profile
+                    p = get_profile(profile_name)
+                    cmd.extend(["--width", str(p.width), "--height", str(p.height)])
+                except (ImportError, ValueError):
+                    pass
+
+            # Optional creator-facing render timeout. Remotion's `--timeout` (ms)
+            # governs headless-browser setup and delayRender(); on slow machines or
+            # restricted networks the default 30s browser setup times out with an
+            # opaque failure. Pass it through and give the subprocess enough headroom
+            # so run_command() does not kill Remotion before its own timeout fires.
+            remotion_timeout_ms = inputs.get("remotion_timeout_ms")
+            scene_count = len(props.get("scenes") or props.get("cuts") or [])
+            subprocess_timeout = max(600, scene_count * 15)
+            if remotion_timeout_ms:
+                try:
+                    ms = int(remotion_timeout_ms)
+                    cmd.append(f"--timeout={ms}")
+                    subprocess_timeout = max(subprocess_timeout, ms // 1000 + 60)
+                except (TypeError, ValueError):
+                    pass
+
             # Invoke from inside the composer dir so npx can resolve the
             # local remotion binary via node_modules/.bin. Without this,
             # Windows npx cannot locate the CLI and returns "could not


### PR DESCRIPTION
## Summary

Fixes four defects in the Remotion render-scoped asset staging that landed in `9482edd` (#466). Each fix ships with a regression test that fails without it.

**Why this PR exists (and how it relates to #328).**

I opened #328 on 2026-07-07 to fix Remotion local-asset staging, and iterated through three review rounds — Windows `file://` normalization, staging containment, and staging/cleanup lifecycle. On 2026-08-03, #466 independently implemented staging on `main` via `_stage_remotion_media()` + `--public-dir`, drawing on the local-media handling in #461/#459.

#466 swept "the latest 80 pull requests" (#377–#464); #328 predates that window and is not in its superseded list, so the two implementations were written without knowledge of each other.

Rather than re-litigate architecture, **this PR keeps `main`'s implementation as-is** and contributes only what it is missing: the four defects that #328's review rounds surfaced, which the parallel implementation reproduced. That turns five conflicting commits into a three-file delta on top of `4eab34c`.

I'd suggest closing #328 in favour of this PR — its remaining unique change (slug-traversal rejection) does not apply here, because `main`'s design never derives a path segment from artifact metadata, so that attack surface does not exist.

## Related issue

Refs #328 (original PR, superseded by this one)
Refs #466 (introduced the code being fixed)

## Changes

**1. Naive Windows `file://` URIs are silently dropped.**
A bare `f"file://{path}"` on Windows produces `file://C:\Users\...`. With no slash after the scheme, `urlsplit` puts the entire drive path in `netloc` and leaves `path` empty. The current code reads that as a UNC authority (`//C:\Users\...`), which never resolves — so the asset is skipped rather than staged, and the render silently loses media. Verified against the current parser:

```
file://C:\Users\me\voice.mp3  ->  //C:\Users\me\voice.mp3   (never resolves)
```

Parsing is extracted to `_file_uri_to_raw_path()` so every URI shape is unit-testable off Windows. A genuine UNC host (`file://server/share/...`) is still treated as a network path.

**2. `--public-dir` makes pre-staged `public/` assets 404.**
`--public-dir` *replaces* Remotion's default public dir for the render. Assets that earlier pipeline stages staged into `remotion-composer/public/` — `anime_scene.images[]`, `screenshot_scene.backgroundImage`, demo-props fixtures, all documented in `SCENE_TYPES.md` as public/-relative `staticFile()` paths — stop resolving as soon as a render points at its own dir. `_mirror_public_dir()` links the real tree in read-only, without clobbering staged media. Only applied to the dir we create and delete; a caller-supplied `public_dir` is left untouched.

**3. Staging dir was not unique per render.**
Naming it only after the output stem means every render of that output shares one directory: concurrent renders overwrite each other's media, the first to finish deletes the other's inputs, and cleanup can erase a pre-existing directory that happens to match the name. A random suffix makes the removed dir always one this invocation created.

**4. Staging ran outside the `try/finally`.**
A failure after the directory was created but before the render (props write, command setup) left staged user media on disk. The guard now spans the whole staging/setup/render lifetime.

## Testing

`tests/tools/test_remotion_media_staging.py` and `tests/tools/test_remotion_staging_lifecycle.py` — 16 tests.

Each was confirmed to fail without the fix: **14 fail against pristine `4eab34c`**, all 16 pass with it.

No regressions in `tests/tools/`:

| | result |
|---|---|
| baseline `4eab34c` | 30 failed, 244 passed |
| this branch | 30 failed, **260** passed |

Same 30 pre-existing failures (missing API keys / optional deps in a clean venv); the +16 is exactly this PR's additions.

**Not covered:** no end-to-end Remotion CLI render was run. The tests exercise the Python staging path with the CLI stubbed, so they do not prove `staticFile()` resolves a mirrored asset at actual render time. Worth a maintainer spot-check on a machine with `remotion-composer/node_modules` installed.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally where applicable.
- [ ] I updated docs/README if behavior or usage changed. — no behavior/usage change; internal staging only.
- [x] No unrelated files (build artifacts, local config) are included in the diff.
