### PR TITLE
Fix: chart scenes unreadable on dark themes

### DIFF
--- a/remotion-composer/src/Explainer.tsx
+++ b/remotion-composer/src/Explainer.tsx
@@ -220,6 +220,7 @@ interface Cut {
   heroSubtitle?: string;
   // Styling overrides
   backgroundColor?: string;
+  cardBackgroundColor?: string; // Inner card surface (comparison); defaults to theme.surfaceColor
   backgroundImage?: string; // AI-generated or stock image rendered behind the component
   backgroundVideo?: string; // Video clip rendered behind the component (takes priority over backgroundImage)
   backgroundVideoStart?: number; // Seek position in seconds for background video (default 0)
@@ -602,6 +603,7 @@ const SceneRenderer: React.FC<{ cut: Cut; theme: ThemeConfig }> = ({ cut, theme 
         leftLabel={cut.leftLabel} rightLabel={cut.rightLabel}
         leftValue={cut.leftValue} rightValue={cut.rightValue}
         title={cut.title} backgroundColor={bgColor} textColor={textColor}
+        cardBackgroundColor={cut.cardBackgroundColor || theme.surfaceColor}
       />
     );
   }
@@ -640,6 +642,7 @@ const SceneRenderer: React.FC<{ cut: Cut; theme: ThemeConfig }> = ({ cut, theme 
         data={cut.chartData} title={cut.title} colors={cut.chartColors || theme.chartColors}
         animationStyle={(cut.chartAnimation as any) || "grow-up"}
         showGrid={cut.showGrid} showValues={cut.showValues} backgroundColor={bgColor}
+        textColor={textColor}
       />
     );
   }
@@ -650,6 +653,7 @@ const SceneRenderer: React.FC<{ cut: Cut; theme: ThemeConfig }> = ({ cut, theme 
         animationStyle={(cut.chartAnimation as any) || "draw"}
         showGrid={cut.showGrid} showMarkers={cut.showMarkers} showLegend={cut.showLegend}
         xLabel={cut.xLabel} yLabel={cut.yLabel} backgroundColor={bgColor}
+        textColor={textColor}
       />
     );
   }
@@ -660,6 +664,7 @@ const SceneRenderer: React.FC<{ cut: Cut; theme: ThemeConfig }> = ({ cut, theme 
         animationStyle={(cut.chartAnimation as any) || "expand"}
         donut={cut.donut} centerLabel={cut.centerLabel} centerValue={cut.centerValue}
         showLegend={cut.showLegend} backgroundColor={bgColor}
+        textColor={textColor}
       />
     );
   }
@@ -669,6 +674,7 @@ const SceneRenderer: React.FC<{ cut: Cut; theme: ThemeConfig }> = ({ cut, theme 
         metrics={cut.chartData} title={cut.title} columns={cut.columns}
         colors={cut.chartColors || theme.chartColors} animationStyle={(cut.chartAnimation as any) || "count-up"}
         backgroundColor={bgColor}
+        textColor={textColor}
       />
     );
   }

--- a/tests/contracts/test_remotion_video_transition_contract.py
+++ b/tests/contracts/test_remotion_video_transition_contract.py
@@ -26,3 +26,43 @@ def test_cinematic_fades_are_bounded_by_each_scene_duration() -> None:
 
     assert "Math.round(scene.durationSeconds * fps)" in source
     assert "durationInFrames - fadeOutFrames" in source
+
+
+def _jsx_block(source: str, component: str) -> str:
+    """Return the JSX element text for <Component ... /> in the source."""
+    start = source.index(f"<{component}")
+    end = source.index("/>", start)
+    return source[start:end]
+
+
+def test_chart_scenes_receive_the_theme_text_color() -> None:
+    """Charts default textColor to near-black (#1F2937).
+
+    If Explainer does not forward the theme's textColor, every chart title,
+    axis label, category label and value renders dark-on-dark and is invisible
+    on any dark theme.
+    """
+    source = (REPO_ROOT / "remotion-composer/src/Explainer.tsx").read_text(
+        encoding="utf-8"
+    )
+
+    for component in ("BarChart", "LineChart", "PieChart", "KPIGrid"):
+        assert "textColor={textColor}" in _jsx_block(source, component), (
+            f"{component} must receive the theme textColor, "
+            f"or its labels are invisible on dark themes"
+        )
+
+
+def test_comparison_card_surface_follows_the_theme() -> None:
+    """ComparisonCard hardcodes cardBackgroundColor to a light grey (#F3F4F6).
+
+    On a dark theme it receives the theme's light textColor, so without a
+    themed card surface the labels are light-on-light.
+    """
+    source = (REPO_ROOT / "remotion-composer/src/Explainer.tsx").read_text(
+        encoding="utf-8"
+    )
+    block = _jsx_block(source, "ComparisonCard")
+
+    assert "textColor={textColor}" in block
+    assert "cardBackgroundColor={cut.cardBackgroundColor || theme.surfaceColor}" in block


### PR DESCRIPTION
# Fix: chart scenes unreadable on dark themes

Companion to #469 ("keep themed text legible on light playbooks"), which threads
theme colours into the text overlay components (`CaptionOverlay`, `SectionTitle`,
`StatReveal`, `HeroTitle`). This does the same for the chart components and
`ComparisonCard`, which #469 explicitly leaves untouched — same root cause
(hardcoded colour defaults that `Explainer.tsx` never overrides), opposite
direction (near-black defaults invisible on dark themes, rather than near-white
defaults invisible on light ones).

Both touch `Explainer.tsx` but in different JSX blocks, so whichever lands second
should rebase cleanly.

## Problem

`Explainer.tsx` passes `backgroundColor={bgColor}` to the chart components but
never passes `textColor`. All four chart components — `BarChart`, `LineChart`,
`PieChart` and `KPIGrid` — default `textColor` to `"#1F2937"` (near-black).

On any dark theme the chart title, axis scale, category labels and value labels
are therefore drawn dark-on-dark and are invisible. The data renders correctly;
it simply cannot be seen. Bars, gridlines and series colours are unaffected,
which makes the failure look like "the labels aren't being passed" rather than a
colour bug.

`ComparisonCard` has the mirror-image version of the same problem: it *does*
receive `textColor`, but hardcodes `cardBackgroundColor = "#F3F4F6"`. A dark
theme's light text then lands on a light card. Same symptom, opposite cause.

## Reproduction

Render any `explainer-data` composition on the default dark theme with a
`bar_chart` or `comparison` scene:

```json
{
  "type": "bar_chart",
  "title": "Neurons (millions)",
  "showValues": true,
  "chartData": [
    { "label": "Octopus", "value": 500 },
    { "label": "Dog", "value": 530 }
  ]
}
```

Before: bars and gridlines only — no title, no axis scale, no labels, no values.
After: all text visible.

## Fix

- Forward `textColor={textColor}` to `BarChart`, `LineChart`, `PieChart` and `KPIGrid`.
- Pass `cardBackgroundColor={cut.cardBackgroundColor || theme.surfaceColor}` to
  `ComparisonCard` so the inner card follows the active theme.
- Add `cardBackgroundColor?: string` to the `Cut` interface, so a scene can still
  force a light card on a dark theme when a design calls for it.

Six lines, one file. No behaviour change on light themes: the components already
default to the same near-black, so forwarding an explicitly light-theme
`textColor` produces the identical result.

## Tests

Adds two contract tests to `tests/contracts/test_remotion_video_transition_contract.py`,
following the existing source-assertion style in that file:

- `test_chart_scenes_receive_the_theme_text_color` — asserts each of the four
  chart components receives `textColor={textColor}`
- `test_comparison_card_surface_follows_the_theme` — asserts ComparisonCard gets
  a themed `cardBackgroundColor`

Both fail against the pre-fix `Explainer.tsx` and pass after it, verified by
stashing the change and re-running.

## Verification

Rendered a 7-scene explainer (`hero_title`, `text_card`, `stat_card`, `bar_chart`,
`comparison`, `callout`) on the default dark theme, before and after. Before, the
bar chart showed bars and gridlines only and the comparison card's labels were
invisible. After, the chart shows its title, y-axis scale (0–530), category
labels and per-bar values, and the comparison card shows both labels on a themed
surface. The other five scenes are pixel-identical.

`npx tsc --noEmit` passes.
