### PR TITLE
fix(compose): honor the requested frame rate and resolve schema-conformant asset paths

### DIFF
--- a/skills/pipelines/cinematic/compose-director.md
+++ b/skills/pipelines/cinematic/compose-director.md
@@ -85,8 +85,38 @@ Recommended metadata keys:
 - `mix_notes`
 - `variant_outputs`
 
+### 5. State The Frame Rate When It Is Not 30
+
+The FFmpeg compose path normalizes every segment to one frame rate, because
+concat with `-c copy` requires a consistent fps across segments. That rate
+defaults to **30**, so say otherwise when the footage is not 30fps:
+
+```json
+"metadata": {
+  "compose_target": {"width": 832, "height": 480, "fit": "pad", "fps": 64}
+}
+```
+
+(or pass `fps` directly to `video_compose.execute()`, which takes precedence).
+
+Getting this wrong is quiet rather than loud. Interpolated 64fps footage
+composed at 30 is decimated back to half its frames -- the smoothness that was
+just paid for is discarded. Generative 16fps footage composed at 30 is padded by
+uneven frame duplication at a 1.875 ratio, which reads as judder rather than as
+a wrong setting.
+
+### 6. Asset Paths Resolve Against The Project Directory
+
+`asset_manifest` asset paths are, per the schema, relative to the project
+directory -- `assets/video/shot1.mp4`, not a repo-relative or absolute path.
+Cut sources are looked up first relative to the process working directory and
+then relative to the project directory inferred from `output_path`, so both
+conventions work. If a source cannot be found the error lists every base that
+was tried; read it before assuming the file is missing.
+
 ## Common Pitfalls
 
+- Composing non-30fps footage without setting `compose_target.fps` -- see step 5.
 - Flattening the audio so the piece loses dynamics.
 - Applying letterbox to footage that needs every pixel.
 - Letting grading or sharpening damage faces or text.

--- a/tests/tools/test_video_compose_fps_and_sources.py
+++ b/tests/tools/test_video_compose_fps_and_sources.py
@@ -1,0 +1,229 @@
+"""Frame rate and asset-path resolution for video_compose's FFmpeg compose.
+
+Two regressions of the same shape as the vertical-resolution bug covered in
+`test_video_compose_vertical.py` -- the tool documented a contract and then
+ignored it:
+
+1. The per-segment filter chain hardcoded `fps=30` (and `-r 30`), so a caller
+   composing 64fps interpolated footage got it silently decimated to 30, and
+   16fps generative footage got uneven frame duplication that reads as judder.
+
+2. `asset_manifest.schema.json` defines an asset `path` as a "relative path
+   within the pipeline project directory", but cut sources were opened relative
+   to the process CWD -- so a manifest that followed the schema only worked if
+   the caller happened to run from inside the project directory.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tools.video.video_compose import VideoCompose
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None,
+    reason="ffmpeg/ffprobe not available",
+)
+
+
+def _make_clip(path: Path, fps: int = 30, d: int = 2) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["ffmpeg", "-y", "-f", "lavfi", "-i",
+         f"color=c=teal:s=320x240:d={d}:r={fps}",
+         "-c:v", "libx264", "-crf", "28", "-pix_fmt", "yuv420p", str(path)],
+        capture_output=True, check=True,
+    )
+
+
+def _fps(path: Path) -> str:
+    return subprocess.check_output(
+        ["ffprobe", "-v", "error", "-select_streams", "v:0",
+         "-show_entries", "stream=r_frame_rate", "-of", "csv=p=0", str(path)]
+    ).decode().strip()
+
+
+def _edit_decisions(src: Path, metadata: dict | None = None) -> dict:
+    ed = {
+        "version": "1.0",
+        "render_runtime": "ffmpeg",
+        "cuts": [{"id": "c1", "source": str(src), "in_seconds": 0, "out_seconds": 2}],
+    }
+    if metadata:
+        ed["metadata"] = metadata
+    return ed
+
+
+# ---------------------------------------------------------------------------
+# Frame rate
+# ---------------------------------------------------------------------------
+
+def test_compose_default_fps_is_30(tmp_path):
+    """No fps requested → 30, exactly as before (backward compatible)."""
+    src = tmp_path / "in.mp4"
+    _make_clip(src, fps=24)
+    out = tmp_path / "out.mp4"
+
+    result = VideoCompose().execute({
+        "operation": "compose",
+        "edit_decisions": _edit_decisions(src),
+        "output_path": str(out),
+    })
+
+    assert result.success, result.error
+    assert _fps(out) == "30/1"
+
+
+def test_compose_target_fps_is_honored(tmp_path):
+    """A 64fps interpolated source stays 64fps when asked for."""
+    src = tmp_path / "in64.mp4"
+    _make_clip(src, fps=64)
+    out = tmp_path / "out64.mp4"
+
+    result = VideoCompose().execute({
+        "operation": "compose",
+        "edit_decisions": _edit_decisions(
+            src, {"compose_target": {"width": 320, "height": 240, "fps": 64}}
+        ),
+        "output_path": str(out),
+    })
+
+    assert result.success, result.error
+    assert _fps(out) == "64/1", "compose_target.fps was ignored — output decimated"
+
+
+def test_inputs_fps_overrides_compose_target(tmp_path):
+    """An explicit `fps` input wins over the artifact's compose_target."""
+    src = tmp_path / "in.mp4"
+    _make_clip(src, fps=30)
+    out = tmp_path / "out.mp4"
+
+    result = VideoCompose().execute({
+        "operation": "compose",
+        "edit_decisions": _edit_decisions(
+            src, {"compose_target": {"width": 320, "height": 240, "fps": 24}}
+        ),
+        "fps": 50,
+        "output_path": str(out),
+    })
+
+    assert result.success, result.error
+    assert _fps(out) == "50/1"
+
+
+@pytest.mark.parametrize("bad", [0, -5, "sixty", None])
+def test_invalid_fps_falls_back_to_default(tmp_path, bad):
+    """Garbage in compose_target.fps must not produce a broken ffmpeg command."""
+    src = tmp_path / "in.mp4"
+    _make_clip(src)
+    out = tmp_path / f"out_{bad}.mp4"
+
+    result = VideoCompose().execute({
+        "operation": "compose",
+        "edit_decisions": _edit_decisions(
+            src, {"compose_target": {"width": 320, "height": 240, "fps": bad}}
+        ),
+        "output_path": str(out),
+    })
+
+    assert result.success, result.error
+    assert _fps(out) == "30/1"
+
+
+# ---------------------------------------------------------------------------
+# Asset path resolution
+# ---------------------------------------------------------------------------
+
+def test_source_relative_to_project_dir_resolves(tmp_path):
+    """The path layout the asset_manifest schema prescribes must work.
+
+    `projects/<id>/assets/video/shot.mp4` referenced as `assets/video/shot.mp4`,
+    with the output going to `projects/<id>/renders/`, and the process running
+    from somewhere else entirely.
+    """
+    project = tmp_path / "projects" / "demo"
+    clip = project / "assets" / "video" / "shot1.mp4"
+    _make_clip(clip)
+    out = project / "renders" / "final.mp4"
+
+    resolved, tried = VideoCompose._resolve_source("assets/video/shot1.mp4", out)
+
+    assert resolved == clip.resolve(), f"unresolved; tried {tried}"
+
+
+def test_source_relative_to_cwd_still_resolves(tmp_path, monkeypatch):
+    """Existing callers that pass CWD-relative paths keep working."""
+    clip = tmp_path / "shots" / "shot1.mp4"
+    _make_clip(clip)
+    monkeypatch.chdir(tmp_path)
+
+    resolved, _ = VideoCompose._resolve_source("shots/shot1.mp4", tmp_path / "out.mp4")
+
+    assert resolved is not None and resolved.exists()
+
+
+def test_absolute_source_is_used_as_given(tmp_path):
+    clip = tmp_path / "abs.mp4"
+    _make_clip(clip)
+
+    resolved, _ = VideoCompose._resolve_source(str(clip), tmp_path / "out.mp4")
+
+    assert resolved == clip
+
+
+def test_missing_source_reports_every_base_tried(tmp_path):
+    """The error must say where it looked, not just that a path is missing."""
+    out = tmp_path / "projects" / "demo" / "renders" / "final.mp4"
+    out.parent.mkdir(parents=True)
+
+    resolved, tried = VideoCompose._resolve_source("assets/video/nope.mp4", out)
+
+    assert resolved is None
+    assert len(tried) == 2, tried
+    assert any("projects/demo" in str(t) for t in tried)
+
+
+def test_project_dir_inference():
+    """`renders/` is the marker for a project workspace; anything else is not."""
+    assert VideoCompose._project_dir_for(
+        Path("/w/projects/demo/renders/final.mp4")
+    ) == Path("/w/projects/demo")
+    assert VideoCompose._project_dir_for(Path("/w/out/final.mp4")) == Path("/w/out")
+
+
+def test_render_resolves_manifest_asset_by_id(tmp_path, monkeypatch):
+    """End to end through the render op: id → schema-relative path → output."""
+    project = tmp_path / "projects" / "demo"
+    clip = project / "assets" / "video" / "shot1.mp4"
+    _make_clip(clip)
+    out = project / "renders" / "final.mp4"
+    monkeypatch.chdir(tmp_path)  # not inside the project dir
+
+    result = VideoCompose().execute({
+        "operation": "render",
+        "edit_decisions": {
+            "version": "1.0",
+            "render_runtime": "ffmpeg",
+            "renderer_family": "cinematic-trailer",
+            "cuts": [{"id": "c1", "source": "shot1", "in_seconds": 0, "out_seconds": 1}],
+        },
+        "asset_manifest": {
+            "version": "1.0",
+            "assets": [{
+                "id": "shot1",
+                "type": "video",
+                "path": "assets/video/shot1.mp4",
+                "source_tool": "test",
+                "scene_id": "s1",
+            }],
+            "total_cost_usd": 0,
+        },
+        "output_path": str(out),
+    })
+
+    assert result.success, result.error
+    assert out.exists()

--- a/tests/tools/test_video_compose_fps_and_sources.py
+++ b/tests/tools/test_video_compose_fps_and_sources.py
@@ -182,9 +182,14 @@ def test_missing_source_reports_every_base_tried(tmp_path):
 
     resolved, tried = VideoCompose._resolve_source("assets/video/nope.mp4", out)
 
+    project_dir = out.parent.parent.resolve()
+
     assert resolved is None
     assert len(tried) == 2, tried
-    assert any("projects/demo" in str(t) for t in tried)
+    # Compare Path objects, not rendered strings: `str(Path)` uses the host
+    # separator, so a "projects/demo" substring check passes on POSIX and
+    # fails on Windows for the very path it is meant to accept.
+    assert project_dir / "assets" / "video" / "nope.mp4" in tried, tried
 
 
 def test_project_dir_inference():

--- a/tools/video/video_compose.py
+++ b/tools/video/video_compose.py
@@ -192,6 +192,19 @@ class VideoCompose(BaseTool):
             "codec": {"type": "string", "default": "libx264"},
             "crf": {"type": "integer", "default": 23},
             "preset": {"type": "string", "default": "medium"},
+            "fps": {
+                "type": "integer",
+                "default": 30,
+                "description": (
+                    "Output frame rate for the FFmpeg compose path. Overrides "
+                    "edit_decisions.metadata.compose_target.fps. Every segment is "
+                    "normalized to this rate, because concat with -c copy requires "
+                    "a consistent fps across segments. Set it when the source is "
+                    "not 30fps — interpolated footage composed at the default is "
+                    "silently decimated, and generative 16fps footage gains judder "
+                    "from uneven frame duplication."
+                ),
+            },
             "remotion_timeout_ms": {
                 "type": "integer",
                 "description": (
@@ -433,6 +446,54 @@ class VideoCompose(BaseTool):
             artifacts=[str(video_path)],
         )
 
+    @staticmethod
+    def _project_dir_for(output_path: Path) -> Optional[Path]:
+        """Infer the project directory from where the output is being written.
+
+        The workspace convention is ``projects/<id>/renders/final.mp4``, so the
+        project directory is the parent of ``renders/``. Anything else falls
+        back to the output's own directory.
+        """
+        parent = output_path.parent
+        if parent.name == "renders":
+            return parent.parent
+        return parent
+
+    @classmethod
+    def _resolve_source(
+        cls, raw: str, output_path: Path
+    ) -> tuple[Optional[Path], list[Path]]:
+        """Find a cut source on disk, returning the path and everything tried.
+
+        ``asset_manifest.schema.json`` defines an asset ``path`` as a "relative
+        path within the pipeline project directory", but sources used to be
+        opened relative to the process CWD -- so a manifest that followed the
+        schema only worked when the caller happened to be running from inside
+        the project directory. Callers worked around it by storing
+        repo-relative paths instead, which then broke if the process ran from
+        anywhere else.
+
+        Both now resolve. CWD is tried first so existing callers keep the
+        behavior they have, then the project directory the schema describes.
+        Returning the list of attempts lets the error say where it looked
+        instead of just naming a path that "does not exist".
+        """
+        candidate = Path(raw)
+        if candidate.is_absolute():
+            return (candidate, [candidate]) if candidate.exists() else (None, [candidate])
+
+        tried: list[Path] = []
+        bases = [Path.cwd()]
+        project_dir = cls._project_dir_for(output_path)
+        if project_dir is not None:
+            bases.append(project_dir.resolve())
+        for base in bases:
+            resolved = base / candidate
+            tried.append(resolved)
+            if resolved.exists():
+                return resolved, tried
+        return None, tried
+
     def _compose(self, inputs: dict[str, Any]) -> ToolResult:
         """FFmpeg composition: concat video cuts, add audio, burn subtitles.
 
@@ -461,6 +522,17 @@ class VideoCompose(BaseTool):
         # fit="cover" scales-to-fill and centre-crops (better for vertical social).
         resolution = "1920x1080"
         fit_mode = "pad"
+        # Output frame rate. 30 stays the default, so callers that say nothing
+        # get exactly what they got before. Every segment is normalized to this
+        # rate because the concat demuxer with `-c copy` requires identical fps
+        # across segments -- which is why this is one value for the whole
+        # composition rather than per-cut.
+        #
+        # It matters for sources that are not 30fps: a 64fps interpolated clip
+        # composed at 30 is silently decimated, and a 16fps generative clip is
+        # padded by uneven frame duplication (a 1.875 ratio), which reads as
+        # judder. Both look like a bad render rather than a wrong setting.
+        target_fps = 30
         compose_target = (edit_decisions.get("metadata") or {}).get("compose_target")
         if isinstance(compose_target, dict):
             try:
@@ -469,6 +541,18 @@ class VideoCompose(BaseTool):
                 pass
             if compose_target.get("fit") in ("pad", "cover"):
                 fit_mode = compose_target["fit"]
+            try:
+                requested_fps = int(compose_target["fps"])
+                if requested_fps > 0:
+                    target_fps = requested_fps
+            except (KeyError, ValueError, TypeError):
+                pass
+        try:
+            requested_fps = int(inputs["fps"])
+            if requested_fps > 0:
+                target_fps = requested_fps
+        except (KeyError, ValueError, TypeError):
+            pass
         if profile_name:
             try:
                 from lib.media_profiles import get_profile
@@ -508,9 +592,15 @@ class VideoCompose(BaseTool):
 
         try:
             for i, cut in enumerate(cuts):
-                source = Path(cut["source"])
-                if not source.exists():
-                    return ToolResult(success=False, error=f"Cut source not found: {source}")
+                source, tried = self._resolve_source(cut["source"], output_path)
+                if source is None:
+                    return ToolResult(
+                        success=False,
+                        error=(
+                            f"Cut source not found: {cut['source']}\n"
+                            "Tried, in order: " + ", ".join(str(t) for t in tried)
+                        ),
+                    )
 
                 seg_path = temp_dir / f"seg_{i:04d}.mp4"
                 in_s = cut["in_seconds"]
@@ -556,7 +646,7 @@ class VideoCompose(BaseTool):
                     # pix_fmt / sar across ALL segments — otherwise it throws
                     # "Non-monotonous DTS" or silently produces corrupt output.
                     #
-                    # Target is target_w x target_h @ 30fps, yuv420p, sar=1
+                    # Target is target_w x target_h @ target_fps, yuv420p, sar=1
                     # (default 1920x1080; overridable via `profile` or
                     # edit_decisions.metadata.compose_target — see above).
                     # fit="pad" letterboxes to preserve all content; fit="cover"
@@ -571,7 +661,7 @@ class VideoCompose(BaseTool):
                             f"scale={target_w}:{target_h}:force_original_aspect_ratio=decrease",
                             f"pad={target_w}:{target_h}:(ow-iw)/2:(oh-ih)/2:color=black",
                         ]
-                    vf_parts: list[str] = [*geom, "setsar=1", "fps=30"]
+                    vf_parts: list[str] = [*geom, "setsar=1", f"fps={target_fps}"]
                     af_parts: list[str] = []
                     if speed != 1.0:
                         vf_parts.append(f"setpts={1.0/speed}*PTS")
@@ -586,7 +676,7 @@ class VideoCompose(BaseTool):
                         "-crf", str(crf),
                         "-preset", preset,
                         "-pix_fmt", "yuv420p",
-                        "-r", "30",
+                        "-r", str(target_fps),
                     ])
 
                     # Audio handling: some source clips have no audio stream
@@ -621,7 +711,7 @@ class VideoCompose(BaseTool):
                             "-crf", str(crf),
                             "-preset", preset,
                             "-pix_fmt", "yuv420p",
-                            "-r", "30",
+                            "-r", str(target_fps),
                             "-c:a", "aac",
                             "-b:a", "192k",
                             "-ar", "48000",


### PR DESCRIPTION
## Summary

`video_compose`'s FFmpeg compose path documented two contracts and ignored both. Neither failure is loud: one produces a render that quietly looks worse than its inputs, the other produces an error that points at the wrong thing.

**Frame rate.** The per-segment filter chain hardcoded `fps=30` and `-r 30` in all three encode paths, so output was 30fps regardless of source or request. Interpolated 64fps footage is decimated back to half its frames, discarding smoothness that was just paid for; generative 16fps footage is padded by uneven frame duplication at a 1.875 ratio, which reads as judder rather than as a wrong setting.

**Asset paths.** `asset_manifest.schema.json` defines an asset `path` as a *"Relative path within the pipeline project directory"*, but cut sources were opened relative to the process CWD — so a manifest that followed the schema only worked when the caller happened to be running from inside the project directory. Callers worked around it by storing repo-relative paths instead, which then broke if the process ran from anywhere else.

## Related issue

Closes #528

## Changes

- `_compose` resolves an output frame rate the same way it already resolves the target resolution: `edit_decisions.metadata.compose_target.fps`, with a new `fps` input taking precedence. Defaults to 30, so callers that say nothing get exactly what they got before. It remains one value for the whole composition because concat with `-c copy` requires a consistent fps across segments.
- New `_resolve_source` / `_project_dir_for` helpers. Sources resolve against CWD first (existing behavior preserved), then the project directory inferred from `output_path` (`projects/<id>/renders/out.mp4` → `projects/<id>`). Absolute paths are used as given. A miss now reports every base that was tried.
- `fps` declared in the input schema.
- 13 tests, and the compose-director skill gains the two things an agent needs to know: state the frame rate when footage is not 30fps, and what an asset path is relative to.

### Notes for review

- **Two fixes in one PR.** They are separate defects, and I am happy to split them if you would prefer. I kept them together because they are the same shape — the compose path not honoring what the caller specified — they touch the same method, and they share a test file. Each is its own commit.
- **Backward compatibility is the design constraint.** The fps default stays 30 and CWD stays the first resolution base, so no existing caller changes behavior. Five of the thirteen tests assert exactly this and pass both before and after the fix; the other eight fail without it.
- **Invalid `fps` values fall back to 30** rather than erroring — `0`, negative numbers, non-numeric strings and `null` are covered by a parametrized test. A malformed artifact field should not produce a broken ffmpeg command.
- The Remotion and HyperFrames render paths are untouched; they take resolution from `profile` and are not affected by either issue.
- I did not change the 1920×1080 default. It is already overridable through `compose_target` on this path, so it is a default rather than a defect.

## Testing

- `make lint` — clean.
- `make test` — 1406 passed, 11 skipped (skips are the pre-existing opt-in/live/fixture-dependent ones).
- New tests verified against the unfixed code by stashing the fix: 8 fail, 5 pass (the backward-compatibility ones).
- Reproduced both defects on `main` before fixing, using ffmpeg `lavfi` fixtures rather than project media:
  - fps: source 64/1 → output `30/1`, `success=True`.
  - path: `Cut source not found: assets/video/shot1.mp4` — the exact layout the schema prescribes.
- After the fix, the same reproduction gives 64/1 output and a successful render.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [x] I updated docs/README if behavior or usage changed.
- [x] No unrelated files (build artifacts, local config) are included in the diff.
