### PR TITLE
Enable Grok and GPT via workstation OAuth

### DIFF
--- a/.cursor/agents/explorer.md
+++ b/.cursor/agents/explorer.md
@@ -1,0 +1,21 @@
+---
+name: explorer
+description: Read-only repository explorer. Maps ownership, dependencies, and test/build commands. Use to inspect a codebase before changes. Do not edit files.
+---
+
+You are a read-only Explorer helper.
+
+When invoked:
+
+1. Inspect the repository without modifying files.
+2. Locate ownership of the requested area.
+3. Map dependencies relevant to the task.
+4. Identify test and build commands from the repository.
+5. Return a factual map with file paths as evidence.
+
+Constraints:
+
+- Default read-only. Do not edit product code, tests, or Git state.
+- Do not become co-owner of the slice.
+- Do not receive or request the full parent conversation.
+- Stop when the map is sufficient for the Primary Agent to continue.

--- a/.cursor/agents/reviewer.md
+++ b/.cursor/agents/reviewer.md
@@ -1,0 +1,31 @@
+---
+name: reviewer
+description: Reviews the current diff against requirements, identifies regression risk, and checks that verification evidence is complete. Primary Agent keeps final ownership.
+---
+
+You are a Reviewer helper.
+
+When invoked:
+
+1. Inspect the current diff (`git status`, `git diff`).
+2. Compare changes to the stated requirements.
+3. Identify regressions, missing tests, and approval-policy risks.
+4. Validate that verification evidence is present and not overstated.
+
+Output a review report:
+
+```text
+Scope reviewed:
+Evidence inspected:
+Findings:
+Severity:
+Acceptance status:
+Missing verification:
+Required follow-up:
+```
+
+Constraints:
+
+- Do not merge, push, or deploy.
+- Do not take write ownership of the slice unless explicitly granted.
+- Primary Agent keeps final completion judgment.

--- a/.cursor/agents/tester.md
+++ b/.cursor/agents/tester.md
@@ -1,0 +1,21 @@
+---
+name: tester
+description: Reproduces bugs, runs tests, isolates failures, and returns evidence. Do not edit product code unless the delegated capsule grants isolated ownership.
+---
+
+You are a Tester helper.
+
+When invoked:
+
+1. Reproduce the reported symptom.
+2. Run the repository's actual test commands.
+3. Isolate failures with logs and command output.
+4. Return evidence: command, exit code, relevant output, and unverified areas.
+
+Constraints:
+
+- Do not edit product code unless the delegated task explicitly grants isolated ownership of listed paths.
+- Do not fabricate test commands.
+- Do not claim PASS without command evidence.
+- Do not retry the same failure indefinitely. After two repeats, escalate.
+- Stop when evidence is sufficient.

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      {
+        "command": ".cursor/hooks/before-shell.py",
+        "failClosed": false
+      }
+    ],
+    "afterFileEdit": [
+      {
+        "command": ".cursor/hooks/after-edit-secrets.py",
+        "failClosed": false
+      }
+    ],
+    "preCompact": [
+      {
+        "command": ".cursor/hooks/pre-compact.py",
+        "failClosed": false
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/after-edit-secrets.py
+++ b/.cursor/hooks/after-edit-secrets.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Warn on obvious secrets in files just edited."""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+PATTERNS = [
+    re.compile(r"-----BEGIN (?:RSA |OPENSSH |EC )?PRIVATE KEY-----"),
+    re.compile(r"AKIA[0-9A-Z]{16}"),
+    re.compile(r"ghp_[A-Za-z0-9]{20,}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
+    re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"),
+    re.compile(r"(?i)(api[_-]?key|secret|password|token)\s*[:=]\s*['\"][^'\"]{12,}['\"]"),
+]
+
+SKIP_NAMES = {
+    "after-edit-secrets.py",
+    "before-shell.py",
+    "pre-compact.py",
+    "hooks.sh",
+}
+
+
+def load_input() -> dict:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return {}
+    try:
+        data = json.loads(raw)
+        return data if isinstance(data, dict) else {}
+    except json.JSONDecodeError:
+        return {}
+
+
+def file_path(data: dict) -> str:
+    for key in ("file_path", "path", "file", "uri"):
+        value = data.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def main() -> None:
+    data = load_input()
+    path = file_path(data)
+    if not path or not os.path.isfile(path):
+        print(json.dumps({}))
+        return
+    if os.path.basename(path) in SKIP_NAMES:
+        print(json.dumps({}))
+        return
+    try:
+        with open(path, "r", encoding="utf-8", errors="ignore") as handle:
+            text = handle.read(200_000)
+    except OSError:
+        print(json.dumps({}))
+        return
+    hits = [pattern.pattern for pattern in PATTERNS if pattern.search(text)]
+    if not hits:
+        print(json.dumps({}))
+        return
+    print(
+        json.dumps(
+            {
+                "additional_context": (
+                    f"Secret-hygiene hook flagged {path}. "
+                    "Do not commit secrets. Move credentials to an untracked secret file."
+                )
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.cursor/hooks/before-shell.py
+++ b/.cursor/hooks/before-shell.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Gate destructive shell commands without a naive string blacklist."""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+DENY_MSG = {
+    "permission": "deny",
+    "user_message": "A Cursor hook blocked this command.",
+    "agent_message": "",
+}
+ASK_MSG = {
+    "permission": "ask",
+    "user_message": "Review this command before continuing.",
+    "agent_message": "",
+}
+
+
+def allow() -> None:
+    print(json.dumps({"permission": "allow"}))
+    sys.exit(0)
+
+
+def ask(agent: str, user: str | None = None) -> None:
+    payload = dict(ASK_MSG)
+    payload["agent_message"] = agent
+    if user:
+        payload["user_message"] = user
+    print(json.dumps(payload))
+    sys.exit(0)
+
+
+def deny(agent: str, user: str | None = None) -> None:
+    payload = dict(DENY_MSG)
+    payload["agent_message"] = agent
+    if user:
+        payload["user_message"] = user
+    print(json.dumps(payload))
+    sys.exit(0)
+
+
+def read_command() -> str:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return ""
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return raw.strip()
+    for key in ("command", "cmd", "shell_command"):
+        value = data.get(key)
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def normalize(command: str) -> str:
+    return " ".join(command.strip().split())
+
+
+def is_force_push(command: str) -> bool:
+    if not re.search(r"\bgit\b", command):
+        return False
+    if re.search(r"\bpush\b", command) and re.search(
+        r"(--force-with-lease|--force|-f\b)", command
+    ):
+        return True
+    return False
+
+
+def is_hard_reset(command: str) -> bool:
+    return bool(re.search(r"\bgit\b.*\breset\b.*--hard\b", command)) or bool(
+        re.search(r"\bgit\b.*\bcheckout\b.*--force\b", command)
+    )
+
+
+def is_history_rewrite(command: str) -> bool:
+    return bool(
+        re.search(r"\bgit\b.*\bfilter-(branch|repo)\b", command)
+        or re.search(r"\bgit\b.*\brebase\b.*\b-i\b", command)
+        or re.search(r"\bgit\b.*\bpush\b.*\b--mirror\b", command)
+    )
+
+
+def is_sql_destructive(command: str) -> bool:
+    upper = command.upper()
+    return bool(
+        re.search(r"\bDROP\s+(DATABASE|SCHEMA|TABLE)\b", upper)
+        or re.search(r"\bTRUNCATE\b", upper)
+    )
+
+
+def rm_rf_targets(command: str) -> list[str]:
+    if not re.search(r"\brm\b", command) or not re.search(r"-[^\s]*r[^\s]*f|-[^\s]*f[^\s]*r", command):
+        return []
+    tokens = command.split()
+    out: list[str] = []
+    started = False
+    for token in tokens:
+        if token in {"sudo", "command"}:
+            continue
+        if token == "rm" or token.startswith("rm"):
+            started = True
+            continue
+        if not started:
+            continue
+        if token.startswith("-"):
+            continue
+        out.append(token)
+    return out
+
+
+def dangerous_rm_target(path: str) -> bool:
+    expanded = os.path.expanduser(path)
+    stripped = expanded.rstrip("/")
+    if stripped in {"", ".", ".."}:
+        return True
+    if stripped in {"/", "/Users", "/home", "/System", "/Library", "/opt", "/usr", "/bin", "/sbin", "/etc", "/var", "/private"}:
+        return True
+    home = os.path.expanduser("~").rstrip("/")
+    if stripped == home:
+        return True
+    if stripped.startswith("/volume1") and stripped.count("/") <= 2:
+        return True
+    return False
+
+
+def git_diff_check_cached() -> str | None:
+    try:
+        proc = subprocess.run(
+            ["git", "diff", "--cached", "--check"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    if proc.returncode == 0:
+        return None
+    return (proc.stdout or proc.stderr or "git diff --check failed").strip()
+
+
+def main() -> None:
+    command = normalize(read_command())
+    if not command:
+        allow()
+
+    if is_force_push(command) or is_history_rewrite(command):
+        deny(
+            "Force-push or shared-history rewrite requires Level 3 human approval.",
+            "This Git command can rewrite shared history. It was blocked.",
+        )
+
+    if is_hard_reset(command):
+        ask(
+            "git reset --hard / force checkout discards work. Confirm before running.",
+        )
+
+    if is_sql_destructive(command):
+        ask("DROP/TRUNCATE can destroy data. Confirm before running.")
+
+    for target in rm_rf_targets(command):
+        if dangerous_rm_target(target):
+            deny(
+                f"Refusing rm -rf of high-risk path: {target}",
+                f"Blocked rm -rf targeting {target}.",
+            )
+
+    if re.search(r"\bgit\b", command) and re.search(r"\bcommit\b", command):
+        problem = git_diff_check_cached()
+        if problem:
+            ask(
+                "git diff --cached --check failed. Fix whitespace/conflict markers before commit.\n"
+                + problem[:2000]
+            )
+
+    allow()
+
+
+if __name__ == "__main__":
+    main()

--- a/.cursor/hooks/pre-compact.py
+++ b/.cursor/hooks/pre-compact.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Before context compaction: require HANDOFF and capture mechanical Git state."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+
+def git(*args: str) -> str:
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return ""
+    return (proc.stdout or "").strip()
+
+
+def main() -> None:
+    handoff = os.path.join("docs", "continuity", "HANDOFF.md")
+    missing = not os.path.isfile(handoff)
+    status = git("status", "--short")
+    branch = git("rev-parse", "--abbrev-ref", "HEAD")
+    head = git("rev-parse", "--short", "HEAD")
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    os.makedirs(os.path.join("docs", "continuity"), exist_ok=True)
+    state_path = os.path.join("docs", "continuity", ".last-git-state.txt")
+    try:
+        with open(state_path, "w", encoding="utf-8") as handle:
+            handle.write(f"captured_at: {stamp}\n")
+            handle.write(f"branch: {branch or 'unknown'}\n")
+            handle.write(f"head: {head or 'unknown'}\n")
+            handle.write("status:\n")
+            handle.write((status or "(clean)") + "\n")
+    except OSError:
+        pass
+
+    notes = [
+        f"preCompact git: branch={branch or 'unknown'} head={head or 'unknown'}",
+        f"status: {status or 'clean'}",
+    ]
+    if missing:
+        notes.append(
+            "HANDOFF.md is missing. Update docs/continuity/HANDOFF.md before this session continues."
+        )
+
+    print(json.dumps({"additional_context": "\n".join(notes)}))
+
+
+if __name__ == "__main__":
+    main()

--- a/.cursor/rules/00-core.mdc
+++ b/.cursor/rules/00-core.mdc
@@ -1,0 +1,17 @@
+---
+description: Core Agent operating principles. Always apply.
+alwaysApply: true
+---
+
+# Core
+
+Follow `core/constitution.md` and `core/authority.md`.
+
+- Latest explicit user instruction wins.
+- Inspect before modifying.
+- Repository files and Git state outrank chat memory.
+- One Primary Agent owns the active slice. Helpers are bounded.
+- Default is a single Agent. Max two active Agents unless the user approves a third.
+- Complexity must be earned. Do not add frameworks, routers, or extra Agents speculatively.
+- Preserve unrelated user work.
+- Do not invent machine state, licenses, secrets, or remote settings.

--- a/.cursor/rules/10-plan-before-code.mdc
+++ b/.cursor/rules/10-plan-before-code.mdc
@@ -1,0 +1,17 @@
+---
+description: Plan from repository evidence before material code changes.
+alwaysApply: true
+---
+
+# Plan before code
+
+Before material edits:
+
+1. Rehydrate if this is a new session or provider switch.
+2. Read the files that will change.
+3. State the smallest change that satisfies the request.
+4. Identify verification that will prove the change.
+
+Do not start a broad rewrite to "clean up" adjacent code.
+
+If requirements are ambiguous and the next step is destructive, privileged, or public, stop and ask. Local reversible work may proceed when the user already authorized implementation.

--- a/.cursor/rules/20-implementation.mdc
+++ b/.cursor/rules/20-implementation.mdc
@@ -1,0 +1,14 @@
+---
+description: Implementation constraints for local repository work.
+alwaysApply: true
+---
+
+# Implementation
+
+- Change only files required for the requested slice.
+- Match existing style. Do not introduce a new stack because it is familiar.
+- Do not add Python to a JavaScript-only repository, or the reverse, without a real need.
+- Respect `.node-version`, `.nvmrc`, `packageManager`, lockfiles, and `pyproject.toml`.
+- Use project-local `node_modules` or `.venv`. No global project installs.
+- Do not regenerate lockfiles casually.
+- Canonical human checkout is `~/Developer/<repository>/`.

--- a/.cursor/rules/30-testing.mdc
+++ b/.cursor/rules/30-testing.mdc
@@ -1,0 +1,20 @@
+---
+description: Verification evidence required before claiming completion.
+alwaysApply: true
+---
+
+# Testing
+
+Completion requires verification evidence. "Implemented" is not complete.
+
+Use only relevant layers:
+
+```text
+static → lint/format → typecheck → unit → integration → build → runtime/E2E → acceptance
+```
+
+Report each as `PASS`, `WARN`, `FAIL`, `NOT RUN`, or `NOT APPLICABLE`.
+
+Discover commands from the repository. Do not invent them.
+
+Do not describe skipped checks as passed.

--- a/.cursor/rules/40-git.mdc
+++ b/.cursor/rules/40-git.mdc
@@ -1,0 +1,14 @@
+---
+description: Git safety and commit policy for this workstation.
+alwaysApply: true
+---
+
+# Git
+
+- Do not commit unless the user asked.
+- Do not push, force-push, rewrite shared history, or change remote visibility unless explicitly approved.
+- Do not amend a commit you did not create in this session, or a commit already pushed.
+- Do not skip hooks (`--no-verify`) unless the user explicitly requested it.
+- Do not invent `user.name` or `user.email`.
+- Default branch name is `main`.
+- Never put secrets in Git, committed `.env`, handoff, or CI logs.

--- a/.cursor/rules/50-security.mdc
+++ b/.cursor/rules/50-security.mdc
@@ -1,0 +1,23 @@
+---
+description: Security and approval gates for privileged actions.
+alwaysApply: true
+---
+
+# Security
+
+Never store secrets in Git, committed `.env`, browser bundles, localStorage, Docker ARG/layers, handoff files, CI logs, or Agent prompt history stored as project data.
+
+Level 3 actions require explicit human approval:
+
+- production deploy or production database mutation
+- destructive data operations
+- force push / shared history rewrite
+- secret rotation
+- making a repository or package public
+- license change
+- paid provider spend
+- billing
+- account deletion
+- public network exposure
+
+A request to view or locally serve an app is not permission to deploy it publicly.

--- a/.cursor/rules/60-workflow-entry.mdc
+++ b/.cursor/rules/60-workflow-entry.mdc
@@ -1,0 +1,36 @@
+---
+description: Automatic Agent-managed workflow on work start and finish. Always apply.
+alwaysApply: true
+---
+
+# Workflow entry
+
+Do not open `~/Developer/agent-rules-kit` just to start or apply kit procedure to another repo. Stay in the current workspace.
+
+Kit CLI if `ark` is missing from PATH:
+
+```text
+~/Developer/agent-rules-kit/bin/ark
+```
+
+Users should not have to name `ark init`, `rehydrate`, `verify`, or `checkpoint`.
+
+Natural-language entry:
+
+- "작업 시작해" / start work / continue this project → treat as managed-session start
+- "이걸 새 프로젝트로 시작해" → new-repo path
+- "이 GitHub repo 가져와서…" with a URL → external-repo path (audit first)
+- "여기까지 마무리해" / wrap up / that's all for today → verify + checkpoint
+
+On material work start:
+
+1. Detect whether the checkout is Agent-managed (AGENTS.md + BRIEF + DECISIONS + HANDOFF).
+2. If managed, rehydrate automatically from those files plus live Git. Do not wait for the user to say `ark rehydrate`.
+3. If unmanaged, run `ark init` dry-run before material edits. Never `--apply` conflicts automatically. If the dry-run is only CREATE, ask once.
+4. If the folder is not a git repository, ask once before `git init` and contract creation.
+5. After contracts exist in this repo, dry-run then ask once to install the Cursor adapter here (`~/Developer/agent-rules-kit/adapters/cursor/install/install.sh . --apply`).
+6. For an external URL, read-only audit (license, scripts, submodules, install) before clone extras, dependency install, or execution. Ask the user to choose Reference / Fork / Derivative.
+7. Skip `ark doctor` and full repo-audit on a normal managed session. Use them on first adoption, workstation/kit change, or a real problem.
+8. Before declaring material work complete, run relevant verification including `ark verify` when this is a kit checkout, update HANDOFF semantics, then `ark checkpoint`.
+
+Automate procedure, not decisions. Still require a human for conflict overwrite, remote creation, push, public visibility, license, paid spend, deploy, and destructive data changes.

--- a/.cursor/skills/ark-start/SKILL.md
+++ b/.cursor/skills/ark-start/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: ark-start
+description: Starts Agent-managed work in the current workspace using agent-rules-kit without opening the kit repo. Use when the user starts work, creates a new project, applies the kit, clones a GitHub URL, wraps up, or says 작업 시작해 / 새 프로젝트로 시작해 / 가져와 / 여기까지 마무리해.
+---
+
+# ark-start
+
+Workstation entry for any Cursor workspace. Do not open `~/Developer/agent-rules-kit` just to apply the kit.
+
+## Kit location
+
+```text
+KIT=$HOME/Developer/agent-rules-kit
+ARK=ark   # if missing: $KIT/bin/ark
+```
+
+Stay in the current workspace cwd.
+
+## On work start
+
+1. Run `$ARK` (same as `ark start`) in the current directory.
+2. Follow the printed mode:
+
+| Mode | Action |
+|---|---|
+| managed | Rehydrate from AGENTS / BRIEF / DECISIONS / HANDOFF + live Git. Skip doctor. |
+| unmanaged | Init is dry-run only. Never `--apply` conflicts. If `SAFE_CREATE: yes`, ask once. |
+| empty | Ask once before `git init` and contract creation. |
+
+3. After contracts exist in **this** repo, dry-run then ask once to install the Cursor adapter here:
+
+```bash
+"$KIT/adapters/cursor/install/install.sh" . --apply
+```
+
+4. Continue work in this workspace. Do not hop back to the kit.
+
+## External GitHub URL
+
+Read-only audit first (license, scripts, submodules, install). Do not clone extras, install dependencies, or execute untrusted files until the user chooses Reference / Fork / Derivative.
+
+## Wrap-up
+
+Verify in this repo, update HANDOFF, then `ark checkpoint`. Automate procedure, not decisions (no auto push, public, license, deploy, or overwrite).

--- a/.cursor/skills/bad-code-triage/SKILL.md
+++ b/.cursor/skills/bad-code-triage/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: bad-code-triage
+description: Reproduce a defect, identify the source, apply the smallest justified repair, add a regression check, and verify. Use when debugging failures or unexpected behavior.
+---
+
+# bad-code-triage
+
+```text
+symptom
+→ reproduce
+→ identify source
+→ smallest justified repair
+→ regression test
+→ verify
+```
+
+Avoid broad rewrites before reproducing the problem.
+
+Do not edit product code until reproduction evidence exists, unless the user explicitly asked for an immediate guarded fix and the failure is already captured.

--- a/.cursor/skills/checkpoint/SKILL.md
+++ b/.cursor/skills/checkpoint/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: checkpoint
+description: Update docs/continuity/HANDOFF.md from actual Git and verification state before context compaction, session end, or provider transition.
+---
+
+# checkpoint
+
+Update the current handoff from actual repository state.
+
+## Inputs
+
+- current goal
+- Git branch / status / diff
+- verified work
+- decisions
+- risks
+- exact next actions
+
+## Template
+
+Use `project/templates/docs/continuity/HANDOFF.md`.
+
+## Rules
+
+- concise, current slice only
+- no transcripts, secrets, tokens, passwords, or giant logs
+- do not guess progress
+- write `HANDOFF.md` before context loss or provider switch
+
+The `<!-- ark:git-state -->` block is a checkpoint snapshot (time, branch, HEAD, short status). It is not a declaration of live HEAD. Live `git status` / `git log` / `git diff` take precedence on rehydrate.
+
+## CLI
+
+```bash
+ark checkpoint
+```

--- a/.cursor/skills/project-start/SKILL.md
+++ b/.cursor/skills/project-start/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: project-start
+description: Initialize or reconcile project continuity files (AGENTS.md, BRIEF, DECISIONS, HANDOFF) with dry-run default and no silent overwrites. Use when starting a repository, running ark init, or installing missing Agent contracts.
+---
+
+# project-start
+
+Generalization of former `studio-start`.
+
+## Behavior
+
+```text
+inspect
+→ dry-run
+→ report planned changes/conflicts
+→ explicit apply
+→ validate
+```
+
+Default is **dry-run**. `--apply` is required to write files.
+
+Create only missing files. Never overwrite conflicts silently.
+
+Status vocabulary:
+
+```text
+CREATE     destination missing
+UNCHANGED  destination identical to template
+CONFLICT   destination exists and differs; left untouched
+```
+
+Do not automatically:
+
+- commit
+- push
+- create a public repository
+- change license
+- install a CI runner
+- deploy
+- change remote URL
+
+Do not infer a license.
+
+## Files
+
+From `project/templates/`:
+
+- `AGENTS.md`
+- `docs/product/BRIEF.md`
+- `docs/decisions/DECISIONS.md`
+- `docs/continuity/HANDOFF.md`
+
+## CLI
+
+```bash
+ark init .
+ark init . --apply
+```
+
+## Stop condition
+
+Print planned actions, conflicts, and created files. Exit non-zero if apply was requested and a write failed. Leave existing conflicting files untouched.

--- a/.cursor/skills/rehydrate/SKILL.md
+++ b/.cursor/skills/rehydrate/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: rehydrate
+description: Resume a session by reading AGENTS.md, BRIEF, DECISIONS, HANDOFF, and Git state, then returning a concise resume report before editing.
+---
+
+# rehydrate
+
+Read, in order:
+
+1. `AGENTS.md`
+2. `docs/product/BRIEF.md`
+3. `docs/decisions/DECISIONS.md`
+4. `docs/continuity/HANDOFF.md`
+5. Git status / log / diff
+6. target files that will be modified
+
+Return a concise resume report before editing.
+
+Do not trust previous Agent memory.
+
+## CLI
+
+```bash
+ark rehydrate
+```

--- a/.cursor/skills/repo-audit/SKILL.md
+++ b/.cursor/skills/repo-audit/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: repo-audit
+description: Produce a factual evidence-based audit of repository identity, Git state, runtime, package manager, tests, and external assumptions before material changes.
+---
+
+# repo-audit
+
+Before material changes, determine from the repository:
+
+- identity (name, remotes, visibility if known)
+- branch / status / existing user changes
+- runtime
+- package manager
+- build / test commands
+- database and migration system
+- auth
+- storage
+- deployment assumptions
+- external providers
+
+## Rules
+
+- Output must be factual and evidence-based.
+- Cite the file or command that established each fact.
+- Mark unknowns as unknown. Do not guess.
+- Do not modify files.

--- a/.cursor/skills/verify/SKILL.md
+++ b/.cursor/skills/verify/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: verify
+description: Run only the repository-relevant lint, typecheck, test, and build checks and report PASS/WARN/FAIL/NOT RUN/NOT APPLICABLE with real evidence.
+---
+
+# verify
+
+Run only the checks relevant to the repository and change.
+
+Do not fabricate command names.
+
+Discover them from:
+
+- package scripts
+- build files
+- CI
+- README
+- AGENTS.md
+- existing test configuration
+
+## Status vocabulary
+
+```text
+PASS
+WARN
+FAIL
+NOT RUN
+NOT APPLICABLE
+```
+
+Skipped layers must not be represented as passed.
+
+## CLI
+
+```bash
+ark verify
+```

--- a/.env.example
+++ b/.env.example
@@ -55,9 +55,12 @@ GOOGLE_CLOUD_LOCATION=
 # --- Voice ---
 # TTS narration, music generation, sound effects.
 ELEVENLABS_API_KEY=
-# OpenAI TTS fallback and GPT Image 2 image generation.
+# OpenAI TTS fallback, Sora, and optional GPT Image 2 via API key.
+# GPT Image 2 also works without this key when the Cursor GPT OAuth
+# connector (gpt-media-mcp) is signed in. Sora and OpenAI TTS still need it.
 OPENAI_API_KEY=
-# Grok image generation/editing and Grok video generation.
+# Grok Imagine via API key. Not required when the Cursor Grok OAuth
+# connector (grok-media-mcp) is signed in.
 XAI_API_KEY=
 # Volcengine Doubao Speech TTS (new console API Key).
 DOUBAO_SPEECH_API_KEY=

--- a/docs/continuity/HANDOFF.md
+++ b/docs/continuity/HANDOFF.md
@@ -1,0 +1,54 @@
+# HANDOFF
+
+## Objective
+
+Ship the OAuth + kit-contract work to `suyaleo/OpenMontage` main and open the local studio so the owner can start a real production.
+
+## Current State
+
+Local checkout is `/Users/macbook/Developer/open-montage`. Live Git outranks the snapshot below.
+
+- Fork origin: https://github.com/suyaleo/OpenMontage
+- Upstream remains `calesthio/OpenMontage` (no upstream PR unless asked)
+- Grok/GPT OAuth live smoke passed
+- `.env` stays local and gitignored; no tokens committed
+- Backlot is the local use surface (`python -m backlot open`)
+
+## Decisions This Slice
+
+- D-20260820-05 Grok/GPT providers use workstation OAuth, not API keys
+- Commit and merge to the fork `main` on explicit user request
+- Do not open a PR against upstream in this slice
+
+## Files Changed
+
+- OAuth wiring, kit contracts, Cursor adapter files, tests, HANDOFF
+
+## Verification Evidence
+
+```text
+pytest oauth/openai/grok quality: 16 passed
+live oauth smoke: grok_image + openai_image wrote projects/oauth-smoke/*.png
+```
+
+## Risks / Blockers
+
+- This is a local studio, not a hosted SaaS deploy.
+- Sora and OpenAI TTS still need `OPENAI_API_KEY`.
+- Grok HTTP 403 is an entitlement failure; do not retry.
+
+## Next Exact Actions
+
+1. Open Backlot library and keep the local venv active.
+2. On a video request, read `AGENT_GUIDE.md`, run preflight, pick a pipeline.
+3. Do not PR upstream unless the user asks.
+
+## Resume Point
+
+Fork main should hold the OAuth + kit work. Real use starts in this workspace with Backlot open and `AGENT_GUIDE.md`.
+
+<!-- ark:git-state -->
+Checkpoint captured: 2026-08-20T03:49:00+09:00
+Branch at checkpoint: main
+HEAD at checkpoint: 1bab711
+<!-- /ark:git-state -->

--- a/docs/decisions/DECISIONS.md
+++ b/docs/decisions/DECISIONS.md
@@ -1,0 +1,120 @@
+# Decisions
+
+Durable approved decisions. Do not repeat Git commit history.
+
+## D-20260820-01 — Fork adoption of OpenMontage
+
+Date: 2026-08-20
+Status: active
+
+### Context
+
+The workspace `/Users/macbook/Developer/open-montage` was empty. The user asked to apply `ark start` to https://github.com/calesthio/OpenMontage and then chose Fork after a read-only audit.
+
+### Decision
+
+Fork the public upstream to `suyaleo/OpenMontage` and clone it into this workspace. Keep `origin` as the fork and `upstream` as `calesthio/OpenMontage`. Visibility stays PUBLIC because GitHub inherited it from the public source.
+
+### Alternatives rejected
+
+- Reference-only (no working clone)
+- Derivative without a GitHub fork relationship
+
+### Consequences
+
+This is a fork, not an original product. AGPLv3 still applies. Do not change visibility, license, or remotes without an explicit human decision.
+
+## D-20260820-02 — Keep upstream AGENTS.md; add kit contracts only
+
+Date: 2026-08-20
+Status: active
+
+### Context
+
+`ark init` dry-run was `SAFE_CREATE: no` because `AGENTS.md` already exists. That file is OpenMontage's pointer to `AGENT_GUIDE.md`, not a kit template.
+
+### Decision
+
+Never overwrite `AGENTS.md`. Create only the missing kit contracts: `docs/product/BRIEF.md`, `docs/decisions/DECISIONS.md`, and `docs/continuity/HANDOFF.md`. For OpenMontage production work, `AGENT_GUIDE.md` remains mandatory.
+
+### Alternatives rejected
+
+- Overwriting `AGENTS.md` with the kit template
+- Leaving the checkout unmanaged with no continuity files
+
+### Consequences
+
+Kit rehydrate uses BRIEF / DECISIONS / HANDOFF plus live Git. Pipeline routing still starts from `AGENT_GUIDE.md`.
+
+## D-20260820-03 — Install Cursor adapter beside OpenMontage rules
+
+Date: 2026-08-20
+Status: active
+
+### Context
+
+Contracts existed. The user approved installing the kit Cursor adapter. Upstream already had `.cursor/rules/openmontage.mdc` and `.cursor/commands/*`.
+
+### Decision
+
+Install the adapter into this repo. Add kit rules, agents, hooks, and skills. Do not overwrite `openmontage.mdc` or existing commands.
+
+### Alternatives rejected
+
+- Skipping the adapter
+- Replacing OpenMontage `.cursor` files
+
+### Consequences
+
+Both stacks coexist. Adapter source of truth remains `~/Developer/agent-rules-kit/adapters/cursor/`. Re-run the installer after kit changes; do not edit generated `.cursor` kit files here.
+
+## D-20260820-04 — Run make setup
+
+Date: 2026-08-20
+Status: active
+
+### Context
+
+The user approved `make setup`. System Python was 3.9.6; FFmpeg 9.0.1 and Node v24.19.0 were already present. `uv` was available.
+
+### Decision
+
+Run `make setup` in this checkout. Use `uv` to create `.venv` with CPython 3.10.21. Install `requirements.txt`, `remotion-composer` npm deps, `piper-tts`, warm HyperFrames via npx, and copy `.env.example` to `.env`.
+
+### Alternatives rejected
+
+- `make install-gpu` (not requested; needs NVIDIA GPU)
+- Filling API keys
+- `npm audit fix` for the Remotion high-severity advisory
+
+### Consequences
+
+Local zero-key path is available. `.env` and `.venv` are gitignored. Do not commit secrets.
+
+## D-20260820-05 — Grok/GPT providers use workstation OAuth, not API keys
+
+Date: 2026-08-20
+Status: active
+
+### Context
+
+The user asked to connect Grok and GPT providers with the existing Grok/GPT OAuth connectors so OpenMontage does not need `XAI_API_KEY` or `OPENAI_API_KEY`. Cursor already had `grok-media-mcp` and `gpt-media-mcp` installed and signed in on macOS Keychain.
+
+### Decision
+
+Keep the connectors at the workstation MCP. Do not copy tokens into `.env`. OpenMontage tools read the same Keychain items:
+
+- `grok_image` / `grok_video` → `com.cursor.grok-media-mcp`
+- `openai_image` → `com.cursor.gpt-media-mcp` (ChatGPT/Codex image path)
+
+Sora (`sora_video`) and OpenAI TTS (`openai_tts`) stay API-key-only. GPT OAuth does not cover those APIs.
+
+### Alternatives rejected
+
+- Writing OAuth tokens into `.env`
+- Treating Codex OAuth as an OpenAI platform API key
+- Installing Hermes or Codex as a coding runtime
+
+### Consequences
+
+Grok image/video and GPT Image 2 consume subscription quota, not billed API keys. HTTP 403 means the account lacks entitlement; do not retry. Codex image generation is best-effort.

--- a/docs/product/BRIEF.md
+++ b/docs/product/BRIEF.md
@@ -1,0 +1,51 @@
+# Product brief
+
+Durable product intent. Not a session log.
+
+## Problem
+
+AI coding assistants can write code, but they are not a video production studio. Users need an agent-first pipeline that turns a brief or reference video into a finished render with research, script, assets, edit, composition, quality gates, and cost control.
+
+## Target users
+
+The workstation owner (`suyaleo`) operating a local fork of OpenMontage in Cursor, plus future contributors who follow the same Agent contracts.
+
+## Primary workflow
+
+```text
+rehydrate → pick pipeline → research/proposal → script → scene_plan → assets → edit → compose → self-review
+```
+
+Human approval gates stay at proposal, script, scene plan, generated assets, and publish.
+
+## Desired final artifact / outcome
+
+A local, Agent-managed checkout of `suyaleo/OpenMontage` that can resume from repository contracts, run OpenMontage pipelines through Cursor, and keep kit continuity without overwriting upstream agent files.
+
+## Scope
+
+- Fork and track `calesthio/OpenMontage` (`upstream`) from `suyaleo/OpenMontage` (`origin`)
+- Keep upstream `AGENTS.md` / `AGENT_GUIDE.md` as the OpenMontage operating contract
+- Add kit contracts only: BRIEF, DECISIONS, HANDOFF
+- Optional later: Cursor adapter install, `make setup`, API keys, first pipeline run
+
+## Non-goals
+
+- Overwriting upstream `AGENTS.md` or `AGENT_GUIDE.md`
+- Relicensing away from GNU AGPLv3
+- Changing GitHub visibility without an explicit decision
+- Running `make setup`, installing GPU extras, or spending cloud API credits without approval
+- Treating this checkout as a clean-room original product
+
+## Product constraints
+
+- License is GNU AGPLv3. Network use and distribution require corresponding source.
+- Python provides tools and persistence only. The agent is the orchestrator.
+- Automate kit procedure, not decisions: no auto push, public-visibility change, license change, deploy, or overwrite.
+- Secrets stay in `.env` (from `.env.example`). Do not commit keys.
+
+## Acceptance direction
+
+- Contracts exist and match live Git.
+- Upstream OpenMontage instructions remain authoritative for production work.
+- Setup and first render happen only after explicit approval.

--- a/lib/oauth_connectors.py
+++ b/lib/oauth_connectors.py
@@ -1,0 +1,381 @@
+"""Workstation Grok/GPT OAuth credentials for OpenMontage tools.
+
+Reads the same macOS Keychain items as `grok-media-mcp` and `gpt-media-mcp`.
+Never logs, prints, or returns raw OAuth tokens to callers except
+`get_access_token`, which tools must use only as an Authorization header.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import threading
+import time
+from typing import Any
+
+GROK_CONNECTOR = "grok"
+GPT_CONNECTOR = "gpt"
+
+_GROK_STORE = ("com.cursor.grok-media-mcp", "xai-oauth:default")
+_GPT_STORE = ("com.cursor.gpt-media-mcp", "openai-codex:default")
+
+_XAI_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"
+_XAI_TOKEN_ENDPOINT = "https://auth.x.ai/oauth2/token"
+
+_OPENAI_CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+_OPENAI_TOKEN_ENDPOINT = "https://auth.openai.com/oauth/token"
+_CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses"
+_CODEX_HOST_MODEL = "gpt-5.5"
+_CODEX_IMAGE_MODEL = "gpt-image-2"
+_CODEX_SIZES = {
+    "landscape": "1536x1024",
+    "square": "1024x1024",
+    "portrait": "1024x1536",
+}
+_MAX_IMAGE_BYTES = 50 * 1024 * 1024
+
+_locks = {
+    GROK_CONNECTOR: threading.Lock(),
+    GPT_CONNECTOR: threading.Lock(),
+}
+
+
+class OAuthError(RuntimeError):
+    pass
+
+
+class OAuthEntitlementError(OAuthError):
+    pass
+
+
+def _store(connector_id: str) -> tuple[str, str]:
+    if connector_id == GROK_CONNECTOR:
+        return _GROK_STORE
+    if connector_id == GPT_CONNECTOR:
+        return _GPT_STORE
+    raise OAuthError(f"unsupported oauth connector: {connector_id}")
+
+
+def _jwt_exp(token: str) -> float:
+    try:
+        payload = token.split(".")[1]
+        payload += "=" * (-len(payload) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload))
+        return float(claims.get("exp", 0))
+    except (IndexError, TypeError, ValueError, json.JSONDecodeError):
+        return 0.0
+
+
+def _chatgpt_account_id(access_token: str) -> str | None:
+    try:
+        payload = access_token.split(".")[1]
+        payload += "=" * (-len(payload) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload))
+        auth_claims = claims.get("https://api.openai.com/auth")
+        value = auth_claims.get("chatgpt_account_id") if isinstance(auth_claims, dict) else None
+        return value if isinstance(value, str) and value else None
+    except (IndexError, TypeError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def _load_raw(connector_id: str) -> dict[str, Any] | None:
+    import keyring
+
+    service, account = _store(connector_id)
+    raw = keyring.get_password(service, account)
+    if not raw:
+        return None
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise OAuthError("The saved OAuth credential is malformed; log in again.") from exc
+    if not isinstance(value, dict):
+        raise OAuthError("The saved OAuth credential has an invalid shape.")
+    return value
+
+
+def _save_raw(connector_id: str, value: dict[str, Any]) -> None:
+    import keyring
+
+    service, account = _store(connector_id)
+    keyring.set_password(service, account, json.dumps(value, separators=(",", ":")))
+
+
+def auth_status(connector_id: str) -> dict[str, Any]:
+    """Public status only. Never includes tokens."""
+    try:
+        credentials = _load_raw(connector_id)
+    except OAuthError as exc:
+        return {"authenticated": False, "connector": connector_id, "error": str(exc)}
+    except Exception as exc:
+        return {
+            "authenticated": False,
+            "connector": connector_id,
+            "error": f"OAuth store unavailable: {exc.__class__.__name__}",
+        }
+    if not credentials:
+        return {"authenticated": False, "connector": connector_id}
+    expires_at = float(credentials.get("expires_at") or _jwt_exp(str(credentials.get("access_token") or "")))
+    return {
+        "authenticated": True,
+        "connector": connector_id,
+        "expires_in": max(0, int(expires_at - time.time())) if expires_at else None,
+        "credential_store": _store(connector_id)[0],
+    }
+
+
+def is_authenticated(connector_id: str) -> bool:
+    return bool(auth_status(connector_id).get("authenticated"))
+
+
+def get_access_token(connector_id: str) -> str | None:
+    """Return a valid access token, or None when the user has not signed in."""
+    lock = _locks.get(connector_id)
+    if lock is None:
+        raise OAuthError(f"unsupported oauth connector: {connector_id}")
+    with lock:
+        credentials = _load_raw(connector_id)
+        if not credentials:
+            return None
+        access_token = str(credentials.get("access_token") or "")
+        expires_at = float(credentials.get("expires_at") or _jwt_exp(access_token))
+        if access_token and (not expires_at or expires_at - time.time() > 180):
+            return access_token
+        refresh_token = str(credentials.get("refresh_token") or "")
+        if not refresh_token:
+            raise OAuthError("No refresh token is available. Log in again.")
+        if connector_id == GROK_CONNECTOR:
+            next_credentials = _refresh_grok(refresh_token)
+        else:
+            next_credentials = _refresh_gpt(refresh_token)
+        credentials.update(next_credentials)
+        _save_raw(connector_id, credentials)
+        return str(credentials["access_token"])
+
+
+def _refresh_grok(refresh_token: str) -> dict[str, Any]:
+    import requests
+
+    response = requests.post(
+        _XAI_TOKEN_ENDPOINT,
+        data={
+            "grant_type": "refresh_token",
+            "client_id": _XAI_CLIENT_ID,
+            "refresh_token": refresh_token,
+        },
+        timeout=30,
+    )
+    if response.status_code == 403:
+        raise OAuthEntitlementError(
+            "xAI denied OAuth API access for this subscription (HTTP 403)."
+        )
+    if response.status_code != 200:
+        raise OAuthError(f"xAI token refresh failed with HTTP {response.status_code}.")
+    payload = response.json()
+    access_token = payload.get("access_token")
+    if not access_token:
+        raise OAuthError("xAI refresh returned no access token.")
+    expires_in = max(60, int(payload.get("expires_in", 3600)))
+    return {
+        "access_token": access_token,
+        "refresh_token": payload.get("refresh_token") or refresh_token,
+        "expires_at": time.time() + expires_in,
+    }
+
+
+def _refresh_gpt(refresh_token: str) -> dict[str, Any]:
+    import requests
+
+    response = requests.post(
+        _OPENAI_TOKEN_ENDPOINT,
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": _OPENAI_CODEX_CLIENT_ID,
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        timeout=30,
+    )
+    if response.status_code != 200:
+        raise OAuthError(f"Codex token refresh failed with HTTP {response.status_code}.")
+    payload = response.json()
+    access_token = payload.get("access_token")
+    if not access_token:
+        raise OAuthError("Codex refresh returned no access token.")
+    return {
+        "access_token": access_token,
+        "refresh_token": payload.get("refresh_token") or refresh_token,
+        "expires_at": _jwt_exp(str(access_token)),
+    }
+
+
+def grok_bearer_token() -> str | None:
+    """API key wins if set; otherwise the Grok OAuth access token."""
+    import os
+
+    api_key = os.environ.get("XAI_API_KEY")
+    if api_key:
+        return api_key
+    return get_access_token(GROK_CONNECTOR)
+
+
+def grok_auth_available() -> bool:
+    import os
+
+    return bool(os.environ.get("XAI_API_KEY") or is_authenticated(GROK_CONNECTOR))
+
+
+def gpt_image_auth_available() -> bool:
+    import os
+
+    return bool(os.environ.get("OPENAI_API_KEY") or is_authenticated(GPT_CONNECTOR))
+
+
+def _iter_sse_json(response: Any) -> Any:
+    event_name: str | None = None
+    data_lines: list[str] = []
+
+    def flush() -> dict[str, Any] | None:
+        nonlocal event_name, data_lines
+        if not data_lines:
+            event_name = None
+            return None
+        raw = "\n".join(data_lines).strip()
+        event = event_name
+        event_name = None
+        data_lines = []
+        if not raw or raw == "[DONE]":
+            return None
+        value = json.loads(raw)
+        if not isinstance(value, dict):
+            return None
+        if event and "type" not in value:
+            value["type"] = event
+        return value
+
+    for line in response.iter_lines():
+        if isinstance(line, bytes):
+            line = line.decode("utf-8", errors="replace")
+        if line == "":
+            value = flush()
+            if value is not None:
+                yield value
+        elif line.startswith(":"):
+            continue
+        elif line.startswith("event:"):
+            event_name = line[6:].strip()
+        elif line.startswith("data:"):
+            data_lines.append(line[5:].lstrip())
+    value = flush()
+    if value is not None:
+        yield value
+
+
+def _extract_image_b64(value: Any) -> str | None:
+    found: str | None = None
+    if isinstance(value, dict):
+        if value.get("type") == "image_generation_call":
+            result = value.get("result")
+            if isinstance(result, str) and result:
+                found = result
+        partial = value.get("partial_image_b64")
+        if isinstance(partial, str) and partial:
+            found = partial
+        for child in value.values():
+            nested = _extract_image_b64(child)
+            if nested:
+                found = nested
+    elif isinstance(value, list):
+        for child in value:
+            nested = _extract_image_b64(child)
+            if nested:
+                found = nested
+    return found
+
+
+def generate_gpt_oauth_image(
+    prompt: str,
+    *,
+    aspect_ratio: str = "square",
+    quality: str = "medium",
+) -> bytes:
+    """Best-effort GPT Image 2 via ChatGPT/Codex OAuth. No API key."""
+    import requests
+
+    prompt = prompt.strip()
+    if not prompt or len(prompt) > 20_000:
+        raise OAuthError("Prompt must contain 1–20,000 characters.")
+    if aspect_ratio not in _CODEX_SIZES:
+        raise OAuthError("aspect_ratio must be landscape, square, or portrait.")
+    if quality not in {"low", "medium", "high"}:
+        raise OAuthError("quality must be low, medium, or high.")
+
+    token = get_access_token(GPT_CONNECTOR)
+    if not token:
+        raise OAuthError("GPT OAuth is not signed in. Run gpt-media-mcp login.")
+
+    headers = {
+        "Accept": "text/event-stream",
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "User-Agent": "codex_cli_rs/0.0.0 (OpenMontage)",
+        "originator": "codex_cli_rs",
+    }
+    account_id = _chatgpt_account_id(token)
+    if account_id:
+        headers["ChatGPT-Account-ID"] = account_id
+
+    body = {
+        "model": _CODEX_HOST_MODEL,
+        "store": False,
+        "instructions": (
+            "You are an assistant that must fulfill image generation and image "
+            "editing requests by using the image_generation tool when provided."
+        ),
+        "input": [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": prompt}],
+            }
+        ],
+        "tools": [
+            {
+                "type": "image_generation",
+                "model": _CODEX_IMAGE_MODEL,
+                "size": _CODEX_SIZES[aspect_ratio],
+                "quality": quality,
+                "output_format": "png",
+                "background": "opaque",
+                "partial_images": 1,
+            }
+        ],
+        "stream": True,
+    }
+
+    image_b64: str | None = None
+    with requests.post(
+        _CODEX_RESPONSES_URL,
+        headers=headers,
+        json=body,
+        stream=True,
+        timeout=300,
+    ) as response:
+        if response.status_code >= 400:
+            raise OAuthError(
+                f"Codex Responses API returned HTTP {response.status_code}."
+            )
+        for event in _iter_sse_json(response):
+            found = _extract_image_b64(event)
+            if found:
+                image_b64 = found
+
+    if not image_b64:
+        raise OAuthError(
+            "Codex returned no image. The hosted model may decline image_generation; "
+            "this path is best-effort and is not an API-key fallback."
+        )
+    raw = base64.b64decode(image_b64)
+    if len(raw) > _MAX_IMAGE_BYTES:
+        raise OAuthError("Generated image exceeds the 50 MiB safety limit.")
+    return raw

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ requests>=2.31
 google-auth>=2.0       # service-account auth for Google TTS + Imagen (Vertex AI)
 google-genai>=1.0.0    # Gemini Developer API clients for Lyria, Veo, and Gemini Omni
 openai>=2.44.0         # Videos API support for Sora 2
+keyring>=25.0          # macOS Keychain Grok/GPT OAuth connectors
 
 # Backlot - the living storyboard (local board server)
 fastapi>=0.110

--- a/tests/lib/test_oauth_connectors.py
+++ b/tests/lib/test_oauth_connectors.py
@@ -1,0 +1,72 @@
+"""OAuth connector helpers never expose tokens in public status."""
+
+from __future__ import annotations
+
+import json
+import time
+
+from lib import oauth_connectors as oauth
+
+
+class _FakeKeyring:
+    def __init__(self, stores: dict[tuple[str, str], str] | None = None):
+        self.stores = stores or {}
+
+    def get_password(self, service: str, account: str):
+        return self.stores.get((service, account))
+
+    def set_password(self, service: str, account: str, password: str):
+        self.stores[(service, account)] = password
+
+
+def test_auth_status_omits_tokens(monkeypatch):
+    fake = _FakeKeyring(
+        {
+            ("com.cursor.grok-media-mcp", "xai-oauth:default"): json.dumps(
+                {
+                    "access_token": "secret-access",
+                    "refresh_token": "secret-refresh",
+                    "expires_at": time.time() + 3600,
+                }
+            )
+        }
+    )
+    monkeypatch.setattr(oauth, "_load_raw", lambda connector_id: json.loads(
+        fake.get_password(*oauth._store(connector_id))
+    ))
+    status = oauth.auth_status("grok")
+    dumped = json.dumps(status)
+    assert status["authenticated"] is True
+    assert "secret-access" not in dumped
+    assert "secret-refresh" not in dumped
+    assert "access_token" not in dumped
+
+
+def test_unauthenticated_when_store_empty(monkeypatch):
+    monkeypatch.setattr(oauth, "_load_raw", lambda connector_id: None)
+    assert oauth.is_authenticated("grok") is False
+    assert oauth.auth_status("gpt")["authenticated"] is False
+
+
+def test_grok_bearer_prefers_api_key(monkeypatch):
+    monkeypatch.setenv("XAI_API_KEY", "env-key")
+    monkeypatch.setattr(oauth, "get_access_token", lambda connector_id: "oauth-token")
+    assert oauth.grok_bearer_token() == "env-key"
+
+
+def test_grok_bearer_uses_oauth_without_api_key(monkeypatch):
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.setattr(oauth, "get_access_token", lambda connector_id: "oauth-token")
+    assert oauth.grok_bearer_token() == "oauth-token"
+
+
+def test_extract_image_b64_from_nested_event():
+    event = {
+        "type": "response.completed",
+        "response": {
+            "output": [
+                {"type": "image_generation_call", "result": "abc123"}
+            ]
+        },
+    }
+    assert oauth._extract_image_b64(event) == "abc123"

--- a/tests/tools/test_oauth_provider_status.py
+++ b/tests/tools/test_oauth_provider_status.py
@@ -1,0 +1,65 @@
+"""Grok/GPT tools become available via workstation OAuth without API keys."""
+
+from __future__ import annotations
+
+from tools.base_tool import ToolStatus
+from tools.graphics.grok_image import GrokImage
+from tools.graphics.openai_image import OpenAIImage
+from tools.video.grok_video import GrokVideo
+from tools.video.sora_video import SoraVideo
+from tools.audio.openai_tts import OpenAITTS
+
+
+def test_grok_image_available_via_oauth(monkeypatch):
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "lib.oauth_connectors.is_authenticated",
+        lambda connector_id: connector_id == "grok",
+    )
+    assert GrokImage().get_status() == ToolStatus.AVAILABLE
+
+
+def test_grok_video_available_via_oauth(monkeypatch):
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "lib.oauth_connectors.is_authenticated",
+        lambda connector_id: connector_id == "grok",
+    )
+    assert GrokVideo().get_status() == ToolStatus.AVAILABLE
+
+
+def test_openai_image_available_via_oauth(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "lib.oauth_connectors.is_authenticated",
+        lambda connector_id: connector_id == "gpt",
+    )
+    assert OpenAIImage().get_status() == ToolStatus.AVAILABLE
+
+
+def test_sora_and_openai_tts_still_need_api_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr("lib.oauth_connectors.is_authenticated", lambda connector_id: True)
+    assert SoraVideo().get_status() == ToolStatus.UNAVAILABLE
+    assert OpenAITTS().get_status() == ToolStatus.UNAVAILABLE
+
+
+def test_openai_oauth_execute_writes_bytes(monkeypatch, tmp_path):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "lib.oauth_connectors.is_authenticated",
+        lambda connector_id: connector_id == "gpt",
+    )
+    monkeypatch.setattr(
+        "lib.oauth_connectors.generate_gpt_oauth_image",
+        lambda prompt, aspect_ratio="square", quality="medium": b"PNGDATA",
+    )
+    out = tmp_path / "oauth.png"
+    result = OpenAIImage().execute({"prompt": "a lamp", "output_path": str(out)})
+    assert result.success
+    assert result.data["auth_source"] == "oauth"
+    assert out.read_bytes() == b"PNGDATA"
+    assert "PNGDATA" not in str(result.data)
+    dumped = str(result.data)
+    assert "access_token" not in dumped
+    assert "Bearer" not in dumped

--- a/tools/graphics/grok_image.py
+++ b/tools/graphics/grok_image.py
@@ -56,8 +56,9 @@ class GrokImage(BaseTool):
 
     dependencies = []
     install_instructions = (
-        "Set XAI_API_KEY to your xAI API key.\n"
-        "  Get one from the xAI developer console"
+        "Sign in with the Cursor Grok OAuth connector (grok-media-mcp), "
+        "or set XAI_API_KEY.\n"
+        "  OAuth uses the macOS Keychain item com.cursor.grok-media-mcp"
     )
     agent_skills = ["grok-media"]
 
@@ -136,7 +137,9 @@ class GrokImage(BaseTool):
     user_visible_verification = ["Inspect generated image(s) for composition quality and edit fidelity"]
 
     def get_status(self) -> ToolStatus:
-        if os.environ.get("XAI_API_KEY"):
+        from lib.oauth_connectors import grok_auth_available
+
+        if grok_auth_available():
             return ToolStatus.AVAILABLE
         return ToolStatus.UNAVAILABLE
 
@@ -223,16 +226,23 @@ class GrokImage(BaseTool):
         return [base.parent / f"{base.name}_{idx + 1}{suffix}" for idx in range(count)]
 
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
-        api_key = os.environ.get("XAI_API_KEY")
+        from lib.oauth_connectors import OAuthEntitlementError, grok_bearer_token
+
+        try:
+            api_key = grok_bearer_token()
+        except OAuthEntitlementError as exc:
+            return ToolResult(success=False, error=str(exc))
         if not api_key:
             return ToolResult(
                 success=False,
-                error="XAI_API_KEY not set. " + self.install_instructions,
+                error="Grok OAuth is not signed in and XAI_API_KEY is not set. "
+                + self.install_instructions,
             )
 
         import requests
 
         start = time.time()
+        auth_source = "api_key" if os.environ.get("XAI_API_KEY") else "oauth"
         try:
             endpoint, payload = self._build_payload(inputs)
             response = requests.post(
@@ -244,6 +254,11 @@ class GrokImage(BaseTool):
                 json=payload,
                 timeout=180,
             )
+            if response.status_code == 403:
+                return ToolResult(
+                    success=False,
+                    error="xAI denied this OAuth account access to image generation (HTTP 403).",
+                )
             response.raise_for_status()
             data = response.json()
 
@@ -285,6 +300,7 @@ class GrokImage(BaseTool):
                 "model": payload["model"],
                 "prompt": inputs["prompt"],
                 "generation_mode": inputs.get("generation_mode", "generate"),
+                "auth_source": auth_source,
                 "output": primary_output,
                 "outputs": outputs,
                 "images_generated": len(outputs),

--- a/tools/graphics/openai_image.py
+++ b/tools/graphics/openai_image.py
@@ -35,8 +35,10 @@ class OpenAIImage(BaseTool):
 
     dependencies = []  # checked dynamically
     install_instructions = (
-        "Set OPENAI_API_KEY to your OpenAI API key.\n"
-        "  pip install openai"
+        "For GPT Image 2: sign in with the Cursor GPT OAuth connector "
+        "(gpt-media-mcp), or set OPENAI_API_KEY.\n"
+        "  OAuth uses the macOS Keychain item com.cursor.gpt-media-mcp\n"
+        "  Sora and OpenAI TTS still require OPENAI_API_KEY."
     )
     agent_skills = ["flux-best-practices"]  # general image gen knowledge
 
@@ -111,7 +113,9 @@ class OpenAIImage(BaseTool):
         return [base.parent / f"{base.name}_{idx + 1}{suffix}" for idx in range(count)]
 
     def get_status(self) -> ToolStatus:
-        if os.environ.get("OPENAI_API_KEY"):
+        from lib.oauth_connectors import gpt_image_auth_available
+
+        if gpt_image_auth_available():
             return ToolStatus.AVAILABLE
         return ToolStatus.UNAVAILABLE
 
@@ -123,25 +127,50 @@ class OpenAIImage(BaseTool):
         cost_map = {"low": 0.006, "medium": 0.053, "high": 0.211, "auto": 0.053}
         return cost_map.get(quality, 0.053) * n
 
+    @staticmethod
+    def _oauth_aspect(size: str) -> str:
+        if size in {"1536x1024"}:
+            return "landscape"
+        if size in {"1024x1536"}:
+            return "portrait"
+        return "square"
+
+    @staticmethod
+    def _oauth_quality(quality: str) -> str:
+        if quality in {"low", "medium", "high"}:
+            return quality
+        return "medium"
+
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
-        if not os.environ.get("OPENAI_API_KEY"):
-            return ToolResult(
-                success=False,
-                error="OPENAI_API_KEY not set. " + self.install_instructions,
-            )
-
-        from openai import OpenAI
-
         start = time.time()
-        client = OpenAI()
         model = inputs.get("model", "gpt-image-2")
         prompt = inputs["prompt"]
         size = inputs.get("size", "1024x1024")
         n = inputs.get("n", 1)
+        quality = inputs.get("quality", "high")
+        output_format = inputs.get("output_format", "png")
+
+        if os.environ.get("OPENAI_API_KEY"):
+            result = self._execute_api_key(inputs, model, prompt, size, n, quality, output_format)
+        else:
+            result = self._execute_oauth(inputs, model, prompt, size, n, quality, output_format)
+        result.duration_seconds = round(time.time() - start, 2)
+        return result
+
+    def _execute_api_key(
+        self,
+        inputs: dict[str, Any],
+        model: str,
+        prompt: str,
+        size: str,
+        n: int,
+        quality: str,
+        output_format: str,
+    ) -> ToolResult:
+        from openai import OpenAI
 
         try:
-            quality = inputs.get("quality", "high")
-            output_format = inputs.get("output_format", "png")
+            client = OpenAI()
             response = client.images.generate(
                 model=model,
                 prompt=prompt,
@@ -172,12 +201,64 @@ class OpenAIImage(BaseTool):
                 "provider": "openai",
                 "model": model,
                 "prompt": prompt,
+                "auth_source": "api_key",
                 "output": outputs[0],
                 "outputs": outputs,
                 "images_generated": len(outputs),
             },
             artifacts=outputs,
             cost_usd=self.estimate_cost(inputs),
-            duration_seconds=round(time.time() - start, 2),
+            model=model,
+        )
+
+    def _execute_oauth(
+        self,
+        inputs: dict[str, Any],
+        model: str,
+        prompt: str,
+        size: str,
+        n: int,
+        quality: str,
+        output_format: str,
+    ) -> ToolResult:
+        from lib.oauth_connectors import OAuthError, generate_gpt_oauth_image, is_authenticated
+
+        if not is_authenticated("gpt"):
+            return ToolResult(
+                success=False,
+                error="GPT OAuth is not signed in and OPENAI_API_KEY is not set. "
+                + self.install_instructions,
+            )
+
+        try:
+            output_paths = self._output_paths(inputs.get("output_path"), n, output_format)
+            outputs: list[str] = []
+            for out_path in output_paths:
+                raw = generate_gpt_oauth_image(
+                    prompt,
+                    aspect_ratio=self._oauth_aspect(size),
+                    quality=self._oauth_quality(quality),
+                )
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+                out_path.write_bytes(raw)
+                outputs.append(str(out_path))
+        except OAuthError as e:
+            return ToolResult(success=False, error=str(e))
+        except Exception as e:
+            return ToolResult(success=False, error=f"GPT OAuth image generation failed: {e}")
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": "openai",
+                "model": model,
+                "prompt": prompt,
+                "auth_source": "oauth",
+                "output": outputs[0],
+                "outputs": outputs,
+                "images_generated": len(outputs),
+            },
+            artifacts=outputs,
+            cost_usd=0.0,
             model=model,
         )

--- a/tools/video/grok_video.py
+++ b/tools/video/grok_video.py
@@ -59,8 +59,9 @@ class GrokVideo(BaseTool):
 
     dependencies = []
     install_instructions = (
-        "Set XAI_API_KEY to your xAI API key.\n"
-        "  Get one from the xAI developer console"
+        "Sign in with the Cursor Grok OAuth connector (grok-media-mcp), "
+        "or set XAI_API_KEY.\n"
+        "  OAuth uses the macOS Keychain item com.cursor.grok-media-mcp"
     )
     agent_skills = ["grok-media", "ai-video-gen"]
 
@@ -147,7 +148,9 @@ class GrokVideo(BaseTool):
     user_visible_verification = ["Watch generated clip for motion quality and prompt fidelity"]
 
     def get_status(self) -> ToolStatus:
-        if os.environ.get("XAI_API_KEY"):
+        from lib.oauth_connectors import grok_auth_available
+
+        if grok_auth_available():
             return ToolStatus.AVAILABLE
         return ToolStatus.UNAVAILABLE
 
@@ -218,17 +221,24 @@ class GrokVideo(BaseTool):
         return payload
 
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
-        api_key = os.environ.get("XAI_API_KEY")
+        from lib.oauth_connectors import OAuthEntitlementError, grok_bearer_token
+
+        try:
+            api_key = grok_bearer_token()
+        except OAuthEntitlementError as exc:
+            return ToolResult(success=False, error=str(exc))
         if not api_key:
             return ToolResult(
                 success=False,
-                error="XAI_API_KEY not set. " + self.install_instructions,
+                error="Grok OAuth is not signed in and XAI_API_KEY is not set. "
+                + self.install_instructions,
             )
 
         import requests
         from tools.video._shared import probe_output
 
         start = time.time()
+        auth_source = "api_key" if os.environ.get("XAI_API_KEY") else "oauth"
         headers = {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
@@ -242,6 +252,11 @@ class GrokVideo(BaseTool):
                 json=payload,
                 timeout=60,
             )
+            if response.status_code == 403:
+                return ToolResult(
+                    success=False,
+                    error="xAI denied this OAuth account access to video generation (HTTP 403).",
+                )
             response.raise_for_status()
             request_id = response.json()["request_id"]
 
@@ -290,6 +305,7 @@ class GrokVideo(BaseTool):
                 "model": payload["model"],
                 "prompt": inputs["prompt"],
                 "operation": inputs.get("operation", "text_to_video"),
+                "auth_source": auth_source,
                 "request_id": request_id,
                 "output": str(output_path),
                 "output_path": str(output_path),


### PR DESCRIPTION
## Summary
- Let `grok_image`, `grok_video`, and `openai_image` use the existing Cursor Grok/GPT OAuth connectors in macOS Keychain so this fork does not need `XAI_API_KEY` or `OPENAI_API_KEY` for those tools.
- Add kit continuity files and the Cursor adapter beside upstream OpenMontage rules.

## Related issue
Refs local workstation setup. No upstream issue.

## Changes
- Keychain OAuth helper in `lib/oauth_connectors.py`
- Grok/GPT tool status and execute paths accept OAuth
- Tests for status, token-free public status, and OAuth execute
- BRIEF / DECISIONS / HANDOFF plus kit Cursor adapter files

## Testing
- `pytest tests/lib/test_oauth_connectors.py tests/tools/test_oauth_provider_status.py tests/tools/test_openai_image_multi_output.py tests/tools/test_grok_video_quality_score.py` — 16 passed
- Live smoke: `grok_image` and `openai_image` each wrote one sample under `projects/oauth-smoke/` with `auth_source=oauth`
- `.env` was not committed

## Checklist
- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [x] I updated docs/README if behavior or usage changed.
- [x] No unrelated files (build artifacts, local config) are included in the diff.


Made with [Cursor](https://cursor.com)