### PR TITLE
feat(providers): OpenSpeaker (TTS/music/image) + fal GPT Image 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ venv/
 
 # Backlot local cache (thumbnails)
 .backlot/
+
+# Playwright MCP browser scratch output
+.playwright-mcp/

--- a/docs/openspeaker-api.md
+++ b/docs/openspeaker-api.md
@@ -1,0 +1,472 @@
+# OpenSpeaker API Documentation
+
+> **Status in OpenMontage:** selected provider for **TTS** and **image generation**
+> (and available for music, sound effects, STT, dubbing, voice cloning).
+> No OpenMontage `BaseTool` wrapper exists yet — see "Integration notes" at the end.
+
+Base URL: https://api.ai33.pro
+
+## Authentication
+
+External API endpoints use the `xi-api-key` header unless an endpoint explicitly says otherwise.
+
+```http
+xi-api-key: <YOUR_API_KEY>
+```
+
+v3 endpoints accept the same `xi-api-key` header, or `Authorization: <YOUR_API_KEY>` (raw key, no `Bearer` prefix).
+
+## Rate Limits
+
+Every authenticated API, including v3, returns the same rate-limit response headers:
+
+| Header | Meaning |
+|---|---|
+| `X-RateLimit-Limit` | Sustained token refill rate per second for the current workload |
+| `X-RateLimit-Burst` | Maximum token capacity for the current workload |
+| `X-RateLimit-Remaining` | Remaining tokens currently available |
+| `X-RateLimit-Scope` | Workload bucket: `create`, `poll`, `read`, `upload`, or `command` |
+| `Retry-After` | Seconds to wait before retrying; returned when the API responds with HTTP 429 |
+
+Task-detail polling costs 1 token; task-list polling costs 2 tokens. API keys and JWTs belonging to the same user share one quota because rate limiting is based on the authenticated user, not the credential.
+
+On HTTP 429, read `Retry-After`, wait that many seconds, then retry with exponential backoff and jitter. HTTP 503 with code `server_busy` is temporary server capacity pressure and should also be retried; it is not a user rate-limit violation.
+
+## Common Task Flow
+
+Most generation APIs are asynchronous. Create endpoints return `task_id`; poll `GET /v1/task/{task_id}` or pass `receive_url` for webhook delivery.
+
+```bash
+curl "https://api.ai33.pro/v1/task/$task_id" \
+  -H "Content-Type: application/json" \
+  -H "xi-api-key: $API_KEY"
+```
+
+```json
+{
+  "id": "uuid_task_id",
+  "created_at": "2026-06-15T00:00:00.000Z",
+  "status": "doing",
+  "error_message": null,
+  "credit_cost": 1,
+  "metadata": {},
+  "progress": 60,
+  "type": "tts"
+}
+```
+
+Common task utilities:
+
+```bash
+curl "https://api.ai33.pro/v1/tasks?page=1&limit=20&type=tts" \
+  -H "Content-Type: application/json" \
+  -H "xi-api-key: $API_KEY"
+
+curl -X POST "https://api.ai33.pro/v1/task/delete" \
+  -H "Content-Type: application/json" \
+  -H "xi-api-key: $API_KEY" \
+  --data-raw '{"task_ids":["uuid_task_id"]}'
+
+curl "https://api.ai33.pro/v1/credits" \
+  -H "Content-Type: application/json" \
+  -H "xi-api-key: $API_KEY"
+
+curl "https://api.ai33.pro/v1/health-check" \
+  -H "Content-Type: application/json" \
+  -H "xi-api-key: $API_KEY"
+```
+
+## V3 APIs
+
+### Text To Speech (v3)
+
+Unified v3 endpoint. Send FormData; `voice_id` must use a provider prefix: `elevenlabs_`, `minimax_`, `clone_`, `edge_`, `kokoro_`, `vbee_`, or `fishaudio_`.
+
+```bash
+curl -X POST "https://api.ai33.pro/v3/text-to-speech" \
+  -H "xi-api-key: $API_KEY" \
+  -F text="Xin chào, đây là API v3." \
+  -F voice_id="minimax_male-qn-qingse" \
+  -F speed="1" \
+  -F with_transcript="false" \
+  -F receive_url="https://your-site.com/api/callback"
+```
+
+Fields: `voice_id` required; `text` required (max 1,000,000 chars); `speed` 0.5-1.5 (default 1); `with_transcript` optional (default false); `file_name` optional; `receive_url` optional; `pronunciation_dictionary_id` optional (apply a pronunciation dictionary — only affects audio). Returns `{ success, task_id }`.
+
+### Text To Dialogue (v3)
+
+`speakers` is a JSON array; text labels `A>`, `B>`, `C>` map to speakers by index.
+
+```bash
+curl -X POST "https://api.ai33.pro/v3/text-to-speech/dialogue" \
+  -H "xi-api-key: $API_KEY" \
+  -F text=$'A> Xin chào.\nB> Chào bạn.\nC> Mình là Edge voice.' \
+  -F speakers='[{"voice_id":"elevenlabs_hpp4J3VqNfWAUOO0d1Us","speed":1},{"voice_id":"minimax_male-qn-qingse","speed":1},{"voice_id":"edge_vi-VN-HoaiMyNeural"}]' \
+  -F delay="0.4" \
+  -F with_transcript="true"
+```
+
+Fields: `text` required; `speakers` required (JSON array, min 2; each `{ voice_id, speed? }`, mapped by label index); `delay` 0-5 (default 0); `with_transcript` top-level (default false); `receive_url`/`file_name` optional; `pronunciation_dictionary_id` optional (applies to all lines, speaker labels untouched). Transcript is controlled only by the top-level `with_transcript` — do not put it inside `speakers`.
+
+### Voice Library (v3)
+
+Lists ElevenLabs, Minimax, cloned, Edge, Kokoro, Vbee, and Fish Audio voices in one normalized format. Use the returned `voice_id` directly (already prefixed) in v3 TTS, dialogue, voice changer, and dubbing.
+
+```bash
+curl "https://api.ai33.pro/v3/voices?provider=edge&language=Vietnamese&gender=Female" \
+  -H "xi-api-key: $API_KEY"
+```
+
+Query params: `provider` required (`elevenlabs`, `minimax`, `clone`, `edge`, `kokoro`, `vbee`, `fishaudio`); `search`/`q`/`keywords`; `page` (default 1); `page_size`/`limit` (default 30, max 100); plus CSV filters `tags`/`tag_list`, `language`, `locale`, `gender`, `age`, `accent`, `category`, `use_case`(s), `descriptive`(s)/`style`(s). Provider-specific: vbee `voice_ownership` (`community` | `vbee` | `all`) + `locale` (`northern`/`central`/`southern`) + `category`; fishaudio `sort` (`score`/`task_count`/`created_at`/`trending`) + `tag`. Returns `{ success, data[], pagination }`.
+
+### Clone Voice (v3)
+
+```bash
+curl -X POST "https://api.ai33.pro/v3/text-to-speech/voice-clone" \
+  -H "xi-api-key: $API_KEY" \
+  -F voice_name="My cloned voice" \
+  -F audio_file=@sample.mp3
+```
+
+Fields: `voice_name` required; `audio_file` required (max 10MB). Returns `data.voice_id`; use it as `clone_<voice_id>` in v3 TTS, dialogue, voice changer, and dubbing.
+
+### Delete Clone Voice (v3)
+
+```bash
+curl -X DELETE "https://api.ai33.pro/v3/text-to-speech/voice-clone/$voice_clone_id" \
+  -H "xi-api-key: $API_KEY"
+```
+
+Returns `{ success: true }`.
+
+### Pronunciation Dictionary (v3)
+
+Rules that replace text before synthesis to fix pronunciation. Attach via `pronunciation_dictionary_id` in v3 TTS/dialogue — only the audio changes. JSON body; `xi-api-key` or Supabase JWT.
+
+```bash
+curl -X POST "https://api.ai33.pro/v3/dictionaries" \
+  -H "xi-api-key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Brand names","rules":[{"from":"AI","to":"Ây Ai","matchType":"word","caseSensitive":true}]}'
+```
+
+Rule: `{ from, to, matchType, caseSensitive }`; `matchType` = `word` | `contains` (default `word`). Other endpoints: `GET /v3/dictionaries` (list), `GET/PUT/DELETE /v3/dictionaries/{id}`, `POST /v3/dictionaries/preview` (`{ text, rules }` → `{ input, output }`). Use the returned `id` as `pronunciation_dictionary_id` in TTS/dialogue.
+
+## ElevenLabs APIs (v1)
+
+### Dubbing
+
+Creates the default dubbed audio and SRT. Pass optional `voice_id` to synthesize the completed SRT once more and receive a second audio output using that replacement voice.
+
+#### Multipart request
+
+```bash
+curl -X POST "https://api.ai33.pro/v1/task/dubbing" \
+  -H "xi-api-key: $API_KEY" \
+  -H "Content-Type: multipart/form-data" \
+  -F file=@audio.mp3 \
+  -F num_speakers="0" \
+  -F disable_voice_cloning="false" \
+  -F source_lang="auto" \
+  -F target_lang="en" \
+  -F voice_id="elevenlabs_TX3LPaxmHKxFdv7VOQHJ" \
+  -F receive_url="https://your-site.com/api/callback"
+```
+
+#### JSON request after a presigned upload
+
+First create an upload with `POST /v1/uploads` using `kind: "dubbing"`, then PUT the file to its `put_url`. Submit the returned `upload_id` with the audio duration:
+
+```bash
+curl -X POST "https://api.ai33.pro/v1/task/dubbing" \
+  -H "xi-api-key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "upload_id": "uuid_from_v1_uploads",
+    "duration_seconds": 62.5,
+    "num_speakers": "0",
+    "disable_voice_cloning": "false",
+    "source_lang": "auto",
+    "target_lang": "en",
+    "voice_id": "elevenlabs_TX3LPaxmHKxFdv7VOQHJ",
+    "receive_url": "https://your-site.com/api/callback"
+  }'
+```
+
+Input fields: multipart requires `file`; JSON requires `upload_id` and `duration_seconds > 0`. `num_speakers` defaults to 0; `source_lang` defaults to `auto`; `target_lang` and `receive_url` are required by `/v1/task/dubbing`.
+
+`voice_id` is optional in both request formats. Use a provider-prefixed v3 voice ID from `GET /v3/voices`: `elevenlabs_`, `minimax_`, `clone_`, `edge_`, `vbee_`, or `fishaudio_`. Kokoro is not supported because its SRT-to-TTS path is unavailable. Because it is synthesized from SRT, the replacement output is voice-only and does not include music or other background audio from the source. The replacement output is loudness-normalized automatically; there is no separate request field. A replacement voice increases that task's dubbing credit cost by 25%, rounded up.
+
+Poll `GET /v1/task/{task_id}` or receive the same final task payload at `receive_url`. On success, `metadata.audio_url` remains the default dubbed audio and `metadata.replacement_audio_url` is the optional replacement-voice audio:
+
+```json
+{
+  "status": "done",
+  "metadata": {
+    "audio_url": "https://example.com/default.m4a",
+    "srt_url": "https://example.com/translated.srt",
+    "replacement_voice_id": "elevenlabs_TX3LPaxmHKxFdv7VOQHJ",
+    "replacement_credit_multiplier": 1.25,
+    "replacement_status": "done",
+    "replacement_audio_url": "https://example.com/replacement.mp3"
+  },
+  "type": "dubbing"
+}
+```
+
+If replacement synthesis fails after the default dubbing succeeds, the task still finishes with `status: "done"`; default audio and SRT remain available, `replacement_audio_url` is omitted, and metadata contains:
+
+```json
+{
+  "replacement_status": "failed",
+  "replacement_error": {
+    "code": "text_to_speech_failed",
+    "message": "Text-to-speech failed"
+  }
+}
+```
+
+### Speech To Text
+
+```bash
+curl -X POST "https://api.ai33.pro/v1/task/speech-to-text" \
+  -H "xi-api-key: $API_KEY" \
+  -H "Content-Type: multipart/form-data" \
+  -F file=@audio.mp3 \
+  -F tag_audio_events=true \
+  -F receive_url="https://your-site.com/api/callback"
+```
+
+Fields: `file` required; supported formats include mp3, aac, aiff, ogg, opus, wav, webm, flac, m4a; max 200MB.
+
+### Sound Effect
+
+```bash
+curl -X POST "https://api.ai33.pro/v1/task/sound-effect" \
+  -H "Content-Type: application/json" \
+  -H "xi-api-key: $API_KEY" \
+  -d '{
+    "text": "Thunder rolling with heavy rain",
+    "duration_seconds": 5,
+    "prompt_influence": 0.3,
+    "loop": false,
+    "model_id": "eleven_text_to_sound_v2",
+    "receive_url": "https://your-site.com/api/callback"
+  }'
+```
+
+Credit cost: auto duration costs 200 credits; specified duration costs 50 credits per second; minimum 50 credits.
+
+### Voice Changer
+
+```bash
+curl -X POST "https://api.ai33.pro/v1/task/voice-changer" \
+  -H "xi-api-key: $API_KEY" \
+  -F 'file=@audio.mp3' \
+  -F 'voice_id=21m00Tcm4TlvDq8ikWAM' \
+  -F 'model_id=eleven_multilingual_sts_v2' \
+  -F 'voice_settings={"stability":0.5,"similarity_boost":0.75,"style":0.2,"use_speaker_boost":true}' \
+  -F 'remove_background_noise=true'
+```
+
+### Voice Isolate
+
+```bash
+curl -X POST "https://api.ai33.pro/v1/task/voice-isolate" \
+  -H "xi-api-key: $API_KEY" \
+  -F 'file=@audio.mp3'
+```
+
+## Suno Music Generation
+
+Create an asynchronous Suno music generation task. The endpoint returns a `task_id`; poll the common task endpoint or use `receive_url` for webhook delivery.
+
+### POST /v1s/task/music-generation
+
+Simple mode creates a song from a short description.
+
+```bash
+curl -X POST "https://api.ai33.pro/v1s/task/music-generation" \
+  -H "Content-Type: application/json" \
+  -H "xi-api-key: $API_KEY" \
+  -d '{
+    "create_mode": "simple",
+    "gpt_description_prompt": "Percussive indie pop song about the border between two lives",
+    "make_instrumental": false,
+    "receive_url": "https://your-site.com/api/suno-callback"
+  }'
+```
+
+Custom mode creates a song from title, lyrics, and style tags.
+
+```bash
+curl -X POST "https://api.ai33.pro/v1s/task/music-generation" \
+  -H "Content-Type: application/json" \
+  -H "xi-api-key: $API_KEY" \
+  -d '{
+    "create_mode": "custom",
+    "title": "Border Lights",
+    "lyrics": "[Verse 1]\nI walk the line between two lives",
+    "tags": "indie pop, emotional, cinematic drums",
+    "vocal_gender": "f",
+    "receive_url": "https://your-site.com/api/suno-callback"
+  }'
+```
+
+| Field | Mode | Required | Default | Notes |
+|---|---|---|---|---|
+| `create_mode` | all | no | `simple` | `simple` or `custom` |
+| `receive_url` | all | no | - | Webhook URL called when task completes/errors |
+| `gpt_description_prompt` | simple | yes | - | 1-500 characters |
+| `make_instrumental` | simple | no | `false` | Instrumental output, simple mode only |
+| `title` | custom | no | empty | Max 80 characters |
+| `lyrics` | custom | conditional | empty | Max 5000 characters; `lyrics` or `tags` is required |
+| `tags` | custom | conditional | empty | Max 1000 characters; `lyrics` or `tags` is required |
+| `vocal_gender` | custom | no | - | `f` or `m` |
+
+Success response:
+
+```json
+{
+  "success": true,
+  "task_id": "uuid_task_id",
+  "ec_remain_credits": "9500"
+}
+```
+
+## Common Task Polling
+
+Use this endpoint for Suno and other async tasks.
+
+```bash
+curl "https://api.ai33.pro/v1/task/$task_id" \
+  -H "Content-Type: application/json" \
+  -H "xi-api-key: $API_KEY"
+```
+
+Suno completed task response includes final audio URLs and generated metadata.
+
+```json
+{
+  "id": "uuid_task_id",
+  "status": "done",
+  "progress": 100,
+  "type": "suno_music",
+  "metadata": {
+    "create_mode": "custom",
+    "major_model_version": "v4.5-all",
+    "title": "Border Lights",
+    "lyrics": "[Verse 1]\nI walk the line between two lives",
+    "image_url": "https://cdn2.suno.ai/image_xxx.jpeg",
+    "audio_url": "https://cdn1.suno.ai/xxx.mp3",
+    "all_audio_urls": [
+      "https://cdn1.suno.ai/xxx.mp3",
+      "https://cdn1.suno.ai/yyy.mp3"
+    ],
+    "suno_result": {
+      "clips": [
+        {
+          "id": "clip_id",
+          "title": "Border Lights",
+          "audio_url": "https://cdn1.suno.ai/xxx.mp3",
+          "image_url": "https://cdn2.suno.ai/image_xxx.jpeg",
+          "duration": 187.96,
+          "tags": "indie pop, emotional, cinematic drums"
+        }
+      ]
+    }
+  }
+}
+```
+
+When a Suno task is still processing, `metadata.stream_url` and `metadata.suno_stream_result.clips[].stream_url` may be available for preview. Final files are in `metadata.audio_url` and `metadata.suno_result.clips[].audio_url` when `status` is `done`.
+
+## Imagen APIs
+
+### List Models
+
+```bash
+curl "https://api.ai33.pro/v1i/models" \
+  -H "xi-api-key: $API_KEY"
+```
+
+### Get Price
+
+```bash
+curl -X POST "https://api.ai33.pro/v1i/task/price" \
+  -H "Content-Type: application/json" \
+  -H "xi-api-key: $API_KEY" \
+  -d '{
+    "model_id": "bytedance-seedream-4.5",
+    "generations_count": 1,
+    "model_parameters": {
+      "aspect_ratio": "16:9",
+      "resolution": "2K"
+    },
+    "assets": 2
+  }'
+```
+
+### Generate Image
+
+```bash
+curl -X POST "https://api.ai33.pro/v1i/task/generate-image" \
+  -H "xi-api-key: $API_KEY" \
+  -F 'prompt=A beautiful sunset over the ocean in watercolor style' \
+  -F 'model_id=bytedance-seedream-4.5' \
+  -F 'generations_count=1' \
+  -F 'model_parameters={"aspect_ratio":"16:9","resolution":"2K"}' \
+  -F 'receive_url=https://your-site.com/api/callback'
+```
+
+Reference images: send multiple `assets` fields. Use `@img1`, `@img2`, etc. in `prompt`; the number of `@img` references must match the number of uploaded `assets` files.
+
+Imagen task type is `imagen2`. Poll with `GET /v1/task/{task_id}` or list with `GET /v1/tasks?type=imagen2&page=1&limit=20`.
+
+## Typical Success Response Shape
+
+Create endpoints usually return:
+
+```json
+{
+  "success": true,
+  "task_id": "uuid_task_id",
+  "ec_remain_credits": "9500"
+}
+```
+
+Polling completed task example:
+
+```json
+{
+  "id": "uuid_task_id",
+  "created_at": "2026-06-15T00:00:00.000Z",
+  "status": "done",
+  "error_message": null,
+  "credit_cost": 3600,
+  "metadata": {
+    "audio_url": "https://example.com/output.mp3"
+  },
+  "progress": 100,
+  "type": "suno_music"
+}
+```
+
+## Integration notes (OpenMontage-specific)
+
+Not part of the vendor docs — notes for wiring this provider into OpenMontage.
+
+- **Credential:** single env var (proposed `OPENSPEAKER_API_KEY`) → sent as the `xi-api-key` header. Add to `.env` (no `.env` exists on this machine yet; only `.env.example`).
+- **Tools that would need to exist** (each a `BaseTool` subclass, PascalCase, no `Tool` suffix, discovered by `tools/tool_registry.py`):
+  | Capability | Endpoint | Suggested tool |
+  |---|---|---|
+  | `tts` | `POST /v3/text-to-speech` | `tools/tts/openspeaker_tts.py` → `OpenSpeakerTTS` |
+  | `image_generation` | `POST /v1i/task/generate-image` | `tools/image/openspeaker_image.py` → `OpenSpeakerImage` |
+  | `music_generation` | `POST /v1s/task/music-generation` | `OpenSpeakerMusic` (optional) |
+  | `analysis` (STT) | `POST /v1/task/speech-to-text` | `OpenSpeakerSTT` (optional) |
+- **Async contract:** every create endpoint returns `task_id` only. Tools must poll `GET /v1/task/{task_id}` until `status: "done"`, then download `metadata.audio_url` / image URL to an explicit `output_path` under `projects/<project-id>/assets/…` (workspace contract in `AGENT_GUIDE.md`).
+- **Polling budget:** detail poll = 1 token, list poll = 2 tokens. Poll the detail endpoint, honor `Retry-After` on 429, retry `server_busy` 503s with backoff + jitter.
+- **Selector routing:** once registered with `capability="tts"` / `"image_generation"`, `tts_selector` and `image_selector` pick these up automatically — no selector code changes.
+- **Voice discovery:** `GET /v3/voices?provider=…` is the source of truth for `voice_id`; IDs are already provider-prefixed (`elevenlabs_`, `minimax_`, `edge_`, `kokoro_`, `vbee_`, `fishaudio_`, `clone_`). Do not hardcode voice lists.
+- **Cost tracking:** create responses carry `ec_remain_credits`; completed tasks carry `credit_cost`. Feed both into `tools/cost_tracker.py`.

--- a/tools/audio/openspeaker_music.py
+++ b/tools/audio/openspeaker_music.py
@@ -1,0 +1,225 @@
+"""OpenSpeaker music generation tool (Suno via api.ai33.pro).
+
+Two creation modes:
+  simple  — one short description drives the whole song (`gpt_description_prompt`)
+  custom  — explicit title + lyrics + style tags, with optional vocal gender
+
+Suno returns multiple clips per task; the first is written to `output_path` and
+the rest alongside it so the agent can pick the best take.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+from tools.openspeaker_client import OpenSpeakerError, api_key, download, poll_task, request
+
+
+class OpenSpeakerMusic(BaseTool):
+    name = "openspeaker_music"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "music_generation"
+    provider = "openspeaker"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.ASYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = ["requests"]
+    install_instructions = (
+        "Set the OPENSPEAKER_API_KEY environment variable in .env:\n"
+        "  OPENSPEAKER_API_KEY=your_key_here\n"
+        "Music routes through Suno on POST /v1s/task/music-generation.\n"
+        "See docs/openspeaker-api.md"
+    )
+    fallback = None
+    fallback_tools = ["music_gen", "music_library"]
+    agent_skills = ["music"]
+
+    capabilities = ["music_generation", "instrumental_generation", "lyric_song_generation"]
+    supports = {
+        "instrumental": True,
+        "lyrics": True,
+        "style_tags": True,
+        "vocal_gender": True,
+        "offline": False,
+    }
+    best_for = [
+        "background beds for ads and explainers",
+        "instrumental scoring matched to a specific mood and tempo",
+        "full songs with lyrics when the brief calls for one",
+    ]
+    not_good_for = [
+        "exact-length beds (Suno picks its own duration; trim in post)",
+        "licensed/cleared music where provenance must be contractual",
+        "offline generation",
+    ]
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "Simple mode: song description (1-500 chars).",
+            },
+            "create_mode": {
+                "type": "string",
+                "enum": ["simple", "custom"],
+                "default": "simple",
+            },
+            "instrumental": {
+                "type": "boolean",
+                "default": True,
+                "description": "Simple mode only. Background beds should almost always be instrumental.",
+            },
+            "title": {"type": "string", "description": "Custom mode. Max 80 chars."},
+            "lyrics": {"type": "string", "description": "Custom mode. Max 5000 chars."},
+            "tags": {"type": "string", "description": "Custom mode style tags. Max 1000 chars."},
+            "vocal_gender": {"type": "string", "enum": ["f", "m"]},
+            "output_path": {"type": "string"},
+            "timeout_seconds": {"type": "integer", "default": 900},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=200, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=3, retryable_errors=["rate_limit", "timeout", "server_busy"])
+    idempotency_key_fields = ["prompt", "create_mode", "tags", "lyrics", "instrumental"]
+    side_effects = ["writes audio file(s) to output_path", "calls OpenSpeaker API", "consumes credits"]
+    user_visible_verification = [
+        "Listen to each returned take and confirm mood, tempo, and that it sits under narration without competing",
+    ]
+
+    def get_status(self) -> ToolStatus:
+        if not api_key():
+            return ToolStatus.UNAVAILABLE
+        enabled = (os.environ.get("OPENSPEAKER_MUSIC_ENABLED") or "").strip().lower()
+        if enabled in ("false", "0", "no"):
+            return ToolStatus.UNAVAILABLE
+        return ToolStatus.AVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        # Billed in credits; the real figure comes back on the task payload.
+        return 0.0
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        start = time.time()
+        try:
+            result = self._generate(inputs)
+        except OpenSpeakerError as exc:
+            return ToolResult(success=False, error=f"OpenSpeaker music generation failed: {exc}")
+        except Exception as exc:  # noqa: BLE001 - surfaced to the agent as a tool error
+            return ToolResult(success=False, error=f"OpenSpeaker music generation failed: {exc}")
+        result.duration_seconds = round(time.time() - start, 2)
+        return result
+
+    def _generate(self, inputs: dict[str, Any]) -> ToolResult:
+        mode = inputs.get("create_mode", "simple")
+        body: dict[str, Any] = {"create_mode": mode}
+
+        if mode == "custom":
+            if not (inputs.get("lyrics") or inputs.get("tags")):
+                raise OpenSpeakerError("custom mode requires `lyrics` or `tags`.")
+            body["title"] = (inputs.get("title") or "")[:80]
+            body["lyrics"] = (inputs.get("lyrics") or "")[:5000]
+            body["tags"] = (inputs.get("tags") or inputs.get("prompt") or "")[:1000]
+            if inputs.get("vocal_gender"):
+                body["vocal_gender"] = inputs["vocal_gender"]
+        else:
+            prompt = (inputs.get("prompt") or "").strip()
+            if not prompt:
+                raise OpenSpeakerError("simple mode requires `prompt`.")
+            if len(prompt) > 500:
+                raise OpenSpeakerError(
+                    f"gpt_description_prompt is limited to 500 chars (got {len(prompt)})."
+                )
+            body["gpt_description_prompt"] = prompt
+            body["make_instrumental"] = bool(inputs.get("instrumental", True))
+
+        created = request("POST", "/v1s/task/music-generation", json_body=body, timeout=60)
+        task_id = created.get("task_id")
+        if not task_id:
+            raise OpenSpeakerError(f"No task_id in create response: {created}")
+
+        task = poll_task(task_id, timeout_seconds=int(inputs.get("timeout_seconds", 900)))
+        metadata = task.get("metadata") or {}
+        urls = self._extract_audio_urls(metadata)
+        if not urls:
+            raise OpenSpeakerError(f"Task {task_id} finished without audio urls: {list(metadata)}")
+
+        output_path = Path(inputs.get("output_path") or f"openspeaker_music_{task_id}.mp3")
+        written: list[str] = []
+        for index, url in enumerate(urls):
+            target = (
+                output_path
+                if index == 0
+                else output_path.with_name(f"{output_path.stem}_take{index + 1}{output_path.suffix}")
+            )
+            download(url, target)
+            written.append(str(target))
+
+        clips = ((metadata.get("suno_result") or {}).get("clips")) or []
+        durations = [c.get("duration") for c in clips if isinstance(c, dict)]
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": self.provider,
+                "engine": "suno",
+                "create_mode": mode,
+                "task_id": task_id,
+                "credit_cost": task.get("credit_cost"),
+                "model_version": metadata.get("major_model_version"),
+                "title": metadata.get("title"),
+                "tags": metadata.get("tags") or body.get("tags"),
+                "takes": len(written),
+                "durations_seconds": durations,
+                "output": written[0],
+                "outputs": written,
+            },
+            artifacts=written,
+            model=f"suno:{metadata.get('major_model_version') or 'unknown'}",
+        )
+
+    @staticmethod
+    def _extract_audio_urls(metadata: dict[str, Any]) -> list[str]:
+        """Collect final (non-stream) audio urls, preserving order and de-duping."""
+        candidates: list[str] = []
+
+        primary = metadata.get("audio_url")
+        if isinstance(primary, str):
+            candidates.append(primary)
+
+        for url in metadata.get("all_audio_urls") or []:
+            if isinstance(url, str):
+                candidates.append(url)
+
+        for clip in ((metadata.get("suno_result") or {}).get("clips")) or []:
+            if isinstance(clip, dict) and isinstance(clip.get("audio_url"), str):
+                candidates.append(clip["audio_url"])
+
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for url in candidates:
+            if url and url not in seen:
+                seen.add(url)
+                ordered.append(url)
+        return ordered

--- a/tools/audio/openspeaker_music.py
+++ b/tools/audio/openspeaker_music.py
@@ -27,7 +27,14 @@ from tools.base_tool import (
     ToolStatus,
     ToolTier,
 )
-from tools.openspeaker_client import OpenSpeakerError, api_key, download, poll_task, request
+from tools.openspeaker_client import (
+    OpenSpeakerError,
+    api_key,
+    download,
+    poll_task,
+    request,
+    safe_media_path,
+)
 
 
 class OpenSpeakerMusic(BaseTool):
@@ -165,7 +172,7 @@ class OpenSpeakerMusic(BaseTool):
         if not urls:
             raise OpenSpeakerError(f"Task {task_id} finished without audio urls: {list(metadata)}")
 
-        output_path = Path(inputs.get("output_path") or f"openspeaker_music_{task_id}.mp3")
+        output_path = safe_media_path(inputs.get("output_path") or f"openspeaker_music_{task_id}.mp3")
         written: list[str] = []
         for index, url in enumerate(urls):
             target = (

--- a/tools/audio/openspeaker_tts.py
+++ b/tools/audio/openspeaker_tts.py
@@ -24,7 +24,14 @@ from tools.base_tool import (
     ToolStatus,
     ToolTier,
 )
-from tools.openspeaker_client import OpenSpeakerError, api_key, download, poll_task, request
+from tools.openspeaker_client import (
+    OpenSpeakerError,
+    api_key,
+    download,
+    poll_task,
+    request,
+    safe_media_path,
+)
 
 VALID_VOICE_PREFIXES = (
     "elevenlabs_",
@@ -230,7 +237,7 @@ class OpenSpeakerTTS(BaseTool):
         if not audio_url:
             raise OpenSpeakerError(f"Task {task_id} finished without an audio_url: {metadata}")
 
-        output_path = Path(inputs.get("output_path") or f"openspeaker_tts_{task_id}.mp3")
+        output_path = safe_media_path(inputs.get("output_path") or f"openspeaker_tts_{task_id}.mp3")
         download(audio_url, output_path)
         audio_duration = probe_duration(output_path)
 

--- a/tools/audio/openspeaker_tts.py
+++ b/tools/audio/openspeaker_tts.py
@@ -1,0 +1,252 @@
+"""OpenSpeaker text-to-speech provider tool (api.ai33.pro, v3 unified endpoint).
+
+The v3 TTS endpoint has no `model` field — the prefixed `voice_id` IS the model
+selector. Valid prefixes: elevenlabs_, minimax_, clone_, edge_, kokoro_, vbee_,
+fishaudio_. Discover IDs via GET /v3/voices (they come back pre-prefixed).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+from tools.openspeaker_client import OpenSpeakerError, api_key, download, poll_task, request
+
+VALID_VOICE_PREFIXES = (
+    "elevenlabs_",
+    "minimax_",
+    "clone_",
+    "edge_",
+    "kokoro_",
+    "vbee_",
+    "fishaudio_",
+)
+
+
+class OpenSpeakerTTS(BaseTool):
+    name = "openspeaker_tts"
+    version = "0.1.0"
+    tier = ToolTier.VOICE
+    capability = "tts"
+    provider = "openspeaker"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.ASYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = ["requests"]
+    install_instructions = (
+        "Set the OPENSPEAKER_API_KEY environment variable in .env:\n"
+        "  OPENSPEAKER_API_KEY=your_key_here\n"
+        "Optionally set OPENSPEAKER_TTS_VOICE_ID to a default prefixed voice id\n"
+        "(e.g. elevenlabs_cjVigY5qzO86Huf0OWal). List voices with\n"
+        "  GET https://api.ai33.pro/v3/voices?provider=elevenlabs\n"
+        "See docs/openspeaker-api.md"
+    )
+    fallback = "piper_tts"
+    fallback_tools = ["piper_tts", "elevenlabs_tts"]
+    agent_skills = ["text-to-speech", "elevenlabs"]
+
+    capabilities = [
+        "text_to_speech",
+        "voice_selection",
+        "multi_provider_voices",
+        "pronunciation_dictionary",
+    ]
+    supports = {
+        "voice_cloning": True,
+        "multilingual": True,
+        "offline": False,
+        "native_audio": True,
+        "word_timestamps": True,
+    }
+    best_for = [
+        "narration with ElevenLabs/Minimax/Edge/Fish Audio voices through one key",
+        "multilingual narration including Vietnamese and Arabic-market English",
+        "projects that also need cloned voices or a pronunciation dictionary",
+    ]
+    not_good_for = [
+        "fully offline production",
+        "sub-second latency streaming",
+    ]
+
+    input_schema = {
+        "type": "object",
+        "required": ["text"],
+        "properties": {
+            "text": {"type": "string", "description": "Text to speak (max 1,000,000 chars)."},
+            "voice_id": {
+                "type": "string",
+                "description": (
+                    "Prefixed voice id from GET /v3/voices, e.g. "
+                    "elevenlabs_cjVigY5qzO86Huf0OWal. Defaults to "
+                    "OPENSPEAKER_TTS_VOICE_ID."
+                ),
+            },
+            "voice": {
+                "type": "string",
+                "description": "Alias for voice_id, for selector compatibility.",
+            },
+            "speed": {
+                "type": "number",
+                "minimum": 0.5,
+                "maximum": 1.5,
+                "default": 1.0,
+                "description": "Speaking rate. API default is 1.",
+            },
+            "with_transcript": {
+                "type": "boolean",
+                "default": False,
+                "description": "Request word-level timing data alongside the audio.",
+            },
+            "pronunciation_dictionary_id": {
+                "type": "string",
+                "description": "Optional dictionary id from POST /v3/dictionaries.",
+            },
+            "output_path": {"type": "string"},
+            "timeout_seconds": {"type": "integer", "default": 900},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=100, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=3, retryable_errors=["rate_limit", "timeout", "server_busy"])
+    idempotency_key_fields = ["text", "voice_id", "speed", "pronunciation_dictionary_id"]
+    side_effects = ["writes audio file to output_path", "calls OpenSpeaker API", "consumes credits"]
+    user_visible_verification = [
+        "Listen to generated audio for intelligibility, pace, and pronunciation of brand names",
+    ]
+
+    def get_status(self) -> ToolStatus:
+        if not api_key():
+            return ToolStatus.UNAVAILABLE
+        # A key without a usable default voice still works when the caller
+        # passes voice_id explicitly, so this is DEGRADED rather than a hard no.
+        default_voice = (os.environ.get("OPENSPEAKER_TTS_VOICE_ID") or "").strip()
+        if default_voice and not default_voice.startswith(VALID_VOICE_PREFIXES):
+            return ToolStatus.DEGRADED
+        return ToolStatus.AVAILABLE
+
+    def get_info(self) -> dict[str, Any]:
+        info = super().get_info() if hasattr(super(), "get_info") else {}
+        default_voice = (os.environ.get("OPENSPEAKER_TTS_VOICE_ID") or "").strip()
+        info.update(
+            {
+                "default_voice_id": default_voice or None,
+                "valid_voice_prefixes": list(VALID_VOICE_PREFIXES),
+                "voice_discovery": "GET /v3/voices?provider=<provider>",
+            }
+        )
+        if default_voice and not default_voice.startswith(VALID_VOICE_PREFIXES):
+            info["warning"] = (
+                f"OPENSPEAKER_TTS_VOICE_ID={default_voice!r} has no provider prefix. "
+                "The v3 API requires one of "
+                f"{', '.join(VALID_VOICE_PREFIXES)}. Pass voice_id explicitly or fix .env."
+            )
+        return info
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        # Billed in account credits, not USD. Cost is reported from the task
+        # payload after execution; this is a conservative placeholder.
+        return 0.0
+
+    def _resolve_voice_id(self, inputs: dict[str, Any]) -> str:
+        voice_id = (
+            inputs.get("voice_id")
+            or inputs.get("voice")
+            or os.environ.get("OPENSPEAKER_TTS_VOICE_ID")
+            or ""
+        ).strip()
+        if not voice_id:
+            raise OpenSpeakerError(
+                "No voice_id given and OPENSPEAKER_TTS_VOICE_ID is unset. "
+                "List voices with GET /v3/voices?provider=elevenlabs"
+            )
+        if not voice_id.startswith(VALID_VOICE_PREFIXES):
+            raise OpenSpeakerError(
+                f"voice_id {voice_id!r} is missing a provider prefix. The v3 API "
+                f"requires one of: {', '.join(VALID_VOICE_PREFIXES)}. "
+                "Note that names like 'eleven_multilingual_v2' are ElevenLabs MODEL "
+                "ids, not voice ids — use GET /v3/voices to get a real one."
+            )
+        return voice_id
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        start = time.time()
+        try:
+            result = self._generate(inputs)
+        except OpenSpeakerError as exc:
+            return ToolResult(success=False, error=f"OpenSpeaker TTS failed: {exc}")
+        except Exception as exc:  # noqa: BLE001 - surfaced to the agent as a tool error
+            return ToolResult(success=False, error=f"OpenSpeaker TTS failed: {exc}")
+        result.duration_seconds = round(time.time() - start, 2)
+        return result
+
+    def _generate(self, inputs: dict[str, Any]) -> ToolResult:
+        from tools.analysis.audio_probe import probe_duration
+
+        text = inputs["text"]
+        voice_id = self._resolve_voice_id(inputs)
+        speed = inputs.get("speed")
+        if speed is None:
+            env_speed = (os.environ.get("OPENSPEAKER_TTS_SPEED") or "").strip()
+            speed = float(env_speed) if env_speed else 1.0
+
+        form: dict[str, Any] = {
+            "text": text,
+            "voice_id": voice_id,
+            "speed": str(speed),
+            "with_transcript": "true" if inputs.get("with_transcript") else "false",
+        }
+        dictionary_id = inputs.get("pronunciation_dictionary_id") or os.environ.get(
+            "OPENSPEAKER_PRONUNCIATION_DICTIONARY_ID"
+        )
+        if dictionary_id:
+            form["pronunciation_dictionary_id"] = dictionary_id
+
+        created = request("POST", "/v3/text-to-speech", data=form, timeout=60)
+        task_id = created.get("task_id")
+        if not task_id:
+            raise OpenSpeakerError(f"No task_id in create response: {created}")
+
+        task = poll_task(task_id, timeout_seconds=int(inputs.get("timeout_seconds", 900)))
+        metadata = task.get("metadata") or {}
+        audio_url = metadata.get("audio_url")
+        if not audio_url:
+            raise OpenSpeakerError(f"Task {task_id} finished without an audio_url: {metadata}")
+
+        output_path = Path(inputs.get("output_path") or f"openspeaker_tts_{task_id}.mp3")
+        download(audio_url, output_path)
+        audio_duration = probe_duration(output_path)
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": self.provider,
+                "voice_id": voice_id,
+                "speed": speed,
+                "task_id": task_id,
+                "credit_cost": task.get("credit_cost"),
+                "text_length": len(text),
+                "audio_duration_seconds": round(audio_duration, 2) if audio_duration else None,
+                "transcript": metadata.get("transcript") or metadata.get("transcript_url"),
+                "output": str(output_path),
+            },
+            artifacts=[str(output_path)],
+            model=voice_id,
+        )

--- a/tools/graphics/fal_gpt_image.py
+++ b/tools/graphics/fal_gpt_image.py
@@ -1,0 +1,285 @@
+"""GPT Image 2 via fal.ai (https://fal.run/openai/gpt-image-2).
+
+Used in this project because the OpenSpeaker Imagen queue stalls under load.
+fal.run is a synchronous endpoint — it returns the finished images on the same
+request, so there is no task to poll and no queue to get stuck behind.
+
+Cost is driven by the `quality` parameter (fal defaults to `high`). This tool
+defaults to `low` deliberately: the caller asked for low quality at ~1K, which
+is roughly an order of magnitude cheaper per image than the fal default.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+import requests
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+ENDPOINT = "https://fal.run/openai/gpt-image-2"
+
+# fal constrains concrete sizes: both dimensions multiples of 16, max edge 3840,
+# aspect ratio <= 3:1, and total pixels between 655,360 and 8,294,400.
+# 1024x576 (a naive "1K 16:9") is only 589,824 px and is REJECTED — 1280x720 is
+# the smallest compliant 16:9 size, so that is what "1K landscape" maps to here.
+SIZE_PRESETS: dict[str, dict[str, int]] = {
+    "16:9": {"width": 1280, "height": 720},
+    "9:16": {"width": 720, "height": 1280},
+    "1:1": {"width": 1024, "height": 1024},
+    "4:3": {"width": 1024, "height": 768},
+    "3:4": {"width": 768, "height": 1024},
+}
+
+MIN_PIXELS = 655_360
+MAX_PIXELS = 8_294_400
+MAX_EDGE = 3840
+
+
+class FalGPTImage(BaseTool):
+    name = "fal_gpt_image"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "image_generation"
+    provider = "fal"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = ["requests"]
+    install_instructions = (
+        "Set FAL_KEY to your fal.ai API key.\n"
+        "  FAL_KEY=your_key_here\n"
+        "Get one at https://fal.ai/dashboard/keys"
+    )
+    fallback = "openspeaker_image"
+    fallback_tools = ["openspeaker_image", "flux_image"]
+    agent_skills = ["flux-best-practices", "visual-style"]
+
+    capabilities = ["text_to_image", "typography_rendering"]
+    supports = {
+        "reference_images": False,
+        "aspect_ratio_control": True,
+        "resolution_control": True,
+        "offline": False,
+        "batch": True,
+        "synchronous": True,
+    }
+    best_for = [
+        "fast synchronous image generation with no task queue to stall behind",
+        "images containing fine typography and legible on-image text",
+        "cheap iteration at quality=low",
+    ]
+    not_good_for = [
+        "reference-image conditioning (use openspeaker_image or flux_image)",
+        "deterministic reruns",
+    ]
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+            "prompt": {"type": "string"},
+            "aspect_ratio": {
+                "type": "string",
+                "description": "Preset key: 16:9, 9:16, 1:1, 4:3, 3:4. Mapped to a fal-compliant size.",
+            },
+            "width": {"type": "integer", "description": "Explicit width. Must be a multiple of 16."},
+            "height": {"type": "integer", "description": "Explicit height. Must be a multiple of 16."},
+            "quality": {
+                "type": "string",
+                "enum": ["auto", "low", "medium", "high"],
+                "default": "low",
+                "description": "fal defaults to 'high'; this tool defaults to 'low' for cost.",
+            },
+            "num_images": {"type": "integer", "default": 1, "minimum": 1, "maximum": 4},
+            "output_format": {
+                "type": "string",
+                "enum": ["jpeg", "png", "webp"],
+                "default": "png",
+            },
+            "output_path": {"type": "string"},
+            "timeout_seconds": {"type": "integer", "default": 300},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=200, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
+    idempotency_key_fields = ["prompt", "width", "height", "quality"]
+    side_effects = ["writes image file(s) to output_path", "calls fal.ai API", "incurs USD cost"]
+    user_visible_verification = [
+        "Open the image and check composition, on-image text spelling, and that no invented branding appears",
+    ]
+
+    @staticmethod
+    def _api_key() -> Optional[str]:
+        return os.environ.get("FAL_KEY") or os.environ.get("FAL_AI_API_KEY")
+
+    def get_status(self) -> ToolStatus:
+        return ToolStatus.AVAILABLE if self._api_key() else ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        # fal bills image output tokens; quality dominates. These are rough
+        # per-image figures for ~1MP output, used for budget reporting only.
+        per_image = {"low": 0.011, "medium": 0.042, "high": 0.167, "auto": 0.042}
+        quality = inputs.get("quality", "low")
+        return round(per_image.get(quality, 0.042) * int(inputs.get("num_images", 1)), 4)
+
+    def _resolve_size(self, inputs: dict[str, Any]) -> tuple[dict[str, int], list[str]]:
+        """Return a fal-compliant {width, height} plus any adjustment notes."""
+        notes: list[str] = []
+        width, height = inputs.get("width"), inputs.get("height")
+
+        if not (width and height):
+            aspect = (inputs.get("aspect_ratio") or "16:9").strip()
+            preset = SIZE_PRESETS.get(aspect)
+            if preset is None:
+                notes.append(f"aspect_ratio {aspect!r} unknown; used 16:9")
+                preset = SIZE_PRESETS["16:9"]
+            width, height = preset["width"], preset["height"]
+
+        # Snap to multiples of 16 rather than letting fal reject the request.
+        snapped_w, snapped_h = (max(16, round(v / 16) * 16) for v in (width, height))
+        if (snapped_w, snapped_h) != (width, height):
+            notes.append(f"size {width}x{height} snapped to {snapped_w}x{snapped_h} (multiples of 16)")
+        width, height = snapped_w, snapped_h
+
+        if max(width, height) > MAX_EDGE:
+            notes.append(f"edge exceeded {MAX_EDGE}px; falling back to 16:9 preset")
+            width, height = SIZE_PRESETS["16:9"].values()
+
+        pixels = width * height
+        if not (MIN_PIXELS <= pixels <= MAX_PIXELS):
+            preset = SIZE_PRESETS["16:9"]
+            notes.append(
+                f"{width}x{height} is {pixels:,}px, outside fal's "
+                f"{MIN_PIXELS:,}-{MAX_PIXELS:,} range; used "
+                f"{preset['width']}x{preset['height']}"
+            )
+            width, height = preset["width"], preset["height"]
+
+        return {"width": width, "height": height}, notes
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        api_key = self._api_key()
+        if not api_key:
+            return ToolResult(success=False, error="No fal.ai API key. " + self.install_instructions)
+
+        start = time.time()
+        try:
+            result = self._generate(inputs, api_key)
+        except Exception as exc:  # noqa: BLE001 - surfaced to the agent as a tool error
+            return ToolResult(success=False, error=f"fal GPT Image 2 failed: {exc}")
+        result.duration_seconds = round(time.time() - start, 2)
+        result.cost_usd = self.estimate_cost(inputs)
+        return result
+
+    def _generate(self, inputs: dict[str, Any], api_key: str) -> ToolResult:
+        image_size, size_notes = self._resolve_size(inputs)
+        quality = inputs.get("quality", "low")
+        num_images = int(inputs.get("num_images", 1))
+        output_format = inputs.get("output_format", "png")
+
+        payload = {
+            "prompt": inputs["prompt"],
+            "image_size": image_size,
+            "quality": quality,
+            "num_images": num_images,
+            "output_format": output_format,
+        }
+
+        # Transient DNS/connection failures to fal.run were observed in practice,
+        # so a bare single attempt is not good enough for a batch of scenes.
+        timeout = int(inputs.get("timeout_seconds", 300))
+        attempts = self.retry_policy.max_retries + 1
+        response = None
+        for attempt in range(attempts):
+            try:
+                response = requests.post(
+                    ENDPOINT,
+                    headers={
+                        "Authorization": f"Key {api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json=payload,
+                    timeout=timeout,
+                )
+                break
+            except requests.RequestException as exc:
+                if attempt >= attempts - 1:
+                    raise RuntimeError(f"network error after {attempts} attempts: {exc}") from exc
+                time.sleep(2 ** attempt)
+
+        if response.status_code == 429 or response.status_code >= 500:
+            raise RuntimeError(
+                f"HTTP {response.status_code} (retryable): {response.text[:300]}"
+            )
+        if response.status_code >= 400:
+            raise RuntimeError(f"HTTP {response.status_code}: {response.text[:400]}")
+
+        data = response.json()
+        images = data.get("images") or []
+        if not images:
+            raise RuntimeError(f"No images in response: {str(data)[:300]}")
+
+        suffix = f".{output_format}"
+        output_path = Path(inputs.get("output_path") or f"fal_gpt_image{suffix}")
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        written: list[str] = []
+        for index, image in enumerate(images):
+            url = image.get("url")
+            if not url:
+                continue
+            target = (
+                output_path
+                if index == 0
+                else output_path.with_name(f"{output_path.stem}_{index + 1}{output_path.suffix}")
+            )
+            with requests.get(url, stream=True, timeout=180) as stream:
+                stream.raise_for_status()
+                with open(target, "wb") as handle:
+                    for chunk in stream.iter_content(chunk_size=1 << 16):
+                        if chunk:
+                            handle.write(chunk)
+            written.append(str(target))
+
+        if not written:
+            raise RuntimeError("Response contained images but none had a url")
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": self.provider,
+                "model_id": "openai/gpt-image-2",
+                "image_size": image_size,
+                "quality": quality,
+                "parameter_adjustments": size_notes,
+                "dimensions": [
+                    {"width": i.get("width"), "height": i.get("height")} for i in images
+                ],
+                "generations": len(written),
+                "prompt": inputs["prompt"],
+                "output": written[0],
+                "outputs": written,
+            },
+            artifacts=written,
+            model="openai/gpt-image-2",
+        )

--- a/tools/graphics/fal_gpt_image.py
+++ b/tools/graphics/fal_gpt_image.py
@@ -15,9 +15,11 @@ import os
 import time
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import urlparse
 
 import requests
 
+from tools.openspeaker_client import safe_media_path
 from tools.base_tool import (
     BaseTool,
     Determinism,
@@ -48,6 +50,9 @@ SIZE_PRESETS: dict[str, dict[str, int]] = {
 MIN_PIXELS = 655_360
 MAX_PIXELS = 8_294_400
 MAX_EDGE = 3840
+
+# A single generated still that exceeds this is a bug, not a big image.
+MAX_IMAGE_BYTES = 128 * 1024 * 1024
 
 
 class FalGPTImage(BaseTool):
@@ -240,7 +245,7 @@ class FalGPTImage(BaseTool):
             raise RuntimeError(f"No images in response: {str(data)[:300]}")
 
         suffix = f".{output_format}"
-        output_path = Path(inputs.get("output_path") or f"fal_gpt_image{suffix}")
+        output_path = safe_media_path(inputs.get("output_path") or f"fal_gpt_image{suffix}")
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
         written: list[str] = []
@@ -253,12 +258,25 @@ class FalGPTImage(BaseTool):
                 if index == 0
                 else output_path.with_name(f"{output_path.stem}_{index + 1}{output_path.suffix}")
             )
+            # The URL is chosen by the API, not the caller: https only, and the
+            # write is capped so a malformed response cannot fill the disk.
+            if urlparse(url).scheme != "https":
+                raise RuntimeError(f"refusing to download image over non-https url: {url[:40]}…")
+            written_bytes = 0
             with requests.get(url, stream=True, timeout=180) as stream:
                 stream.raise_for_status()
                 with open(target, "wb") as handle:
                     for chunk in stream.iter_content(chunk_size=1 << 16):
-                        if chunk:
-                            handle.write(chunk)
+                        if not chunk:
+                            continue
+                        written_bytes += len(chunk)
+                        if written_bytes > MAX_IMAGE_BYTES:
+                            handle.close()
+                            target.unlink(missing_ok=True)
+                            raise RuntimeError(
+                                f"image download exceeded {MAX_IMAGE_BYTES} bytes, aborted"
+                            )
+                        handle.write(chunk)
             written.append(str(target))
 
         if not written:

--- a/tools/graphics/openspeaker_image.py
+++ b/tools/graphics/openspeaker_image.py
@@ -25,9 +25,20 @@ from tools.base_tool import (
     ToolStatus,
     ToolTier,
 )
-from tools.openspeaker_client import OpenSpeakerError, api_key, download, poll_task, request
+from tools.openspeaker_client import (
+    OpenSpeakerError,
+    api_key,
+    download,
+    poll_task,
+    request,
+    safe_media_path,
+)
 
 DEFAULT_MODEL = "gpt-image-2"
+
+# Reference uploads are restricted to real image types so a path that slips
+# through cannot ship arbitrary file contents to the provider.
+ALLOWED_REFERENCE_SUFFIXES = {".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp"}
 
 # Populated on first use from GET /v1i/models; see OpenSpeakerImage._model_spec.
 _MODEL_CACHE: Optional[dict[str, dict[str, Any]]] = None
@@ -257,11 +268,19 @@ class OpenSpeakerImage(BaseTool):
         if model_parameters:
             form.append(("model_parameters", (None, json.dumps(model_parameters))))
 
+        # Reference images are read off local disk and uploaded to a third-party
+        # API. That makes this the one input in this tool that can exfiltrate
+        # file contents, so it is constrained twice: the path must resolve
+        # inside the workspace, and it must actually be an image. Without both,
+        # a poisoned scene_plan could name ".env" or a private key and ship it.
         references = inputs.get("reference_images") or []
         for ref in references:
-            ref_path = Path(ref)
-            if not ref_path.is_file():
-                raise OpenSpeakerError(f"reference image not found: {ref_path}")
+            ref_path = safe_media_path(ref, must_exist=True)
+            if ref_path.suffix.lower() not in ALLOWED_REFERENCE_SUFFIXES:
+                raise OpenSpeakerError(
+                    f"reference image must be one of "
+                    f"{sorted(ALLOWED_REFERENCE_SUFFIXES)}, got {ref_path.suffix!r}: {ref_path.name}"
+                )
             handle = open(ref_path, "rb")
             open_files.append(handle)
             form.append(("assets", (ref_path.name, handle)))
@@ -278,7 +297,7 @@ class OpenSpeakerImage(BaseTool):
                 f"Task {task_id} finished without image urls: {task.get('metadata')}"
             )
 
-        output_path = Path(inputs.get("output_path") or f"openspeaker_image_{task_id}.png")
+        output_path = safe_media_path(inputs.get("output_path") or f"openspeaker_image_{task_id}.png")
         written: list[str] = []
         for index, url in enumerate(urls[:count]):
             target = (

--- a/tools/graphics/openspeaker_image.py
+++ b/tools/graphics/openspeaker_image.py
@@ -1,0 +1,363 @@
+"""OpenSpeaker image generation tool (api.ai33.pro Imagen API).
+
+One key fronts many models — gpt-image-2, gemini-3.x, recraft-v4.1,
+bytedance-seedream-*, flux-2-pro, krea-2-*, runway-gen4-image, and others.
+List what the account can use with GET /v1i/models.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+from tools.openspeaker_client import OpenSpeakerError, api_key, download, poll_task, request
+
+DEFAULT_MODEL = "gpt-image-2"
+
+# Populated on first use from GET /v1i/models; see OpenSpeakerImage._model_spec.
+_MODEL_CACHE: Optional[dict[str, dict[str, Any]]] = None
+
+
+class OpenSpeakerImage(BaseTool):
+    name = "openspeaker_image"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "image_generation"
+    provider = "openspeaker"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.ASYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = ["requests"]
+    install_instructions = (
+        "Set the OPENSPEAKER_API_KEY environment variable in .env:\n"
+        "  OPENSPEAKER_API_KEY=your_key_here\n"
+        "Optionally set OPENSPEAKER_IMAGE_MODEL (default gpt-image-2).\n"
+        "List available models with GET https://api.ai33.pro/v1i/models\n"
+        "See docs/openspeaker-api.md"
+    )
+    fallback = None
+    fallback_tools = ["flux_image", "openai_image", "recraft_image"]
+    agent_skills = ["flux-best-practices", "visual-style"]
+
+    _MODEL_CACHE: Optional[dict[str, dict[str, Any]]] = None
+
+    capabilities = [
+        "text_to_image",
+        "image_to_image",
+        "reference_images",
+        "multi_model_routing",
+    ]
+    supports = {
+        "reference_images": True,
+        "aspect_ratio_control": True,
+        "resolution_control": True,
+        "offline": False,
+        "batch": True,
+    }
+    best_for = [
+        "one key across many frontier image models (GPT Image, Gemini, Seedream, FLUX, Recraft)",
+        "brand and marketing stills where accurate on-image text matters (recraft-v4.1)",
+        "reference-image-driven consistency across a scene set",
+    ]
+    not_good_for = [
+        "offline generation",
+        "guaranteed-deterministic reruns",
+    ]
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+            "prompt": {"type": "string", "description": "Image prompt."},
+            "model_id": {
+                "type": "string",
+                "description": "Model id from GET /v1i/models. Defaults to OPENSPEAKER_IMAGE_MODEL.",
+            },
+            "model": {"type": "string", "description": "Alias for model_id."},
+            "generations_count": {"type": "integer", "default": 1, "minimum": 1, "maximum": 4},
+            "aspect_ratio": {"type": "string", "description": "e.g. 16:9, 9:16, 1:1."},
+            "resolution": {"type": "string", "description": "e.g. 1K, 2K, 4K (model dependent)."},
+            "quality": {"type": "string", "description": "low|medium|high, where the model supports it."},
+            "model_parameters": {
+                "type": "object",
+                "description": "Raw passthrough; merged over aspect_ratio/resolution/quality.",
+            },
+            "reference_images": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Local paths uploaded as `assets`. Reference them in the prompt "
+                    "as @img1, @img2 — the count must match."
+                ),
+            },
+            "output_path": {"type": "string"},
+            "timeout_seconds": {"type": "integer", "default": 600},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=200, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=3, retryable_errors=["rate_limit", "timeout", "server_busy"])
+    idempotency_key_fields = ["prompt", "model_id", "aspect_ratio", "resolution"]
+    side_effects = ["writes image file(s) to output_path", "calls OpenSpeaker API", "consumes credits"]
+    user_visible_verification = [
+        "Open the generated image and check composition, on-image text spelling, and brand safety",
+    ]
+
+    def get_status(self) -> ToolStatus:
+        return ToolStatus.AVAILABLE if api_key() else ToolStatus.UNAVAILABLE
+
+    def get_info(self) -> dict[str, Any]:
+        info = super().get_info() if hasattr(super(), "get_info") else {}
+        info.update(
+            {
+                "default_model": self._default_model(),
+                "model_discovery": "GET /v1i/models",
+                "price_check": "POST /v1i/task/price",
+            }
+        )
+        return info
+
+    @staticmethod
+    def _default_model() -> str:
+        return (os.environ.get("OPENSPEAKER_IMAGE_MODEL") or "").strip() or DEFAULT_MODEL
+
+    def list_models(self) -> list[dict[str, Any]]:
+        """Live model catalogue. Useful for the agent at proposal time."""
+        payload = request("GET", "/v1i/models", timeout=30)
+        return payload.get("models", [])
+
+    @classmethod
+    def _model_spec(cls, model_id: str) -> dict[str, Any]:
+        """Return the catalogue entry for a model, cached for the process.
+
+        Model capabilities vary a lot (gemini-3.1-flash-lite-image is 1K-only,
+        gpt-image-2 goes to 4K, krea-* take no resolution at all). Fetching the
+        spec lets the tool drop parameters a model cannot accept instead of
+        failing the whole generation on an HTTP 400.
+        """
+        if cls._MODEL_CACHE is None:
+            try:
+                payload = request("GET", "/v1i/models", timeout=30)
+                cls._MODEL_CACHE = {
+                    m["model_id"]: m for m in payload.get("models", []) if m.get("model_id")
+                }
+            except OpenSpeakerError:
+                cls._MODEL_CACHE = {}
+        return cls._MODEL_CACHE.get(model_id, {})
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        # Billed in credits, not USD; actual credit_cost comes back on the task.
+        return 0.0
+
+    def _build_model_parameters(
+        self, inputs: dict[str, Any], model_id: str
+    ) -> tuple[dict[str, Any], list[str]]:
+        """Assemble model_parameters, dropping values this model rejects.
+
+        Returns (params, notes) where notes records every adjustment so the
+        agent sees what was changed rather than silently getting a different
+        image than it asked for.
+        """
+        params: dict[str, Any] = {}
+        notes: list[str] = []
+        spec = self._model_spec(model_id)
+
+        aspect = inputs.get("aspect_ratio") or os.environ.get("OPENSPEAKER_IMAGE_ASPECT_RATIO")
+        if aspect and str(aspect).strip():
+            aspect = str(aspect).strip()
+            allowed = spec.get("aspect_ratios")
+            if allowed and aspect not in allowed:
+                fallback = spec.get("default_aspect_ratio")
+                notes.append(
+                    f"aspect_ratio {aspect!r} unsupported by {model_id} "
+                    f"(allowed: {allowed}); used {fallback!r}"
+                )
+                aspect = fallback
+            if aspect:
+                params["aspect_ratio"] = aspect
+
+        resolution = inputs.get("resolution") or os.environ.get("OPENSPEAKER_IMAGE_RESOLUTION")
+        if resolution and str(resolution).strip():
+            # The API expects "2K"/"4K" uppercase; .env may hold "2k".
+            value = str(resolution).strip()
+            value = value.upper() if value.lower().endswith("k") else value
+            allowed = spec.get("resolutions")
+            if allowed is None and spec:
+                notes.append(f"{model_id} takes no resolution parameter; dropped {value!r}")
+                value = None
+            elif allowed and value not in allowed:
+                fallback = spec.get("default_resolution") or allowed[-1]
+                notes.append(
+                    f"resolution {value!r} unsupported by {model_id} "
+                    f"(allowed: {allowed}); used {fallback!r}"
+                )
+                value = fallback
+            if value:
+                params["resolution"] = value
+
+        quality = inputs.get("quality")
+        if quality:
+            allowed = spec.get("qualities")
+            if allowed and quality not in allowed:
+                notes.append(f"quality {quality!r} unsupported by {model_id}; dropped")
+            else:
+                params["quality"] = quality
+
+        params.update(inputs.get("model_parameters") or {})
+        return params, notes
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        start = time.time()
+        open_files: list = []
+        try:
+            result = self._generate(inputs, open_files)
+        except OpenSpeakerError as exc:
+            return ToolResult(success=False, error=f"OpenSpeaker image generation failed: {exc}")
+        except Exception as exc:  # noqa: BLE001 - surfaced to the agent as a tool error
+            return ToolResult(success=False, error=f"OpenSpeaker image generation failed: {exc}")
+        finally:
+            for handle in open_files:
+                try:
+                    handle.close()
+                except Exception:  # noqa: BLE001 - cleanup must never mask the real error
+                    pass
+        result.duration_seconds = round(time.time() - start, 2)
+        return result
+
+    def _generate(self, inputs: dict[str, Any], open_files: list) -> ToolResult:
+        prompt = inputs["prompt"]
+        model_id = (inputs.get("model_id") or inputs.get("model") or self._default_model()).strip()
+        count = int(inputs.get("generations_count", 1))
+        model_parameters, param_notes = self._build_model_parameters(inputs, model_id)
+
+        form: list[tuple[str, Any]] = [
+            ("prompt", (None, prompt)),
+            ("model_id", (None, model_id)),
+            ("generations_count", (None, str(count))),
+        ]
+        if model_parameters:
+            form.append(("model_parameters", (None, json.dumps(model_parameters))))
+
+        references = inputs.get("reference_images") or []
+        for ref in references:
+            ref_path = Path(ref)
+            if not ref_path.is_file():
+                raise OpenSpeakerError(f"reference image not found: {ref_path}")
+            handle = open(ref_path, "rb")
+            open_files.append(handle)
+            form.append(("assets", (ref_path.name, handle)))
+
+        created = request("POST", "/v1i/task/generate-image", files=form, timeout=120)
+        task_id = created.get("task_id")
+        if not task_id:
+            raise OpenSpeakerError(f"No task_id in create response: {created}")
+
+        task = poll_task(task_id, timeout_seconds=int(inputs.get("timeout_seconds", 600)))
+        urls = self._extract_image_urls(task)
+        if not urls:
+            raise OpenSpeakerError(
+                f"Task {task_id} finished without image urls: {task.get('metadata')}"
+            )
+
+        output_path = Path(inputs.get("output_path") or f"openspeaker_image_{task_id}.png")
+        written: list[str] = []
+        for index, url in enumerate(urls[:count]):
+            target = (
+                output_path
+                if index == 0
+                else output_path.with_name(f"{output_path.stem}_{index + 1}{output_path.suffix}")
+            )
+            download(url, target)
+            written.append(str(target))
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": self.provider,
+                "model_id": model_id,
+                "model_parameters": model_parameters,
+                "parameter_adjustments": param_notes,
+                "task_id": task_id,
+                "credit_cost": task.get("credit_cost"),
+                "generations": len(written),
+                "prompt": prompt,
+                "output": written[0],
+                "outputs": written,
+            },
+            artifacts=written,
+            model=model_id,
+        )
+
+    # Observed shape (2026-08): metadata.result_images[] = [{id, width, height,
+    # imageUrl, mimeType, previewUrl}]. Note imageUrl is camelCase — the older
+    # snake_case spellings are kept as fallbacks in case the API varies.
+    _URL_KEYS = ("imageUrl", "image_url", "url", "outputUrl", "output_url")
+
+    @classmethod
+    def _extract_image_urls(cls, task: dict[str, Any]) -> list[str]:
+        """Pull full-resolution image urls out of the task metadata.
+
+        `previewUrl` is deliberately not used as a primary source — it is a
+        downscaled proxy, and silently shipping previews as final assets would
+        be a quality regression nobody would notice until render.
+        """
+        metadata = task.get("metadata") or {}
+        candidates: list[str] = []
+
+        for key in ("result_images", "image_urls", "all_image_urls", "images", "urls"):
+            value = metadata.get(key)
+            if isinstance(value, list):
+                for item in value:
+                    if isinstance(item, str):
+                        candidates.append(item)
+                    elif isinstance(item, dict):
+                        url = next(
+                            (item[k] for k in cls._URL_KEYS if isinstance(item.get(k), str)),
+                            None,
+                        )
+                        if url:
+                            candidates.append(url)
+
+        for key in ("image_url", "url", "output_url"):
+            value = metadata.get(key)
+            if isinstance(value, str):
+                candidates.append(value)
+
+        result = metadata.get("imagen_result") or metadata.get("result") or {}
+        if isinstance(result, dict):
+            for item in result.get("images", []) or []:
+                if isinstance(item, dict):
+                    url = next(
+                        (item[k] for k in cls._URL_KEYS if isinstance(item.get(k), str)), None
+                    )
+                    if url:
+                        candidates.append(url)
+                elif isinstance(item, str):
+                    candidates.append(item)
+
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for url in candidates:
+            if url not in seen:
+                seen.add(url)
+                ordered.append(url)
+        return ordered

--- a/tools/openspeaker_client.py
+++ b/tools/openspeaker_client.py
@@ -12,9 +12,11 @@ from __future__ import annotations
 
 import os
 import random
+import tempfile
 import time
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import urlparse
 
 import requests
 
@@ -196,16 +198,87 @@ def poll_task(
     raise OpenSpeakerError(f"Task {task_id} did not finish within {timeout_seconds}s")
 
 
-def download(url: str, output_path: Path, *, timeout: int = 300) -> Path:
-    """Stream a result URL to disk. Result URLs are pre-signed — no auth header."""
-    output_path.parent.mkdir(parents=True, exist_ok=True)
+# A generated asset that legitimately exceeds this is a bug, not a big render.
+MAX_DOWNLOAD_BYTES = 512 * 1024 * 1024
+
+
+def allowed_roots() -> list[Path]:
+    """Directories these tools may read from and write to.
+
+    The project tree plus the system temp dir. These tools run inside an agent
+    loop that ingests untrusted material (reference videos, web pages), so a
+    path arriving in a tool call is not necessarily one a human chose.
+    """
+    roots = [Path.cwd().resolve(), Path(tempfile.gettempdir()).resolve()]
+    extra = os.environ.get("OPENMONTAGE_EXTRA_MEDIA_ROOTS", "")
+    roots += [Path(p).expanduser().resolve() for p in extra.split(os.pathsep) if p.strip()]
+    return roots
+
+
+def _is_contained(path: Path, roots: list[Path]) -> bool:
+    for root in roots:
+        try:
+            path.relative_to(root)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def safe_media_path(candidate: str | Path, *, must_exist: bool = False) -> Path:
+    """Resolve a caller-supplied media path, refusing to escape the workspace.
+
+    Resolution happens BEFORE the containment test so that `../` sequences and
+    symlinks pointing outside the tree are both caught. Set
+    OPENMONTAGE_EXTRA_MEDIA_ROOTS (os.pathsep-separated) to widen the allowlist
+    deliberately rather than by accident.
+    """
+    path = Path(candidate).expanduser()
+    resolved = (Path.cwd() / path).resolve() if not path.is_absolute() else path.resolve()
+
+    if not _is_contained(resolved, allowed_roots()):
+        raise OpenSpeakerError(
+            f"refusing to use path outside the allowed roots: {resolved}. "
+            "Media must live under the project tree or the system temp dir. "
+            "Set OPENMONTAGE_EXTRA_MEDIA_ROOTS to widen this deliberately."
+        )
+    if must_exist and not resolved.is_file():
+        raise OpenSpeakerError(f"file not found: {resolved}")
+    return resolved
+
+
+def download(
+    url: str, output_path: Path, *, timeout: int = 300, max_bytes: int = MAX_DOWNLOAD_BYTES
+) -> Path:
+    """Stream a result URL to disk. Result URLs are pre-signed — no auth header.
+
+    The URL comes back from the API rather than from the caller, so it is
+    treated as untrusted: https only, and the write is capped so a malformed or
+    hostile response cannot fill the disk.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise OpenSpeakerError(f"refusing to download from non-https url: {parsed.scheme}://…")
+
+    target = safe_media_path(output_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    written = 0
     with requests.get(url, stream=True, timeout=timeout) as response:
         response.raise_for_status()
-        with open(output_path, "wb") as handle:
+        with open(target, "wb") as handle:
             for chunk in response.iter_content(chunk_size=1 << 16):
-                if chunk:
-                    handle.write(chunk)
-    return output_path
+                if not chunk:
+                    continue
+                written += len(chunk)
+                if written > max_bytes:
+                    handle.close()
+                    target.unlink(missing_ok=True)
+                    raise OpenSpeakerError(
+                        f"download exceeded {max_bytes} bytes and was aborted: {target.name}"
+                    )
+                handle.write(chunk)
+    return target
 
 
 def credits_remaining() -> Optional[int]:

--- a/tools/openspeaker_client.py
+++ b/tools/openspeaker_client.py
@@ -1,0 +1,218 @@
+"""Shared HTTP client for the OpenSpeaker API (api.ai33.pro).
+
+All OpenSpeaker generation endpoints are asynchronous: the create call returns a
+`task_id`, and the caller polls `GET /v1/task/{task_id}` until the task reaches a
+terminal state. This module centralises auth, polling, rate-limit handling, and
+artifact download so the individual tools stay thin.
+
+See docs/openspeaker-api.md for the full API surface.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+import requests
+
+# Importing base_tool loads .env into os.environ (module-level side effect), so
+# this client works when used directly, not only via a BaseTool subclass.
+# base_tool does not import this module, so there is no cycle.
+import tools.base_tool  # noqa: F401
+
+DEFAULT_BASE_URL = "https://api.ai33.pro"
+
+# Terminal task states reported by GET /v1/task/{id}.
+_DONE = "done"
+_FAILED_STATES = {"failed", "error", "cancelled", "canceled"}
+
+# Error codes that mean "try again", not "this request was wrong".
+_TRANSIENT_CODES = {"server_busy", "rate_limited", "too_many_requests"}
+
+
+class OpenSpeakerError(RuntimeError):
+    """Raised when the OpenSpeaker API returns an unrecoverable error."""
+
+
+def api_key() -> str:
+    """Return the configured key, or "" when unset."""
+    return (os.environ.get("OPENSPEAKER_API_KEY") or "").strip()
+
+
+def base_url() -> str:
+    return (os.environ.get("OPENSPEAKER_BASE_URL") or DEFAULT_BASE_URL).strip().rstrip("/")
+
+
+def _headers() -> dict[str, str]:
+    key = api_key()
+    if not key:
+        raise OpenSpeakerError(
+            "OPENSPEAKER_API_KEY is not set. Add it to .env "
+            "(see docs/openspeaker-api.md)."
+        )
+    return {"xi-api-key": key}
+
+
+def _sleep_for_retry(response: requests.Response, attempt: int) -> float:
+    """Honour Retry-After when present, else exponential backoff with jitter."""
+    retry_after = response.headers.get("Retry-After")
+    if retry_after:
+        try:
+            return max(0.0, float(retry_after))
+        except ValueError:
+            pass
+    return min(30.0, (2 ** attempt)) + random.uniform(0, 1)
+
+
+def request(
+    method: str,
+    path: str,
+    *,
+    data: Optional[dict[str, Any]] = None,
+    files: Optional[list] = None,
+    json_body: Optional[dict[str, Any]] = None,
+    params: Optional[dict[str, Any]] = None,
+    timeout: int = 60,
+    max_retries: int = 4,
+) -> dict[str, Any]:
+    """Make an authenticated request, retrying 429s and transient 5xxs.
+
+    HTTP 429 is a rate-limit violation (honour Retry-After); HTTP 503 with code
+    `server_busy` is capacity pressure and is also retryable per the API docs.
+    """
+    url = f"{base_url()}{path}"
+    last_error = ""
+    for attempt in range(max_retries + 1):
+        try:
+            response = requests.request(
+                method,
+                url,
+                headers=_headers(),
+                data=data,
+                files=files,
+                json=json_body,
+                params=params,
+                timeout=timeout,
+            )
+        except requests.RequestException as exc:
+            last_error = f"network error: {exc}"
+            if attempt >= max_retries:
+                break
+            time.sleep(min(30.0, 2 ** attempt) + random.uniform(0, 1))
+            continue
+
+        if response.status_code == 429 or (
+            response.status_code == 503 and "server_busy" in response.text
+        ):
+            last_error = f"HTTP {response.status_code}: {response.text[:200]}"
+            if attempt >= max_retries:
+                break
+            time.sleep(_sleep_for_retry(response, attempt))
+            continue
+
+        if response.status_code >= 400:
+            raise OpenSpeakerError(f"HTTP {response.status_code}: {response.text[:400]}")
+
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise OpenSpeakerError(f"Non-JSON response from {path}: {exc}") from exc
+
+        # The API also signals back-pressure as HTTP 200 with an error body
+        # ({"success": false, "code": "server_busy"}). Without this branch the
+        # caller would treat the envelope as a task payload and poll forever.
+        if isinstance(payload, dict) and payload.get("success") is False:
+            code = str(payload.get("code") or "")
+            message = str(payload.get("message") or "")
+            if code in _TRANSIENT_CODES:
+                last_error = f"{code}: {message}"
+                if attempt >= max_retries:
+                    break
+                time.sleep(_sleep_for_retry(response, attempt))
+                continue
+            raise OpenSpeakerError(f"{path} returned {code or 'error'}: {message}")
+
+        return payload
+
+    raise OpenSpeakerError(f"{path} failed after {max_retries} retries. {last_error}")
+
+
+_TRANSIENT_MARKERS = ("server_busy", "HTTP 503", "HTTP 429", "network error")
+
+
+def poll_task(
+    task_id: str,
+    *,
+    timeout_seconds: int = 900,
+    interval_seconds: float = 3.0,
+    on_progress=None,
+) -> dict[str, Any]:
+    """Poll GET /v1/task/{id} until terminal. Returns the final task payload.
+
+    Detail polling costs 1 rate-limit token per call, so this uses a steady
+    interval rather than a tight loop.
+
+    A busy poll endpoint must not abort the whole wait: the generation task is
+    already running and paid for. Transient poll failures (`server_busy`, 429,
+    network blips) are absorbed and retried until the overall deadline; only a
+    genuinely failed task, or repeated hard errors, stop the loop.
+    """
+    deadline = time.time() + timeout_seconds
+    last_progress = -1
+    hard_errors = 0
+    while time.time() < deadline:
+        try:
+            # max_retries=0: this loop owns the retry cadence, not request().
+            task = request("GET", f"/v1/task/{task_id}", timeout=30, max_retries=0)
+            hard_errors = 0
+        except OpenSpeakerError as exc:
+            message = str(exc)
+            if any(marker in message for marker in _TRANSIENT_MARKERS):
+                time.sleep(min(15.0, interval_seconds * 2) + random.uniform(0, 1))
+                continue
+            hard_errors += 1
+            if hard_errors >= 3:
+                raise
+            time.sleep(interval_seconds)
+            continue
+
+        status = str(task.get("status", "")).lower()
+        progress = task.get("progress")
+        if on_progress and progress is not None and progress != last_progress:
+            last_progress = progress
+            on_progress(progress, status)
+
+        if status == _DONE:
+            return task
+        if status in _FAILED_STATES:
+            raise OpenSpeakerError(
+                f"Task {task_id} {status}: {task.get('error_message') or 'no error message'}"
+            )
+        time.sleep(interval_seconds)
+
+    raise OpenSpeakerError(f"Task {task_id} did not finish within {timeout_seconds}s")
+
+
+def download(url: str, output_path: Path, *, timeout: int = 300) -> Path:
+    """Stream a result URL to disk. Result URLs are pre-signed — no auth header."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with requests.get(url, stream=True, timeout=timeout) as response:
+        response.raise_for_status()
+        with open(output_path, "wb") as handle:
+            for chunk in response.iter_content(chunk_size=1 << 16):
+                if chunk:
+                    handle.write(chunk)
+    return output_path
+
+
+def credits_remaining() -> Optional[int]:
+    """Return the account credit balance, or None when the call fails."""
+    try:
+        payload = request("GET", "/v1/credits", timeout=20)
+    except OpenSpeakerError:
+        return None
+    value = payload.get("credits")
+    return int(value) if isinstance(value, (int, float, str)) and str(value).isdigit() else value


### PR DESCRIPTION
Adds five `BaseTool` providers and the OpenSpeaker API reference. On a machine with these keys configured this takes `tts` from 0/6 → 1/7 and `image_generation` from 0/11 → 5/13. Everything routes through the existing selectors — no selector changes needed, since they auto-discover by capability.

Built and exercised end to end while producing a real 63s explainer, so these have generated actual narration, music, and stills rather than just passing a smoke test.

## Tools

| Tool | Capability | Notes |
|---|---|---|
| `openspeaker_tts` | `tts` | ElevenLabs / Minimax / Edge / Kokoro / Vbee / Fish Audio + cloned voices via one v3 endpoint |
| `openspeaker_music` | `music_generation` | Suno, simple + custom modes, returns all takes |
| `openspeaker_image` | `image_generation` | Imagen, ~20 models |
| `fal_gpt_image` | `image_generation` | GPT Image 2, synchronous |
| `openspeaker_client` | — | Shared async task/polling/auth layer |

## Design notes worth reviewing

**The v3 TTS endpoint has no `model` field.** The provider-prefixed `voice_id` *is* the model selector. A bare ElevenLabs model id like `eleven_multilingual_v2` looks plausible in config and fails at call time with an opaque error, so `get_status()` returns `DEGRADED` and `get_info()` explains the problem rather than letting it surface mid-render.

**Image model capabilities vary a lot** — `gemini-3.1-flash-lite-image` is 1K-only, `gpt-image-2` goes to 4K, `krea-*` take no `resolution` at all. `openspeaker_image` fetches the catalogue once (cached per process) and clamps unsupported values instead of failing the generation on an HTTP 400. Every adjustment is returned in `data.parameter_adjustments` rather than applied silently.

**fal rejects the obvious "1K 16:9".** 1024×576 is 589,824px, under fal's 655,360 minimum. `_resolve_size` snaps to 1280×720 (the smallest compliant 16:9) and reports it.

## Three API behaviours found the hard way

1. `server_busy` arrives **both** as HTTP 503 **and** as HTTP 200 with `{"success": false}` in the body. Treating the second as a task payload makes the poller spin until timeout on a task that has already finished.
2. A busy poll endpoint must not abort the wait — the generation is already running and paid for. Transient poll failures are absorbed until the overall deadline; only genuine task failure or repeated hard errors stop the loop.
3. Completed image tasks return `metadata.result_images[].imageUrl` (camelCase). `previewUrl` sits alongside it and is a downscaled proxy — easy to ship as a final asset by accident, so it is explicitly excluded.

## Not included

Provider-specific Layer 3 skills under `.agents/skills/`. Happy to add them if you'd like the prompting guidance to live alongside the tools.

## Testing

- All four register as `available` with keys set, `unavailable` without.
- `BaseTool` contract verified: schemas, `install_instructions`, `fallback_tools`, `get_status`, `estimate_cost`.
- Live end-to-end: 13 TTS segments, 1 Suno bed (2 takes), 4 fal images.
- Per-model clamping verified against `gemini-3.1-flash-lite-image`, `gpt-image-2`, `krea-2-medium`.
- URL extraction verified against a captured real payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)