### PR TITLE
fix(hyperframes_compose): stop scaffolding over hand-authored compositions

### DIFF
--- a/tools/video/hyperframes_compose.py
+++ b/tools/video/hyperframes_compose.py
@@ -179,6 +179,16 @@ class HyperFramesCompose(BaseTool):
                 "enum": [24, 30, 60],
                 "default": 30,
             },
+            "preserve_workspace": {
+                "type": "boolean",
+                "default": False,
+                "description": (
+                    "Render the workspace's existing hand-authored index.html "
+                    "instead of regenerating it from edit_decisions. Required "
+                    "for composition_mode='atelier', where scaffolding would "
+                    "overwrite the bespoke composition. lint/validate still run."
+                ),
+            },
             "strict": {
                 "type": "boolean",
                 "default": False,
@@ -203,7 +213,9 @@ class HyperFramesCompose(BaseTool):
     )
     retry_policy = RetryPolicy(max_retries=0)
     resume_support = ResumeSupport.FROM_START
-    idempotency_key_fields = ["operation", "workspace_path", "edit_decisions"]
+    idempotency_key_fields = [
+        "operation", "workspace_path", "edit_decisions", "preserve_workspace",
+    ]
     side_effects = [
         "writes HTML/CSS/JS files into workspace_path",
         "copies asset files into workspace_path/assets/",
@@ -710,14 +722,28 @@ class HyperFramesCompose(BaseTool):
         steps: dict[str, Any] = {}
 
         # 1. Scaffold — generate HTML/CSS/assets.
-        scaffold = self._scaffold(inputs)
-        steps["scaffold"] = scaffold.data
-        if not scaffold.success:
-            return ToolResult(
-                success=False,
-                error=f"Scaffold failed: {scaffold.error}",
-                data={"steps": steps},
-            )
+        #    Atelier mode hand-authors index.html, so scaffolding would overwrite
+        #    the composition it is supposed to render. Skip it and render what is
+        #    already on disk; lint/validate below still gate the output.
+        if inputs.get("preserve_workspace"):
+            if not (workspace / "index.html").exists():
+                return ToolResult(
+                    success=False,
+                    error=(
+                        f"preserve_workspace=true but no index.html in {workspace}. "
+                        "Hand-author the composition first, or drop the flag to scaffold."
+                    ),
+                )
+            steps["scaffold"] = {"skipped": "preserve_workspace=true (atelier)"}
+        else:
+            scaffold = self._scaffold(inputs)
+            steps["scaffold"] = scaffold.data
+            if not scaffold.success:
+                return ToolResult(
+                    success=False,
+                    error=f"Scaffold failed: {scaffold.error}",
+                    data={"steps": steps},
+                )
 
         # 2. Lint — static contract checks.
         lint = self._lint({"workspace_path": str(workspace)})


### PR DESCRIPTION
## Summary

`hyperframes_compose`'s compose operation always scaffolds `index.html` from `edit_decisions`. In atelier mode `index.html` **is** the deliverable — hand-authored for that one piece — so scaffolding overwrites the composition it is about to render.

This adds `preserve_workspace` to render what is already on disk instead of regenerating it.

## Related issue

None — filing the fix directly.

## Changes

- New `preserve_workspace` boolean input (default `false`, so existing behavior is unchanged). When true, scaffolding is skipped and the workspace's existing `index.html` is rendered.
- `lint` and `validate` still run in preserve mode, so output stays gated by the same contract checks.
- `preserve_workspace` joins `idempotency_key_fields`: without it, a scaffolded run and a preserved run of the same `edit_decisions` would collide on one cache key.
- `preserve_workspace=true` with no `index.html` in the workspace fails with an actionable error rather than rendering a blank composition.

## Testing

- `python -m pytest tests/contracts/ -q` — 630 passed, 7 skipped.
- `python -m pytest tests/tools/test_hyperframes_compose.py -q` — 46 passed.
- Guard verified directly: `render` with `preserve_workspace=true` against a workspace containing no `index.html` returns

  ```
  preserve_workspace=true but no index.html in <path>. Hand-author the composition first, or drop the flag to scaffold.
  ```

- Cache-key separation verified: `idempotency_key()` returns different keys for `preserve_workspace` true vs false on otherwise identical inputs.
- Not verified: a full atelier render end-to-end, which needs a real hand-authored composition and `npx hyperframes` on the machine. The scaffold-skip and guard paths above are what this diff changes.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [x] I updated docs/README if behavior or usage changed. — the new input is documented in the tool's `input_schema`.
- [x] No unrelated files (build artifacts, local config) are included in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYThSL15CujvBwD1wuUmr9
