### PR TITLE
Add VLM-based semantic footage rating tools

### DIFF
--- a/.agents/skills/vlm-footage-rating/SKILL.md
+++ b/.agents/skills/vlm-footage-rating/SKILL.md
@@ -31,8 +31,30 @@ adding footage only processes the new clips.
 ## Prerequisites
 
 - ffmpeg/ffprobe on PATH
-- Ollama running with a vision model: `ollama pull gemma4:12b` (12B, ~8GB
-  VRAM) or `gemma3n:4b` for smaller GPUs
+- Ollama running with a vision model.
+
+**Recommended and tested: `gemma4:12b`** (this is the model the tools were
+built and validated against: ~8GB VRAM, best quality for behavior nuance).
+The behavior taxonomy, JSON schema, and prompts were tuned on it.
+
+```bash
+ollama pull gemma4:12b
+```
+
+Other vision models may work (the tools are model-agnostic over Ollama's
+API), but they are NOT tested:
+
+| Model | VRAM (approx) | Fits | Status |
+|---|---|---|---|
+| `gemma3n:e4b` | ~3.5GB | 4GB GPUs | Untested, smaller/faster |
+| `gemma3n:e2b` | ~1.5GB | any GPU | Untested, fastest/lightest |
+| `qwen2.5vl:3b` | ~3GB | 4GB GPUs | Untested |
+| `qwen2.5vl:7b` | ~6GB | 8GB GPUs | Untested |
+| `gemma4:12b` | ~8GB | 12GB+ GPUs | **TESTED, recommended** |
+
+If you try a smaller model, expect possible differences in JSON
+conformance and rating quality; the defensive parsing handles most drift.
+For 4b-class models, passing `frame_scale: 384` speeds up inference.
 
 ## Usage
 

--- a/.agents/skills/vlm-footage-rating/SKILL.md
+++ b/.agents/skills/vlm-footage-rating/SKILL.md
@@ -33,6 +33,10 @@ adding footage only processes the new clips.
 - ffmpeg/ffprobe on PATH
 - Ollama running with a vision model.
 
+The tools accept only `localhost` or loopback-IP Ollama URLs. Video frames
+are base64-encoded in requests, so remote endpoints are rejected to preserve
+the advertised local-only privacy boundary.
+
 **Recommended and tested: `gemma4:12b`** (this is the model the tools were
 built and validated against: ~8GB VRAM, best quality for behavior nuance).
 The behavior taxonomy, JSON schema, and prompts were tuned on it.

--- a/.agents/skills/vlm-footage-rating/SKILL.md
+++ b/.agents/skills/vlm-footage-rating/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: vlm-footage-rating
+description: Semantic video understanding for footage selection. Use when a clip library needs to be rated by behavior, camera stability, subject visibility, composition, or temporal structure; when clips must be selected for a montage by semantics instead of filename; when the editor needs frame-accurate timestamps of interesting moments; or when two candidate clips need a relative comparison with reasoning. Works fully local with an Ollama vision model (e.g. Gemma 4 12B, Gemma 3n, Qwen-VL). No API keys required.
+license: MIT
+metadata:
+  requires:
+    env: []
+    ollama: true
+---
+
+# VLM Footage Rating (Semantic Video Understanding)
+
+Rate a folder of video clips with a local vision-language model and get an
+editorial database: behavior, camera quality, composition, subject (product)
+visibility, timestamped segments, highlights, rankings, and match-cut
+continuity. This is the layer static CLIP retrieval cannot provide:
+temporal and behavioral semantics.
+
+## Pipeline Overview
+
+```
+vlm_clip_rating        -> clip_tags.jsonl      (coarse: behavior/camera/shot/subject/segments)
+vlm_zoom_rating        -> clip_zooms.jsonl     (frame-accurate timestamps + deep-dive descriptions)
+vlm_editorial_ranking  -> editorial_rankings.json (composite scores, leaderboards, match cuts)
+vlm_comparative_rank   -> comparative_rankings.jsonl (optional: relative ranking with reasoning)
+```
+
+Each stage is idempotent (skips already-processed clips), so re-running after
+adding footage only processes the new clips.
+
+## Prerequisites
+
+- ffmpeg/ffprobe on PATH
+- Ollama running with a vision model: `ollama pull gemma4:12b` (12B, ~8GB
+  VRAM) or `gemma3n:4b` for smaller GPUs
+
+## Usage
+
+### 1. Coarse rating
+
+```python
+from tools.video.vlm_clip_rating import VlmClipRating
+tool = VlmClipRating()
+tool.execute({
+    "input_dir": "/path/to/clips",
+    "output_path": "/path/to/clip_tags.jsonl",
+    "focus_prompt": "a black collar (the product being advertised)",
+    "model": "gemma4:12b",
+})
+```
+
+`focus_prompt` is optional: set it to whatever subject the edit cares about
+(a product, an animal behavior, a person) and the model rates its visibility
+in every clip. Leave empty for generic footage rating.
+
+### 2. Zoom pass (frame-accurate timestamps)
+
+```python
+from tools.video.vlm_zoom_rating import VlmZoomRating
+VlmZoomRating().execute({
+    "ratings_path": "/path/to/clip_tags.jsonl",
+    "output_path": "/path/to/clip_zooms.jsonl",
+})
+```
+
+Re-examines each flagged highlight/segment at 4 fps, producing sub-beats with
+precise start/end times, camera angle, subject facing direction (for match
+cuts), deep-dive descriptions, and vibe.
+
+### 3. Editorial ranking
+
+```python
+from tools.video.vlm_editorial_ranking import VlmEditorialRanking
+VlmEditorialRanking().execute({
+    "ratings_path": "/path/to/clip_tags.jsonl",
+    "zooms_path": "/path/to/clip_zooms.jsonl",   # optional
+    "output_path": "/path/to/editorial_rankings.json",
+    "weights": {"stability": 0.25, "quality": 0.25, "subject": 0.25,
+                "composition": 0.15, "vibe": 0.10},
+})
+```
+
+Weights must sum to 1.0 and are campaign-tunable (bias toward product shots,
+stability, or energy).
+
+### 4. Comparative ranking (optional tiebreaker)
+
+```python
+from tools.video.vlm_comparative_rank import VlmComparativeRank
+VlmComparativeRank().execute({
+    "rankings_path": "/path/to/editorial_rankings.json",
+    "output_path": "/path/to/comparative_rankings.jsonl",
+    "purpose": "subject_hero",
+})
+```
+
+Shows 4 candidate clips in one context, asks for a relative ranking,
+calibrated scores, and reasons for best/worst. Use when two clips score
+close and you want the model to argue about which wins.
+
+## Output Schema Highlights
+
+| Field | Meaning |
+|---|---|
+| `overall.behavior` | walking_calm, pulling, sniffing, trotting, sitting, lying, greeting, playing, expression, other |
+| `overall.energy` | calm, neutral, excited, hyper |
+| `camera.stability_score` | 0-1 camera shake quality |
+| `shot.type` | extreme_wide ... extreme_close_up |
+| `shot.rule_of_thirds_score` | 0-1 composition |
+| `product.subject_visibility` | not_visible, partial, clear, featured |
+| `product.subject_quality_score` | 0-1 how well the subject of interest is shown |
+| `segments[].start_s/end_s` | coarse timestamped beats |
+| `highlights[].start_s/end_s` | keeper moments (coarse) |
+| zoom `sub_beats[]` | frame-accurate beats: start_s/end_s, camera_angle, subject_facing, deep_dive, vibe, use |
+
+## Editing Recipes
+
+- **Subject hero shots**: filter `product.subject_visibility` in
+  ("featured", "clear"), rank by `subject_quality_score`.
+- **Stability gate**: only use clips with `camera.stability_score >= 0.9`.
+- **Match cuts**: `editorial_rankings.json` -> `match_cuts` -> chains by
+  subject facing direction (left/right). Cut same-direction shots together.
+- **Story beats**: pick behavior buckets (open wide, calm walk, action,
+  subject close-up) and use zoom timestamps for precise cut points.
+
+## Pitfalls
+
+- The VLM occasionally emits malformed JSON (string entries in arrays,
+  non-numeric timestamps). The tools guard this; if you hand-parse the
+  JSONL, filter `isinstance(x, dict)` and use safe float conversion.
+- Zoom sub-beat timestamps are window-relative: real clip time is
+  `window_start_s + sub_beat.start_s`.
+- First clip per run is slower (model load). Subsequent clips are ~5-15s.
+- Runtime scales with clip count: ~8-15s per clip for coarse, ~30s per
+  zoom window. Budget accordingly for large libraries.

--- a/.claude/skills/vlm-footage-rating/SKILL.md
+++ b/.claude/skills/vlm-footage-rating/SKILL.md
@@ -31,8 +31,30 @@ adding footage only processes the new clips.
 ## Prerequisites
 
 - ffmpeg/ffprobe on PATH
-- Ollama running with a vision model: `ollama pull gemma4:12b` (12B, ~8GB
-  VRAM) or `gemma3n:4b` for smaller GPUs
+- Ollama running with a vision model.
+
+**Recommended and tested: `gemma4:12b`** (this is the model the tools were
+built and validated against: ~8GB VRAM, best quality for behavior nuance).
+The behavior taxonomy, JSON schema, and prompts were tuned on it.
+
+```bash
+ollama pull gemma4:12b
+```
+
+Other vision models may work (the tools are model-agnostic over Ollama's
+API), but they are NOT tested:
+
+| Model | VRAM (approx) | Fits | Status |
+|---|---|---|---|
+| `gemma3n:e4b` | ~3.5GB | 4GB GPUs | Untested, smaller/faster |
+| `gemma3n:e2b` | ~1.5GB | any GPU | Untested, fastest/lightest |
+| `qwen2.5vl:3b` | ~3GB | 4GB GPUs | Untested |
+| `qwen2.5vl:7b` | ~6GB | 8GB GPUs | Untested |
+| `gemma4:12b` | ~8GB | 12GB+ GPUs | **TESTED, recommended** |
+
+If you try a smaller model, expect possible differences in JSON
+conformance and rating quality; the defensive parsing handles most drift.
+For 4b-class models, passing `frame_scale: 384` speeds up inference.
 
 ## Usage
 

--- a/.claude/skills/vlm-footage-rating/SKILL.md
+++ b/.claude/skills/vlm-footage-rating/SKILL.md
@@ -33,6 +33,10 @@ adding footage only processes the new clips.
 - ffmpeg/ffprobe on PATH
 - Ollama running with a vision model.
 
+The tools accept only `localhost` or loopback-IP Ollama URLs. Video frames
+are base64-encoded in requests, so remote endpoints are rejected to preserve
+the advertised local-only privacy boundary.
+
 **Recommended and tested: `gemma4:12b`** (this is the model the tools were
 built and validated against: ~8GB VRAM, best quality for behavior nuance).
 The behavior taxonomy, JSON schema, and prompts were tuned on it.

--- a/.claude/skills/vlm-footage-rating/SKILL.md
+++ b/.claude/skills/vlm-footage-rating/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: vlm-footage-rating
+description: Semantic video understanding for footage selection. Use when a clip library needs to be rated by behavior, camera stability, subject visibility, composition, or temporal structure; when clips must be selected for a montage by semantics instead of filename; when the editor needs frame-accurate timestamps of interesting moments; or when two candidate clips need a relative comparison with reasoning. Works fully local with an Ollama vision model (e.g. Gemma 4 12B, Gemma 3n, Qwen-VL). No API keys required.
+license: MIT
+metadata:
+  requires:
+    env: []
+    ollama: true
+---
+
+# VLM Footage Rating (Semantic Video Understanding)
+
+Rate a folder of video clips with a local vision-language model and get an
+editorial database: behavior, camera quality, composition, subject (product)
+visibility, timestamped segments, highlights, rankings, and match-cut
+continuity. This is the layer static CLIP retrieval cannot provide:
+temporal and behavioral semantics.
+
+## Pipeline Overview
+
+```
+vlm_clip_rating        -> clip_tags.jsonl      (coarse: behavior/camera/shot/subject/segments)
+vlm_zoom_rating        -> clip_zooms.jsonl     (frame-accurate timestamps + deep-dive descriptions)
+vlm_editorial_ranking  -> editorial_rankings.json (composite scores, leaderboards, match cuts)
+vlm_comparative_rank   -> comparative_rankings.jsonl (optional: relative ranking with reasoning)
+```
+
+Each stage is idempotent (skips already-processed clips), so re-running after
+adding footage only processes the new clips.
+
+## Prerequisites
+
+- ffmpeg/ffprobe on PATH
+- Ollama running with a vision model: `ollama pull gemma4:12b` (12B, ~8GB
+  VRAM) or `gemma3n:4b` for smaller GPUs
+
+## Usage
+
+### 1. Coarse rating
+
+```python
+from tools.video.vlm_clip_rating import VlmClipRating
+tool = VlmClipRating()
+tool.execute({
+    "input_dir": "/path/to/clips",
+    "output_path": "/path/to/clip_tags.jsonl",
+    "focus_prompt": "a black collar (the product being advertised)",
+    "model": "gemma4:12b",
+})
+```
+
+`focus_prompt` is optional: set it to whatever subject the edit cares about
+(a product, an animal behavior, a person) and the model rates its visibility
+in every clip. Leave empty for generic footage rating.
+
+### 2. Zoom pass (frame-accurate timestamps)
+
+```python
+from tools.video.vlm_zoom_rating import VlmZoomRating
+VlmZoomRating().execute({
+    "ratings_path": "/path/to/clip_tags.jsonl",
+    "output_path": "/path/to/clip_zooms.jsonl",
+})
+```
+
+Re-examines each flagged highlight/segment at 4 fps, producing sub-beats with
+precise start/end times, camera angle, subject facing direction (for match
+cuts), deep-dive descriptions, and vibe.
+
+### 3. Editorial ranking
+
+```python
+from tools.video.vlm_editorial_ranking import VlmEditorialRanking
+VlmEditorialRanking().execute({
+    "ratings_path": "/path/to/clip_tags.jsonl",
+    "zooms_path": "/path/to/clip_zooms.jsonl",   # optional
+    "output_path": "/path/to/editorial_rankings.json",
+    "weights": {"stability": 0.25, "quality": 0.25, "subject": 0.25,
+                "composition": 0.15, "vibe": 0.10},
+})
+```
+
+Weights must sum to 1.0 and are campaign-tunable (bias toward product shots,
+stability, or energy).
+
+### 4. Comparative ranking (optional tiebreaker)
+
+```python
+from tools.video.vlm_comparative_rank import VlmComparativeRank
+VlmComparativeRank().execute({
+    "rankings_path": "/path/to/editorial_rankings.json",
+    "output_path": "/path/to/comparative_rankings.jsonl",
+    "purpose": "subject_hero",
+})
+```
+
+Shows 4 candidate clips in one context, asks for a relative ranking,
+calibrated scores, and reasons for best/worst. Use when two clips score
+close and you want the model to argue about which wins.
+
+## Output Schema Highlights
+
+| Field | Meaning |
+|---|---|
+| `overall.behavior` | walking_calm, pulling, sniffing, trotting, sitting, lying, greeting, playing, expression, other |
+| `overall.energy` | calm, neutral, excited, hyper |
+| `camera.stability_score` | 0-1 camera shake quality |
+| `shot.type` | extreme_wide ... extreme_close_up |
+| `shot.rule_of_thirds_score` | 0-1 composition |
+| `product.subject_visibility` | not_visible, partial, clear, featured |
+| `product.subject_quality_score` | 0-1 how well the subject of interest is shown |
+| `segments[].start_s/end_s` | coarse timestamped beats |
+| `highlights[].start_s/end_s` | keeper moments (coarse) |
+| zoom `sub_beats[]` | frame-accurate beats: start_s/end_s, camera_angle, subject_facing, deep_dive, vibe, use |
+
+## Editing Recipes
+
+- **Subject hero shots**: filter `product.subject_visibility` in
+  ("featured", "clear"), rank by `subject_quality_score`.
+- **Stability gate**: only use clips with `camera.stability_score >= 0.9`.
+- **Match cuts**: `editorial_rankings.json` -> `match_cuts` -> chains by
+  subject facing direction (left/right). Cut same-direction shots together.
+- **Story beats**: pick behavior buckets (open wide, calm walk, action,
+  subject close-up) and use zoom timestamps for precise cut points.
+
+## Pitfalls
+
+- The VLM occasionally emits malformed JSON (string entries in arrays,
+  non-numeric timestamps). The tools guard this; if you hand-parse the
+  JSONL, filter `isinstance(x, dict)` and use safe float conversion.
+- Zoom sub-beat timestamps are window-relative: real clip time is
+  `window_start_s + sub_beat.start_s`.
+- First clip per run is slower (model load). Subsequent clips are ~5-15s.
+- Runtime scales with clip count: ~8-15s per clip for coarse, ~30s per
+  zoom window. Budget accordingly for large libraries.

--- a/skills/INDEX.md
+++ b/skills/INDEX.md
@@ -284,6 +284,7 @@ Cross-cutting skills that apply to all pipelines:
 | Checkpoint Protocol | `meta/checkpoint-protocol.md` | When/how to checkpoint and request human approval |
 | Skill Creator | `meta/skill-creator.md` | Dynamically create new skills during pipeline runs |
 | Animation Runtime Selector | `meta/animation-runtime-selector.md` | Choose render runtime + animation library per scene |
+| Buzzback Footage Production | `meta/buzzback-production.md` | Cut dog-walk footage from AI ratings (behavior/collar/stability/match-cuts) |
 | Taste Direction | `meta/taste-direction.md` | Convert a brief into taste dials, anti-patterns, and reference strategy for proposal/playbook/atelier work |
 | Bespoke Composition (Atelier) | `meta/bespoke-composition.md` | Hand-author a composition from scratch (hero work) — no stock scene-types; routes art-direction → motion principles → engine mechanics → atelier render |
 
@@ -320,3 +321,4 @@ Claude Code accesses them via symlinks in `.claude/skills/`.
 | **AI Video/Image/TTS/Avatar (Kling Official)** | `kling-official` - official direct API auth, Classic/Turbo/Omni task protocols, multi-reference Omni syntax, internal Elements/Account Usage helpers, callback notes, TTS voice parameters, avatar/lip-sync face selection, error handling, and cost governance for `kling_official_video` / `kling_official_image` / `kling_tts` / `kling_avatar` / `kling_lip_sync` | Local OpenMontage skill |
 | **AI Video (Premium)** | `seedance-2-0` — preferred premium default (cinematic, trailer, multi-shot, lip-sync, synced audio); accessed via `seedance_video` (fal.ai) or `heygen_video` Avatar Shots | Local OpenMontage skill |
 | **Infrastructure** | `acestep`, `ltx2`, `playwright-recording` | `digitalsamba/claude-code-video-toolkit` |
+| **Video Understanding** | `vlm-footage-rating` | Local OpenMontage skill (VLM clip rating, zoom timestamps, editorial ranking) |

--- a/tests/tools/test_vlm_determinism_contract.py
+++ b/tests/tools/test_vlm_determinism_contract.py
@@ -1,0 +1,79 @@
+"""Metadata contract test: determinism claims must match seed support.
+
+The registry and planning layer read a tool's `determinism` attribute to
+decide whether it can be re-run reproducibly. This test locks the contract:
+
+  - A tool declaring Determinism.SEEDED MUST accept a `seed` input and
+    propagate it to the underlying inference (or the claim is a lie).
+  - VLM-based tools are stochastic by nature (nonzero-temperature Ollama
+    inference, no seed plumbing) and MUST declare STOCHASTIC.
+
+If this test fails, the tool metadata drifted from its runtime behaviour —
+fix the declaration, not the test.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from tools.base_tool import Determinism  # noqa: E402
+from tools.video.vlm_clip_rating import VlmClipRating  # noqa: E402
+from tools.video.vlm_comparative_rank import VlmComparativeRank  # noqa: E402
+from tools.video.vlm_zoom_rating import VlmZoomRating  # noqa: E402
+
+# The VLM rating tools use Ollama with a nonzero temperature and do not
+# expose or forward a seed. They are honest stochastic tools.
+VLM_TOOLS = [VlmClipRating, VlmZoomRating, VlmComparativeRank]
+
+
+class TestDeterminismMetadataContract(unittest.TestCase):
+    def test_vlm_tools_are_stochastic(self):
+        """VLM rating tools must NOT claim SEEDED without seed plumbing."""
+        for tool_cls in VLM_TOOLS:
+            tool = tool_cls()
+            self.assertEqual(
+                tool.determinism,
+                Determinism.STOCHASTIC,
+                f"{tool_cls.__name__} claims {tool.determinism.value} but "
+                f"does not accept/propagate a seed — it must be STOCHASTIC.",
+            )
+
+    def test_seeded_tools_expose_seed_parameter(self):
+        """Any tool claiming SEEDED must accept a `seed` input."""
+        import importlib
+        import pkgutil
+        import tools.video as video_pkg
+
+        for mod in pkgutil.iter_modules(video_pkg.__path__):
+            if not mod.name.startswith("vlm_"):
+                continue
+            module = importlib.import_module(f"tools.video.{mod.name}")
+            for attr in dir(module):
+                cls = getattr(module, attr)
+                if not isinstance(cls, type) or not hasattr(cls, "determinism"):
+                    continue
+                # instantiate only BaseTool subclasses
+                try:
+                    tool = cls()
+                except Exception:
+                    continue
+                if not hasattr(tool, "input_schema"):
+                    continue
+                if tool.determinism == Determinism.SEEDED:
+                    props = tool.input_schema.get("properties", {})
+                    self.assertIn(
+                        "seed",
+                        props,
+                        f"{cls.__name__} claims SEEDED but has no `seed` "
+                        f"parameter — either add seed plumbing or mark "
+                        f"STOCHASTIC.",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_vlm_rating_common.py
+++ b/tests/tools/test_vlm_rating_common.py
@@ -1,0 +1,119 @@
+"""Tests for vlm_rating_common: shared plumbing for the VLM rating family.
+
+Covers: defensive JSON parsing, safe float coercion, drift normalization,
+JSONL resume, and prompt building. No network or model needed.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from tools.video.vlm_rating_common import (  # noqa: E402
+    append_record,
+    build_behavior_taxonomy,
+    load_rated_ids,
+    normalize_drift,
+    parse_vlm_json,
+    safe_float,
+)
+
+
+class ParseVlmJsonTests(unittest.TestCase):
+    def test_strict_json_parses(self) -> None:
+        raw = '{"behavior": "walking_calm", "confidence": 0.9}'
+        result = parse_vlm_json(raw)
+        self.assertEqual(result["behavior"], "walking_calm")
+
+    def test_prose_wrapped_json_extracted(self) -> None:
+        raw = 'Sure! Here is my analysis:\n{"behavior": "pulling", "ok": true}\nHope that helps.'
+        result = parse_vlm_json(raw)
+        self.assertEqual(result["behavior"], "pulling")
+
+    def test_malformed_json_returns_error_dict(self) -> None:
+        raw = "not json at all {{{"
+        result = parse_vlm_json(raw)
+        self.assertIn("error", result)
+        self.assertIn("raw", result)
+
+    def test_empty_response_returns_error(self) -> None:
+        result = parse_vlm_json("")
+        self.assertIn("error", result)
+
+    def test_non_dict_json_returns_error(self) -> None:
+        result = parse_vlm_json("[1, 2, 3]")
+        self.assertIn("error", result)
+
+
+class SafeFloatTests(unittest.TestCase):
+    def test_plain_number(self) -> None:
+        self.assertEqual(safe_float(0.75), 0.75)
+
+    def test_numeric_string(self) -> None:
+        self.assertEqual(safe_float("0.5"), 0.5)
+
+    def test_garbage_string(self) -> None:
+        self.assertEqual(safe_float(": 6.25, "), 0.0)
+
+    def test_none_uses_default(self) -> None:
+        self.assertEqual(safe_float(None, 1.0), 1.0)
+
+
+class NormalizeDriftTests(unittest.TestCase):
+    def test_canonical_name_wins(self) -> None:
+        rec = {"subject_visibility": "clear"}
+        normalize_drift(rec, {"collar_visibility": ["product_visibility"]})
+        self.assertEqual(rec["subject_visibility"], "clear")
+
+    def test_alias_folded_to_canonical(self) -> None:
+        rec = {"product_visibility": "featured"}
+        normalize_drift(rec, {"collar_visibility": ["product_visibility"]})
+        self.assertIn("collar_visibility", rec)
+        self.assertEqual(rec["collar_visibility"], "featured")
+
+    def test_first_present_alias_used(self) -> None:
+        rec = {"purpose": "lifestyle"}
+        normalize_drift(rec, {"shot_purpose": ["purpose", "intent"]})
+        self.assertEqual(rec["shot_purpose"], "lifestyle")
+
+
+class JsonlIOTests(unittest.TestCase):
+    def test_append_and_load_roundtrip(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            path = str(Path(td) / "out.jsonl")
+            append_record(path, {"clip": "a.mp4", "behavior": "walking"})
+            append_record(path, {"clip": "b.mp4", "behavior": "sitting"})
+            rated = load_rated_ids(path)
+            self.assertEqual(rated, {"a.mp4", "b.mp4"})
+
+    def test_load_missing_file_returns_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            self.assertEqual(load_rated_ids(str(Path(td) / "nope.jsonl")), set())
+
+    def test_load_skips_bad_lines(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "out.jsonl"
+            path.write_text('{"clip": "a.mp4"}\nnot-json\n{"clip": "b.mp4"}\n')
+            self.assertEqual(load_rated_ids(str(path)), {"a.mp4", "b.mp4"})
+
+
+class BehaviorTaxonomyTests(unittest.TestCase):
+    def test_default_taxonomy(self) -> None:
+        tax = build_behavior_taxonomy()
+        self.assertIn("walking_calm", tax)
+        self.assertIn("other", tax)
+
+    def test_custom_labels_appended(self) -> None:
+        tax = build_behavior_taxonomy("chasing,drinking")
+        self.assertIn("chasing", tax)
+        self.assertIn("drinking", tax)
+        self.assertIn("walking_calm", tax)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_vlm_rating_common.py
+++ b/tests/tools/test_vlm_rating_common.py
@@ -10,6 +10,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
@@ -19,8 +20,10 @@ from tools.video.vlm_rating_common import (  # noqa: E402
     build_behavior_taxonomy,
     load_rated_ids,
     normalize_drift,
+    ollama_model_available,
     parse_vlm_json,
     safe_float,
+    validate_local_ollama_url,
 )
 
 
@@ -100,6 +103,46 @@ class JsonlIOTests(unittest.TestCase):
             path = Path(td) / "out.jsonl"
             path.write_text('{"clip": "a.mp4"}\nnot-json\n{"clip": "b.mp4"}\n')
             self.assertEqual(load_rated_ids(str(path)), {"a.mp4", "b.mp4"})
+
+    def test_load_does_not_mark_error_records_complete(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "out.jsonl"
+            path.write_text(
+                '{"clip": "retry.mp4", "error": "ollama down"}\n'
+                '{"clip": "done.mp4", "quality": {"overall_score": 0.8}}\n'
+            )
+            self.assertEqual(load_rated_ids(str(path)), {"done.mp4"})
+
+
+class OllamaRuntimeTests(unittest.TestCase):
+    def test_local_url_validation_accepts_loopback(self) -> None:
+        self.assertEqual(
+            validate_local_ollama_url("http://localhost:11434/"),
+            "http://localhost:11434",
+        )
+        self.assertEqual(
+            validate_local_ollama_url("http://[::1]:11434"),
+            "http://[::1]:11434",
+        )
+
+    def test_local_url_validation_rejects_remote_hosts(self) -> None:
+        with self.assertRaisesRegex(ValueError, "loopback"):
+            validate_local_ollama_url("https://ollama.example.com")
+
+    def test_model_status_checks_installed_tags(self) -> None:
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self):
+                return b'{"models": [{"name": "gemma4:12b"}]}'
+
+        with patch("urllib.request.urlopen", return_value=Response()):
+            self.assertTrue(ollama_model_available(model="gemma4:12b"))
+            self.assertFalse(ollama_model_available(model="missing:1b"))
 
 
 class BehaviorTaxonomyTests(unittest.TestCase):

--- a/tests/tools/test_vlm_rating_tools.py
+++ b/tests/tools/test_vlm_rating_tools.py
@@ -1,0 +1,331 @@
+"""Tests for the VLM clip rating tools.
+
+All Ollama HTTP calls are mocked so the suite runs with no model, no
+network, and no GPU. Frame extraction uses tiny synthetic videos generated
+with ffmpeg (color bars), so the tools exercise their real code paths.
+
+Covered tools: vlm_clip_rating, vlm_zoom_rating, vlm_editorial_ranking,
+vlm_comparative_rank.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from tools.base_tool import ToolResult  # noqa: E402
+from tools.video.vlm_clip_rating import VlmClipRating  # noqa: E402
+from tools.video.vlm_comparative_rank import VlmComparativeRank  # noqa: E402
+from tools.video.vlm_editorial_ranking import VlmEditorialRanking  # noqa: E402
+from tools.video.vlm_zoom_rating import VlmZoomRating  # noqa: E402
+
+
+def make_test_video(path: Path, seconds: float = 2.0) -> None:
+    """Generate a tiny synthetic video (color bars + tone) with ffmpeg."""
+    subprocess.run(
+        [
+            "ffmpeg", "-y", "-v", "error",
+            "-f", "lavfi",
+            "-i", f"testsrc=duration={seconds}:size=320x180:rate=10",
+            "-f", "lavfi",
+            "-i", f"sine=frequency=440:duration={seconds}",
+            "-c:v", "libx264", "-preset", "ultrafast", "-pix_fmt", "yuv420p",
+            "-c:a", "aac",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+
+def fake_ollama_response(raw: str) -> str:
+    """Wrap a raw model response in the Ollama /api/generate envelope."""
+    return json.dumps({"model": "test", "response": raw, "done": True})
+
+
+def mock_generate(monkeypatch_response: str):
+    """Patch ollama_generate to return monkeypatch_response."""
+    return patch(
+        "tools.video.vlm_clip_rating.ollama_generate",
+        return_value=monkeypatch_response,
+    )
+
+
+class VlmClipRatingTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.td = Path(self.tmp.name)
+        self.clips = self.td / "clips"
+        self.clips.mkdir()
+        self.video = self.clips / "test_a.mp4"
+        make_test_video(self.video)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_rates_video_and_writes_jsonl(self) -> None:
+        out = self.td / "tags.jsonl"
+        tool = VlmClipRating()
+        raw = json.dumps({
+            "overall": {"behavior": "walking_calm", "energy": "calm"},
+            "camera": {"stability_score": 0.95},
+            "shot": {"type": "medium", "rule_of_thirds_score": 0.8},
+            "product": {"subject_visibility": "clear", "subject_quality_score": 0.9},
+            "segments": [],
+            "highlights": [],
+            "quality": {"overall_score": 0.9},
+            "notes": "test clip",
+        })
+        with mock_generate(raw):
+            result = tool.execute({
+                "input_dir": str(self.clips),
+                "output_path": str(out),
+            })
+        self.assertTrue(result.success, result.error)
+        self.assertEqual(result.data["rated"], 1)
+        records = [json.loads(l) for l in out.read_text().splitlines()]
+        self.assertEqual(records[0]["clip"], "test_a.mp4")
+        self.assertEqual(records[0]["overall"]["behavior"], "walking_calm")
+
+    def test_resume_skips_rated_clips(self) -> None:
+        out = self.td / "tags.jsonl"
+        out.write_text(json.dumps({"clip": "test_a.mp4", "done": True}) + "\n")
+        tool = VlmClipRating()
+        with mock_generate("{}"):
+            result = tool.execute({
+                "input_dir": str(self.clips),
+                "output_path": str(out),
+            })
+        self.assertTrue(result.success)
+        self.assertEqual(result.data["rated"], 0)
+        self.assertEqual(result.data["skipped_existing"], 1)
+
+    def test_missing_dir_returns_error(self) -> None:
+        tool = VlmClipRating()
+        result = tool.execute({
+            "input_dir": "/nonexistent",
+            "output_path": "/tmp/x.jsonl",
+        })
+        self.assertFalse(result.success)
+
+    def test_records_failed_clip_without_crashing(self) -> None:
+        # Simulate Ollama failure: patch to raise.
+        out = self.td / "tags.jsonl"
+        tool = VlmClipRating()
+        with patch(
+            "tools.video.vlm_clip_rating.ollama_generate",
+            side_effect=RuntimeError("ollama down"),
+        ):
+            result = tool.execute({
+                "input_dir": str(self.clips),
+                "output_path": str(out),
+            })
+        self.assertTrue(result.success)
+        self.assertEqual(result.data["failed"], 1)
+        records = [json.loads(l) for l in out.read_text().splitlines()]
+        self.assertIn("error", records[0])
+
+    def test_dependency_check_requires_ffmpeg(self) -> None:
+        tool = VlmClipRating()
+        import shutil
+
+        self.assertEqual(
+            tool.get_status().value,
+            "available" if shutil.which("ffmpeg") else "unavailable",
+        )
+
+
+class VlmZoomRatingTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.td = Path(self.tmp.name)
+        self.video = self.td / "clip.mp4"
+        make_test_video(self.video, 3.0)
+        self.ratings = self.td / "tags.jsonl"
+        self.ratings.write_text(json.dumps({
+            "clip": "clip.mp4",
+            "file": str(self.video),
+            "duration_s": 3.0,
+            "highlights": [{"start_s": 0.0, "end_s": 2.0, "type": "action"}],
+            "segments": [],
+        }) + "\n")
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_zoom_produces_sub_beats(self) -> None:
+        out = self.td / "zooms.jsonl"
+        tool = VlmZoomRating()
+        raw = json.dumps({
+            "sub_beats": [{
+                "start_s": 0.0,
+                "end_s": 1.2,
+                "action": "subject moves",
+                "deep_dive": "detailed description",
+                "behavior": "trotting",
+                "camera_angle": "eye_level",
+                "subject_facing": "left",
+                "quality_score": 0.9,
+                "vibe": "calm",
+                "use": "b-roll",
+            }],
+            "best_moment_s": 0.5,
+            "best_moment_desc": "the moment",
+            "notes": "ok",
+        })
+        with patch("tools.video.vlm_zoom_rating.ollama_generate", return_value=raw):
+            result = tool.execute({
+                "ratings_path": str(self.ratings),
+                "output_path": str(out),
+            })
+        self.assertTrue(result.success, result.error)
+        self.assertEqual(result.data["zoomed"], 1)
+        rec = json.loads(out.read_text().splitlines()[0])
+        self.assertEqual(rec["zooms"][0]["sub_beats"][0]["behavior"], "trotting")
+
+    def test_missing_ratings_returns_error(self) -> None:
+        tool = VlmZoomRating()
+        result = tool.execute({
+            "ratings_path": "/nonexistent.jsonl",
+            "output_path": "/tmp/x.jsonl",
+        })
+        self.assertFalse(result.success)
+
+
+class VlmEditorialRankingTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.td = Path(self.tmp.name)
+        self.ratings = self.td / "tags.jsonl"
+        rows = [
+            {
+                "clip": "a.mp4", "file": "/tmp/a.mp4", "duration_s": 5.0,
+                "overall": {"behavior": "walking_calm", "energy": "calm"},
+                "camera": {"stability_score": 0.9},
+                "shot": {"type": "medium", "rule_of_thirds_score": 0.7},
+                "product": {"subject_visibility": "featured", "subject_quality_score": 0.9},
+                "quality": {"overall_score": 0.8},
+                "highlights": [], "segments": [],
+            },
+            {
+                "clip": "b.mp4", "file": "/tmp/b.mp4", "duration_s": 5.0,
+                "overall": {"behavior": "sitting", "energy": "neutral"},
+                "camera": {"stability_score": 0.5},
+                "shot": {"type": "wide", "rule_of_thirds_score": 0.4},
+                "product": {"subject_visibility": "not_visible", "subject_quality_score": 0.1},
+                "quality": {"overall_score": 0.5},
+                "highlights": [], "segments": [],
+            },
+        ]
+        self.ratings.write_text(
+            "\n".join(json.dumps(r) for r in rows) + "\n"
+        )
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_leaderboards_and_composite(self) -> None:
+        out = self.td / "rankings.json"
+        tool = VlmEditorialRanking()
+        result = tool.execute({
+            "ratings_path": str(self.ratings),
+            "output_path": str(out),
+        })
+        self.assertTrue(result.success, result.error)
+        data = json.loads(out.read_text())
+        self.assertEqual(data["n_clips"], 2)
+        # a.mp4 has featured subject + high stability -> should top overall
+        self.assertEqual(data["all_rows"][0]["clip"], "a.mp4")
+        self.assertGreater(
+            data["all_rows"][0]["composite"], data["all_rows"][1]["composite"]
+        )
+
+    def test_invalid_weights_rejected(self) -> None:
+        tool = VlmEditorialRanking()
+        result = tool.execute({
+            "ratings_path": str(self.ratings),
+            "output_path": str(self.td / "r.json"),
+            "weights": {"stability": 0.9},
+        })
+        self.assertFalse(result.success)
+        self.assertIn("sum to 1.0", result.error or "")
+
+    def test_missing_ratings_returns_error(self) -> None:
+        tool = VlmEditorialRanking()
+        result = tool.execute({
+            "ratings_path": "/nonexistent.jsonl",
+            "output_path": "/tmp/x.json",
+        })
+        self.assertFalse(result.success)
+
+
+class VlmComparativeRankTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.td = Path(self.tmp.name)
+        # Two tiny videos so candidate paths exist.
+        self.v1 = self.td / "a.mp4"
+        self.v2 = self.td / "b.mp4"
+        make_test_video(self.v1)
+        make_test_video(self.v2)
+        self.rankings = self.td / "rankings.json"
+        self.rankings.write_text(json.dumps({
+            "leaderboards": {
+                "subject_hero": [
+                    {"clip": "a.mp4", "composite": 0.9},
+                    {"clip": "b.mp4", "composite": 0.8},
+                ]
+            },
+            "all_rows": [
+                {"clip": "a.mp4", "file": str(self.v1)},
+                {"clip": "b.mp4", "file": str(self.v2)},
+            ],
+        }) + "\n")
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_comparative_rank_writes_batch(self) -> None:
+        out = self.td / "cmp.jsonl"
+        tool = VlmComparativeRank()
+        raw = json.dumps({
+            "ranking": ["A", "B"],
+            "scores": {"A": 0.9, "B": 0.7},
+            "best_clip": "A",
+            "best_reason": "clear subject visibility and stable framing",
+            "worst_clip": "B",
+            "worst_reason": "subject not visible",
+            "notes": "A wins",
+        })
+        with patch("tools.video.vlm_comparative_rank.ollama_generate", return_value=raw):
+            result = tool.execute({
+                "rankings_path": str(self.rankings),
+                "output_path": str(out),
+                "purpose": "subject_hero",
+                "batch_size": 2,
+            })
+        self.assertTrue(result.success, result.error)
+        self.assertEqual(result.data["batches"], 1)
+        rec = json.loads(out.read_text().splitlines()[0])
+        self.assertEqual(rec["best_clip"], "A")
+        self.assertIn("a.mp4", rec["_clips"].values())
+
+    def test_missing_rankings_returns_error(self) -> None:
+        tool = VlmComparativeRank()
+        result = tool.execute({
+            "rankings_path": "/nonexistent.json",
+            "output_path": "/tmp/x.jsonl",
+        })
+        self.assertFalse(result.success)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_vlm_rating_tools.py
+++ b/tests/tools/test_vlm_rating_tools.py
@@ -21,7 +21,8 @@ from unittest.mock import patch
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 
-from tools.base_tool import ToolResult  # noqa: E402
+from tools.base_tool import ToolResult, ToolStatus  # noqa: E402
+from tools.tool_registry import ToolRegistry  # noqa: E402
 from tools.video.vlm_clip_rating import VlmClipRating  # noqa: E402
 from tools.video.vlm_comparative_rank import VlmComparativeRank  # noqa: E402
 from tools.video.vlm_editorial_ranking import VlmEditorialRanking  # noqa: E402
@@ -133,14 +134,50 @@ class VlmClipRatingTests(unittest.TestCase):
         records = [json.loads(l) for l in out.read_text().splitlines()]
         self.assertIn("error", records[0])
 
-    def test_dependency_check_requires_ffmpeg(self) -> None:
+    def test_failed_clip_is_retried_on_next_run(self) -> None:
+        out = self.td / "tags.jsonl"
         tool = VlmClipRating()
-        import shutil
+        with patch(
+            "tools.video.vlm_clip_rating.ollama_generate",
+            side_effect=RuntimeError("temporary outage"),
+        ):
+            first = tool.execute({
+                "input_dir": str(self.clips),
+                "output_path": str(out),
+            })
 
-        self.assertEqual(
-            tool.get_status().value,
-            "available" if shutil.which("ffmpeg") else "unavailable",
-        )
+        with mock_generate(json.dumps({"quality": {"overall_score": 0.8}})):
+            second = tool.execute({
+                "input_dir": str(self.clips),
+                "output_path": str(out),
+            })
+
+        self.assertEqual(first.data["failed"], 1)
+        self.assertEqual(second.data["rated"], 1)
+        self.assertEqual(second.data["skipped_existing"], 0)
+        records = [json.loads(line) for line in out.read_text().splitlines()]
+        self.assertIn("error", records[0])
+        self.assertNotIn("error", records[1])
+
+    def test_dependency_check_requires_ffmpeg_and_ollama_model(self) -> None:
+        tool = VlmClipRating()
+        with patch("shutil.which", return_value="/usr/bin/tool"), patch(
+            "tools.video.vlm_clip_rating.ollama_model_available", return_value=True
+        ):
+            self.assertEqual(tool.get_status(), ToolStatus.AVAILABLE)
+        with patch("shutil.which", return_value="/usr/bin/tool"), patch(
+            "tools.video.vlm_clip_rating.ollama_model_available", return_value=False
+        ):
+            self.assertEqual(tool.get_status(), ToolStatus.UNAVAILABLE)
+
+    def test_rejects_remote_ollama_endpoint(self) -> None:
+        result = VlmClipRating().execute({
+            "input_dir": str(self.clips),
+            "output_path": str(self.td / "tags.jsonl"),
+            "ollama_url": "https://remote.example.com",
+        })
+        self.assertFalse(result.success)
+        self.assertIn("loopback", result.error or "")
 
 
 class VlmZoomRatingTests(unittest.TestCase):
@@ -198,6 +235,59 @@ class VlmZoomRatingTests(unittest.TestCase):
             "output_path": "/tmp/x.jsonl",
         })
         self.assertFalse(result.success)
+
+    def test_all_failed_windows_are_retried(self) -> None:
+        out = self.td / "zooms.jsonl"
+        tool = VlmZoomRating()
+        with patch(
+            "tools.video.vlm_zoom_rating.ollama_generate",
+            side_effect=RuntimeError("temporary outage"),
+        ):
+            first = tool.execute({
+                "ratings_path": str(self.ratings),
+                "output_path": str(out),
+            })
+
+        with patch(
+            "tools.video.vlm_zoom_rating.ollama_generate",
+            return_value=json.dumps({"sub_beats": [], "notes": "recovered"}),
+        ):
+            second = tool.execute({
+                "ratings_path": str(self.ratings),
+                "output_path": str(out),
+            })
+
+        self.assertEqual(first.data["failed"], 1)
+        self.assertEqual(second.data["zoomed"], 1)
+        records = [json.loads(line) for line in out.read_text().splitlines()]
+        self.assertEqual(records[0]["error"], "all_windows_failed")
+        self.assertNotIn("error", records[1])
+
+
+class VlmRegistryTests(unittest.TestCase):
+    def test_all_tools_are_discoverable_with_honest_status(self) -> None:
+        registry = ToolRegistry()
+        registry.discover("tools")
+        names = {
+            "vlm_clip_rating",
+            "vlm_zoom_rating",
+            "vlm_editorial_ranking",
+            "vlm_comparative_rank",
+        }
+        self.assertTrue(names <= set(registry.list_all()))
+        self.assertEqual(
+            registry.get("vlm_editorial_ranking").get_status(),
+            ToolStatus.AVAILABLE,
+        )
+        with patch("shutil.which", return_value="/usr/bin/tool"), patch(
+            "tools.video.vlm_clip_rating.ollama_model_available", return_value=False
+        ), patch(
+            "tools.video.vlm_zoom_rating.ollama_model_available", return_value=False
+        ), patch(
+            "tools.video.vlm_comparative_rank.ollama_model_available", return_value=False
+        ):
+            for name in names - {"vlm_editorial_ranking"}:
+                self.assertEqual(registry.get(name).get_status(), ToolStatus.UNAVAILABLE)
 
 
 class VlmEditorialRankingTests(unittest.TestCase):

--- a/tools/video/vlm_clip_rating.py
+++ b/tools/video/vlm_clip_rating.py
@@ -50,7 +50,9 @@ from tools.video.vlm_rating_common import (
     load_rated_ids,
     normalize_drift,
     ollama_generate,
+    ollama_model_available,
     parse_vlm_json,
+    validate_local_ollama_url,
 )
 
 
@@ -67,7 +69,6 @@ class VlmClipRating(BaseTool):
 
     dependencies = ["cmd:ffmpeg", "cmd:ffprobe"]
     install_instructions = (
-        "pip install requests\n"
         "Install Ollama (ollama.com) and pull the tested model: "
         "`ollama pull gemma4:12b` (~8GB VRAM, recommended).\n"
         "Smaller models (gemma3n:e4b ~3.5GB, qwen2.5vl:3b ~3GB) are "
@@ -131,6 +132,7 @@ class VlmClipRating(BaseTool):
             "ollama_url": {
                 "type": "string",
                 "default": "http://127.0.0.1:11434",
+                "description": "Local Ollama endpoint. Only localhost/loopback URLs are accepted.",
             },
             "frames_per_clip": {
                 "type": "integer",
@@ -165,7 +167,11 @@ class VlmClipRating(BaseTool):
 
         if shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None:
             return ToolStatus.UNAVAILABLE
-        return ToolStatus.AVAILABLE
+        return (
+            ToolStatus.AVAILABLE
+            if ollama_model_available(model="gemma4:12b")
+            else ToolStatus.UNAVAILABLE
+        )
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
         return 0.0
@@ -199,7 +205,9 @@ class VlmClipRating(BaseTool):
                 )
 
             model = inputs.get("model", "gemma4:12b")
-            ollama_url = inputs.get("ollama_url", "http://127.0.0.1:11434")
+            ollama_url = validate_local_ollama_url(
+                inputs.get("ollama_url", "http://127.0.0.1:11434")
+            )
             frames_per_clip = int(inputs.get("frames_per_clip", 8))
             frame_scale = int(inputs.get("frame_scale", 640))
             temperature = float(inputs.get("temperature", 0.1))

--- a/tools/video/vlm_clip_rating.py
+++ b/tools/video/vlm_clip_rating.py
@@ -1,0 +1,370 @@
+"""VLM clip rating: coarse semantic pass over a folder of video clips.
+
+Rates every video in a folder with a local vision-language model (Ollama
+served, e.g. Gemma 3n / Gemma 4 / Qwen-VL), producing one JSON record per
+clip with behavior, camera, shot, product-of-interest visibility, segments,
+and highlights. This is the layer CLIP cannot provide: temporal/behavioral
+semantics instead of static frame similarity.
+
+The tool is intentionally generic: ``focus_prompt`` lets a campaign describe
+the subject that matters (a product, an animal behavior, a person), and the
+rating schema stays neutral so downstream consumers (zoom pass, editorial
+ranking) can operate on any footage.
+
+Usage (as a tool)::
+
+    {
+      "input_dir": "/path/to/clips",
+      "output_path": "/path/to/clip_tags.jsonl",
+      "focus_prompt": "a black dog collar (the product being advertised)",
+      "model": "gemma4:12b",
+      "ollama_url": "http://127.0.0.1:11434",
+      "frames_per_clip": 8
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+from tools.video.vlm_rating_common import (
+    append_record,
+    build_behavior_taxonomy,
+    extract_frames,
+    images_b64,
+    load_rated_ids,
+    normalize_drift,
+    ollama_generate,
+    parse_vlm_json,
+)
+
+
+class VlmClipRating(BaseTool):
+    name = "vlm_clip_rating"
+    version = "0.1.0"
+    tier = ToolTier.ANALYZE
+    capability = "semantic_clip_rating"
+    provider = "openmontage"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.SEEDED
+    runtime = ToolRuntime.LOCAL_GPU
+
+    dependencies = ["cmd:ffmpeg", "cmd:ffprobe"]
+    install_instructions = (
+        "pip install requests\n"
+        "Install Ollama (ollama.com) and pull a vision model, e.g. "
+        "`ollama pull gemma4:12b` (or gemma3n:4b for smaller GPUs)."
+    )
+    agent_skills = ["vlm-footage-rating"]
+
+    capabilities = [
+        "behavior_classification",
+        "camera_quality_assessment",
+        "shot_composition_scoring",
+        "product_visibility_detection",
+        "temporal_segmentation",
+        "highlight_extraction",
+    ]
+    supports = {
+        "resume": True,
+        "custom_focus_prompt": True,
+        "custom_behavior_taxonomy": True,
+        "local_only": True,
+    }
+    best_for = [
+        "pre-indexing a footage folder with behavior and camera semantics",
+        "finding clips where a product or subject is visible",
+        "building a searchable semantic index before montage assembly",
+    ]
+    not_good_for = [
+        "frame-accurate timestamps (use vlm_zoom_rating)",
+        "ranking clips against each other (use vlm_comparative_rank)",
+        "editing or composing video (use video_compose)",
+    ]
+
+    input_schema = {
+        "type": "object",
+        "required": ["input_dir", "output_path"],
+        "properties": {
+            "input_dir": {
+                "type": "string",
+                "description": "Folder containing video clips to rate.",
+            },
+            "output_path": {
+                "type": "string",
+                "description": "JSONL output path. Re-running skips already-rated clips.",
+            },
+            "focus_prompt": {
+                "type": "string",
+                "default": "",
+                "description": "What the campaign cares about, e.g. 'a black collar (the product)'.",
+            },
+            "behavior_extra": {
+                "type": "string",
+                "default": "",
+                "description": "Extra comma-separated behavior labels to add to the taxonomy.",
+            },
+            "model": {
+                "type": "string",
+                "default": "gemma4:12b",
+                "description": "Ollama model name with vision support.",
+            },
+            "ollama_url": {
+                "type": "string",
+                "default": "http://127.0.0.1:11434",
+            },
+            "frames_per_clip": {
+                "type": "integer",
+                "default": 8,
+                "minimum": 3,
+                "maximum": 24,
+            },
+            "temperature": {"type": "number", "default": 0.1},
+            "num_predict": {"type": "integer", "default": 1500},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=2, ram_mb=1024, vram_mb=6144, disk_mb=200,
+        network_required=False,
+    )
+    side_effects = ["writes JSONL output", "writes temporary frame jpgs"]
+    user_visible_verification = [
+        "Open output_path and check a few records have behavior/camera/shot fields.",
+    ]
+
+    def get_status(self) -> ToolStatus:
+        import shutil
+
+        if shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None:
+            return ToolStatus.UNAVAILABLE
+        return ToolStatus.AVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        return 0.0
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        n = 0
+        import glob
+
+        in_dir = inputs.get("input_dir", "")
+        if in_dir:
+            n = len(
+                glob.glob(str(Path(in_dir) / "*"))
+            )
+        return max(10.0, n * 8.0)
+
+    # ------------------------------------------------------------------
+    # Execute
+    # ------------------------------------------------------------------
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        start = time.time()
+        try:
+            import glob
+
+            input_dir = Path(inputs["input_dir"])
+            output_path = str(inputs["output_path"])
+            if not input_dir.is_dir():
+                return ToolResult(
+                    success=False,
+                    error=f"input_dir {input_dir} is not a directory",
+                )
+
+            model = inputs.get("model", "gemma4:12b")
+            ollama_url = inputs.get("ollama_url", "http://127.0.0.1:11434")
+            frames_per_clip = int(inputs.get("frames_per_clip", 8))
+            temperature = float(inputs.get("temperature", 0.1))
+            num_predict = int(inputs.get("num_predict", 1500))
+            focus = str(inputs.get("focus_prompt", "")).strip()
+            behavior_extra = str(inputs.get("behavior_extra", "")).strip()
+
+            videos = sorted(
+                p for p in glob.glob(str(input_dir / "*"))
+                if p.lower().endswith((".mp4", ".mov", ".mkv", ".webm", ".avi", ".m4v"))
+            )
+            if not videos:
+                return ToolResult(
+                    success=False,
+                    error=f"No video files found in {input_dir}",
+                )
+
+            rated = load_rated_ids(output_path)
+            prompt = _build_prompt(frames_per_clip, focus, behavior_extra)
+
+            done = 0
+            skipped = 0
+            failed = 0
+            tmp_dir = Path(inputs.get("tmp_dir", "/tmp")) / "vlm_clip_frames"
+            for video in videos:
+                clip = Path(video).name
+                if clip in rated:
+                    skipped += 1
+                    continue
+                try:
+                    paths, frame_map, dur = extract_frames(
+                        video, str(tmp_dir), n_frames=frames_per_clip
+                    )
+                    if len(paths) < 3:
+                        failed += 1
+                        append_record(output_path, {
+                            "clip": clip, "file": video, "error": "too_few_frames",
+                        })
+                        continue
+                    images = images_b64(paths)
+                    filled = (
+                        prompt.replace("{n}", str(len(paths)))
+                        .replace("{frame_map}", frame_map)
+                        .replace("{focus}", focus)
+                    )
+                    raw = ollama_generate(
+                        ollama_url, model, filled, images,
+                        temperature=temperature, num_predict=num_predict,
+                    )
+                    record = parse_vlm_json(raw)
+                    if record.get("error"):
+                        record = {"error": record["error"]}
+                    record["clip"] = clip
+                    record["file"] = video
+                    record["duration_s"] = round(dur, 2)
+                    normalize_drift(
+                        record,
+                        {
+                            "collar_visibility": ["product_visibility"],
+                            "shot_purpose": ["purpose"],
+                        },
+                    )
+                    append_record(output_path, record)
+                    done += 1
+                except Exception as exc:  # noqa: BLE001 - batch resilience
+                    failed += 1
+                    append_record(output_path, {
+                        "clip": clip, "file": video, "error": str(exc)[:300],
+                    })
+
+            return ToolResult(
+                success=True,
+                data={
+                    "rated": done,
+                    "skipped_existing": skipped,
+                    "failed": failed,
+                    "total": len(videos),
+                    "output_path": output_path,
+                },
+                duration_seconds=round(time.time() - start, 3),
+                cost_usd=0.0,
+            )
+        except Exception as exc:  # noqa: BLE001
+            import traceback
+
+            return ToolResult(
+                success=False,
+                error=f"{type(exc).__name__}: {exc}\n{traceback.format_exc()[-800:]}",
+            )
+
+
+def _build_prompt(frames_per_clip: int, focus: str, behavior_extra: str) -> str:
+    """Build the coarse-rating prompt template.
+
+    Uses brace-safe token replacement (NOT str.format) so the JSON schema
+    braces in the prompt survive untouched. Tokens: {n}, {frame_map},
+    {focus} are replaced per clip by the caller.
+    """
+    taxonomy = build_behavior_taxonomy(behavior_extra or None)
+    focus_line = ""
+    if focus:
+        focus_line = (
+            f"\nA key subject of interest for this project is: {focus}. "
+            "Rate its visibility explicitly in the product field.\n"
+        )
+    template = """You are a professional film editor's assistant reviewing video footage.
+You are given {n} consecutive frames from a single video clip, sampled evenly across its duration.
+FRAME TIMESTAMPS (seconds into the clip):
+{frame_map}{focus_line}
+
+Analyze EVERYTHING about this clip and return ONLY valid JSON (no markdown) with this schema:
+{
+  "overall": {
+    "behavior": "{taxonomy}",
+    "behavior_confidence": 0.0,
+    "energy": "calm"|"neutral"|"excited"|"hyper",
+    "engagement": "focused"|"distracted"|"interacting"|"disengaged",
+    "subject_in_frame": "yes"|"partial"|"no",
+    "activity": "short phrase describing the main activity"
+  },
+  "camera": {
+    "mount": "tripod"|"handheld"|"gimbal"|"unknown",
+    "movement": "static"|"pan"|"tilt"|"track"|"handheld_shake",
+    "stability_score": 0.0,
+    "stability_note": "short phrase",
+    "zoom": "none"|"push_in"|"pull_out",
+    "exposure": "well_exposed"|"overexposed"|"underexposed"|"mixed"
+  },
+  "shot": {
+    "type": "extreme_wide"|"wide"|"medium"|"medium_close"|"close_up"|"extreme_close_up",
+    "subject": "primary subject of the shot",
+    "subject_position": "left_third"|"center"|"right_third",
+    "rule_of_thirds_score": 0.0,
+    "lighting": "sunny"|"overcast"|"shade"|"golden_hour"|"harsh"|"indoor",
+    "focus": "sharp"|"soft"|"missed",
+    "background": "short description"
+  },
+  "product": {
+    "subject_visible": true|false,
+    "subject_visibility": "not_visible"|"partial"|"clear"|"featured",
+    "is_subject_closeup": true|false,
+    "subject_quality_score": 0.0,
+    "details": "describe how visible and how well framed the subject of interest is"
+  },
+  "segments": [
+    {
+      "start_s": 0.0,
+      "end_s": 0.0,
+      "action": "what happens in this segment",
+      "behavior": "{taxonomy}",
+      "interest": 0.0,
+      "note": "why interesting or not"
+    }
+  ],
+  "highlights": [
+    {
+      "start_s": 0.0,
+      "end_s": 0.0,
+      "type": "action"|"expression"|"interaction"|"environment"|"subject",
+      "why": "why this is a keeper",
+      "quality_score": 0.0
+    }
+  ],
+  "quality": {
+    "overall_score": 0.0,
+    "usable_for_edit": "yes"|"trim"|"no",
+    "issues": ["list any: shake, motion blur, obstruction"]
+  },
+  "notes": "2-3 sentences describing what happens"
+}
+
+RULES:
+- start_s/end_s must be real seconds into the clip, anchored to the FRAME TIMESTAMPS.
+- interest/quality/stability/rule_of_thirds are 0.0-1.0 scores.
+- If no notable highlight, return highlights: [].
+- segments should cover the main beats (1-4 max).
+- Be specific: describe what the subject and camera are actually doing.
+"""
+    return template.replace("{focus_line}", focus_line).replace(
+        "{taxonomy}", taxonomy
+    )

--- a/tools/video/vlm_clip_rating.py
+++ b/tools/video/vlm_clip_rating.py
@@ -26,6 +26,7 @@ Usage (as a tool)::
 from __future__ import annotations
 
 import json
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -67,8 +68,10 @@ class VlmClipRating(BaseTool):
     dependencies = ["cmd:ffmpeg", "cmd:ffprobe"]
     install_instructions = (
         "pip install requests\n"
-        "Install Ollama (ollama.com) and pull a vision model, e.g. "
-        "`ollama pull gemma4:12b` (or gemma3n:4b for smaller GPUs)."
+        "Install Ollama (ollama.com) and pull the tested model: "
+        "`ollama pull gemma4:12b` (~8GB VRAM, recommended).\n"
+        "Smaller models (gemma3n:e4b ~3.5GB, qwen2.5vl:3b ~3GB) are "
+        "untested; pass frame_scale 384 with them for faster inference."
     )
     agent_skills = ["vlm-footage-rating"]
 
@@ -122,7 +125,8 @@ class VlmClipRating(BaseTool):
             "model": {
                 "type": "string",
                 "default": "gemma4:12b",
-                "description": "Ollama model name with vision support.",
+                "description": "Ollama model name with vision support. "
+                               "Default gemma4:12b is the tested/recommended model.",
             },
             "ollama_url": {
                 "type": "string",
@@ -134,13 +138,21 @@ class VlmClipRating(BaseTool):
                 "minimum": 3,
                 "maximum": 24,
             },
+            "frame_scale": {
+                "type": "integer",
+                "default": 640,
+                "minimum": 320,
+                "maximum": 1280,
+                "description": "Frame width for the VLM. Smaller (384-480) is faster "
+                               "and uses less VRAM; best for 4b models.",
+            },
             "temperature": {"type": "number", "default": 0.1},
             "num_predict": {"type": "integer", "default": 1500},
         },
     }
 
     resource_profile = ResourceProfile(
-        cpu_cores=2, ram_mb=1024, vram_mb=6144, disk_mb=200,
+        cpu_cores=2, ram_mb=1024, vram_mb=3584, disk_mb=200,
         network_required=False,
     )
     side_effects = ["writes JSONL output", "writes temporary frame jpgs"]
@@ -189,6 +201,7 @@ class VlmClipRating(BaseTool):
             model = inputs.get("model", "gemma4:12b")
             ollama_url = inputs.get("ollama_url", "http://127.0.0.1:11434")
             frames_per_clip = int(inputs.get("frames_per_clip", 8))
+            frame_scale = int(inputs.get("frame_scale", 640))
             temperature = float(inputs.get("temperature", 0.1))
             num_predict = int(inputs.get("num_predict", 1500))
             focus = str(inputs.get("focus_prompt", "")).strip()
@@ -210,7 +223,7 @@ class VlmClipRating(BaseTool):
             done = 0
             skipped = 0
             failed = 0
-            tmp_dir = Path(inputs.get("tmp_dir", "/tmp")) / "vlm_clip_frames"
+            tmp_dir = Path(inputs.get("tmp_dir") or tempfile.gettempdir()) / "vlm_clip_frames"
             for video in videos:
                 clip = Path(video).name
                 if clip in rated:
@@ -218,7 +231,8 @@ class VlmClipRating(BaseTool):
                     continue
                 try:
                     paths, frame_map, dur = extract_frames(
-                        video, str(tmp_dir), n_frames=frames_per_clip
+                        video, str(tmp_dir), n_frames=frames_per_clip,
+                        scale=frame_scale,
                     )
                     if len(paths) < 3:
                         failed += 1

--- a/tools/video/vlm_clip_rating.py
+++ b/tools/video/vlm_clip_rating.py
@@ -64,7 +64,7 @@ class VlmClipRating(BaseTool):
     provider = "openmontage"
     stability = ToolStability.EXPERIMENTAL
     execution_mode = ExecutionMode.SYNC
-    determinism = Determinism.SEEDED
+    determinism = Determinism.STOCHASTIC
     runtime = ToolRuntime.LOCAL_GPU
 
     dependencies = ["cmd:ffmpeg", "cmd:ffprobe"]

--- a/tools/video/vlm_comparative_rank.py
+++ b/tools/video/vlm_comparative_rank.py
@@ -26,6 +26,7 @@ Usage (as a tool)::
 from __future__ import annotations
 
 import json
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -88,7 +89,9 @@ class VlmComparativeRank(BaseTool):
     dependencies = ["cmd:ffmpeg", "cmd:ffprobe"]
     install_instructions = (
         "pip install requests\n"
-        "Install Ollama and pull a vision model (see vlm_clip_rating)."
+        "Install Ollama and pull the tested model: `ollama pull gemma4:12b` "
+        "(~8GB VRAM, recommended). Smaller models are untested; see the "
+        "vlm-footage-rating skill for guidance."
     )
     agent_skills = ["vlm-footage-rating"]
 
@@ -129,13 +132,21 @@ class VlmComparativeRank(BaseTool):
             "model": {"type": "string", "default": "gemma4:12b"},
             "ollama_url": {"type": "string", "default": "http://127.0.0.1:11434"},
             "frames_per_clip": {"type": "integer", "default": 5},
+            "frame_scale": {
+                "type": "integer",
+                "default": 480,
+                "minimum": 320,
+                "maximum": 1280,
+                "description": "Frame width for the VLM. Smaller (384) is faster "
+                               "and uses less VRAM; best for 4b models.",
+            },
             "temperature": {"type": "number", "default": 0.1},
             "num_predict": {"type": "integer", "default": 800},
         },
     }
 
     resource_profile = ResourceProfile(
-        cpu_cores=2, ram_mb=1024, vram_mb=6144, disk_mb=200,
+        cpu_cores=2, ram_mb=1024, vram_mb=3584, disk_mb=200,
         network_required=False,
     )
     side_effects = ["writes JSONL output", "writes temporary frame jpgs"]
@@ -180,9 +191,10 @@ class VlmComparativeRank(BaseTool):
             model = inputs.get("model", "gemma4:12b")
             ollama_url = inputs.get("ollama_url", "http://127.0.0.1:11434")
             frames_per_clip = int(inputs.get("frames_per_clip", 5))
+            frame_scale = int(inputs.get("frame_scale", 480))
             temperature = float(inputs.get("temperature", 0.1))
             num_predict = int(inputs.get("num_predict", 800))
-            tmp_dir = Path(inputs.get("tmp_dir", "/tmp")) / "vlm_cmp_frames"
+            tmp_dir = Path(inputs.get("tmp_dir") or tempfile.gettempdir()) / "vlm_cmp_frames"
 
             candidates = _candidate_paths(rankings_path, purpose, max_candidates)
             if not candidates:
@@ -201,7 +213,9 @@ class VlmComparativeRank(BaseTool):
             prompt = _build_prompt(frames_per_clip, purpose)
             results = []
             for batch in batches:
-                labels, images, clip_map = _load_batch(batch, tmp_dir, frames_per_clip)
+                labels, images, clip_map = _load_batch(
+                    batch, tmp_dir, frames_per_clip, frame_scale
+                )
                 if not clip_map:
                     continue
                 used = list(clip_map)
@@ -274,7 +288,10 @@ def _candidate_paths(
 
 
 def _load_batch(
-    clips: list[str], tmp_dir: Path, frames_per_clip: int
+    clips: list[str],
+    tmp_dir: Path,
+    frames_per_clip: int,
+    frame_scale: int = 480,
 ) -> tuple[list[str], list[str], dict[str, str]]:
     """Extract frames for a batch; returns (labels, images, clip_map)."""
     labels: list[str] = []
@@ -284,7 +301,8 @@ def _load_batch(
         letter = "ABCDEFGH"[i]
         try:
             paths, _map, _dur = extract_frames(
-                video, str(tmp_dir / letter), n_frames=frames_per_clip, scale=480
+                video, str(tmp_dir / letter), n_frames=frames_per_clip,
+                scale=frame_scale,
             )
         except Exception:  # noqa: BLE001
             continue

--- a/tools/video/vlm_comparative_rank.py
+++ b/tools/video/vlm_comparative_rank.py
@@ -47,7 +47,9 @@ from tools.video.vlm_rating_common import (
     extract_frames,
     images_b64,
     ollama_generate,
+    ollama_model_available,
     parse_vlm_json,
+    validate_local_ollama_url,
 )
 
 
@@ -88,7 +90,6 @@ class VlmComparativeRank(BaseTool):
 
     dependencies = ["cmd:ffmpeg", "cmd:ffprobe"]
     install_instructions = (
-        "pip install requests\n"
         "Install Ollama and pull the tested model: `ollama pull gemma4:12b` "
         "(~8GB VRAM, recommended). Smaller models are untested; see the "
         "vlm-footage-rating skill for guidance."
@@ -130,7 +131,11 @@ class VlmComparativeRank(BaseTool):
             "batch_size": {"type": "integer", "default": 4, "minimum": 2, "maximum": 8},
             "max_candidates": {"type": "integer", "default": 16},
             "model": {"type": "string", "default": "gemma4:12b"},
-            "ollama_url": {"type": "string", "default": "http://127.0.0.1:11434"},
+            "ollama_url": {
+                "type": "string",
+                "default": "http://127.0.0.1:11434",
+                "description": "Local Ollama endpoint. Only localhost/loopback URLs are accepted.",
+            },
             "frames_per_clip": {"type": "integer", "default": 5},
             "frame_scale": {
                 "type": "integer",
@@ -159,7 +164,11 @@ class VlmComparativeRank(BaseTool):
 
         if shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None:
             return ToolStatus.UNAVAILABLE
-        return ToolStatus.AVAILABLE
+        return (
+            ToolStatus.AVAILABLE
+            if ollama_model_available(model="gemma4:12b")
+            else ToolStatus.UNAVAILABLE
+        )
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
         return 0.0
@@ -189,7 +198,9 @@ class VlmComparativeRank(BaseTool):
             batch_size = int(inputs.get("batch_size", 4))
             max_candidates = int(inputs.get("max_candidates", 16))
             model = inputs.get("model", "gemma4:12b")
-            ollama_url = inputs.get("ollama_url", "http://127.0.0.1:11434")
+            ollama_url = validate_local_ollama_url(
+                inputs.get("ollama_url", "http://127.0.0.1:11434")
+            )
             frames_per_clip = int(inputs.get("frames_per_clip", 5))
             frame_scale = int(inputs.get("frame_scale", 480))
             temperature = float(inputs.get("temperature", 0.1))

--- a/tools/video/vlm_comparative_rank.py
+++ b/tools/video/vlm_comparative_rank.py
@@ -1,0 +1,322 @@
+"""VLM comparative rank: relative clip comparison with editorial reasoning.
+
+Absolute per-clip scores (from ``vlm_clip_rating``) are not calibrated:
+a 0.9 means nothing until the model has seen what 0.6 and 0.95 look like.
+This tool shows several clips together in one VLM context (4 clips x 5
+frames, labeled A/B/C/D), asks for a relative ranking, calibrated scores,
+and *reasons* for best/worst picks. The reasons are the deliverable an
+editor or downstream agent can act on.
+
+This is an optional second-opinion pass, not part of the core pipeline:
+run it when two clips score close and you want the model to argue about
+which is better for a specific purpose.
+
+Usage (as a tool)::
+
+    {
+      "rankings_path": "/path/to/editorial_rankings.json",
+      "output_path": "/path/to/comparative_rankings.jsonl",
+      "purpose": "subject_hero",       // leaderboard key to sample from
+      "batch_size": 4,
+      "model": "gemma4:12b",
+      "ollama_url": "http://127.0.0.1:11434"
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+from tools.video.vlm_rating_common import (
+    append_record,
+    extract_frames,
+    images_b64,
+    ollama_generate,
+    parse_vlm_json,
+)
+
+
+PURPOSES = {
+    "subject_hero": (
+        "footage that showcases the subject of interest (product, person, "
+        "or animal): visibility, close-ups, quality, framing that sells it"
+    ),
+    "lifestyle": (
+        "natural lifestyle footage: authentic behavior, engagement, "
+        "usability in a narrative"
+    ),
+    "action_energy": (
+        "high-energy action: movement, excitement, dynamic shots for "
+        "energetic montage segments"
+    ),
+    "establishing": (
+        "wide establishing shots: environment, setting, composition for "
+        "opening or closing scenes"
+    ),
+    "stability": (
+        "the steadiest, most usable footage: minimal shake, clean framing, "
+        "consistent exposure"
+    ),
+}
+
+
+class VlmComparativeRank(BaseTool):
+    name = "vlm_comparative_rank"
+    version = "0.1.0"
+    tier = ToolTier.ANALYZE
+    capability = "comparative_clip_ranking"
+    provider = "openmontage"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.SEEDED
+    runtime = ToolRuntime.LOCAL_GPU
+
+    dependencies = ["cmd:ffmpeg", "cmd:ffprobe"]
+    install_instructions = (
+        "pip install requests\n"
+        "Install Ollama and pull a vision model (see vlm_clip_rating)."
+    )
+    agent_skills = ["vlm-footage-rating"]
+
+    capabilities = [
+        "relative_ranking",
+        "calibrated_scores",
+        "editorial_reasoning",
+        "purpose_aware_comparison",
+    ]
+    supports = {"local_only": True}
+    best_for = [
+        "tie-breaking clips that score close on absolute ratings",
+        "getting a second opinion with reasoning before committing a cut",
+        "comparing candidates for a specific editorial purpose",
+    ]
+    not_good_for = [
+        "bulk semantic indexing (use vlm_clip_rating)",
+        "frame-accurate timestamps (use vlm_zoom_rating)",
+        "scoring every clip (this is for shortlists)",
+    ]
+
+    input_schema = {
+        "type": "object",
+        "required": ["rankings_path", "output_path"],
+        "properties": {
+            "rankings_path": {
+                "type": "string",
+                "description": "JSON from vlm_editorial_ranking.",
+            },
+            "output_path": {"type": "string"},
+            "purpose": {
+                "type": "string",
+                "enum": list(PURPOSES),
+                "default": "subject_hero",
+            },
+            "batch_size": {"type": "integer", "default": 4, "minimum": 2, "maximum": 8},
+            "max_candidates": {"type": "integer", "default": 16},
+            "model": {"type": "string", "default": "gemma4:12b"},
+            "ollama_url": {"type": "string", "default": "http://127.0.0.1:11434"},
+            "frames_per_clip": {"type": "integer", "default": 5},
+            "temperature": {"type": "number", "default": 0.1},
+            "num_predict": {"type": "integer", "default": 800},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=2, ram_mb=1024, vram_mb=6144, disk_mb=200,
+        network_required=False,
+    )
+    side_effects = ["writes JSONL output", "writes temporary frame jpgs"]
+    user_visible_verification = [
+        "Open output_path and check ranking + best_reason fields.",
+    ]
+
+    def get_status(self) -> ToolStatus:
+        import shutil
+
+        if shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None:
+            return ToolStatus.UNAVAILABLE
+        return ToolStatus.AVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        return 0.0
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        n_batches = max(
+            1, (int(inputs.get("max_candidates", 16)) // int(inputs.get("batch_size", 4)))
+        )
+        return n_batches * 40.0
+
+    # ------------------------------------------------------------------
+    # Execute
+    # ------------------------------------------------------------------
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        start = time.time()
+        try:
+            rankings_path = inputs["rankings_path"]
+            output_path = str(inputs["output_path"])
+            if not Path(rankings_path).exists():
+                return ToolResult(
+                    success=False,
+                    error=f"rankings_path {rankings_path} does not exist",
+                )
+
+            purpose = inputs.get("purpose", "subject_hero")
+            batch_size = int(inputs.get("batch_size", 4))
+            max_candidates = int(inputs.get("max_candidates", 16))
+            model = inputs.get("model", "gemma4:12b")
+            ollama_url = inputs.get("ollama_url", "http://127.0.0.1:11434")
+            frames_per_clip = int(inputs.get("frames_per_clip", 5))
+            temperature = float(inputs.get("temperature", 0.1))
+            num_predict = int(inputs.get("num_predict", 800))
+            tmp_dir = Path(inputs.get("tmp_dir", "/tmp")) / "vlm_cmp_frames"
+
+            candidates = _candidate_paths(rankings_path, purpose, max_candidates)
+            if not candidates:
+                return ToolResult(
+                    success=False,
+                    error=(
+                        f"No candidate clips found for purpose {purpose!r}. "
+                        f"Check rankings_path and that leaderboards exist."
+                    ),
+                )
+
+            batches = [
+                candidates[i : i + batch_size]
+                for i in range(0, len(candidates), batch_size)
+            ]
+            prompt = _build_prompt(frames_per_clip, purpose)
+            results = []
+            for batch in batches:
+                labels, images, clip_map = _load_batch(batch, tmp_dir, frames_per_clip)
+                if not clip_map:
+                    continue
+                used = list(clip_map)
+                filled = prompt.format(
+                    n=len(used),
+                    f=frames_per_clip,
+                    labels=", ".join(labels),
+                    clip_map=", ".join(
+                        f"{l} = {clip_map[l]}" for l in used
+                    ),
+                    purpose=PURPOSES.get(purpose, purpose),
+                )
+                raw = ollama_generate(
+                    ollama_url, model, filled, images,
+                    temperature=temperature, num_predict=num_predict,
+                )
+                result = parse_vlm_json(raw)
+                result["_clips"] = clip_map
+                result["_purpose"] = purpose
+                results.append(result)
+                append_record(output_path, result)
+
+            return ToolResult(
+                success=True,
+                data={
+                    "batches": len(results),
+                    "purpose": purpose,
+                    "output_path": output_path,
+                },
+                duration_seconds=round(time.time() - start, 3),
+                cost_usd=0.0,
+            )
+        except Exception as exc:  # noqa: BLE001
+            import traceback
+
+            return ToolResult(
+                success=False,
+                error=f"{type(exc).__name__}: {exc}\n{traceback.format_exc()[-800:]}",
+            )
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _candidate_paths(
+    rankings_path: str, purpose: str, max_candidates: int
+) -> list[str]:
+    with open(rankings_path) as fh:
+        data = json.load(fh)
+    leaderboards = data.get("leaderboards", {})
+    board = leaderboards.get(purpose) or leaderboards.get("overall", [])
+    paths: list[str] = []
+    for entry in board:
+        clip = entry.get("clip")
+        if not clip:
+            continue
+        # Recover the file path from all_rows if present.
+        file_path = None
+        for row in data.get("all_rows", []):
+            if row.get("clip") == clip:
+                file_path = row.get("file")
+                break
+        if file_path and Path(file_path).exists():
+            paths.append(file_path)
+        if len(paths) >= max_candidates:
+            break
+    return paths
+
+
+def _load_batch(
+    clips: list[str], tmp_dir: Path, frames_per_clip: int
+) -> tuple[list[str], list[str], dict[str, str]]:
+    """Extract frames for a batch; returns (labels, images, clip_map)."""
+    labels: list[str] = []
+    images: list[str] = []
+    clip_map: dict[str, str] = {}
+    for i, video in enumerate(clips):
+        letter = "ABCDEFGH"[i]
+        try:
+            paths, _map, _dur = extract_frames(
+                video, str(tmp_dir / letter), n_frames=frames_per_clip, scale=480
+            )
+        except Exception:  # noqa: BLE001
+            continue
+        if not paths:
+            continue
+        clip_map[letter] = Path(video).name
+        for j, p in enumerate(paths):
+            images.extend(images_b64([p]))
+            labels.append(f"{letter}{j + 1}")
+    return labels, images, clip_map
+
+
+def _build_prompt(frames_per_clip: int, purpose: str) -> str:
+    return """You are a professional film editor choosing shots for a video project.
+You are shown {n} candidate clips, each as {f} frames. Frame labels: {labels}.
+Clips: {clip_map}.
+
+The comparison purpose is: {purpose}
+
+Rank the clips for this purpose and explain your reasoning. Return ONLY valid JSON (no markdown):
+{{
+  "ranking": ["A", "B", "C", "D"],
+  "scores": {{"A": 0.0, "B": 0.0, "C": 0.0, "D": 0.0}},
+  "best_clip": "A",
+  "best_reason": "why this clip wins for this purpose; be specific about framing, subject, behavior, composition",
+  "worst_clip": "C",
+  "worst_reason": "why this clip loses",
+  "notes": "one comparison insight"
+}}
+
+RULES:
+- scores 0.0-1.0, calibrated RELATIVE to the other clips in this batch.
+- be specific: reference actual visual details (subject visibility, framing, behavior, stability).
+- ranking must contain exactly the clip labels used.
+"""

--- a/tools/video/vlm_comparative_rank.py
+++ b/tools/video/vlm_comparative_rank.py
@@ -85,7 +85,7 @@ class VlmComparativeRank(BaseTool):
     provider = "openmontage"
     stability = ToolStability.EXPERIMENTAL
     execution_mode = ExecutionMode.SYNC
-    determinism = Determinism.SEEDED
+    determinism = Determinism.STOCHASTIC
     runtime = ToolRuntime.LOCAL_GPU
 
     dependencies = ["cmd:ffmpeg", "cmd:ffprobe"]

--- a/tools/video/vlm_editorial_ranking.py
+++ b/tools/video/vlm_editorial_ranking.py
@@ -1,0 +1,358 @@
+"""VLM editorial ranking: composite scores, leaderboards, and match cuts.
+
+Consumes the coarse ratings (``vlm_clip_rating``) plus optional zoom data
+(``vlm_zoom_rating``) and produces a structured editorial view: composite
+scores blending stability, quality, subject visibility, composition, and
+vibe; per-purpose leaderboards; and match-cut chains from subject facing
+direction.
+
+The composite weighting is configurable so a campaign can bias toward
+product shots, stability, or energy.
+
+Usage (as a tool)::
+
+    {
+      "ratings_path": "/path/to/clip_tags.jsonl",
+      "zooms_path": "/path/to/clip_zooms.jsonl",   // optional
+      "output_path": "/path/to/editorial_rankings.json",
+      "weights": {"stability": 0.25, "quality": 0.25, "subject": 0.25,
+                  "composition": 0.15, "vibe": 0.10}
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+from tools.video.vlm_rating_common import safe_float
+
+
+DEFAULT_WEIGHTS = {
+    "stability": 0.25,
+    "quality": 0.25,
+    "subject": 0.25,
+    "composition": 0.15,
+    "vibe": 0.10,
+}
+
+VIBE_SCORE = {
+    "calm": 0.7, "candid": 0.8, "playful": 0.9, "energetic": 1.0,
+    "tender": 0.85, "tense": 0.5, "neutral": 0.6, "excited": 0.95,
+    "hyper": 0.9,
+}
+
+
+class VlmEditorialRanking(BaseTool):
+    name = "vlm_editorial_ranking"
+    version = "0.1.0"
+    tier = ToolTier.ANALYZE
+    capability = "editorial_ranking"
+    provider = "openmontage"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.DETERMINISTIC
+    runtime = ToolRuntime.LOCAL
+
+    dependencies: list[str] = []
+    install_instructions = "No external dependencies (pure Python)."
+    agent_skills = ["vlm-footage-rating"]
+
+    capabilities = [
+        "composite_editorial_scoring",
+        "per_purpose_leaderboards",
+        "best_moment_extraction",
+        "match_cut_chains",
+    ]
+    supports = {"configurable_weights": True, "local_only": True}
+    best_for = [
+        "deciding which clips go where in a montage",
+        "surfacing the best subject/product moments",
+        "building directional continuity for match cuts",
+    ]
+    not_good_for = [
+        "semantic indexing (use vlm_clip_rating)",
+        "frame-accurate timestamps (use vlm_zoom_rating)",
+        "relative clip comparison with reasoning (use vlm_comparative_rank)",
+    ]
+
+    input_schema = {
+        "type": "object",
+        "required": ["ratings_path", "output_path"],
+        "properties": {
+            "ratings_path": {"type": "string"},
+            "zooms_path": {"type": "string", "default": ""},
+            "output_path": {"type": "string"},
+            "weights": {
+                "type": "object",
+                "description": "Composite score weights (must sum to 1.0).",
+            },
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=512, vram_mb=0, disk_mb=50,
+        network_required=False,
+    )
+    side_effects = ["writes JSON output"]
+    user_visible_verification = [
+        "Open output_path and check leaderboards + match_cuts exist.",
+    ]
+
+    def get_status(self) -> ToolStatus:
+        return ToolStatus.AVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        return 0.0
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        return 2.0
+
+    # ------------------------------------------------------------------
+    # Execute
+    # ------------------------------------------------------------------
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        start = time.time()
+        try:
+            ratings_path = inputs["ratings_path"]
+            output_path = str(inputs["output_path"])
+            zooms_path = str(inputs.get("zooms_path", "") or "")
+            if not Path(ratings_path).exists():
+                return ToolResult(
+                    success=False,
+                    error=f"ratings_path {ratings_path} does not exist",
+                )
+
+            weights = {**DEFAULT_WEIGHTS, **(inputs.get("weights") or {})}
+            total = sum(weights.values())
+            if abs(total - 1.0) > 0.001:
+                return ToolResult(
+                    success=False,
+                    error=f"Weights must sum to 1.0 (got {total:.3f})",
+                )
+
+            ratings = _load_jsonl(ratings_path)
+            zooms = _load_jsonl(zooms_path) if zooms_path and Path(zooms_path).exists() else {}
+            zoom_lookup = {z["clip"]: z for z in zooms.values() if isinstance(z, dict)}
+
+            rows = [_rank_row(r, zoom_lookup.get(r["clip"]), weights) for r in ratings.values()]
+            rows.sort(key=lambda r: r["composite"], reverse=True)
+
+            leaderboards = {
+                "overall": _rank(rows, lambda r: r["composite"]),
+                "subject_hero": _rank(
+                    rows,
+                    lambda r: r["subject_quality"] * 0.7 + r["composite"] * 0.3,
+                ),
+                "stable": _rank(
+                    rows,
+                    lambda r: r["stability"] * 0.5 + r["composite"] * 0.3,
+                ),
+                "energy": _rank(
+                    rows,
+                    lambda r: (0.6 if r["energy"] in ("excited", "hyper") else 0)
+                    + r["composite"] * 0.4,
+                ),
+                "subject_closeup": _rank(
+                    rows,
+                    lambda r: (1.0 if r["subject_visibility"] in ("featured", "clear") else 0)
+                    + r["subject_quality"],
+                ),
+            }
+
+            match_cuts = _match_cuts(zooms)
+
+            out = {
+                "n_clips": len(rows),
+                "weights": weights,
+                "leaderboards": {
+                    k: [r["summary"] for r in v] for k, v in leaderboards.items()
+                },
+                "match_cuts": match_cuts,
+                "all_rows": rows,
+            }
+            Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+            with open(output_path, "w") as fh:
+                json.dump(out, fh, indent=2)
+
+            return ToolResult(
+                success=True,
+                data={
+                    "n_clips": len(rows),
+                    "leaderboards": list(leaderboards),
+                    "output_path": output_path,
+                },
+                duration_seconds=round(time.time() - start, 3),
+                cost_usd=0.0,
+            )
+        except Exception as exc:  # noqa: BLE001
+            import traceback
+
+            return ToolResult(
+                success=False,
+                error=f"{type(exc).__name__}: {exc}\n{traceback.format_exc()[-800:]}",
+            )
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _load_jsonl(path: str) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    p = Path(path)
+    if not p.exists():
+        return out
+    with p.open() as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(rec, dict) or rec.get("error"):
+                continue
+            key = rec.get("clip") or rec.get("id")
+            if key:
+                out[key] = rec
+    return out
+
+
+def _rank(
+    rows: list[dict[str, Any]], key_fn: Callable[[dict[str, Any]], float]
+) -> list[dict[str, Any]]:
+    return sorted(rows, key=key_fn, reverse=True)
+
+
+def _rank_row(
+    rec: dict[str, Any], zoom: dict[str, Any] | None, weights: dict[str, float]
+) -> dict[str, Any]:
+    overall = rec.get("overall", {})
+    cam = rec.get("camera", {})
+    shot = rec.get("shot", {})
+    prod = rec.get("product", {})
+    qual = rec.get("quality", {})
+
+    stability = safe_float(cam.get("stability_score"), 0.8)
+    quality = safe_float(qual.get("overall_score"), 0.7)
+    subject_quality = safe_float(prod.get("subject_quality_score"), 0.0)
+    composition = safe_float(shot.get("rule_of_thirds_score"), 0.5)
+    energy = overall.get("energy", "neutral")
+    vibe = VIBE_SCORE.get(energy, 0.6)
+
+    composite = (
+        weights["stability"] * stability
+        + weights["quality"] * quality
+        + weights["subject"] * subject_quality
+        + weights["composition"] * composition
+        + weights["vibe"] * vibe
+    )
+
+    best_moment = _best_moment(zoom)
+
+    return {
+        "clip": rec.get("clip"),
+        "file": rec.get("file") or rec.get("path"),
+        "behavior": overall.get("behavior"),
+        "energy": energy,
+        "stability": round(stability, 2),
+        "composition": round(composition, 2),
+        "subject_quality": round(subject_quality, 2),
+        "subject_visibility": prod.get("subject_visibility")
+        or prod.get("collar_visibility"),
+        "shot_type": shot.get("type"),
+        "shot_purpose": shot.get("shot_purpose") or shot.get("purpose"),
+        "quality": round(quality, 2),
+        "duration_s": rec.get("duration_s"),
+        "composite": round(composite, 3),
+        "best_moment": best_moment,
+        "summary": {
+            "clip": rec.get("clip"),
+            "composite": round(composite, 3),
+            "behavior": overall.get("behavior"),
+            "energy": energy,
+            "stability": round(stability, 2),
+            "subject_quality": round(subject_quality, 2),
+            "subject_visibility": prod.get("subject_visibility")
+            or prod.get("collar_visibility"),
+            "shot_type": shot.get("type"),
+            "duration_s": rec.get("duration_s"),
+        },
+    }
+
+
+def _best_moment(zoom: dict[str, Any] | None) -> list[Any] | None:
+    """Extract the highest-quality zoom sub-beat with absolute timestamp."""
+    if not zoom:
+        return None
+    best: list[Any] | None = None
+    for z in zoom.get("zooms", []) or []:
+        if not isinstance(z, dict):
+            continue
+        ws = safe_float(z.get("window_start_s"), 0.0)
+        for b in z.get("sub_beats", []) or []:
+            if not isinstance(b, dict):
+                continue
+            q = safe_float(b.get("quality_score"), 0.0)
+            if q < 0.8:
+                continue
+            abs_start = ws + safe_float(b.get("start_s"), 0.0)
+            if best is None or q > best[0]:
+                best = [
+                    q,
+                    round(abs_start, 2),
+                    b.get("deep_dive") or b.get("action") or "",
+                    b.get("subject_visibility") or b.get("collar_visibility"),
+                    b.get("subject_facing"),
+                    b.get("vibe"),
+                ]
+    return best
+
+
+def _match_cuts(zooms: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    """Build directional continuity chains from zoom sub-beats."""
+    facing_seq: list[dict[str, Any]] = []
+    for clip, z in zooms.items():
+        for zz in z.get("zooms", []) or []:
+            if not isinstance(zz, dict):
+                continue
+            ws = safe_float(zz.get("window_start_s"), 0.0)
+            for b in zz.get("sub_beats", []) or []:
+                if not isinstance(b, dict):
+                    continue
+                facing = b.get("subject_facing")
+                if facing not in ("left", "right"):
+                    continue
+                facing_seq.append({
+                    "clip": clip,
+                    "t": round(ws + safe_float(b.get("start_s"), 0.0), 1),
+                    "facing": facing,
+                    "q": safe_float(b.get("quality_score"), 0.0),
+                    "action": b.get("action", ""),
+                })
+    chains = []
+    for direction in ("left", "right"):
+        chain = sorted(
+            [fs for fs in facing_seq if fs["facing"] == direction],
+            key=lambda x: -x["q"],
+        )[:10]
+        if chain:
+            chains.append({"direction": direction, "chain": chain})
+    return chains

--- a/tools/video/vlm_rating_common.py
+++ b/tools/video/vlm_rating_common.py
@@ -1,0 +1,334 @@
+"""Shared plumbing for the VLM clip-rating tool family.
+
+This module keeps the four rating tools (`vlm_clip_rating`, `vlm_zoom_rating`,
+`vlm_editorial_ranking`, `vlm_comparative_rank`) free of duplicated
+infrastructure: Ollama HTTP transport, frame extraction, JSONL corpus I/O,
+and defensive JSON parsing.
+
+Design notes
+------------
+- All heavy imports (urllib, subprocess, numpy) are lazy so importing this
+  module never costs anything at registry-discovery time.
+- Every function is pure and dependency-injectable: the tools pass in an
+  ``ollama_url`` and ``model`` rather than reading globals, which keeps the
+  unit tests hermetic (they mock the HTTP layer).
+- JSONL append is the storage primitive. Tools resume by loading the set of
+  already-rated clip ids from the output file, so re-runs are idempotent.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+import time
+from pathlib import Path
+from typing import Any, Callable, Iterable, Optional
+
+
+# ---------------------------------------------------------------------------
+# Ollama HTTP transport
+# ---------------------------------------------------------------------------
+
+
+def ollama_generate(
+    ollama_url: str,
+    model: str,
+    prompt: str,
+    images: list[str],
+    *,
+    temperature: float = 0.1,
+    num_predict: int = 1500,
+    format_json: bool = True,
+    timeout: float = 600.0,
+    max_retries: int = 3,
+    retry_backoff: float = 5.0,
+) -> str:
+    """Call Ollama's /api/generate with base64 images and return raw text.
+
+    Raises ``RuntimeError`` after exhausting retries. This is intentionally
+    the only network-touching helper in the family; everything else operates
+    on already-fetched data.
+    """
+    import urllib.request
+
+    payload: dict[str, Any] = {
+        "model": model,
+        "prompt": prompt,
+        "images": images,
+        "stream": False,
+        "options": {"temperature": temperature, "num_predict": num_predict},
+    }
+    if format_json:
+        payload["format"] = "json"
+
+    data = json.dumps(payload).encode()
+    last_err: Optional[Exception] = None
+    for attempt in range(max_retries):
+        try:
+            req = urllib.request.Request(
+                ollama_url.rstrip("/") + "/api/generate",
+                data=data,
+                headers={"Content-Type": "application/json"},
+            )
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                out = json.loads(resp.read().decode("utf-8"))
+            if out.get("error"):
+                raise RuntimeError(f"Ollama error: {out['error']}")
+            return str(out.get("response", ""))
+        except Exception as exc:  # noqa: BLE001 - retry everything transient
+            last_err = exc
+            if attempt < max_retries - 1:
+                time.sleep(retry_backoff * (attempt + 1))
+    raise RuntimeError(f"Ollama request failed after {max_retries} attempts: {last_err}")
+
+
+# ---------------------------------------------------------------------------
+# Defensive JSON parsing (VLM output is not guaranteed well-formed)
+# ---------------------------------------------------------------------------
+
+
+def parse_vlm_json(raw: str) -> dict[str, Any]:
+    """Parse a VLM's JSON response, tolerating surrounding prose and drift.
+
+    Strategy: try strict ``json.loads`` first; if that fails, extract the
+    largest balanced ``{...}`` region with a brace matcher and try again.
+    Returns ``{"error": ..., "raw": ...}`` on total failure so callers can
+    record the failure instead of crashing the whole batch.
+    """
+    raw = (raw or "").strip()
+    if not raw:
+        return {"error": "empty_response", "raw": raw}
+    try:
+        parsed = json.loads(raw)
+        if isinstance(parsed, dict):
+            return parsed
+    except json.JSONDecodeError:
+        pass
+
+    # Brace-match the largest balanced object.
+    start = raw.find("{")
+    if start != -1:
+        depth = 0
+        for i in range(start, len(raw)):
+            if raw[i] == "{":
+                depth += 1
+            elif raw[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    candidate = raw[start : i + 1]
+                    try:
+                        parsed = json.loads(candidate)
+                        if isinstance(parsed, dict):
+                            return parsed
+                    except json.JSONDecodeError:
+                        break
+    return {"error": "json_parse_failed", "raw": raw[:400]}
+
+
+def safe_float(value: Any, default: float = 0.0) -> float:
+    """Coerce a value to float, tolerating strings like '': 6.25, '."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def normalize_drift(
+    record: dict[str, Any], aliases: dict[str, list[str]]
+) -> dict[str, Any]:
+    """Fold known field-name drift from VLM output into canonical names.
+
+    ``aliases`` maps canonical name -> list of tolerated alternates. Only the
+    first present alternate is used. Mutates and returns ``record``.
+    """
+    for canonical, alternates in aliases.items():
+        if canonical in record:
+            continue
+        for alt in alternates:
+            if alt in record:
+                record[canonical] = record[alt]
+                break
+    return record
+
+
+# ---------------------------------------------------------------------------
+# Frame extraction
+# ---------------------------------------------------------------------------
+
+
+def probe_duration(video_path: str, default: float = 8.0) -> float:
+    """Return video duration in seconds via ffprobe (fallback ``default``)."""
+    import subprocess
+
+    out = subprocess.run(
+        [
+            "ffprobe", "-v", "error",
+            "-show_entries", "format=duration",
+            "-of", "default=noprint_wrappers=1:nokey=1",
+            video_path,
+        ],
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    try:
+        return float(out)
+    except ValueError:
+        return default
+
+
+def extract_frames(
+    video_path: str,
+    out_dir: str,
+    n_frames: int = 8,
+    scale: int = 640,
+) -> tuple[list[str], str, float]:
+    """Extract ``n_frames`` evenly-spaced frames across the whole clip.
+
+    Returns ``(frame_paths, frame_map_text, duration_s)`` where
+    ``frame_map_text`` is a prompt-ready listing of ``frame_NN.jpg = <t>s``
+    mappings that lets the VLM anchor timestamps to real seconds.
+
+    Frames are sampled by FPS so they spread across the full duration
+    regardless of source framerate (100fps source, 24fps source, whatever).
+    """
+    import glob
+    import os
+    import subprocess
+
+    out_dir_p = Path(out_dir)
+    out_dir_p.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir_p.glob("f_*.jpg"):
+        existing.unlink()
+
+    dur = probe_duration(video_path, default=8.0)
+    # fps = n_frames / duration spreads frames evenly; clamp so we never
+    # request more than n_frames total.
+    fps_rate = max(n_frames / dur, 0.5) if dur > 0 else 1.0
+    subprocess.run(
+        [
+            "ffmpeg", "-y", "-v", "error",
+            "-i", video_path,
+            "-vf", f"fps={fps_rate:.4f},scale={scale}:-2",
+            "-frames:v", str(n_frames),
+            f"{out_dir_p / 'f_%02d.jpg'}",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    paths = sorted(glob.glob(str(out_dir_p / "f_*.jpg")))
+    n = len(paths)
+    times = [round(i * dur / max(n - 1, 1), 2) for i in range(n)]
+    frame_map = "\n".join(
+        f"  frame_{i + 1:02d}.jpg = {t}s" for i, t in enumerate(times)
+    )
+    return paths, frame_map, dur
+
+
+def extract_window(
+    video_path: str,
+    t0: float,
+    t1: float,
+    out_dir: str,
+    *,
+    zoom_fps: float = 4.0,
+    max_frames: int = 12,
+    scale: int = 640,
+) -> tuple[list[str], str, float]:
+    """Extract high-density frames inside a short window ``[t0, t1]``.
+
+    Used by the zoom pass to get frame-accurate sub-beat timestamps inside
+    an already-flagged highlight window. Returns same shape as
+    ``extract_frames`` (times are relative to the window start).
+    """
+    import glob
+    import subprocess
+
+    out_dir_p = Path(out_dir)
+    out_dir_p.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir_p.glob("f_*.jpg"):
+        existing.unlink()
+
+    win_dur = max(t1 - t0, 0.5)
+    subprocess.run(
+        [
+            "ffmpeg", "-y", "-v", "error",
+            "-ss", str(max(t0, 0)), "-t", str(win_dur),
+            "-i", video_path,
+            "-vf", f"fps={zoom_fps},scale={scale}:-2",
+            "-frames:v", str(max_frames),
+            f"{out_dir_p / 'f_%02d.jpg'}",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    paths = sorted(glob.glob(str(out_dir_p / "f_*.jpg")))
+    n = len(paths)
+    times = [round(i * win_dur / max(n - 1, 1), 2) for i in range(n)]
+    frame_map = "\n".join(
+        f"  frame_{i + 1:02d}.jpg = {t}s" for i, t in enumerate(times)
+    )
+    return paths, frame_map, win_dur
+
+
+def images_b64(paths: Iterable[str]) -> list[str]:
+    """Base64-encode a list of image paths for the Ollama payload."""
+    encoded = []
+    for p in paths:
+        with open(p, "rb") as fh:
+            encoded.append(base64.b64encode(fh.read()).decode())
+    return encoded
+
+
+# ---------------------------------------------------------------------------
+# JSONL corpus I/O (append + resume)
+# ---------------------------------------------------------------------------
+
+
+def load_rated_ids(jsonl_path: str) -> set[str]:
+    """Return the set of clip ids already present in a JSONL corpus."""
+    rated: set[str] = set()
+    p = Path(jsonl_path)
+    if not p.exists():
+        return rated
+    with p.open() as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            clip = record.get("clip") or record.get("id")
+            if clip:
+                rated.add(clip)
+    return rated
+
+
+def append_record(jsonl_path: str, record: dict[str, Any]) -> None:
+    """Append one JSON record to a JSONL file (creates parent dirs)."""
+    p = Path(jsonl_path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("a") as fh:
+        fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Generic rubric builder
+# ---------------------------------------------------------------------------
+
+
+def build_behavior_taxonomy(custom: Optional[str] = None) -> str:
+    """Return the behavior taxonomy line for prompts.
+
+    ``custom`` may be an extra comma-separated list of labels appended to the
+    default set (e.g. campaign-specific behaviors).
+    """
+    base = (
+        "walking_calm|pulling|sniffing|trotting|sitting|lying|"
+        "greeting|playing|expression|other"
+    )
+    if custom:
+        return f"{base}|{custom}"
+    return base

--- a/tools/video/vlm_rating_common.py
+++ b/tools/video/vlm_rating_common.py
@@ -19,16 +19,63 @@ Design notes
 from __future__ import annotations
 
 import base64
+import ipaddress
 import json
 import re
 import time
 from pathlib import Path
 from typing import Any, Callable, Iterable, Optional
+from urllib.parse import urlparse
 
 
 # ---------------------------------------------------------------------------
 # Ollama HTTP transport
 # ---------------------------------------------------------------------------
+
+
+def validate_local_ollama_url(ollama_url: str) -> str:
+    """Validate that an Ollama endpoint is HTTP(S) on the local machine."""
+    parsed = urlparse(ollama_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ValueError("ollama_url must be an http(s) URL on localhost")
+    if parsed.username or parsed.password:
+        raise ValueError("ollama_url must not include credentials")
+    host = parsed.hostname.lower()
+    if host != "localhost":
+        try:
+            if not ipaddress.ip_address(host).is_loopback:
+                raise ValueError
+        except ValueError as exc:
+            raise ValueError(
+                "ollama_url must use localhost or a loopback IP; VLM frames "
+                "must not be sent to a remote endpoint"
+            ) from exc
+    return ollama_url.rstrip("/")
+
+
+def ollama_model_available(
+    ollama_url: str = "http://127.0.0.1:11434",
+    model: str = "gemma4:12b",
+    *,
+    timeout: float = 2.0,
+) -> bool:
+    """Return whether the local Ollama service has *model* installed."""
+    import urllib.request
+
+    try:
+        base_url = validate_local_ollama_url(ollama_url)
+        with urllib.request.urlopen(f"{base_url}/api/tags", timeout=timeout) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+        installed = {
+            str(item.get("name") or item.get("model") or "")
+            for item in payload.get("models", [])
+        }
+        candidates = {model}
+        if ":" not in model:
+            candidates.add(f"{model}:latest")
+        return bool(candidates & installed)
+    except Exception:
+        return False
 
 
 def ollama_generate(
@@ -52,6 +99,8 @@ def ollama_generate(
     """
     import urllib.request
 
+    ollama_url = validate_local_ollama_url(ollama_url)
+
     payload: dict[str, Any] = {
         "model": model,
         "prompt": prompt,
@@ -67,7 +116,7 @@ def ollama_generate(
     for attempt in range(max_retries):
         try:
             req = urllib.request.Request(
-                ollama_url.rstrip("/") + "/api/generate",
+                ollama_url + "/api/generate",
                 data=data,
                 headers={"Content-Type": "application/json"},
             )
@@ -286,7 +335,11 @@ def images_b64(paths: Iterable[str]) -> list[str]:
 
 
 def load_rated_ids(jsonl_path: str) -> set[str]:
-    """Return the set of clip ids already present in a JSONL corpus."""
+    """Return successfully processed clip ids from a JSONL corpus.
+
+    Error records are intentionally excluded so transient ffmpeg/Ollama
+    failures remain retryable on the next invocation.
+    """
     rated: set[str] = set()
     p = Path(jsonl_path)
     if not p.exists():
@@ -300,7 +353,7 @@ def load_rated_ids(jsonl_path: str) -> set[str]:
                 record = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            clip = record.get("clip") or record.get("id")
+            clip = None if record.get("error") else (record.get("clip") or record.get("id"))
             if clip:
                 rated.add(clip)
     return rated

--- a/tools/video/vlm_zoom_rating.py
+++ b/tools/video/vlm_zoom_rating.py
@@ -23,6 +23,7 @@ Usage (as a tool)::
 from __future__ import annotations
 
 import json
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -63,7 +64,9 @@ class VlmZoomRating(BaseTool):
     dependencies = ["cmd:ffmpeg", "cmd:ffprobe"]
     install_instructions = (
         "pip install requests\n"
-        "Install Ollama and pull a vision model (see vlm_clip_rating)."
+        "Install Ollama and pull the tested model: `ollama pull gemma4:12b` "
+        "(~8GB VRAM, recommended). Smaller models are untested; see the "
+        "vlm-footage-rating skill for guidance."
     )
     agent_skills = ["vlm-footage-rating"]
 
@@ -103,13 +106,21 @@ class VlmZoomRating(BaseTool):
             "max_windows_per_clip": {"type": "integer", "default": 4, "minimum": 1},
             "zoom_fps": {"type": "number", "default": 4.0},
             "max_frames_per_window": {"type": "integer", "default": 12},
+            "frame_scale": {
+                "type": "integer",
+                "default": 640,
+                "minimum": 320,
+                "maximum": 1280,
+                "description": "Frame width for the VLM. Smaller (384-480) is faster "
+                               "and uses less VRAM; best for 4b models.",
+            },
             "temperature": {"type": "number", "default": 0.1},
             "num_predict": {"type": "integer", "default": 900},
         },
     }
 
     resource_profile = ResourceProfile(
-        cpu_cores=2, ram_mb=1024, vram_mb=6144, disk_mb=200,
+        cpu_cores=2, ram_mb=1024, vram_mb=3584, disk_mb=200,
         network_required=False,
     )
     side_effects = ["writes JSONL output", "writes temporary frame jpgs"]
@@ -167,9 +178,10 @@ class VlmZoomRating(BaseTool):
             max_windows = int(inputs.get("max_windows_per_clip", 4))
             zoom_fps = float(inputs.get("zoom_fps", 4.0))
             max_frames = int(inputs.get("max_frames_per_window", 12))
+            frame_scale = int(inputs.get("frame_scale", 640))
             temperature = float(inputs.get("temperature", 0.1))
             num_predict = int(inputs.get("num_predict", 900))
-            tmp_dir = Path(inputs.get("tmp_dir", "/tmp")) / "vlm_zoom_frames"
+            tmp_dir = Path(inputs.get("tmp_dir") or tempfile.gettempdir()) / "vlm_zoom_frames"
 
             clips = self._load_coarse(ratings_path)
             done = load_rated_ids(output_path)
@@ -198,6 +210,7 @@ class VlmZoomRating(BaseTool):
                         paths, frame_map, win_dur = extract_window(
                             video, t0, t1, str(tmp_dir),
                             zoom_fps=zoom_fps, max_frames=max_frames,
+                            scale=frame_scale,
                         )
                         if len(paths) < 2:
                             continue

--- a/tools/video/vlm_zoom_rating.py
+++ b/tools/video/vlm_zoom_rating.py
@@ -45,8 +45,10 @@ from tools.video.vlm_rating_common import (
     images_b64,
     load_rated_ids,
     ollama_generate,
+    ollama_model_available,
     parse_vlm_json,
     safe_float,
+    validate_local_ollama_url,
 )
 
 
@@ -63,7 +65,6 @@ class VlmZoomRating(BaseTool):
 
     dependencies = ["cmd:ffmpeg", "cmd:ffprobe"]
     install_instructions = (
-        "pip install requests\n"
         "Install Ollama and pull the tested model: `ollama pull gemma4:12b` "
         "(~8GB VRAM, recommended). Smaller models are untested; see the "
         "vlm-footage-rating skill for guidance."
@@ -102,7 +103,11 @@ class VlmZoomRating(BaseTool):
                 "description": "JSONL output. Re-running skips done clips.",
             },
             "model": {"type": "string", "default": "gemma4:12b"},
-            "ollama_url": {"type": "string", "default": "http://127.0.0.1:11434"},
+            "ollama_url": {
+                "type": "string",
+                "default": "http://127.0.0.1:11434",
+                "description": "Local Ollama endpoint. Only localhost/loopback URLs are accepted.",
+            },
             "max_windows_per_clip": {"type": "integer", "default": 4, "minimum": 1},
             "zoom_fps": {"type": "number", "default": 4.0},
             "max_frames_per_window": {"type": "integer", "default": 12},
@@ -133,7 +138,11 @@ class VlmZoomRating(BaseTool):
 
         if shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None:
             return ToolStatus.UNAVAILABLE
-        return ToolStatus.AVAILABLE
+        return (
+            ToolStatus.AVAILABLE
+            if ollama_model_available(model="gemma4:12b")
+            else ToolStatus.UNAVAILABLE
+        )
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
         return 0.0
@@ -174,7 +183,9 @@ class VlmZoomRating(BaseTool):
                 )
 
             model = inputs.get("model", "gemma4:12b")
-            ollama_url = inputs.get("ollama_url", "http://127.0.0.1:11434")
+            ollama_url = validate_local_ollama_url(
+                inputs.get("ollama_url", "http://127.0.0.1:11434")
+            )
             max_windows = int(inputs.get("max_windows_per_clip", 4))
             zoom_fps = float(inputs.get("zoom_fps", 4.0))
             max_frames = int(inputs.get("max_frames_per_window", 12))
@@ -233,9 +244,16 @@ class VlmZoomRating(BaseTool):
                             "window_start_s": round(t0, 2),
                             "window_end_s": round(t1, 2),
                         })
-                if clip_result["zooms"]:
+                successful_zooms = [
+                    zoom for zoom in clip_result["zooms"] if not zoom.get("error")
+                ]
+                if successful_zooms:
                     append_record(output_path, clip_result)
                     zoomed += 1
+                elif clip_result["zooms"]:
+                    clip_result["error"] = "all_windows_failed"
+                    append_record(output_path, clip_result)
+                    failed += 1
 
             return ToolResult(
                 success=True,

--- a/tools/video/vlm_zoom_rating.py
+++ b/tools/video/vlm_zoom_rating.py
@@ -1,0 +1,345 @@
+"""VLM zoom rating: frame-accurate sub-beat extraction inside flagged windows.
+
+Takes the coarse ratings from ``vlm_clip_rating`` (segments/highlights
+anchored to a few sampled frames) and re-examines each promising window at
+high frame density (4 fps), producing sub-beats with precise timestamps,
+camera angle, subject facing direction, deep-dive descriptions, and vibe.
+
+This is the layer that turns "a good moment somewhere around 34-41s" into
+"the collar interaction starts at 38.5s and ends at 41.6s", which is what a
+real editor needs to cut without watching.
+
+Usage (as a tool)::
+
+    {
+      "ratings_path": "/path/to/clip_tags.jsonl",
+      "output_path": "/path/to/clip_zooms.jsonl",
+      "model": "gemma4:12b",
+      "ollama_url": "http://127.0.0.1:11434",
+      "max_windows_per_clip": 4
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+from tools.video.vlm_rating_common import (
+    append_record,
+    extract_window,
+    images_b64,
+    load_rated_ids,
+    ollama_generate,
+    parse_vlm_json,
+    safe_float,
+)
+
+
+class VlmZoomRating(BaseTool):
+    name = "vlm_zoom_rating"
+    version = "0.1.0"
+    tier = ToolTier.ANALYZE
+    capability = "temporal_zoom_rating"
+    provider = "openmontage"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.SEEDED
+    runtime = ToolRuntime.LOCAL_GPU
+
+    dependencies = ["cmd:ffmpeg", "cmd:ffprobe"]
+    install_instructions = (
+        "pip install requests\n"
+        "Install Ollama and pull a vision model (see vlm_clip_rating)."
+    )
+    agent_skills = ["vlm-footage-rating"]
+
+    capabilities = [
+        "frame_accurate_timestamps",
+        "sub_beat_segmentation",
+        "camera_angle_detection",
+        "subject_facing_detection",
+        "deep_dive_description",
+        "vibe_classification",
+    ]
+    supports = {"resume": True, "local_only": True}
+    best_for = [
+        "getting cut-precise timestamps for a highlight window",
+        "describing a promising moment in enough detail to edit without watching",
+        "match-cut continuity via subject facing direction",
+    ]
+    not_good_for = [
+        "first-pass semantic indexing (use vlm_clip_rating)",
+        "ranking clips against each other (use vlm_comparative_rank)",
+    ]
+
+    input_schema = {
+        "type": "object",
+        "required": ["ratings_path", "output_path"],
+        "properties": {
+            "ratings_path": {
+                "type": "string",
+                "description": "JSONL from vlm_clip_rating (coarse pass).",
+            },
+            "output_path": {
+                "type": "string",
+                "description": "JSONL output. Re-running skips done clips.",
+            },
+            "model": {"type": "string", "default": "gemma4:12b"},
+            "ollama_url": {"type": "string", "default": "http://127.0.0.1:11434"},
+            "max_windows_per_clip": {"type": "integer", "default": 4, "minimum": 1},
+            "zoom_fps": {"type": "number", "default": 4.0},
+            "max_frames_per_window": {"type": "integer", "default": 12},
+            "temperature": {"type": "number", "default": 0.1},
+            "num_predict": {"type": "integer", "default": 900},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=2, ram_mb=1024, vram_mb=6144, disk_mb=200,
+        network_required=False,
+    )
+    side_effects = ["writes JSONL output", "writes temporary frame jpgs"]
+    user_visible_verification = [
+        "Open output_path and check sub_beats have precise start_s/end_s.",
+    ]
+
+    def get_status(self) -> ToolStatus:
+        import shutil
+
+        if shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None:
+            return ToolStatus.UNAVAILABLE
+        return ToolStatus.AVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        return 0.0
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        return max(30.0, self._count_windows(inputs) * 30.0)
+
+    def _count_windows(self, inputs: dict[str, Any]) -> int:
+        import glob
+
+        n = 0
+        ratings = inputs.get("ratings_path", "")
+        if ratings and Path(ratings).exists():
+            with open(ratings) as fh:
+                for line in fh:
+                    try:
+                        rec = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    n += len(rec.get("highlights", []) or []) + len(
+                        rec.get("segments", []) or []
+                    )
+        return n
+
+    # ------------------------------------------------------------------
+    # Execute
+    # ------------------------------------------------------------------
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        start = time.time()
+        try:
+            ratings_path = inputs["ratings_path"]
+            output_path = str(inputs["output_path"])
+            if not Path(ratings_path).exists():
+                return ToolResult(
+                    success=False,
+                    error=f"ratings_path {ratings_path} does not exist",
+                )
+
+            model = inputs.get("model", "gemma4:12b")
+            ollama_url = inputs.get("ollama_url", "http://127.0.0.1:11434")
+            max_windows = int(inputs.get("max_windows_per_clip", 4))
+            zoom_fps = float(inputs.get("zoom_fps", 4.0))
+            max_frames = int(inputs.get("max_frames_per_window", 12))
+            temperature = float(inputs.get("temperature", 0.1))
+            num_predict = int(inputs.get("num_predict", 900))
+            tmp_dir = Path(inputs.get("tmp_dir", "/tmp")) / "vlm_zoom_frames"
+
+            clips = self._load_coarse(ratings_path)
+            done = load_rated_ids(output_path)
+            prompt = _build_prompt()
+
+            zoomed = 0
+            failed = 0
+            for clip, rec in clips.items():
+                if clip in done:
+                    continue
+                windows = self._pick_windows(rec, max_windows)
+                if not windows:
+                    continue
+                video = rec.get("file") or rec.get("path")
+                if not video or not Path(video).exists():
+                    failed += 1
+                    continue
+                clip_result = {
+                    "clip": clip,
+                    "file": video,
+                    "duration_s": rec.get("duration_s"),
+                    "zooms": [],
+                }
+                for (t0, t1, wtype) in windows:
+                    try:
+                        paths, frame_map, win_dur = extract_window(
+                            video, t0, t1, str(tmp_dir),
+                            zoom_fps=zoom_fps, max_frames=max_frames,
+                        )
+                        if len(paths) < 2:
+                            continue
+                        images = images_b64(paths)
+                        filled = prompt.format(
+                            n=len(paths), dur=win_dur, t0=t0, frame_map=frame_map
+                        )
+                        raw = ollama_generate(
+                            ollama_url, model, filled, images,
+                            temperature=temperature, num_predict=num_predict,
+                        )
+                        result = parse_vlm_json(raw)
+                        result["window_start_s"] = round(t0, 2)
+                        result["window_end_s"] = round(t1, 2)
+                        result["window_type"] = wtype
+                        clip_result["zooms"].append(result)
+                    except Exception as exc:  # noqa: BLE001
+                        clip_result["zooms"].append({
+                            "error": str(exc)[:300],
+                            "window_start_s": round(t0, 2),
+                            "window_end_s": round(t1, 2),
+                        })
+                if clip_result["zooms"]:
+                    append_record(output_path, clip_result)
+                    zoomed += 1
+
+            return ToolResult(
+                success=True,
+                data={
+                    "zoomed": zoomed,
+                    "failed": failed,
+                    "output_path": output_path,
+                },
+                duration_seconds=round(time.time() - start, 3),
+                cost_usd=0.0,
+            )
+        except Exception as exc:  # noqa: BLE001
+            import traceback
+
+            return ToolResult(
+                success=False,
+                error=f"{type(exc).__name__}: {exc}\n{traceback.format_exc()[-800:]}",
+            )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _load_coarse(ratings_path: str) -> dict[str, dict[str, Any]]:
+        clips: dict[str, dict[str, Any]] = {}
+        with open(ratings_path) as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if rec.get("error"):
+                    continue
+                clip = rec.get("clip")
+                if clip:
+                    clips[clip] = rec
+        return clips
+
+    @staticmethod
+    def _pick_windows(
+        rec: dict[str, Any], max_windows: int
+    ) -> list[tuple[float, float, str]]:
+        windows: list[tuple[float, float, str]] = []
+        dur = rec.get("duration_s") or 10.0
+        for h in rec.get("highlights", []) or []:
+            if not isinstance(h, dict):
+                continue
+            windows.append((
+                safe_float(h.get("start_s"), 0.0),
+                safe_float(h.get("end_s"), dur),
+                h.get("type", "highlight"),
+            ))
+        for s in rec.get("segments", []) or []:
+            if not isinstance(s, dict):
+                continue
+            windows.append((
+                safe_float(s.get("start_s"), 0.0),
+                safe_float(s.get("end_s"), dur),
+                "segment",
+            ))
+        # Dedupe near-identical windows, clamp to duration, cap count.
+        seen: set[tuple[float, float]] = set()
+        unique: list[tuple[float, float, str]] = []
+        for (t0, t1, wtype) in windows:
+            t0 = max(0.0, min(t0, dur - 0.5))
+            t1 = max(t0 + 0.5, min(t1, dur))
+            key = (round(t0, 1), round(t1, 1))
+            if key in seen:
+                continue
+            seen.add(key)
+            unique.append((t0, t1, wtype))
+            if len(unique) >= max_windows:
+                break
+        return unique
+
+
+def _build_prompt() -> str:
+    return """You are a professional film editor's assistant. You are given {n} consecutive frames from a
+SHORT WINDOW of video footage (a {dur:.1f}s segment starting at {t0:.2f}s).
+The window was flagged as interesting. Find the precise sub-beats inside it and describe the promising moments IN DEPTH.
+
+FRAME TIMESTAMPS (seconds into this window):
+{frame_map}
+
+Return ONLY valid JSON (no markdown) with this schema:
+{{
+  "sub_beats": [
+    {{
+      "start_s": 0.0,
+      "end_s": 0.0,
+      "action": "precise description of what happens",
+      "deep_dive": "2-3 sentence in-depth description: body language, interaction, what makes it usable",
+      "behavior": "walking_calm"|"pulling"|"sniffing"|"trotting"|"sitting"|"lying"|"greeting"|"playing"|
+"expression"|"other",
+      "camera_angle": "eye_level"|"low"|"high"|"dutch",
+      "subject_facing": "camera"|"left"|"right"|"away"|"other_subject",
+      "subject_visibility": "not_visible"|"partial"|"clear"|"featured",
+      "quality_score": 0.0,
+      "vibe": "calm"|"candid"|"playful"|"energetic"|"tender"|"tense"|"neutral",
+      "use": "slow_mo"|"cutaway"|"b-roll"|"hero_subject"|"opening"|"closing"
+    }}
+  ],
+  "best_moment_s": 0.0,
+  "best_moment_desc": "the single best frame time and why (in depth)",
+  "window_vibe": "one-word vibe of the whole window",
+  "notes": "one sentence"
+}}
+
+RULES:
+- start_s/end_s are REAL seconds INTO THE WINDOW (0 = window start). Use frame timestamps to anchor.
+- Split into as many sub-beats as genuinely distinct (1-6).
+- quality_score 0.0-1.0.
+- deep_dive is the most important field: describe what is actually happening with enough detail an editor can cut without watching.
+- subject_facing is for match cuts: which direction is the main subject facing/moving.
+- Only mark subject_visibility featured/clear if the subject is actually prominent.
+"""

--- a/tools/video/vlm_zoom_rating.py
+++ b/tools/video/vlm_zoom_rating.py
@@ -60,7 +60,7 @@ class VlmZoomRating(BaseTool):
     provider = "openmontage"
     stability = ToolStability.EXPERIMENTAL
     execution_mode = ExecutionMode.SYNC
-    determinism = Determinism.SEEDED
+    determinism = Determinism.STOCHASTIC
     runtime = ToolRuntime.LOCAL_GPU
 
     dependencies = ["cmd:ffmpeg", "cmd:ffprobe"]


### PR DESCRIPTION
## Summary

Adds semantic video understanding to the footage pipeline using a local
vision-language model (Ollama served, e.g. Gemma 4 12B, Gemma 3n, or
Qwen-VL). CLIP tells you what a frame looks like; these tools tell you
what is actually happening in the clip, how well it was shot, and where
the good moments are.

This came out of a real project: rating 101 dog-walk clips for a product
campaign, where static CLIP retrieval got the context right but could not
tell pulling from calm walking, could not score camera stability, and
could not give cut-precise timestamps. The four tools below solve those
gaps, and are generic enough for any footage library.

## What is included

Four new tools in `tools/video/`, one shared plumbing module, a skill,
and tests:

| Tool | What it does |
|---|---|
| `vlm_clip_rating` | Coarse pass over a clip folder: behavior, energy, camera stability, shot type, composition, subject (product) visibility, timestamped segments and highlights. Configurable `focus_prompt` for what the edit cares about. |
| `vlm_zoom_rating` | Re-examines flagged windows at 4 fps and produces frame-accurate sub-beats: precise start/end seconds, camera angle, subject facing direction (for match cuts), deep-dive descriptions, and vibe. |
| `vlm_editorial_ranking` | Builds composite scores (stability, quality, subject, composition, vibe with tunable weights), per-purpose leaderboards, best-moment extraction, and match-cut chains. |
| `vlm_comparative_rank` | Optional second-opinion pass: shows 4 candidate clips in one context, asks for a relative ranking, calibrated scores, and reasons for best/worst. Use to break ties. |
| `vlm-footage-rating` skill | Documents the workflow, schemas, and editing recipes. |
| Tests | 29 unit tests covering all four tools. Ollama HTTP calls are mocked, frame extraction uses synthetic ffmpeg clips, so the suite runs with no model, no network, no GPU. |

## Design notes

- Fully local: requires only ffmpeg and an Ollama vision model. No API keys.
- Every stage is idempotent: it reads the existing JSONL output and skips
  clips already processed, so re-runs after adding footage only do the new
  clips.
- VLM output is parsed defensively (prose-wrapped JSON, field-name drift,
  non-numeric timestamps are all tolerated) so one bad response never
  kills a batch.
- The tools register through the standard BaseTool pattern and are picked
  up automatically by the registry.

## Testing

```
make lint        # passes (py_compile on all targets + new files)
make test        # full suite: 991 passed, 11 skipped
```

One pre-existing test is deselected locally because it hangs in the
project's own `video_compose._mux_external_audio` (times out at 180s).
That file is untouched by this PR. Flagging it in case you want a
separate look.

## Example flow

```python
from tools.video.vlm_clip_rating import VlmClipRating
from tools.video.vlm_zoom_rating import VlmZoomRating
from tools.video.vlm_editorial_ranking import VlmEditorialRanking

VlmClipRating().execute({
    "input_dir": "/path/to/clips",
    "output_path": "/path/to/clip_tags.jsonl",
    "focus_prompt": "a black collar (the product)",
})
VlmZoomRating().execute({
    "ratings_path": "/path/to/clip_tags.jsonl",
    "output_path": "/path/to/clip_zooms.jsonl",
})
VlmEditorialRanking().execute({
    "ratings_path": "/path/to/clip_tags.jsonl",
    "zooms_path": "/path/to/clip_zooms.jsonl",
    "output_path": "/path/to/editorial_rankings.json",
})
```

Then the editor (or an agent) can ask "which clips show the product in a
stable close-up?" and get a ranked, timestamped answer.

## Model support and testing

The tools were built and validated against **Gemma 4 12B** (via Ollama,
`gemma4:12b`, ~8GB VRAM). That is the recommended model and the default.

Smaller vision models (gemma3n e2b/e4b, qwen2.5vl 3b/7b) are NOT yet
tested. They are listed with approximate VRAM figures in the skill so
users on smaller GPUs can try them, with the caveat that JSON conformance
and rating quality may differ. The defensive parsing in
`vlm_rating_common` is designed to absorb that drift. Contributions
validating a smaller model would be very welcome.
