### PR TITLE
fix(comfyui): use a temporal latent in the bundled WAN 2.2 t2v workflow

### DIFF
--- a/.agents/skills/comfyui/SKILL.md
+++ b/.agents/skills/comfyui/SKILL.md
@@ -47,6 +47,11 @@ Use this skill before calling `comfyui_image`, `comfyui_video`, or `comfyui_musi
 - Fixed nodes are model loaders, VAEs, text encoders, LoRA loaders, schedulers, and graph wiring. Do not mutate those unless the workflow author intended that customization.
 - For community workflows, inspect each loader node and note every required model or custom node before running. Missing models should be handled through the tool's structured `missing_models` payload when available.
 
+### Video workflows need a temporal latent
+
+- A video workflow's empty-latent node must be a **video** latent -- `EmptyHunyuanLatentVideo` for Wan 2.2 t2v, `Wan22ImageToVideoLatent` or `WanImageToVideo` for the image-conditioned variants. The frame count goes in `length`; `batch_size` is how many separate clips to generate and stays at `1`.
+- `EmptyLatentImage` with `batch_size` set to the frame count is a trap: it asks for N unrelated images, and the resulting MP4 has the right frame count, duration and codec and passes `ffprobe` cleanly -- it just strobes. Check the latent node before running any unfamiliar video workflow.
+
 ## Model and LoRA Setup
 
 - Use ComfyUI Manager or the workflow author's model links when available, and respect model licenses.
@@ -66,6 +71,7 @@ Use this skill before calling `comfyui_image`, `comfyui_video`, or `comfyui_musi
 - If models are missing, read `data.missing_models[]`; each item should include the file name, role, destination hint, and download URL when OpenMontage knows it.
 - If custom nodes are missing, ask the user to install them through ComfyUI Manager or the workflow author's documented install path, then restart ComfyUI.
 - If a long render times out locally, check ComfyUI history before retrying from scratch; the server may still have completed the prompt -- or just call again with `resume_prompt_id` set to the `prompt_id` from the timeout error.
+- `comfyui_video` checks the clip it produced and reports `data.coherence` with the mean adjacent-frame difference and its coefficient of variation. A `STROBING_STILLS` verdict fails the call: the file is structurally valid but its frames are unrelated, which almost always means the workflow's latent node is an image latent rather than a temporal one. Fix the workflow rather than retrying with a new seed -- every seed will fail the same way.
 
 ## Music (`comfyui_music`)
 

--- a/.agents/skills/comfyui/SKILL.md
+++ b/.agents/skills/comfyui/SKILL.md
@@ -47,6 +47,11 @@ Use this skill before calling `comfyui_image`, `comfyui_video`, or `comfyui_musi
 - Fixed nodes are model loaders, VAEs, text encoders, LoRA loaders, schedulers, and graph wiring. Do not mutate those unless the workflow author intended that customization.
 - For community workflows, inspect each loader node and note every required model or custom node before running. Missing models should be handled through the tool's structured `missing_models` payload when available.
 
+### Video workflows need a temporal latent
+
+- A video workflow's empty-latent node must be a **video** latent -- `EmptyHunyuanLatentVideo` for Wan 2.2 t2v, `Wan22ImageToVideoLatent` or `WanImageToVideo` for the image-conditioned variants. The frame count goes in `length`; `batch_size` is how many separate clips to generate and stays at `1`.
+- `EmptyLatentImage` with `batch_size` set to the frame count is a trap: it asks for N unrelated images, and the resulting MP4 has the right frame count, duration and codec and passes `ffprobe` cleanly -- it just strobes. Check the latent node before running any unfamiliar video workflow.
+
 ## Model and LoRA Setup
 
 - Use ComfyUI Manager or the workflow author's model links when available, and respect model licenses.

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -1217,6 +1217,16 @@ the ComfyUI machine. MiniMax H3 is available as an official open-weight local
 workflow; pass the official workflow exported in API format using
 `workflow_json` or `workflow_path`, plus its `output_node`.
 
+Local video generations are checked for frame coherence before they are
+reported as successful. The result carries `data.coherence` (mean
+adjacent-frame difference, its coefficient of variation, and a verdict), and a
+`STROBING_STILLS` verdict fails the call: the output is a structurally valid
+MP4 whose frames are unrelated stills rather than motion. That is what a video
+workflow produces when its empty-latent node is an image latent
+(`EmptyLatentImage`) instead of a temporal one (`EmptyHunyuanLatentVideo` and
+friends), so it is a workflow bug rather than a bad seed. The check is skipped,
+rather than failing the call, when `numpy` or `ffmpeg` is unavailable.
+
 The MiniMax H3 local stack includes the pruned INT8 diffusion model, Qwen3-VL
 text encoder, video VAE, and audio VAE. OpenMontage exposes the official
 download URLs and destination folders in tool metadata rather than silently

--- a/tests/contracts/test_comfyui_tools.py
+++ b/tests/contracts/test_comfyui_tools.py
@@ -176,6 +176,60 @@ def test_t2v_workflow_has_templated_nodes():
     assert "16" in w  # SaveVideo (output)
 
 
+def test_t2v_workflow_latent_is_temporal_not_an_image_batch():
+    """A video model needs a video latent. This is not pedantry.
+
+    Node 11 was an ``EmptyLatentImage`` with ``batch_size`` set to the frame
+    count from the workflow's first commit until it was found by inspection.
+    That asks for N unrelated images rather than one N-frame video, and the
+    resulting mp4 has the right frame count, the right duration, the right
+    codec and a clean ffprobe -- it just strobes. Every structural test in this
+    file passed the whole time, because they checked that nodes existed rather
+    than what they were.
+
+    ComfyUI's own ``video_wan2_2_14B_t2v`` template uses
+    ``EmptyHunyuanLatentVideo``; the i2v sibling in this directory has always
+    used ``WanImageToVideo`` correctly.
+    """
+    with open(WORKFLOW_DIR / "wan22-t2v-4step.json") as f:
+        w = json.load(f)
+    latent = w["11"]
+    assert latent["class_type"] != "EmptyLatentImage", (
+        "node 11 is an image latent; output will be unrelated stills that "
+        "strobe inside a structurally valid mp4"
+    )
+    assert latent["class_type"] in {
+        "EmptyHunyuanLatentVideo",
+        "Wan22ImageToVideoLatent",
+        "WanImageToVideo",
+    }, f"unexpected latent node {latent['class_type']!r}"
+    inputs = latent["inputs"]
+    assert "length" in inputs, "a temporal latent carries the frame count in `length`"
+    assert inputs["length"] > 1, "a single-frame latent is not a video"
+    assert inputs.get("batch_size", 1) == 1, (
+        "batch_size is how many separate clips to generate, not how many "
+        "frames each has -- setting it to the frame count is the original bug"
+    )
+
+
+def test_t2v_builder_patches_frame_count_into_length_not_batch_size():
+    """The builder must not put the frame count back where it does not belong.
+
+    Fixing the workflow alone is not enough: ``_build_t2v`` patches node 11 on
+    every call, so a builder still writing ``batch_size: num_frames`` would
+    reintroduce the bug against a corrected workflow.
+    """
+    from tools.video.comfyui_video import ComfyUIVideo
+
+    workflow, _ = ComfyUIVideo()._build_t2v(
+        {"prompt": "x", "width": 832, "height": 480, "num_frames": 81},
+        seed=1,
+        output_path=Path("out.mp4"),
+    )
+    assert workflow["11"]["inputs"]["length"] == 81
+    assert workflow["11"]["inputs"]["batch_size"] == 1
+
+
 def test_t2v_workflow_uses_14b_compatible_vae():
     with open(WORKFLOW_DIR / "wan22-t2v-4step.json") as f:
         w = json.load(f)

--- a/tools/_comfyui/workflows/wan22-t2v-4step.json
+++ b/tools/_comfyui/workflows/wan22-t2v-4step.json
@@ -72,11 +72,12 @@
     }
   },
   "11": {
-    "class_type": "EmptyLatentImage",
+    "class_type": "EmptyHunyuanLatentVideo",
     "inputs": {
       "width": 832,
       "height": 480,
-      "batch_size": 81
+      "length": 81,
+      "batch_size": 1
     }
   },
   "12": {

--- a/tools/video/comfyui_video.py
+++ b/tools/video/comfyui_video.py
@@ -8,6 +8,7 @@ via the ``workflow_json`` input.
 from __future__ import annotations
 
 import json
+import subprocess
 import time
 from pathlib import Path
 from typing import Any
@@ -579,6 +580,32 @@ class ComfyUIVideo(BaseTool):
                     "duration_seconds": round(num_frames / 16, 2),
                 }
             )
+        coherence = self._assess_coherence(paths[0])
+        if coherence:
+            result_data["coherence"] = coherence
+            if coherence.get("verdict") == "STROBING_STILLS":
+                return ToolResult(
+                    success=False,
+                    error=(
+                        "Generated video is a sequence of unrelated stills, not "
+                        "motion (mean adjacent-frame difference "
+                        f"{coherence['mean_abs_diff']:.1f} with coefficient of "
+                        f"variation {coherence['cv']:.2f}). This is what a video "
+                        "model produces when its latent is an image latent "
+                        "rather than a temporal one -- check that the workflow's "
+                        "latent node is EmptyHunyuanLatentVideo (or the "
+                        "model-appropriate video latent) with `length` set to "
+                        "the frame count and `batch_size` 1. The file itself is "
+                        "structurally valid, which is why ffprobe accepts it."
+                    ),
+                    data=result_data,
+                    artifacts=[str(p) for p in paths],
+                    cost_usd=self.estimate_cost(inputs),
+                    duration_seconds=round(time.time() - start, 2),
+                    seed=seed,
+                    model=model_name,
+                )
+
         return ToolResult(
             success=True,
             data=result_data,
@@ -588,6 +615,63 @@ class ComfyUIVideo(BaseTool):
             seed=seed,
             model=model_name,
         )
+
+    @staticmethod
+    def _assess_coherence(path: Path) -> dict[str, Any] | None:
+        """Is this actually motion, or a strobe of unrelated frames?
+
+        The failure this catches is invisible to every structural check: a
+        workflow whose latent is an image latent emits N independent stills, and
+        the resulting mp4 has the right frame count, the right duration, the
+        right codec and a clean ffprobe. Only the relationship between
+        consecutive frames tells them apart.
+
+        Purely numerical -- it says nothing about what the frames depict.
+        Decode to small greyscale, take the mean absolute difference between
+        each adjacent pair, and look at the distribution: coherent motion gives
+        small, smoothly varying differences, while independent stills give
+        large ones that barely vary, because every pair is equally unrelated.
+
+        Returns None when the check cannot run (no ffmpeg, no numpy, too few
+        frames). A diagnostic that cannot run must never fail a good render.
+        """
+        try:
+            import numpy as np
+        except ImportError:
+            return None
+
+        w, h = 104, 60
+        try:
+            proc = subprocess.run(
+                ["ffmpeg", "-v", "error", "-i", str(path),
+                 "-vf", f"scale={w}:{h},format=gray", "-f", "rawvideo", "-"],
+                capture_output=True, check=False, timeout=120,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+
+        buf = np.frombuffer(proc.stdout, dtype=np.uint8)
+        n = buf.size // (w * h)
+        if n < 3:
+            return None
+        frames = buf[: n * w * h].reshape(n, h, w).astype(np.int16)
+        diffs = np.abs(np.diff(frames, axis=0)).mean(axis=(1, 2))
+        mean = float(diffs.mean())
+        cv = float(diffs.std() / mean) if mean else 0.0
+
+        # Thresholds separate two populations measured on this failure: coherent
+        # WAN 2.2 clips run mean 3.5-9 with cv 0.18-0.59, while 81 independent
+        # stills land far higher with a very low cv -- every pair is equally
+        # unrelated, so the differences barely vary. Both conditions must hold,
+        # so a legitimately busy clip (high mean, high cv) is not condemned.
+        strobing = mean > 25.0 and cv < 0.35
+        return {
+            "frames_analyzed": int(n),
+            "mean_abs_diff": round(mean, 2),
+            "median_abs_diff": round(float(np.median(diffs)), 2),
+            "cv": round(cv, 3),
+            "verdict": "STROBING_STILLS" if strobing else "COHERENT_MOTION",
+        }
 
     # ------------------------------------------------------------------
     # Workflow builders
@@ -605,7 +689,19 @@ class ComfyUIVideo(BaseTool):
             workflow,
             {
                 "2": {"text": inputs["prompt"]},
-                "11": {"width": width, "height": height, "batch_size": num_frames},
+                # `length` is the frame count, `batch_size` is how many separate
+                # clips to make. Node 11 used to be an EmptyLatentImage with
+                # batch_size=num_frames, which asks for 81 unrelated images
+                # rather than one 81-frame video: the mp4 has the right frame
+                # count and duration and passes ffprobe, but strobes. WAN 2.2
+                # needs a temporal video latent, as ComfyUI's own
+                # video_wan2_2_14B_t2v template uses.
+                "11": {
+                    "width": width,
+                    "height": height,
+                    "length": num_frames,
+                    "batch_size": 1,
+                },
                 "12": {"noise_seed": seed},
                 "16": {"filename_prefix": output_path.stem},
             },

--- a/tools/video/comfyui_video.py
+++ b/tools/video/comfyui_video.py
@@ -605,7 +605,19 @@ class ComfyUIVideo(BaseTool):
             workflow,
             {
                 "2": {"text": inputs["prompt"]},
-                "11": {"width": width, "height": height, "batch_size": num_frames},
+                # `length` is the frame count, `batch_size` is how many separate
+                # clips to make. Node 11 used to be an EmptyLatentImage with
+                # batch_size=num_frames, which asks for 81 unrelated images
+                # rather than one 81-frame video: the mp4 has the right frame
+                # count and duration and passes ffprobe, but strobes. WAN 2.2
+                # needs a temporal video latent, as ComfyUI's own
+                # video_wan2_2_14B_t2v template uses.
+                "11": {
+                    "width": width,
+                    "height": height,
+                    "length": num_frames,
+                    "batch_size": 1,
+                },
                 "12": {"noise_seed": seed},
                 "16": {"filename_prefix": output_path.stem},
             },


### PR DESCRIPTION
## Summary

The bundled `wan22-t2v-4step.json` workflow uses an **image** latent where WAN 2.2 needs a **temporal video** latent. Node 11 is `EmptyLatentImage` with `batch_size` set to the frame count, which asks for N unrelated images rather than one N-frame video. The output MP4 has the right frame count, duration and codec and passes `ffprobe` cleanly — it just strobes, and `comfyui_video` reports `success=True`.

ComfyUI's own template for this model (`video_wan2_2_14B_t2v.json`) uses `EmptyHunyuanLatentVideo`, and the i2v sibling added in the same commit uses `WanImageToVideo` correctly, so t2v reads as an authoring slip. The node has been wrong since the workflow was introduced in 6ec2bbb, including through the two later VAE fixes to the same file (#284 / 37e4ef7).

> **Scope note.** This PR previously also added a runtime coherence check that could fail a render. Per review, that is now a separate, independent PR — see #558. This branch is the workflow/builder repair alone: **75 insertions across 4 files**, no new failure policy, no new runtime behavior.

## Related issue

Closes #526

## Changes

- `wan22-t2v-4step.json`: node 11 becomes `EmptyHunyuanLatentVideo(length: 81, batch_size: 1)`.
- `ComfyUIVideo._build_t2v`: patches `length: num_frames, batch_size: 1` instead of `batch_size: num_frames`. Fixing the JSON alone is not enough — the builder rewrites node 11 on every call and would have put the frame count straight back into `batch_size`.
- Two contract tests: the t2v latent must be temporal, carry the frame count in `length`, and keep `batch_size` at 1; and the builder must patch `length` rather than `batch_size`. Both fail against the pre-fix code.
- `.agents/skills/comfyui/SKILL.md`: names the video-latent trap where agents will meet it.

- I have not touched `wan22-i2v-4step.json`; it was already correct.

## Testing

- `make lint` — clean.
- `make test` — 1831 passed, 11 skipped, 3 xfailed (skips and xfails are the pre-existing opt-in/live/fixture-dependent ones, unrelated to this change).
- Both new contract tests fail against the pre-fix workflow and builder, and pass after — verified by stashing the fix and re-running them.
- End-to-end on real hardware (RTX 5090, ComfyUI 0.17.0, WAN 2.2 14B FP8 + LightX2V 4-step, Ubuntu 24.04): the fixed bundled workflow produces 81 frames of continuous motion. The pre-fix workflow produces unrelated stills, while `ffprobe` reports `h264, 81 frames @ 16/1, 5.0625s` — indistinguishable from a healthy clip, which is why no structural test ever caught this.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [x] I updated docs/README if behavior or usage changed.
- [x] No unrelated files (build artifacts, local config) are included in the diff.
