### PR TITLE
feat(remotion-composer): CJK-aware captions and caption styling props

### DIFF
--- a/remotion-composer/src/TalkingHead.tsx
+++ b/remotion-composer/src/TalkingHead.tsx
@@ -302,6 +302,11 @@ export interface TalkingHeadProps {
   wordsPerPage?: number;
   fontSize?: number;
   highlightColor?: string;
+  captionColor?: string;
+  captionBackgroundColor?: string;
+  captionFontFamily?: string;
+  // Pass "" for CJK captions (no inter-word spacing); defaults to " ".
+  captionWordSeparator?: string;
 }
 
 export const TalkingHead: React.FC<TalkingHeadProps> = ({
@@ -311,6 +316,10 @@ export const TalkingHead: React.FC<TalkingHeadProps> = ({
   wordsPerPage = 4,
   fontSize = 52,
   highlightColor = "#22D3EE",
+  captionColor = "#FFFFFF",
+  captionBackgroundColor = "rgba(0, 0, 0, 0.65)",
+  captionFontFamily,
+  captionWordSeparator,
 }) => {
   const { fps } = useVideoConfig();
 
@@ -345,8 +354,10 @@ export const TalkingHead: React.FC<TalkingHeadProps> = ({
         wordsPerPage={wordsPerPage}
         fontSize={fontSize}
         highlightColor={highlightColor}
-        backgroundColor="rgba(0, 0, 0, 0.65)"
-        color="#FFFFFF"
+        backgroundColor={captionBackgroundColor}
+        color={captionColor}
+        {...(captionFontFamily ? { fontFamily: captionFontFamily } : {})}
+        {...(captionWordSeparator !== undefined ? { wordSeparator: captionWordSeparator } : {})}
       />
     </AbsoluteFill>
   );

--- a/remotion-composer/src/components/CaptionOverlay.tsx
+++ b/remotion-composer/src/components/CaptionOverlay.tsx
@@ -12,6 +12,9 @@ export interface WordCaption {
   word: string;
   startMs: number;
   endMs: number;
+  // Force a page break after this word (e.g. sentence or scene boundaries).
+  // Useful for CJK captions where pages should align with clause boundaries.
+  pageBreakAfter?: boolean;
 }
 
 type CaptionOverlayProps = {
@@ -23,6 +26,9 @@ type CaptionOverlayProps = {
   highlightColor?: string;
   backgroundColor?: string;
   fontFamily?: string;
+  // Separator rendered between words. Space-delimited languages want the
+  // default " "; CJK languages (no inter-word spacing) should pass "".
+  wordSeparator?: string;
 };
 
 interface CaptionPage {
@@ -33,15 +39,21 @@ interface CaptionPage {
 
 function buildPages(words: WordCaption[], wordsPerPage: number): CaptionPage[] {
   const pages: CaptionPage[] = [];
-  for (let i = 0; i < words.length; i += wordsPerPage) {
-    const pageWords = words.slice(i, i + wordsPerPage);
-    if (pageWords.length === 0) continue;
+  let pageWords: WordCaption[] = [];
+  const flush = () => {
+    if (pageWords.length === 0) return;
     pages.push({
       words: pageWords,
       startMs: pageWords[0].startMs,
       endMs: pageWords[pageWords.length - 1].endMs,
     });
+    pageWords = [];
+  };
+  for (const w of words) {
+    pageWords.push(w);
+    if (pageWords.length >= wordsPerPage || w.pageBreakAfter) flush();
   }
+  flush();
   return pages;
 }
 
@@ -52,7 +64,8 @@ const PageRenderer: React.FC<{
   highlightColor: string;
   backgroundColor: string;
   fontFamily: string;
-}> = ({ page, fontSize, color, highlightColor, backgroundColor, fontFamily }) => {
+  wordSeparator: string;
+}> = ({ page, fontSize, color, highlightColor, backgroundColor, fontFamily, wordSeparator }) => {
   const frame = useCurrentFrame();
   const { fps } = useVideoConfig();
 
@@ -100,6 +113,11 @@ const PageRenderer: React.FC<{
               <span
                 key={`${w.startMs}-${i}`}
                 style={{
+                  // Keep each word unbroken so lines wrap only at word
+                  // boundaries. For space-delimited text this matches the
+                  // previous behavior; for CJK it prevents mid-word breaks.
+                  display: "inline-block",
+                  whiteSpace: "nowrap",
                   color: isActive ? highlightColor : isPast ? color : `${color}99`,
                   transition: "none", // CSS transitions forbidden in Remotion
                   textShadow: isActive
@@ -107,7 +125,7 @@ const PageRenderer: React.FC<{
                     : "0 2px 4px rgba(0,0,0,0.5)",
                 }}
               >
-                {w.word}{i < page.words.length - 1 ? " " : ""}
+                {w.word}{i < page.words.length - 1 ? wordSeparator : ""}
               </span>
             );
           })}
@@ -125,6 +143,7 @@ export const CaptionOverlay: React.FC<CaptionOverlayProps> = ({
   highlightColor = "#22D3EE",
   backgroundColor = "rgba(15, 23, 42, 0.75)",
   fontFamily = "Space Grotesk, Inter, system-ui, sans-serif",
+  wordSeparator = " ",
 }) => {
   const { fps } = useVideoConfig();
   const pages = buildPages(words, wordsPerPage);
@@ -148,6 +167,7 @@ export const CaptionOverlay: React.FC<CaptionOverlayProps> = ({
               highlightColor={highlightColor}
               backgroundColor={backgroundColor}
               fontFamily={fontFamily}
+              wordSeparator={wordSeparator}
             />
           </Sequence>
         );


### PR DESCRIPTION
## Summary

`CaptionOverlay` assumes space-delimited text, which breaks captions for CJK languages in three ways:

1. A hardcoded `" "` is rendered between words — Japanese/Chinese don't use inter-word spaces, so captions show spurious gaps.
2. Lines can wrap anywhere inside a word (every CJK character is a CSS line-break opportunity), producing mid-word breaks and punctuation stranded at line starts.
3. Pages are cut every `wordsPerPage` words regardless of sentence boundaries, so a clause from the next sentence can leak onto the current page.

This PR makes the caption system CJK-capable while keeping the default rendering for space-delimited languages pixel-identical, and exposes the caption colors that `TalkingHead` previously hardcoded.

**Before / after** (same props, Japanese captions — the caption text itself explains the fix: "Japanese captions don't put spaces between words!"):

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/sakuraozation/OpenMontage/pr-assets/cjk-captions/before.png) | ![after](https://raw.githubusercontent.com/sakuraozation/OpenMontage/pr-assets/cjk-captions/after.png) |

Before: spurious spaces, a break in the middle of 単語のあいだに, and a stranded ん！ at a line start. After: no spaces, wraps only at word (clause) boundaries.

## Related issue

None filed — happy to open one first if you prefer issue-first workflow.

## Changes

- `CaptionOverlay`: new `wordSeparator` prop (default `" "` keeps current behavior; CJK callers pass `""`).
- `CaptionOverlay`: each word renders as an unbreakable inline block, so lines wrap only at word boundaries. For space-delimited text this matches the previous behavior (browsers already broke at the spaces); for CJK it prevents mid-word breaks.
- `WordCaption`: optional `pageBreakAfter` flag; `buildPages` flushes the page early when set, letting callers align pages with sentence/scene boundaries.
- `TalkingHead`: exposes `captionColor` / `captionBackgroundColor` (previously hardcoded inline), `captionFontFamily`, and `captionWordSeparator`. All default to the current values, so existing props files render identically.

One known limitation, by design: a single word/chunk wider than the caption box will overflow rather than break. Callers control chunk granularity (for Japanese, clause-level chunks of 2–10 characters are natural), so this hasn't been a problem in practice.

## Testing

- Stills rendered with the same Japanese props before/after (screenshots above). Rendered with the `resolveAsset` fix (#506) applied so the demo clip loads; the caption diff is exactly this branch.
- Default-props render of English captions confirmed visually unchanged (separator defaults to `" "`, and word-boundary wrapping matches the browser's existing space-based breaks).
- `tsc --noEmit` clean.
- In production use for Japanese vertical (1080x1920) ad videos — clause-chunked captions with `wordSeparator: ""`, `pageBreakAfter` on scene boundaries, and a Japanese rounded-gothic `captionFontFamily`.

## Checklist

- [x] The change is focused on a single logical concern (caption i18n/styling surface of TalkingHead).
- [x] I ran the relevant tests locally where applicable — no TS test infra for remotion-composer; verified manually as above.
- [x] I updated docs/README if behavior or usage changed — props are documented inline; happy to add a README section if you'd like one.
- [x] No unrelated files are included in the diff.

---

Disclosure: this patch was developed with AI assistance, then human-reviewed and verified in production use. Happy to adjust anything to match project conventions.
