### PR TITLE
Fix invalid httpx2 package name in requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@
 -r requirements.txt
 pytest>=8.0
 pytest-asyncio>=0.23
-httpx2>=2.0
+httpx>=0.24


### PR DESCRIPTION
## Summary
- `requirements-dev.txt` listed `httpx2>=2.0`, but `httpx2` is not a real PyPI package (and no `httpx` version `>=2.0` exists — latest is `0.28.1`).
- `tests/backlot/test_server.py` uses `fastapi.testclient.TestClient`, which depends on `httpx`, so this line should reference the real package.
- Changed to `httpx>=0.24`.

## Test plan
- [x] Confirmed no code references `httpx2` anywhere in the repo
- [x] Confirmed `httpx` (not `httpx2`) is the package actually needed, and is referenced correctly elsewhere in the repo