### PR TITLE
feat(jimeng_video): accept a local first-frame image for image_to_video

### DIFF
--- a/tools/video/jimeng_video.py
+++ b/tools/video/jimeng_video.py
@@ -14,6 +14,7 @@ console.volcengine.com/iam/keymanage.
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import hmac
 import json
@@ -101,6 +102,14 @@ class JimengVideo(BaseTool):
                     "Must be publicly accessible."
                 ),
             },
+            "image_path": {
+                "type": "string",
+                "description": (
+                    "Local first-frame image for image-to-video. Sent as "
+                    "binary_data_base64 so no public URL or object storage is "
+                    "needed. Takes precedence over image_url when both are set."
+                ),
+            },
             "frames": {
                 "type": "integer",
                 "enum": [121, 241],
@@ -144,6 +153,7 @@ class JimengVideo(BaseTool):
         "prompt",
         "operation",
         "image_url",
+        "image_path",
         "frames",
         "aspect_ratio",
         "seed",
@@ -191,11 +201,21 @@ class JimengVideo(BaseTool):
             )
 
         operation = inputs.get("operation", "text_to_video")
-        if operation == "image_to_video" and not inputs.get("image_url"):
-            return ToolResult(
-                success=False,
-                error="image_to_video requires image_url (public URL).",
-            )
+        if operation == "image_to_video":
+            image_path = inputs.get("image_path")
+            if not image_path and not inputs.get("image_url"):
+                return ToolResult(
+                    success=False,
+                    error=(
+                        "image_to_video requires image_path (local file) or "
+                        "image_url (public URL)."
+                    ),
+                )
+            if image_path and not Path(image_path).is_file():
+                return ToolResult(
+                    success=False,
+                    error=f"image_path not found: {image_path}",
+                )
 
         start = time.time()
         try:
@@ -271,8 +291,16 @@ class JimengVideo(BaseTool):
             "aspect_ratio": inputs.get("aspect_ratio", "16:9"),
             "seed": int(inputs.get("seed", -1)),
         }
-        if operation == "image_to_video" and inputs.get("image_url"):
-            payload["image_urls"] = [inputs["image_url"]]
+        if operation == "image_to_video":
+            # A local file wins over a URL: it needs no public hosting, so it is
+            # the safer path for unreleased client artwork.
+            image_path = inputs.get("image_path")
+            if image_path:
+                payload["binary_data_base64"] = [
+                    base64.b64encode(Path(image_path).read_bytes()).decode("ascii")
+                ]
+            elif inputs.get("image_url"):
+                payload["image_urls"] = [inputs["image_url"]]
         return payload
 
     def _submit_task(self, payload: dict[str, Any], *, ak: str, sk: str) -> str:


### PR DESCRIPTION
## Summary

`jimeng_video`'s `image_to_video` requires `image_url` — a publicly reachable URL — so the first frame has to be uploaded to public hosting before it can be animated. For unreleased client artwork that is an avoidable exposure, and it adds an object-storage dependency to an otherwise self-contained local workflow.

The Jimeng API already accepts inline image bytes, so this adds a local-file path.

## Related issue

None — filing the fix directly.

## Changes

- New `image_path` input: a local first-frame image, sent to the API as `binary_data_base64`. No public URL or object storage needed.
- When both are supplied, the local file wins — it is the path that needs no hosting.
- `image_path` is validated with `is_file()` before the API call, so a typo fails fast instead of after a paid submission.
- Validation now accepts either input; the error message names both.
- `image_path` joins `idempotency_key_fields`.

## Testing

- `python -m pytest tests/contracts/ -q` — 630 passed, 7 skipped (includes `test_jimeng_video.py`).
- Payload construction verified directly against `_build_payload`:
  - local `image_path` produces `binary_data_base64`, and the base64 decodes back to the exact file bytes;
  - with both inputs supplied, the payload carries `binary_data_base64` and no `image_urls`;
  - with only `image_url`, the payload is unchanged from today (`image_urls`).
- Validation verified through `execute()`: a nonexistent `image_path` returns `image_path not found: ...` and omitting both returns the new either/or message — both before any network call.
- Not verified: a live submission to the Jimeng API. The base64 field name follows the provider's documented `binary_data_base64` input; worth a maintainer check against your own credentials before merge.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [x] I updated docs/README if behavior or usage changed. — the new input is documented in the tool's `input_schema`.
- [x] No unrelated files (build artifacts, local config) are included in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYThSL15CujvBwD1wuUmr9
