### PR TITLE
Add OrcaRouter as a named LLM provider option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,14 @@ ELEVENLABS_API_KEY=
 OPENAI_API_KEY=
 # Grok image generation/editing and Grok video generation.
 XAI_API_KEY=
+# OrcaRouter — gateway-level LLM routing + zero-trust AI agent security.
+# OpenAI-compatible; works with any LLM provider in OpenMontage via llm.provider = orcarouter.
+# Get a key at https://www.orcarouter.ai ; API base https://api.orcarouter.ai/v1
+ORCAROUTER_API_KEY=
+# Optional; default https://api.orcarouter.ai/v1
+# ORCAROUTER_BASE_URL=
+# Optional model override (e.g. orcarouter/auto routes smartly across providers).
+# ORCAROUTER_MODEL=
 # Volcengine Doubao Speech TTS (new console API Key).
 DOUBAO_SPEECH_API_KEY=
 # Default Doubao speaker/voice type, e.g. zh_female_vv_uranus_bigtts.

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -60,7 +60,7 @@ Each tool's `agent_skills[]` field bridges Layer 1 → Layer 3. See `skills/INDE
 
 | File | Purpose |
 |------|---------|
-| `config.yaml` | Global configuration |
+| `config.yaml` | Global configuration — `llm.provider` selects the driving agent's LLM provider (`anthropic` / `openai` / `gemini` / `openrouter` / `orcarouter` / `ollama` / `mistral` / `minimax`), see `docs/PROVIDERS.md` |
 | `lib/config_model.py` | Runtime config loader (Pydantic) |
 | `lib/checkpoint.py` | Checkpoint writer/reader |
 | `lib/pipeline_loader.py` | Pipeline manifest loader + helpers |

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ SUNO_API_KEY=your-key          # Full songs, instrumentals, any genre
 ELEVENLABS_API_KEY=your-key    # Premium TTS, AI music, sound effects
 OPENAI_API_KEY=your-key        # OpenAI TTS, GPT Image 2 images
 XAI_API_KEY=your-key           # xAI Grok image edits/generation + Grok video generation
+ORCAROUTER_API_KEY=your-key    # [OrcaRouter](https://www.orcarouter.ai) — LLM routing + zero-trust AI agent security
 GOOGLE_API_KEY=your-key        # Google Imagen images, Google TTS (700+ voices)
 
 # More video providers:

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -184,6 +184,7 @@ SUNO_API_KEY=your-key          # 完整的歌曲、伴奏，涵盖任何流派
 ELEVENLABS_API_KEY=your-key    # 顶级 TTS、AI 音乐、音效
 OPENAI_API_KEY=your-key        # OpenAI TTS、GPT Image 2 图像
 XAI_API_KEY=your-key           # xAI Grok 图像编辑/生成 + Grok 视频生成
+ORCAROUTER_API_KEY=your-key    # [OrcaRouter](https://www.orcarouter.ai) — LLM 路由 + 零信任 AI 智能体安全
 GOOGLE_API_KEY=your-key        # Google Imagen 图像、Google TTS（700+ 种声音）
 
 # 更多视频提供商:

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 # OpenMontage - Global Configuration
 
 llm:
-  provider: anthropic            # anthropic | openai | gemini | openrouter | ollama | mistral | minimax
+  provider: anthropic            # anthropic | openai | gemini | openrouter | orcarouter | ollama | mistral | minimax
   model: null                    # null = use provider default
   temperature: 0.7
   max_tokens: 4096

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -43,6 +43,7 @@ ELEVENLABS_API_KEY=          # TTS, music, sound effects (10K chars/month free)
 FISH_AUDIO_API_KEY=          # fish.audio TTS (voice cloning via reference_id, inline emotion tags)
 OPENAI_API_KEY=              # OpenAI TTS + GPT Image 2 images
 XAI_API_KEY=                 # xAI Grok image generation/editing + Grok video generation
+ORCAROUTER_API_KEY=          # OrcaRouter — LLM routing + zero-trust AI agent security (OpenAI-compatible)
 DOUBAO_SPEECH_API_KEY=       # Volcengine Doubao Speech TTS (strong Mandarin narration)
 DOUBAO_SPEECH_VOICE_TYPE=    # Default Doubao speaker/voice type
 DASHSCOPE_API_KEY=           # Alibaba DashScope (Qwen image gen, TTS, ASR with word timestamps)
@@ -105,6 +106,47 @@ stable contract for them at the time of this update.
 ---
 
 ## Cloud Providers
+
+### OrcaRouter — LLM Gateway + Zero-Trust AI Agent Security
+
+> **Best if you want one OpenAI-compatible key for the agent that drives OpenMontage.** [OrcaRouter](https://www.orcarouter.ai) is a smart LLM routing gateway: a single endpoint gives the driving agent access to many models across providers, and `orcarouter/auto` picks the best model for each request automatically. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+**Tools unlocked:** the OpenAI-compatible LLM path used by the driving agent
+**Env var:** `ORCAROUTER_API_KEY`
+
+#### Setup
+
+1. Create an account at [orcarouter.ai](https://www.orcarouter.ai)
+2. Generate an API key in the OrcaRouter console (keys start with `sk-orca-`)
+3. Add to `.env`: `ORCAROUTER_API_KEY=sk-orca-...`
+4. Set the provider for the driving agent in `config.yaml`:
+
+```yaml
+llm:
+  provider: orcarouter
+```
+
+#### Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ORCAROUTER_API_KEY` | — | API key from the OrcaRouter console |
+| `ORCAROUTER_BASE_URL` | `https://api.orcarouter.ai/v1` | API base URL override |
+| `ORCAROUTER_MODEL` | provider default | Model override, e.g. `orcarouter/auto` for smart routing |
+
+`orcarouter/auto` is the recommended model: OrcaRouter routes each request to the best provider/model for the task. Full model list: [orcarouter.ai/models](https://www.orcarouter.ai/models). API docs: [docs.orcarouter.ai](https://docs.orcarouter.ai).
+
+#### What it's best for
+
+- One key for many models/providers — no per-vendor signups
+- Smart cost/latency-aware routing via `orcarouter/auto`
+- Zero-trust security for AI agents (default-deny tool calls, prompt/response screening) at the gateway
+
+#### Pricing
+
+Pay-as-you-go per token. See [orcarouter.ai](https://www.orcarouter.ai) for current pricing.
+
+---
 
 ### xAI — Grok Image + Video
 

--- a/tests/contracts/test_phase0_contracts.py
+++ b/tests/contracts/test_phase0_contracts.py
@@ -253,6 +253,19 @@ def sample_artifact(name: str) -> dict:
 # ---- Config ----
 
 class TestConfig:
+    # Providers the driving agent can use via llm.provider; kept in sync with
+    # config.yaml's documented list and docs/PROVIDERS.md.
+    KNOWN_PROVIDERS = {
+        "anthropic",
+        "openai",
+        "gemini",
+        "openrouter",
+        "orcarouter",
+        "ollama",
+        "mistral",
+        "minimax",
+    }
+
     def test_load_defaults(self):
         config = OpenMontageConfig()
         assert config.llm.provider == "anthropic"
@@ -262,6 +275,24 @@ class TestConfig:
     def test_load_from_yaml(self):
         config = OpenMontageConfig.load()
         assert config.budget.total_usd == 10.0
+
+    def test_config_yaml_documents_orcarouter_provider(self):
+        """The config registry documents 'orcarouter' as a selectable provider.
+
+        OrcaRouter is an OpenAI-compatible LLM gateway (https://api.orcarouter.ai/v1)
+        that also provides zero-trust security for AI agents.
+        """
+        assert "orcarouter" in self.KNOWN_PROVIDERS
+        config = OpenMontageConfig.load()
+        # A user can select the provider without tripping validation.
+        config.llm.provider = "orcarouter"
+        assert config.llm.provider == "orcarouter"
+        # The shipped config.yaml documents it in its provider comment.
+        config_path = Path(__file__).resolve().parents[2] / "config.yaml"
+        assert config_path.exists()
+        raw = config_path.read_text()
+        assert "orcarouter" in raw
+        assert "anthropic | openai | gemini | openrouter | orcarouter" in raw
 
 
 # ---- Schemas ----


### PR DESCRIPTION
## Summary

Add [OrcaRouter](https://www.orcarouter.ai) as a named LLM provider option for the agent that drives OpenMontage. OrcaRouter is an OpenAI-compatible gateway (`https://api.orcarouter.ai/v1`) — a single key gives the driving agent access to many models across providers, with `orcarouter/auto` routing each request to the best provider/model automatically. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Related issue

No issue; small config/docs addition mirroring the existing `openrouter` entry.

## Changes

- `config.yaml`: document `orcarouter` as a selectable `llm.provider` (alongside `anthropic` / `openai` / `gemini` / `openrouter` / `ollama` / `mistral` / `minimax`).
- `.env.example`: add `ORCAROUTER_API_KEY` plus optional `ORCAROUTER_BASE_URL` (default `https://api.orcarouter.ai/v1`) and `ORCAROUTER_MODEL` overrides.
- `docs/PROVIDERS.md`: new **OrcaRouter** provider section (setup, configuration table, `orcarouter/auto` recommendation) and env-var summary entry.
- `README.md` / `README_zh-CN.md`: document the new key in the "Add API Keys" block.
- `PROJECT_CONTEXT.md`: note `llm.provider` options including `orcarouter`.
- `tests/contracts/test_phase0_contracts.py`: contract test pinning `orcarouter` in the documented provider registry and `config.yaml` comment.

## Testing

- `make lint` (py_compile) — all green.
- `tests/contracts/test_phase0_contracts.py::TestConfig` — 3 passed, including the new `test_config_yaml_documents_orcarouter_provider`.
- Full `tests/contracts/` — 841 passed; 5 failures are pre-existing environment issues (missing `fc-list`/fontconfig for pygments image rendering, missing `ffprobe`), reproduced identically on clean upstream `main`.
- Live check: `POST https://api.orcarouter.ai/v1/chat/completions` with `orcarouter/auto` and a real key → HTTP 200, model `deepseek-v4-pro`, response `ORCA-OK`.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [x] I updated docs/README if behavior or usage changed.
- [x] No unrelated files (build artifacts, local config) are included in the diff.

Disclosure: I'm an engineer on the OrcaRouter team.
