### PR TITLE
fix(remotion-composer): resolve videoSrc through resolveAsset in TalkingHead

### DIFF
--- a/remotion-composer/src/TalkingHead.tsx
+++ b/remotion-composer/src/TalkingHead.tsx
@@ -7,6 +7,7 @@ import {
   useVideoConfig,
 } from "remotion";
 import { CaptionOverlay, WordCaption } from "./components/CaptionOverlay";
+import { resolveAsset } from "./lib/resolveAsset";
 import { TextCard } from "./components/TextCard";
 import { StatCard } from "./components/StatCard";
 import { CalloutBox } from "./components/CalloutBox";
@@ -318,7 +319,7 @@ export const TalkingHead: React.FC<TalkingHeadProps> = ({
     <AbsoluteFill style={{ backgroundColor: "#000" }}>
       {/* Layer 1: Video background */}
       <OffthreadVideo
-        src={videoSrc}
+        src={resolveAsset(videoSrc)}
         style={{ width: "100%", height: "100%", objectFit: "cover" }}
       />
 


### PR DESCRIPTION

## Summary

`TalkingHead` passes `videoSrc` straight to `OffthreadVideo`, so a `public/`-relative path (e.g. `"clips/source.mp4"`) fails to load at render time with a 404 from the dev server. Every other composition that accepts a video source (`TitledVideo`, `Explainer`, `CinematicRenderer`) already routes it through `resolveAsset`; this brings `TalkingHead` in line with them.

## Related issue

None filed — happy to open one first if you prefer issue-first workflow.

## Changes

- `remotion-composer/src/TalkingHead.tsx`: import `resolveAsset` and wrap `videoSrc` (`src={resolveAsset(videoSrc)}`), matching `TitledVideo`.

## Testing

- `bunx remotion still src/index.tsx TalkingHead out.png --props=<props with public/-relative videoSrc>`: 404 (`Received a status code of 404 while downloading file http://localhost:3000/<file>`) before this change; renders correctly after.
- Absolute `http(s)` URLs still pass through unchanged (`resolveAsset` is a no-op for URLs).
- `tsc --noEmit` clean.
- We run this patched composition in production for vertical (1080x1920) ad videos.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable — no TS test infra for remotion-composer; verified manually as above.
- [x] I updated docs/README if behavior or usage changed — no usage change (behavior now matches the documented expectation of the other compositions).
- [x] No unrelated files are included in the diff.

---

Disclosure: this patch was developed with AI assistance, then human-reviewed and verified in production use. Happy to adjust anything to match project conventions.
