### PR TITLE
Add GPT Image 2 and Nano Banana 2/Pro tools via fal.ai gateway

### DIFF
--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -313,6 +313,7 @@ reference-image inputs are normalized to the provider's `images` array.
 > **Broad single-key coverage.** One API key unlocks image and video providers across multiple models.
 
 **Tools unlocked:** `flux_image`, `recraft_image`, `seedream_image`,
+`gpt_image2_fal`, `nano_banana_fal`,
 `kling_video`, `veo_video`, `seedance_video`, `gemini_omni_fal`,
 `minimax_fal_video`, `fal_elevenlabs_tts`, `fal_elevenlabs_music`
 **Env var:** `FAL_KEY`
@@ -337,6 +338,9 @@ No subscription — pure pay-as-you-go, no minimum spend.
 | Recraft v3 | ~$0.04/image | 25 images |
 | Seedream 5 Pro (up to 1536x1536) | $0.0675/image | ~14 images |
 | Seedream 5 Pro (up to 2048x2048) | $0.135/image | ~7 images |
+| GPT Image 2 (`gpt_image2_fal`, 1024x1024, high) | $0.211/image | ~5 images |
+| Nano Banana 2 (`nano_banana_fal`, 1K) | $0.08/image | ~12 images |
+| Nano Banana 2 Pro (`nano_banana_fal`, 1K) | $0.08/image (unconfirmed — same base rate as Nano Banana 2, not separately published) | ~12 images |
 
 **Video generation:**
 
@@ -350,6 +354,17 @@ No subscription — pure pay-as-you-go, no minimum spend.
 | WAN 2.5 | $0.05/sec | 20 seconds |
 
 **Free tier:** None — but $0 to start, you only pay for what you use.
+
+`gpt_image2_fal` and `nano_banana_fal` reach OpenAI's GPT Image 2 and
+Google's Nano Banana 2 / Nano Banana 2 Pro directly through fal.ai, gated
+only by `FAL_KEY` — no `OPENAI_API_KEY` or `ATLASCLOUD_API_KEY` required.
+They are separate tools from `openai_image` (direct OpenAI API) and
+`atlas_image` (Atlas Cloud gateway, which does not expose the Pro variant);
+all three are auto-discovered and selectable through `image_selector`.
+Nano Banana 2 Pro's per-image rate was not published on fal.ai's docs at
+the time these tools were built — `nano_banana_fal.estimate_cost()` uses
+Nano Banana 2's confirmed $0.08 base rate as a placeholder for the Pro
+variant. Confirm against fal.ai's live pricing before a paid batch run.
 
 The same key can also access ElevenLabs speech and music through fal.ai. Use
 `fal_elevenlabs_tts` when direct ElevenLabs credentials are unavailable, or
@@ -1356,7 +1371,7 @@ These tools require only FFmpeg or Python packages — no GPU, no API key.
 | **Google** | `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) | `google_tts`, `google_imagen`, `google_music`, `gemini_omni_video`, `veo_video` | Free tier (TTS) + paid |
 | **ElevenLabs** | `ELEVENLABS_API_KEY` | `elevenlabs_tts`, `music_gen` | Free tier + paid |
 | **fish.audio** | `FISH_AUDIO_API_KEY` | `fish_audio_tts` | Free tier (s2.1-pro-free) + paid |
-| **fal.ai** | `FAL_KEY` | `flux_image`, `recraft_image`, `kling_video`, `veo_video`, `seedance_video`, `gemini_omni_fal`, `minimax_fal_video` | Pay-as-you-go |
+| **fal.ai** | `FAL_KEY` | `flux_image`, `recraft_image`, `gpt_image2_fal`, `nano_banana_fal`, `kling_video`, `veo_video`, `seedance_video`, `gemini_omni_fal`, `minimax_fal_video` | Pay-as-you-go |
 | **Atlas Cloud** | `ATLASCLOUD_API_KEY` | `atlas_image`, `atlas_video` | Pay-as-you-go |
 | **Kling Official** | `KLING_API_KEY` | `kling_official_video`, `kling_official_image`, `kling_tts`, `kling_avatar`, `kling_lip_sync` | Pay-as-you-go |
 | **Volcengine Ark** | `ARK_API_KEY` | `seedance_ark` | Pay-as-you-go |
@@ -1381,7 +1396,7 @@ How many providers cover each capability:
 
 | Capability | Cloud Providers | Local Providers | Free Options |
 |-----------|----------------|-----------------|--------------|
-| **Image Generation** | FLUX, Kling Official, Grok, Google Imagen, GPT Image 2, Recraft | Local Diffusion | Pexels, Pixabay (stock) |
+| **Image Generation** | FLUX, Kling Official, Grok, Google Imagen, GPT Image 2 (OpenAI direct, fal.ai, Atlas Cloud), Nano Banana 2 (fal.ai, Atlas Cloud) / Nano Banana 2 Pro (fal.ai only), Recraft | Local Diffusion | Pexels, Pixabay (stock) |
 | **Video Generation** | Grok, Kling Official, fal.ai, Seedance via Volcengine Ark, Runway, Veo, Gemini Omni, Higgsfield, MiniMax, HeyGen, Tencent Hunyuan, ComfyUI Partner Nodes | WAN, Hunyuan, CogVideo, LTX, ComfyUI WAN, ComfyUI MiniMax H3 | Pexels, Pixabay (stock) |
 | **Text-to-Speech** | Azure AI Speech, ElevenLabs, fish.audio, Google TTS, Kling Official, OpenAI | Piper | Piper, Google free tier, ElevenLabs free tier, Azure free tier, fish.audio s2.1-pro-free |
 | **Music Generation** | ElevenLabs, Suno, Google Lyria | — | ElevenLabs free tier |

--- a/tests/tools/test_gpt_image2_fal.py
+++ b/tests/tools/test_gpt_image2_fal.py
@@ -1,0 +1,342 @@
+"""Unit tests for gpt_image2_fal — OpenAI GPT Image 2 via the fal.ai gateway."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.base_tool import ToolStatus
+
+
+# ---------------------------------------------------------------------------
+# Tool discovery & metadata
+# ---------------------------------------------------------------------------
+
+
+def test_gpt_image2_fal_is_discovered_by_registry():
+    from tools.tool_registry import ToolRegistry
+
+    registry = ToolRegistry()
+    registry.discover()
+
+    tool = registry.get("gpt_image2_fal")
+    assert tool is not None
+    assert tool.provider == "openai"
+    assert tool.capability == "image_generation"
+    assert tool.name == "gpt_image2_fal"
+
+
+def test_metadata():
+    from tools.graphics.gpt_image2_fal import GptImage2Fal
+
+    tool = GptImage2Fal()
+    info = tool.get_info()
+
+    assert info["tier"] == "generate"
+    assert info["stability"] == "beta"
+    assert info["runtime"] == "api"
+    assert "image_edit" in info["capabilities"]
+    assert info["supports"]["multiple_reference_images"] is True
+    assert info["supports"]["mask_editing"] is True
+    assert "env:FAL_KEY" in info["dependencies"]
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — every output-affecting input must change the key
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotency:
+    def test_num_images_changes_key(self):
+        from tools.graphics.gpt_image2_fal import GptImage2Fal
+
+        tool = GptImage2Fal()
+        base = {"prompt": "a cat"}
+        assert tool.idempotency_key(base) != tool.idempotency_key(
+            {**base, "num_images": 4}
+        )
+
+    def test_output_format_changes_key(self):
+        from tools.graphics.gpt_image2_fal import GptImage2Fal
+
+        tool = GptImage2Fal()
+        base = {"prompt": "a cat", "output_format": "png"}
+        assert tool.idempotency_key(base) != tool.idempotency_key(
+            {**base, "output_format": "jpeg"}
+        )
+
+    def test_edit_reference_images_change_key(self):
+        from tools.graphics.gpt_image2_fal import GptImage2Fal
+
+        tool = GptImage2Fal()
+        base = {"prompt": "edit this", "operation": "edit"}
+        assert tool.idempotency_key(
+            {**base, "image_urls": ["https://example.com/a.png"]}
+        ) != tool.idempotency_key(
+            {**base, "image_urls": ["https://example.com/b.png"]}
+        )
+
+    def test_mask_changes_key(self):
+        from tools.graphics.gpt_image2_fal import GptImage2Fal
+
+        tool = GptImage2Fal()
+        base = {"prompt": "edit this", "operation": "edit"}
+        assert tool.idempotency_key(base) != tool.idempotency_key(
+            {**base, "mask_url": "https://example.com/mask.png"}
+        )
+
+    def test_same_inputs_produce_same_key(self):
+        from tools.graphics.gpt_image2_fal import GptImage2Fal
+
+        tool = GptImage2Fal()
+        inputs = {"prompt": "a cat", "num_images": 2, "width": 1024, "height": 1024}
+        assert tool.idempotency_key(inputs) == tool.idempotency_key(dict(inputs))
+
+
+# ---------------------------------------------------------------------------
+# Status reporting
+# ---------------------------------------------------------------------------
+
+
+def test_status_unavailable_when_no_api_key(monkeypatch):
+    from tools.graphics.gpt_image2_fal import GptImage2Fal
+
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    monkeypatch.delenv("FAL_AI_API_KEY", raising=False)
+    assert GptImage2Fal().get_status() == ToolStatus.UNAVAILABLE
+
+
+def test_status_available_when_api_key_set(monkeypatch):
+    from tools.graphics.gpt_image2_fal import GptImage2Fal
+
+    monkeypatch.setenv("FAL_KEY", "test-fal-key")
+    assert GptImage2Fal().get_status() == ToolStatus.AVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# Cost estimation
+# ---------------------------------------------------------------------------
+
+
+class TestCostEstimation:
+    def test_default_cost(self):
+        from tools.graphics.gpt_image2_fal import GptImage2Fal
+
+        tool = GptImage2Fal()
+        cost = tool.estimate_cost({})
+        assert cost == pytest.approx(0.211)  # 1024x1024, high
+
+    def test_cost_scales_with_num_images(self):
+        from tools.graphics.gpt_image2_fal import GptImage2Fal
+
+        tool = GptImage2Fal()
+        cost = tool.estimate_cost({"num_images": 3})
+        assert cost == pytest.approx(0.211 * 3)
+
+    def test_cost_varies_by_quality(self):
+        from tools.graphics.gpt_image2_fal import GptImage2Fal
+
+        tool = GptImage2Fal()
+        low = tool.estimate_cost({"quality": "low"})
+        high = tool.estimate_cost({"quality": "high"})
+        assert low < high
+
+    def test_unknown_size_falls_back_to_nearest_bucket(self):
+        from tools.graphics.gpt_image2_fal import GptImage2Fal
+
+        tool = GptImage2Fal()
+        cost = tool.estimate_cost({"width": 100, "height": 100})
+        assert cost > 0
+
+
+# ---------------------------------------------------------------------------
+# Validation & error handling (no network call should happen)
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_missing_api_key_returns_error(self, monkeypatch):
+        from tools.graphics.gpt_image2_fal import GptImage2Fal
+
+        monkeypatch.delenv("FAL_KEY", raising=False)
+        monkeypatch.delenv("FAL_AI_API_KEY", raising=False)
+        result = GptImage2Fal().execute({"prompt": "a cat"})
+        assert not result.success
+        assert "FAL_KEY" in result.error
+
+    def test_unsupported_operation_returns_error(self, monkeypatch):
+        from tools.graphics.gpt_image2_fal import GptImage2Fal
+
+        monkeypatch.setenv("FAL_KEY", "test-fal-key")
+        result = GptImage2Fal().execute({"prompt": "a cat", "operation": "upscale"})
+        assert not result.success
+        assert "unsupported operation" in result.error
+
+    def test_edit_without_images_returns_error(self, monkeypatch):
+        from tools.graphics.gpt_image2_fal import GptImage2Fal
+
+        monkeypatch.setenv("FAL_KEY", "test-fal-key")
+        result = GptImage2Fal().execute({"prompt": "edit this", "operation": "edit"})
+        assert not result.success
+        assert "requires at least one image" in result.error
+
+    def test_edit_rejects_too_many_images(self, monkeypatch):
+        from tools.graphics.gpt_image2_fal import GptImage2Fal
+
+        monkeypatch.setenv("FAL_KEY", "test-fal-key")
+        urls = [f"https://example.com/{i}.png" for i in range(11)]
+        result = GptImage2Fal().execute(
+            {"prompt": "edit this", "operation": "edit", "image_urls": urls}
+        )
+        assert not result.success
+        assert "at most 10 images" in result.error
+
+    def test_validation_error_makes_no_network_call(self, monkeypatch):
+        from tools.graphics.gpt_image2_fal import GptImage2Fal
+
+        monkeypatch.setenv("FAL_KEY", "test-fal-key")
+        with patch("requests.post") as mock_post:
+            GptImage2Fal().execute({"prompt": "edit this", "operation": "edit"})
+            mock_post.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end with mocked API
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, json_data=None, content: bytes = b""):
+        self._json_data = json_data or {}
+        self.content = content
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._json_data
+
+
+def test_execute_generate_full_flow(monkeypatch, tmp_path):
+    from tools.graphics.gpt_image2_fal import GptImage2Fal
+
+    monkeypatch.setenv("FAL_KEY", "test-fal-key")
+
+    calls = []
+
+    def fake_post(url, headers, json, timeout):
+        calls.append((url, headers, json))
+        return _FakeResponse({"images": [{"url": "https://cdn.fal.ai/out.png"}]})
+
+    def fake_get(url, timeout):
+        return _FakeResponse(content=b"GPT_IMAGE_2_BYTES")
+
+    out = tmp_path / "gen.png"
+    with patch("requests.post", side_effect=fake_post), patch(
+        "requests.get", side_effect=fake_get
+    ):
+        result = GptImage2Fal().execute(
+            {
+                "prompt": "a robot painting",
+                "num_images": 1,
+                "output_path": str(out),
+            }
+        )
+
+    assert result.success, result.error
+    assert result.data["provider"] == "openai"
+    assert result.data["model"] == "fal-ai/gpt-image-2"
+    assert result.artifacts == [str(out)]
+    assert out.read_bytes() == b"GPT_IMAGE_2_BYTES"
+    assert calls[0][0] == "https://fal.run/fal-ai/gpt-image-2"
+    assert calls[0][1]["Authorization"] == "Key test-fal-key"
+
+
+def test_execute_edit_uploads_local_reference(monkeypatch, tmp_path):
+    from tools.graphics.gpt_image2_fal import GptImage2Fal
+
+    monkeypatch.setenv("FAL_KEY", "test-fal-key")
+
+    ref = tmp_path / "ref.png"
+    ref.write_bytes(b"local-ref")
+
+    monkeypatch.setattr(
+        "tools.video._shared.upload_image_fal",
+        lambda path: "https://cdn.fal.ai/uploaded.png",
+    )
+
+    calls = []
+
+    def fake_post(url, headers, json, timeout):
+        calls.append((url, json))
+        return _FakeResponse({"images": [{"url": "https://cdn.fal.ai/out.png"}]})
+
+    def fake_get(url, timeout):
+        return _FakeResponse(content=b"EDITED_BYTES")
+
+    out = tmp_path / "edited.png"
+    with patch("requests.post", side_effect=fake_post), patch(
+        "requests.get", side_effect=fake_get
+    ):
+        result = GptImage2Fal().execute(
+            {
+                "prompt": "add a hat",
+                "operation": "edit",
+                "image_paths": [str(ref)],
+                "output_path": str(out),
+            }
+        )
+
+    assert result.success, result.error
+    assert calls[0][0] == "https://fal.run/fal-ai/gpt-image-2/image-to-image"
+    assert calls[0][1]["image_urls"] == ["https://cdn.fal.ai/uploaded.png"]
+
+
+def test_execute_returns_error_when_no_images_in_response(monkeypatch, tmp_path):
+    from tools.graphics.gpt_image2_fal import GptImage2Fal
+
+    monkeypatch.setenv("FAL_KEY", "test-fal-key")
+
+    with patch("requests.post", return_value=_FakeResponse({"images": []})):
+        result = GptImage2Fal().execute({"prompt": "a cat"})
+
+    assert not result.success
+    assert "no image outputs" in result.error
+
+
+def test_execute_multi_output_writes_all_files(monkeypatch, tmp_path):
+    from tools.graphics.gpt_image2_fal import GptImage2Fal
+
+    monkeypatch.setenv("FAL_KEY", "test-fal-key")
+
+    def fake_post(url, headers, json, timeout):
+        return _FakeResponse(
+            {
+                "images": [
+                    {"url": "https://cdn.fal.ai/1.png"},
+                    {"url": "https://cdn.fal.ai/2.png"},
+                ]
+            }
+        )
+
+    def fake_get(url, timeout):
+        return _FakeResponse(content=b"BYTES_" + url.encode()[-5:])
+
+    out = tmp_path / "gen.png"
+    with patch("requests.post", side_effect=fake_post), patch(
+        "requests.get", side_effect=fake_get
+    ):
+        result = GptImage2Fal().execute(
+            {"prompt": "a cat", "num_images": 2, "output_path": str(out)}
+        )
+
+    assert result.success, result.error
+    assert len(result.artifacts) == 2
+    assert result.data["images_generated"] == 2
+    assert result.cost_usd == pytest.approx(GptImage2Fal().estimate_cost({"num_images": 2}))

--- a/tests/tools/test_nano_banana_fal.py
+++ b/tests/tools/test_nano_banana_fal.py
@@ -1,0 +1,376 @@
+"""Unit tests for nano_banana_fal — Google Nano Banana 2 / Pro via the fal.ai gateway."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.base_tool import ToolStatus
+
+
+# ---------------------------------------------------------------------------
+# Tool discovery & metadata
+# ---------------------------------------------------------------------------
+
+
+def test_nano_banana_fal_is_discovered_by_registry():
+    from tools.tool_registry import ToolRegistry
+
+    registry = ToolRegistry()
+    registry.discover()
+
+    tool = registry.get("nano_banana_fal")
+    assert tool is not None
+    assert tool.provider == "google"
+    assert tool.capability == "image_generation"
+    assert tool.name == "nano_banana_fal"
+
+
+def test_metadata():
+    from tools.graphics.nano_banana_fal import NanoBananaFal
+
+    tool = NanoBananaFal()
+    info = tool.get_info()
+
+    assert info["tier"] == "generate"
+    assert info["stability"] == "beta"
+    assert info["runtime"] == "api"
+    assert "image_edit" in info["capabilities"]
+    assert info["supports"]["multiple_reference_images"] is True
+    assert info["supports"]["web_grounding"] is True
+    assert "env:FAL_KEY" in info["dependencies"]
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — every output-affecting input must change the key
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotency:
+    def test_model_variant_changes_key(self):
+        from tools.graphics.nano_banana_fal import NanoBananaFal
+
+        tool = NanoBananaFal()
+        base = {"prompt": "a cat"}
+        assert tool.idempotency_key({**base, "model": "nano-banana-2"}) != tool.idempotency_key(
+            {**base, "model": "nano-banana-pro"}
+        )
+
+    def test_seed_changes_key(self):
+        from tools.graphics.nano_banana_fal import NanoBananaFal
+
+        tool = NanoBananaFal()
+        base = {"prompt": "a cat"}
+        assert tool.idempotency_key(base) != tool.idempotency_key({**base, "seed": 42})
+
+    def test_num_images_changes_key(self):
+        from tools.graphics.nano_banana_fal import NanoBananaFal
+
+        tool = NanoBananaFal()
+        base = {"prompt": "a cat"}
+        assert tool.idempotency_key(base) != tool.idempotency_key(
+            {**base, "num_images": 4}
+        )
+
+    def test_output_format_changes_key(self):
+        from tools.graphics.nano_banana_fal import NanoBananaFal
+
+        tool = NanoBananaFal()
+        base = {"prompt": "a cat"}
+        assert tool.idempotency_key({**base, "output_format": "png"}) != tool.idempotency_key(
+            {**base, "output_format": "webp"}
+        )
+
+    def test_edit_reference_images_change_key(self):
+        from tools.graphics.nano_banana_fal import NanoBananaFal
+
+        tool = NanoBananaFal()
+        base = {"prompt": "edit this", "operation": "edit"}
+        assert tool.idempotency_key(
+            {**base, "image_urls": ["https://example.com/a.png"]}
+        ) != tool.idempotency_key(
+            {**base, "image_urls": ["https://example.com/b.png"]}
+        )
+
+    def test_extra_params_changes_key(self):
+        from tools.graphics.nano_banana_fal import NanoBananaFal
+
+        tool = NanoBananaFal()
+        base = {"prompt": "a cat"}
+        assert tool.idempotency_key(base) != tool.idempotency_key(
+            {**base, "extra_params": {"enable_google_search": True}}
+        )
+
+    def test_same_inputs_produce_same_key(self):
+        from tools.graphics.nano_banana_fal import NanoBananaFal
+
+        tool = NanoBananaFal()
+        inputs = {"prompt": "a cat", "model": "nano-banana-pro", "resolution": "2K"}
+        assert tool.idempotency_key(inputs) == tool.idempotency_key(dict(inputs))
+
+
+# ---------------------------------------------------------------------------
+# Status reporting
+# ---------------------------------------------------------------------------
+
+
+def test_status_unavailable_when_no_api_key(monkeypatch):
+    from tools.graphics.nano_banana_fal import NanoBananaFal
+
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    monkeypatch.delenv("FAL_AI_API_KEY", raising=False)
+    assert NanoBananaFal().get_status() == ToolStatus.UNAVAILABLE
+
+
+def test_status_available_when_api_key_set(monkeypatch):
+    from tools.graphics.nano_banana_fal import NanoBananaFal
+
+    monkeypatch.setenv("FAL_KEY", "test-fal-key")
+    assert NanoBananaFal().get_status() == ToolStatus.AVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# Cost estimation
+# ---------------------------------------------------------------------------
+
+
+class TestCostEstimation:
+    def test_default_cost(self):
+        from tools.graphics.nano_banana_fal import NanoBananaFal
+
+        tool = NanoBananaFal()
+        assert tool.estimate_cost({}) == pytest.approx(0.08)
+
+    def test_cost_scales_with_num_images(self):
+        from tools.graphics.nano_banana_fal import NanoBananaFal
+
+        tool = NanoBananaFal()
+        assert tool.estimate_cost({"num_images": 3}) == pytest.approx(0.08 * 3)
+
+    @pytest.mark.parametrize(
+        "resolution,multiplier",
+        [("0.5K", 0.75), ("1K", 1.0), ("2K", 1.5), ("4K", 2.0)],
+    )
+    def test_cost_varies_by_resolution(self, resolution, multiplier):
+        from tools.graphics.nano_banana_fal import NanoBananaFal
+
+        tool = NanoBananaFal()
+        cost = tool.estimate_cost({"resolution": resolution})
+        assert cost == pytest.approx(0.08 * multiplier)
+
+
+# ---------------------------------------------------------------------------
+# Validation & error handling (no network call should happen)
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_missing_api_key_returns_error(self, monkeypatch):
+        from tools.graphics.nano_banana_fal import NanoBananaFal
+
+        monkeypatch.delenv("FAL_KEY", raising=False)
+        monkeypatch.delenv("FAL_AI_API_KEY", raising=False)
+        result = NanoBananaFal().execute({"prompt": "a cat"})
+        assert not result.success
+        assert "FAL_KEY" in result.error
+
+    def test_unsupported_model_operation_combo_returns_error(self, monkeypatch):
+        from tools.graphics.nano_banana_fal import NanoBananaFal
+
+        monkeypatch.setenv("FAL_KEY", "test-fal-key")
+        result = NanoBananaFal().execute(
+            {"prompt": "a cat", "model": "nano-banana-3", "operation": "generate"}
+        )
+        assert not result.success
+        assert "unsupported model/operation" in result.error
+
+    def test_edit_without_images_returns_error(self, monkeypatch):
+        from tools.graphics.nano_banana_fal import NanoBananaFal
+
+        monkeypatch.setenv("FAL_KEY", "test-fal-key")
+        result = NanoBananaFal().execute({"prompt": "edit this", "operation": "edit"})
+        assert not result.success
+        assert "requires at least one image" in result.error
+
+    def test_edit_rejects_too_many_images(self, monkeypatch):
+        from tools.graphics.nano_banana_fal import NanoBananaFal
+
+        monkeypatch.setenv("FAL_KEY", "test-fal-key")
+        urls = [f"https://example.com/{i}.png" for i in range(15)]
+        result = NanoBananaFal().execute(
+            {"prompt": "edit this", "operation": "edit", "image_urls": urls}
+        )
+        assert not result.success
+        assert "at most 14 images" in result.error
+
+    def test_validation_error_makes_no_network_call(self, monkeypatch):
+        from tools.graphics.nano_banana_fal import NanoBananaFal
+
+        monkeypatch.setenv("FAL_KEY", "test-fal-key")
+        with patch("requests.post") as mock_post:
+            NanoBananaFal().execute({"prompt": "edit this", "operation": "edit"})
+            mock_post.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end with mocked API
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, json_data=None, content: bytes = b""):
+        self._json_data = json_data or {}
+        self.content = content
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._json_data
+
+
+def test_execute_generate_full_flow(monkeypatch, tmp_path):
+    from tools.graphics.nano_banana_fal import NanoBananaFal
+
+    monkeypatch.setenv("FAL_KEY", "test-fal-key")
+
+    calls = []
+
+    def fake_post(url, headers, json, timeout):
+        calls.append((url, headers, json))
+        return _FakeResponse({"images": [{"url": "https://cdn.fal.ai/out.png"}]})
+
+    def fake_get(url, timeout):
+        return _FakeResponse(content=b"NANO_BANANA_BYTES")
+
+    out = tmp_path / "gen.png"
+    with patch("requests.post", side_effect=fake_post), patch(
+        "requests.get", side_effect=fake_get
+    ):
+        result = NanoBananaFal().execute(
+            {"prompt": "a neon city", "output_path": str(out)}
+        )
+
+    assert result.success, result.error
+    assert result.data["provider"] == "google"
+    assert result.data["model"] == "fal-ai/nano-banana-2"
+    assert result.artifacts == [str(out)]
+    assert out.read_bytes() == b"NANO_BANANA_BYTES"
+    assert calls[0][0] == "https://fal.run/fal-ai/nano-banana-2"
+    assert calls[0][1]["Authorization"] == "Key test-fal-key"
+
+
+def test_execute_pro_generate_uses_pro_endpoint(monkeypatch, tmp_path):
+    from tools.graphics.nano_banana_fal import NanoBananaFal
+
+    monkeypatch.setenv("FAL_KEY", "test-fal-key")
+
+    calls = []
+
+    def fake_post(url, headers, json, timeout):
+        calls.append(url)
+        return _FakeResponse({"images": [{"url": "https://cdn.fal.ai/out.png"}]})
+
+    def fake_get(url, timeout):
+        return _FakeResponse(content=b"PRO_BYTES")
+
+    out = tmp_path / "gen.png"
+    with patch("requests.post", side_effect=fake_post), patch(
+        "requests.get", side_effect=fake_get
+    ):
+        result = NanoBananaFal().execute(
+            {"prompt": "a neon city", "model": "nano-banana-pro", "output_path": str(out)}
+        )
+
+    assert result.success, result.error
+    assert calls[0] == "https://fal.run/fal-ai/nano-banana-pro"
+
+
+def test_execute_edit_uploads_local_reference(monkeypatch, tmp_path):
+    from tools.graphics.nano_banana_fal import NanoBananaFal
+
+    monkeypatch.setenv("FAL_KEY", "test-fal-key")
+
+    ref = tmp_path / "ref.png"
+    ref.write_bytes(b"local-ref")
+
+    monkeypatch.setattr(
+        "tools.video._shared.upload_image_fal",
+        lambda path: "https://cdn.fal.ai/uploaded.png",
+    )
+
+    calls = []
+
+    def fake_post(url, headers, json, timeout):
+        calls.append((url, json))
+        return _FakeResponse({"images": [{"url": "https://cdn.fal.ai/out.png"}]})
+
+    def fake_get(url, timeout):
+        return _FakeResponse(content=b"EDITED_BYTES")
+
+    out = tmp_path / "edited.png"
+    with patch("requests.post", side_effect=fake_post), patch(
+        "requests.get", side_effect=fake_get
+    ):
+        result = NanoBananaFal().execute(
+            {
+                "prompt": "add neon signs",
+                "operation": "edit",
+                "image_paths": [str(ref)],
+                "output_path": str(out),
+            }
+        )
+
+    assert result.success, result.error
+    assert calls[0][0] == "https://fal.run/fal-ai/nano-banana-2/edit"
+    assert calls[0][1]["image_urls"] == ["https://cdn.fal.ai/uploaded.png"]
+
+
+def test_execute_returns_error_when_no_images_in_response(monkeypatch):
+    from tools.graphics.nano_banana_fal import NanoBananaFal
+
+    monkeypatch.setenv("FAL_KEY", "test-fal-key")
+
+    with patch("requests.post", return_value=_FakeResponse({"images": []})):
+        result = NanoBananaFal().execute({"prompt": "a cat"})
+
+    assert not result.success
+    assert "no image outputs" in result.error
+
+
+def test_execute_multi_output_writes_all_files(monkeypatch, tmp_path):
+    from tools.graphics.nano_banana_fal import NanoBananaFal
+
+    monkeypatch.setenv("FAL_KEY", "test-fal-key")
+
+    def fake_post(url, headers, json, timeout):
+        return _FakeResponse(
+            {
+                "images": [
+                    {"url": "https://cdn.fal.ai/1.png"},
+                    {"url": "https://cdn.fal.ai/2.png"},
+                ]
+            }
+        )
+
+    def fake_get(url, timeout):
+        return _FakeResponse(content=b"BYTES_" + url.encode()[-5:])
+
+    out = tmp_path / "gen.png"
+    with patch("requests.post", side_effect=fake_post), patch(
+        "requests.get", side_effect=fake_get
+    ):
+        result = NanoBananaFal().execute(
+            {"prompt": "a cat", "num_images": 2, "output_path": str(out)}
+        )
+
+    assert result.success, result.error
+    assert len(result.artifacts) == 2
+    assert result.data["images_generated"] == 2
+    assert result.cost_usd == pytest.approx(NanoBananaFal().estimate_cost({"num_images": 2}))

--- a/tools/graphics/gpt_image2_fal.py
+++ b/tools/graphics/gpt_image2_fal.py
@@ -1,0 +1,264 @@
+"""OpenAI GPT Image 2 generation and multi-reference editing via fal.ai.
+
+Distinct from `openai_image` (calls OpenAI's API directly with OPENAI_API_KEY)
+and from `atlas_image` (routes gpt-image-2 through the Atlas Cloud gateway
+with ATLASCLOUD_API_KEY). This tool reaches the same model through fal.ai,
+gated only by FAL_KEY/FAL_AI_API_KEY.
+
+Endpoints confirmed against fal.ai docs (2026-08-20):
+  https://fal.ai/models/openai/gpt-image-2
+  - generate: fal-ai/gpt-image-2
+  - edit:     fal-ai/gpt-image-2/image-to-image (accepts image_urls + prompt)
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+_ENDPOINTS = {
+    "generate": "fal-ai/gpt-image-2",
+    "edit": "fal-ai/gpt-image-2/image-to-image",
+}
+
+# Per-image pricing by nominal output size and quality tier, from the fal.ai
+# pricing table. Edit pricing is not separately published — approximated
+# with the 1024x1024 column. Verify against fal.ai before a large batch run.
+_PRICE_TABLE: dict[str, dict[str, float]] = {
+    "1024x768": {"low": 0.005, "medium": 0.037, "high": 0.145},
+    "1024x1024": {"low": 0.006, "medium": 0.053, "high": 0.211},
+    "1024x1536": {"low": 0.005, "medium": 0.042, "high": 0.165},
+    "1920x1080": {"low": 0.005, "medium": 0.040, "high": 0.158},
+    "2560x1440": {"low": 0.007, "medium": 0.056, "high": 0.222},
+    "3840x2160": {"low": 0.012, "medium": 0.101, "high": 0.401},
+}
+_MAX_EDIT_IMAGES = 10  # matches the documented OpenAI gpt-image-2 edit limit
+
+
+def _price_bucket(width: int, height: int) -> str:
+    key = f"{width}x{height}"
+    if key in _PRICE_TABLE:
+        return key
+    # Nearest bucket by pixel count for arbitrary sizes.
+    target = width * height
+    return min(_PRICE_TABLE, key=lambda k: abs(int(k.split("x")[0]) * int(k.split("x")[1]) - target))
+
+
+class GptImage2Fal(BaseTool):
+    name = "gpt_image2_fal"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "image_generation"
+    provider = "openai"
+    stability = ToolStability.BETA
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = ["env:FAL_KEY"]
+    install_instructions = (
+        "Set FAL_KEY (or FAL_AI_API_KEY) to your fal.ai API key.\n"
+        "  Get one at https://fal.ai/dashboard/keys"
+    )
+    agent_skills = ["flux-best-practices"]
+
+    capabilities = ["generate_image", "generate_illustration", "text_to_image", "image_edit"]
+    supports = {
+        "complex_instructions": True,
+        "text_in_image": True,
+        "multiple_outputs": True,
+        "image_edit": True,
+        "multiple_reference_images": True,
+        "mask_editing": True,
+    }
+    best_for = [
+        "GPT Image 2 generation and multi-reference editing without an OpenAI or Atlas Cloud key",
+        "complex multi-element compositions",
+        "images with text/labels",
+    ]
+    not_good_for = ["offline generation", "budget-constrained projects at high quality"]
+    fallback_tools = ["openai_image", "atlas_image", "flux_image"]
+    quality_score = 0.86
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+            "prompt": {"type": "string"},
+            "operation": {
+                "type": "string",
+                "enum": ["generate", "edit"],
+                "default": "generate",
+            },
+            "width": {"type": "integer", "default": 1024},
+            "height": {"type": "integer", "default": 1024},
+            "quality": {
+                "type": "string",
+                "enum": ["low", "medium", "high"],
+                "default": "high",
+            },
+            "num_images": {"type": "integer", "default": 1, "minimum": 1, "maximum": 4},
+            "output_format": {
+                "type": "string",
+                "enum": ["png", "jpeg", "webp"],
+                "default": "png",
+            },
+            "image_url": {"type": "string"},
+            "image_path": {"type": "string"},
+            "image_urls": {"type": "array", "items": {"type": "string"}},
+            "image_paths": {"type": "array", "items": {"type": "string"}},
+            "mask_url": {"type": "string"},
+            "mask_path": {"type": "string"},
+            "output_path": {"type": "string"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=512, vram_mb=0, disk_mb=100, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
+    idempotency_key_fields = ["prompt", "operation", "width", "height", "quality"]
+    side_effects = ["writes image file(s) to output_path", "calls fal.ai API"]
+    user_visible_verification = ["Inspect generated image for relevance, quality, and edit fidelity"]
+
+    @staticmethod
+    def _api_key() -> str | None:
+        return os.environ.get("FAL_KEY") or os.environ.get("FAL_AI_API_KEY")
+
+    def get_status(self) -> ToolStatus:
+        return ToolStatus.AVAILABLE if self._api_key() else ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        quality = inputs.get("quality", "high")
+        n = int(inputs.get("num_images", 1))
+        bucket = _price_bucket(int(inputs.get("width", 1024)), int(inputs.get("height", 1024)))
+        return round(_PRICE_TABLE[bucket].get(quality, _PRICE_TABLE[bucket]["high"]) * n, 4)
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        return 25.0
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        api_key = self._api_key()
+        if not api_key:
+            return ToolResult(
+                success=False, error="FAL_KEY not set. " + self.install_instructions
+            )
+
+        import requests
+        from tools.video._shared import upload_image_fal
+
+        operation = inputs.get("operation", "generate")
+        if operation not in _ENDPOINTS:
+            return ToolResult(success=False, error=f"unsupported operation: {operation}")
+
+        start = time.time()
+        prompt = inputs["prompt"]
+        output_format = inputs.get("output_format", "png")
+        headers = {
+            "Authorization": f"Key {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        try:
+            if operation == "generate":
+                payload: dict[str, Any] = {
+                    "prompt": prompt,
+                    "image_size": {
+                        "width": int(inputs.get("width", 1024)),
+                        "height": int(inputs.get("height", 1024)),
+                    },
+                    "quality": inputs.get("quality", "high"),
+                    "num_images": int(inputs.get("num_images", 1)),
+                    "output_format": output_format,
+                }
+            else:
+                urls = list(inputs.get("image_urls") or [])
+                for local in inputs.get("image_paths") or []:
+                    urls.append(upload_image_fal(local))
+                if inputs.get("image_url"):
+                    urls.insert(0, inputs["image_url"])
+                if inputs.get("image_path"):
+                    urls.insert(0, upload_image_fal(inputs["image_path"]))
+                if not urls:
+                    return ToolResult(
+                        success=False,
+                        error="edit requires at least one image_url/image_path",
+                    )
+                if len(urls) > _MAX_EDIT_IMAGES:
+                    return ToolResult(
+                        success=False,
+                        error=f"gpt-image-2 edit accepts at most {_MAX_EDIT_IMAGES} images, got {len(urls)}",
+                    )
+                payload = {
+                    "prompt": prompt,
+                    "image_urls": urls,
+                    "quality": inputs.get("quality", "high"),
+                }
+                mask_url = inputs.get("mask_url")
+                if not mask_url and inputs.get("mask_path"):
+                    mask_url = upload_image_fal(inputs["mask_path"])
+                if mask_url:
+                    payload["mask_image_url"] = mask_url
+
+            endpoint = _ENDPOINTS[operation]
+            response = requests.post(
+                f"https://fal.run/{endpoint}",
+                headers=headers,
+                json=payload,
+                timeout=180,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            images = data.get("images") or []
+            if not images:
+                return ToolResult(success=False, error="fal.ai returned no image outputs")
+
+            requested = Path(inputs.get("output_path") or f"gpt_image2_fal_{operation}.png")
+            output_paths: list[Path] = []
+            for index, item in enumerate(images):
+                out_path = requested if index == 0 else requested.with_name(
+                    f"{requested.stem}_{index + 1}{requested.suffix}"
+                )
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+                image_response = requests.get(item["url"], timeout=60)
+                image_response.raise_for_status()
+                out_path.write_bytes(image_response.content)
+                output_paths.append(out_path)
+
+        except Exception as exc:
+            return ToolResult(success=False, error=f"fal.ai GPT Image 2 {operation} failed: {exc}")
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": "openai",
+                "gateway": "fal.ai",
+                "model": _ENDPOINTS[operation],
+                "operation": operation,
+                "prompt": prompt,
+                "output": str(output_paths[0]),
+                "outputs": [str(p) for p in output_paths],
+                "images_generated": len(output_paths),
+                "source_urls": [item["url"] for item in images],
+            },
+            artifacts=[str(p) for p in output_paths],
+            cost_usd=self.estimate_cost(inputs),
+            duration_seconds=round(time.time() - start, 2),
+            model=_ENDPOINTS[operation],
+        )

--- a/tools/graphics/gpt_image2_fal.py
+++ b/tools/graphics/gpt_image2_fal.py
@@ -132,7 +132,12 @@ class GptImage2Fal(BaseTool):
         cpu_cores=1, ram_mb=512, vram_mb=0, disk_mb=100, network_required=True
     )
     retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
-    idempotency_key_fields = ["prompt", "operation", "width", "height", "quality"]
+    idempotency_key_fields = [
+        "prompt", "operation", "width", "height", "quality",
+        "num_images", "output_format",
+        "image_url", "image_path", "image_urls", "image_paths",
+        "mask_url", "mask_path",
+    ]
     side_effects = ["writes image file(s) to output_path", "calls fal.ai API"]
     user_visible_verification = ["Inspect generated image for relevance, quality, and edit fidelity"]
 

--- a/tools/graphics/nano_banana_fal.py
+++ b/tools/graphics/nano_banana_fal.py
@@ -1,0 +1,273 @@
+"""Google Nano Banana 2 / Nano Banana 2 Pro generation and editing via fal.ai.
+
+Distinct from `atlas_image`, which routes nano-banana-2 through the Atlas
+Cloud gateway (ATLASCLOUD_API_KEY) and does not expose the Pro variant at
+all. This tool reaches both variants directly on fal.ai, gated only by
+FAL_KEY/FAL_AI_API_KEY.
+
+Endpoints confirmed against fal.ai docs (2026-08-20):
+  https://fal.ai/models/fal-ai/nano-banana-2
+  https://fal.ai/models/fal-ai/nano-banana-2/edit
+  https://fal.ai/models/fal-ai/nano-banana-pro/api
+  https://fal.ai/models/fal-ai/nano-banana-pro/edit/api
+  - generate: fal-ai/nano-banana-2 | fal-ai/nano-banana-pro
+  - edit:     fal-ai/nano-banana-2/edit | fal-ai/nano-banana-pro/edit
+    (edit accepts up to 14 reference images via image_urls)
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+_ENDPOINTS = {
+    ("nano-banana-2", "generate"): "fal-ai/nano-banana-2",
+    ("nano-banana-2", "edit"): "fal-ai/nano-banana-2/edit",
+    ("nano-banana-pro", "generate"): "fal-ai/nano-banana-pro",
+    ("nano-banana-pro", "edit"): "fal-ai/nano-banana-pro/edit",
+}
+
+_MAX_EDIT_IMAGES = 14
+
+# $0.08/image base rate confirmed for nano-banana-2 (both operations).
+# nano-banana-pro's exact rate was not published on the fetched docs pages —
+# the same base + multipliers are used as a placeholder estimate. Confirm
+# against fal.ai's live pricing before relying on this for a paid batch run.
+_BASE_PRICE = 0.08
+_RESOLUTION_MULTIPLIER = {"0.5K": 0.75, "1K": 1.0, "2K": 1.5, "4K": 2.0}
+
+
+class NanoBananaFal(BaseTool):
+    name = "nano_banana_fal"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "image_generation"
+    provider = "google"
+    stability = ToolStability.BETA
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = ["env:FAL_KEY"]
+    install_instructions = (
+        "Set FAL_KEY (or FAL_AI_API_KEY) to your fal.ai API key.\n"
+        "  Get one at https://fal.ai/dashboard/keys"
+    )
+    agent_skills = ["flux-best-practices"]
+
+    capabilities = ["generate_image", "generate_illustration", "text_to_image", "image_edit"]
+    supports = {
+        "aspect_ratio": True,
+        "custom_resolution": True,
+        "image_edit": True,
+        "multiple_reference_images": True,
+        "text_in_image": True,
+        "web_grounding": True,
+    }
+    best_for = [
+        "Nano Banana 2 / Nano Banana 2 Pro generation and editing without an Atlas Cloud key",
+        "up to 4K output with up to 14 reference images on edit",
+        "text-heavy compositions (strong text rendering accuracy)",
+    ]
+    not_good_for = ["offline generation", "nano-banana-pro cost-sensitive batches (unconfirmed pricing)"]
+    fallback_tools = ["atlas_image", "flux_image", "recraft_image"]
+    quality_score = 0.87
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+            "prompt": {"type": "string"},
+            "model": {
+                "type": "string",
+                "enum": ["nano-banana-2", "nano-banana-pro"],
+                "default": "nano-banana-2",
+            },
+            "operation": {
+                "type": "string",
+                "enum": ["generate", "edit"],
+                "default": "generate",
+            },
+            "aspect_ratio": {
+                "type": "string",
+                "enum": [
+                    "auto", "21:9", "16:9", "3:2", "4:3", "5:4",
+                    "1:1", "4:5", "3:4", "2:3", "9:16",
+                ],
+                "default": "auto",
+            },
+            "resolution": {
+                "type": "string",
+                "enum": ["0.5K", "1K", "2K", "4K"],
+                "default": "1K",
+            },
+            "num_images": {"type": "integer", "default": 1, "minimum": 1, "maximum": 4},
+            "seed": {"type": "integer"},
+            "output_format": {
+                "type": "string",
+                "enum": ["png", "jpeg", "webp"],
+                "default": "png",
+            },
+            "enable_web_search": {"type": "boolean"},
+            "system_prompt": {"type": "string"},
+            "image_url": {"type": "string"},
+            "image_path": {"type": "string"},
+            "image_urls": {"type": "array", "items": {"type": "string"}},
+            "image_paths": {"type": "array", "items": {"type": "string"}},
+            "extra_params": {"type": "object"},
+            "output_path": {"type": "string"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=512, vram_mb=0, disk_mb=200, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
+    idempotency_key_fields = ["prompt", "model", "operation", "aspect_ratio", "resolution"]
+    side_effects = ["writes image file(s) to output_path", "calls fal.ai API"]
+    user_visible_verification = ["Inspect generated/edited images for prompt fidelity and edit consistency"]
+
+    @staticmethod
+    def _api_key() -> str | None:
+        return os.environ.get("FAL_KEY") or os.environ.get("FAL_AI_API_KEY")
+
+    def get_status(self) -> ToolStatus:
+        return ToolStatus.AVAILABLE if self._api_key() else ToolStatus.UNAVAILABLE
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        n = int(inputs.get("num_images", 1))
+        resolution = inputs.get("resolution", "1K")
+        multiplier = _RESOLUTION_MULTIPLIER.get(resolution, 1.0)
+        return round(_BASE_PRICE * multiplier * n, 4)
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        return 20.0 if inputs.get("model", "nano-banana-2") == "nano-banana-2" else 35.0
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        api_key = self._api_key()
+        if not api_key:
+            return ToolResult(
+                success=False, error="FAL_KEY not set. " + self.install_instructions
+            )
+
+        import requests
+        from tools.video._shared import upload_image_fal
+
+        model = inputs.get("model", "nano-banana-2")
+        operation = inputs.get("operation", "generate")
+        endpoint = _ENDPOINTS.get((model, operation))
+        if not endpoint:
+            return ToolResult(
+                success=False, error=f"unsupported model/operation combo: {model}/{operation}"
+            )
+
+        start = time.time()
+        prompt = inputs["prompt"]
+        headers = {
+            "Authorization": f"Key {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        try:
+            payload: dict[str, Any] = {
+                "prompt": prompt,
+                "aspect_ratio": inputs.get("aspect_ratio", "auto"),
+                "resolution": inputs.get("resolution", "1K"),
+                "num_images": int(inputs.get("num_images", 1)),
+            }
+            if inputs.get("seed") is not None:
+                payload["seed"] = inputs["seed"]
+            if inputs.get("output_format") and inputs["output_format"] != "default":
+                payload["output_format"] = inputs["output_format"]
+            if inputs.get("enable_web_search") is not None:
+                payload["enable_web_search"] = inputs["enable_web_search"]
+            if inputs.get("system_prompt"):
+                payload["system_prompt"] = inputs["system_prompt"]
+
+            if operation == "edit":
+                urls = list(inputs.get("image_urls") or [])
+                for local in inputs.get("image_paths") or []:
+                    urls.append(upload_image_fal(local))
+                if inputs.get("image_url"):
+                    urls.insert(0, inputs["image_url"])
+                if inputs.get("image_path"):
+                    urls.insert(0, upload_image_fal(inputs["image_path"]))
+                if not urls:
+                    return ToolResult(
+                        success=False,
+                        error="edit requires at least one image_url/image_path",
+                    )
+                if len(urls) > _MAX_EDIT_IMAGES:
+                    return ToolResult(
+                        success=False,
+                        error=f"{model} edit accepts at most {_MAX_EDIT_IMAGES} images, got {len(urls)}",
+                    )
+                payload["image_urls"] = urls
+
+            extra = inputs.get("extra_params")
+            if isinstance(extra, dict):
+                payload.update(extra)
+
+            response = requests.post(
+                f"https://fal.run/{endpoint}",
+                headers=headers,
+                json=payload,
+                timeout=180,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            images = data.get("images") or []
+            if not images:
+                return ToolResult(success=False, error="fal.ai returned no image outputs")
+
+            requested = Path(inputs.get("output_path") or f"{model.replace('-', '_')}_{operation}.png")
+            output_paths: list[Path] = []
+            for index, item in enumerate(images):
+                out_path = requested if index == 0 else requested.with_name(
+                    f"{requested.stem}_{index + 1}{requested.suffix}"
+                )
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+                image_response = requests.get(item["url"], timeout=60)
+                image_response.raise_for_status()
+                out_path.write_bytes(image_response.content)
+                output_paths.append(out_path)
+
+        except Exception as exc:
+            return ToolResult(success=False, error=f"fal.ai {model} {operation} failed: {exc}")
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": "google",
+                "gateway": "fal.ai",
+                "model": endpoint,
+                "operation": operation,
+                "prompt": prompt,
+                "description": data.get("description"),
+                "output": str(output_paths[0]),
+                "outputs": [str(p) for p in output_paths],
+                "images_generated": len(output_paths),
+                "source_urls": [item["url"] for item in images],
+            },
+            artifacts=[str(p) for p in output_paths],
+            cost_usd=self.estimate_cost(inputs),
+            duration_seconds=round(time.time() - start, 2),
+            model=endpoint,
+            seed=inputs.get("seed"),
+        )

--- a/tools/graphics/nano_banana_fal.py
+++ b/tools/graphics/nano_banana_fal.py
@@ -138,7 +138,12 @@ class NanoBananaFal(BaseTool):
         cpu_cores=1, ram_mb=512, vram_mb=0, disk_mb=200, network_required=True
     )
     retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
-    idempotency_key_fields = ["prompt", "model", "operation", "aspect_ratio", "resolution"]
+    idempotency_key_fields = [
+        "prompt", "model", "operation", "aspect_ratio", "resolution",
+        "num_images", "seed", "output_format", "enable_web_search", "system_prompt",
+        "image_url", "image_path", "image_urls", "image_paths",
+        "extra_params",
+    ]
     side_effects = ["writes image file(s) to output_path", "calls fal.ai API"]
     user_visible_verification = ["Inspect generated/edited images for prompt fidelity and edit consistency"]
 


### PR DESCRIPTION
## Summary
- New `tools/graphics/gpt_image2_fal.py`: OpenAI GPT Image 2 generation + multi-reference edit (up to 10 images) through fal.ai (`FAL_KEY`), as an alternative to the existing `openai_image` (direct OpenAI API) and `atlas_image` (Atlas Cloud gateway) tools.
- New `tools/graphics/nano_banana_fal.py`: Google Nano Banana 2 **and** Nano Banana 2 Pro, generate + edit (up to 14 reference images, up to 4K) through fal.ai. Nano Banana Pro was not previously available anywhere in the project's tool catalog.
- Both follow the existing `flux_image.py` / `gemini_omni_fal.py` conventions (`BaseTool` subclass, direct `fal.run` POST, `upload_image_fal` from `tools/video/_shared.py` for local reference images) and auto-register via the tool registry's package walk — no registry changes needed.
- Endpoints and parameters verified against live fal.ai docs (fal.ai/models/openai/gpt-image-2, fal.ai/models/fal-ai/nano-banana-2, fal.ai/models/fal-ai/nano-banana-pro) as of 2026-08-20.
- Note: exact per-image pricing for `nano-banana-pro` was not published on the fetched docs pages — the code uses the same base rate + resolution multipliers as `nano-banana-2` as a documented placeholder estimate; flagged in a code comment to confirm before a paid batch run.

## Test plan
- [x] `python -m py_compile` on both new files
- [x] `registry.discover()` — both tools auto-register under `capability=image_generation`, no regressions to the other 121 registered tools
- [x] `get_status()` correctly reports `UNAVAILABLE` without `FAL_KEY`
- [x] `estimate_cost()` sanity-checked against the published fal.ai pricing table
- [x] Edit-operation validation (max reference images: 10 for gpt-image-2, 14 for nano-banana) confirmed to fail fast, before any network call
- [ ] Live API smoke test with a real `FAL_KEY` (not run — no key available in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ALtG5jrC3v5EXnCdLfVfzz