### PR TITLE
fix(stock_sources): fail closed when every archive.org strategy fails…

### DIFF
--- a/tests/tools/test_stock_source_fail_closed.py
+++ b/tests/tools/test_stock_source_fail_closed.py
@@ -1,0 +1,94 @@
+"""Stock source adapters must not report an empty search when the
+transport layer failed.
+
+Context: `corpus_builder` already fails closed with diagnostics when
+every candidate fails (see test_corpus_builder_total_failure.py). The
+fast path (`direct_clip_search` + the source adapters) did not have the
+same guarantee: `ArchiveOrgSource.search` caught every exception in its
+strategy cascade and returned `[]`, which is indistinguishable from
+"archive.org genuinely has no footage for this query".
+
+The visible consequence, reproduced against a real 503 from
+archive.org, was `direct_clip_search` returning:
+
+    success: True, clips_downloaded: 0, errors: []
+
+A production run silently proceeds with zero footage and no signal.
+"""
+
+import pytest
+
+from tools.video.stock_sources.archive_org import ArchiveOrgSource
+from tools.video.stock_sources.base import SearchFilters
+
+
+class _Response:
+    """Minimal stand-in for requests.Response."""
+
+    def __init__(self, status_code: int, payload: dict | None = None) -> None:
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self) -> dict:
+        return self._payload
+
+
+@pytest.fixture
+def patch_requests(monkeypatch):
+    """Patch the lazily-imported requests.get used inside search()."""
+
+    def apply(handler):
+        import requests
+
+        monkeypatch.setattr(requests, "get", handler)
+
+    return apply
+
+
+def test_transport_failure_on_every_strategy_fails_closed(patch_requests) -> None:
+    def always_503(*args, **kwargs):
+        return _Response(503)
+
+    patch_requests(always_503)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        ArchiveOrgSource().search("newspaper printing press", SearchFilters())
+
+    message = str(excinfo.value)
+    assert "archive_org" in message
+    # The diagnostics must name the failing strategies, not just say
+    # "something went wrong".
+    assert "503" in message
+
+
+def test_genuinely_empty_result_is_still_an_empty_list(patch_requests) -> None:
+    """No transport failure, no hits: that is a valid empty search."""
+
+    def empty_ok(*args, **kwargs):
+        return _Response(200, {"response": {"docs": []}})
+
+    patch_requests(empty_ok)
+
+    assert ArchiveOrgSource().search("zzzz no such footage", SearchFilters()) == []
+
+
+def test_one_failing_strategy_does_not_break_a_later_success(patch_requests) -> None:
+    """The cascade must still degrade gracefully when a later strategy works."""
+
+    calls = {"n": 0}
+
+    def fail_then_succeed(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _Response(503)
+        return _Response(200, {"response": {"docs": []}})
+
+    patch_requests(fail_then_succeed)
+
+    # Later strategies returned cleanly, so this is an empty search and
+    # not a hard failure, even though the first strategy died.
+    assert ArchiveOrgSource().search("city street", SearchFilters()) == []

--- a/tools/video/stock_sources/archive_org.py
+++ b/tools/video/stock_sources/archive_org.py
@@ -141,6 +141,9 @@ class ArchiveOrgSource:
 
         import requests  # lazy
 
+        strategy_errors: list[str] = []
+        strategies_completed = 0
+
         for _label, solr_q in self._build_queries(query):
             params = [
                 ("q", solr_q),
@@ -161,10 +164,14 @@ class ArchiveOrgSource:
                 r = requests.get(_SEARCH_URL, params=params, timeout=30)
                 r.raise_for_status()
                 data = r.json()
-            except Exception:
+            except Exception as exc:
                 # One strategy's network/parse error shouldn't kill the
-                # whole cascade — try the next one.
+                # whole cascade — try the next one. But it must not be
+                # invisible either: if every strategy dies this way we
+                # fail closed below with the diagnostics attached.
+                strategy_errors.append(f"{_label}: {type(exc).__name__}: {exc}")
                 continue
+            strategies_completed += 1
             docs = (data.get("response") or {}).get("docs", []) or []
             if not docs:
                 continue
@@ -176,6 +183,17 @@ class ArchiveOrgSource:
                     out.append(cand)
             if out:
                 return out
+
+        if strategy_errors and strategies_completed == 0:
+            # Every query strategy failed at the transport layer. Returning
+            # [] here reads as "archive.org has nothing for this query",
+            # which is a lie: direct_clip_search then reports success with
+            # zero clips and an empty error list. Fail closed instead, the
+            # same way corpus_builder does on total candidate failure.
+            raise RuntimeError(
+                "archive_org search failed on every strategy: "
+                + " | ".join(strategy_errors)
+            )
 
         return []
 


### PR DESCRIPTION
## Summary

`ArchiveOrgSource.search` catches every exception in its strategy cascade and falls through to `return []`. An empty list from a dead endpoint is indistinguishable from an empty list from a genuinely empty query, so `direct_clip_search` reports `success: True`, `clips_downloaded: 0`, `errors: []` and the run proceeds with zero footage and no diagnostic.

`corpus_builder` already fails closed with diagnostics on total candidate failure (`tests/tools/test_corpus_builder_total_failure.py`). This applies the same semantics to the fast path, and nothing more.

## Related issue

Closes #511

## Changes

- `archive_org.py`: collect per-strategy transport errors instead of discarding them, and raise with the diagnostics attached when *every* strategy failed at the transport layer.
- Unchanged behaviour: a genuinely empty result set still returns `[]`, and a partial cascade failure followed by a clean response still returns `[]`.
- New `tests/tools/test_stock_source_fail_closed.py` covering the three cases above.

## Testing

```
python -m pytest tests/tools/test_stock_source_fail_closed.py -q
3 passed

python -m pytest tests/tools tests/contracts -q
1330 passed, 7 skipped, 0 failed
```

macOS 26.5.2, Python 3.14.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [x] I updated docs/README if behavior or usage changed.
- [x] No unrelated files (build artifacts, local config) are included in the diff.

## Follow-up

The same swallow-and-return-empty pattern is in `nara.py`, `loc.py`, `videvo.py`, `mixkit.py`, `esa.py`, `jaxa.py`, `dareful.py` and `wikimedia.py`. Happy to do those in a second PR if this approach looks right.
