### PR TITLE
fix(playbook_loader): load generated playbooks from styles/custom/

### DIFF
--- a/styles/playbook_loader.py
+++ b/styles/playbook_loader.py
@@ -17,6 +17,10 @@ import yaml
 import jsonschema
 
 STYLES_DIR = Path(__file__).resolve().parent
+# Generated playbooks are written to styles/custom/ by
+# lib/playbook_generator.save_playbook(); both lookups below search it as a
+# fallback so those playbooks are visible to the render path.
+CUSTOM_SUBDIR = "custom"
 SCHEMA_PATH = (
     Path(__file__).resolve().parent.parent
     / "schemas"
@@ -33,6 +37,9 @@ def _load_playbook_schema() -> dict:
 def load_playbook(name: str, styles_dir: Optional[Path] = None) -> dict[str, Any]:
     """Load and validate a style playbook by name.
 
+    Presets live directly in the styles dir; generated playbooks live in its
+    ``custom/`` subdirectory. A preset wins when both exist.
+
     Args:
         name: Playbook name (without .yaml extension).
         styles_dir: Override directory for playbook files.
@@ -43,7 +50,12 @@ def load_playbook(name: str, styles_dir: Optional[Path] = None) -> dict[str, Any
     styles_dir = styles_dir or STYLES_DIR
     path = styles_dir / f"{name}.yaml"
     if not path.exists():
-        raise FileNotFoundError(f"Playbook not found: {path}")
+        path = styles_dir / CUSTOM_SUBDIR / f"{name}.yaml"
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Playbook not found: {name!r} "
+            f"(searched {styles_dir} and {styles_dir / CUSTOM_SUBDIR})"
+        )
 
     with open(path, encoding="utf-8") as f:
         playbook = yaml.safe_load(f)
@@ -59,13 +71,17 @@ def validate_playbook(playbook: dict) -> None:
 
 
 def list_playbooks(styles_dir: Optional[Path] = None) -> list[str]:
-    """List all available playbook names."""
+    """List all available playbook names (presets + generated custom ones)."""
     styles_dir = styles_dir or STYLES_DIR
-    return [
+    names = [
         p.stem
         for p in styles_dir.glob("*.yaml")
         if p.stem != "__pycache__"
     ]
+    custom_dir = styles_dir / CUSTOM_SUBDIR
+    if custom_dir.exists():
+        names.extend(p.stem for p in custom_dir.glob("*.yaml"))
+    return sorted(set(names))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Generated playbooks are invisible at render time.

`lib/playbook_generator.save_playbook()` writes them to `styles/custom/` (`:219-220`), and the skills instruct agents to save them there — `skills/meta/capability-extension.md:62`, plus the animation and explainer proposal directors. But `styles/playbook_loader.py` globs only the `styles/` root, and it is the loader `tools/video/video_compose.py` imports (`:1234`, `:1728`). So a playbook created through the documented path can never be loaded by the tool that needs it.

The two modules also disagree with each other: `playbook_generator` has its own `load_playbook`/`list_playbooks` that *do* search `custom/`, but nothing in the Python codebase imports that module — only the three skill docs point at it.

The practical result is that every custom playbook has to be hand-copied up one directory, leaving duplicated pairs in `styles/` and `styles/custom/`.

## Related issue

None — filing the fix directly.

## Changes

- `load_playbook()` falls back to `<styles_dir>/custom/` when the name is not found in the root.
- `list_playbooks()` merges both directories and dedupes.
- Semantics match what `lib/playbook_generator.py:32-49` already implements: a preset wins when both exist.
- The `styles_dir` override parameter still works — the custom subdirectory is resolved relative to it, not hardcoded.
- `FileNotFoundError` now names both directories searched, instead of only the last path tried.

## Testing

- `python -m pytest tests/contracts/ -q` — 630 passed, 7 skipped (includes the 14 playbook cases in `test_phase3_contracts.py` and `test_taste_governance_contracts.py`).
- `python tests/qa/test_07_playbook_intelligence.py` — 56 passed, 0 failed.
- Behavior verified against an isolated styles dir passed via the `styles_dir` override: a playbook present only in `custom/` now loads; with the same name in both places the root preset wins; `list_playbooks()` dedupes the overlap; and a missing name reports both directories searched.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [x] I updated docs/README if behavior or usage changed. — no doc change needed; this makes the existing docs (`capability-extension.md:62` and the proposal directors) true.
- [x] No unrelated files (build artifacts, local config) are included in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYThSL15CujvBwD1wuUmr9
