### PR TITLE
fix(stock-sources): raise transport errors instead of reporting an empty search

### DIFF
--- a/tests/tools/test_stock_source_adapters.py
+++ b/tests/tools/test_stock_source_adapters.py
@@ -1,4 +1,9 @@
-from tools.video.stock_sources import all_sources
+import sys
+import types
+
+import pytest
+
+from tools.video.stock_sources import SearchFilters, all_sources, get_source
 from tools.video.stock_sources.unsplash import _build_download_url, _orientation_for_unsplash
 from tools.video.stock_sources.wikimedia import (
     _build_search_queries,
@@ -70,3 +75,147 @@ def test_unsplash_helpers_preserve_query_params():
     assert "ixid=abc" in url
     assert "w=1920" in url
     assert "fm=jpg" in url
+
+
+# ---------------------------------------------------------------------
+# Transport-error contract (issue #511)
+#
+# `base.StockSource.search` states the rule: "Network errors should be
+# raised — the corpus builder catches and logs per-source so one flaky
+# API doesn't poison the whole run." An adapter that swallows the error
+# and returns `[]` is indistinguishable from a source that genuinely has
+# nothing to offer, so `direct_clip_search` reports `success: True,
+# clips_downloaded: 0, errors: []` on a run where every request failed.
+#
+# The two tests below pin both halves of the contract across *every*
+# registered adapter, so a new source cannot quietly reintroduce the bug.
+# ---------------------------------------------------------------------
+
+# Adapters that gate on a key before they reach the network. Without
+# these the key-gated sources would return early and the test would
+# assert nothing.
+_SOURCE_CREDENTIALS = {
+    "COVERR_API_KEY": "test-coverr",
+    "NARA_API_KEY": "test-nara",
+    "NASA_API_KEY": "test-nasa",
+    "PEXELS_API_KEY": "test-pexels",
+    "PIXABAY_API_KEY": "test-pixabay",
+    "POND5_API_KEY": "test-pond5",
+    "UNSPLASH_ACCESS_KEY": "test-unsplash",
+    "VIDEVO_API_KEY": "test-videvo",
+}
+
+# Adapters that still swallow transport failures, recorded as known
+# defects rather than encoded as expected behavior. `strict=True` means
+# the suite fails the moment one of them is fixed and left in this map.
+_STILL_SWALLOWS_TRANSPORT_ERRORS = {
+    "archive_org": "#511 follow-up: query cascade continues past a failed strategy",
+    "wikimedia": "#511 follow-up: query cascade continues past a failed strategy",
+    "pond5_pd": "#511 follow-up: API failure falls through to the web fallback",
+}
+
+
+class TransportError(Exception):
+    """Distinct failure type so the assertion cannot pass by accident."""
+
+
+class _EmptyOkResponse:
+    """A genuine 200 that simply carries no results."""
+
+    status_code = 200
+    text = "<html><body></body></html>"
+    content = b""
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+
+class _EmptySoup:
+    """Stand-in for `BeautifulSoup`: parses anything, finds nothing."""
+
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    def select(self, *_args, **_kwargs):
+        return []
+
+    def select_one(self, *_args, **_kwargs):
+        return None
+
+    def find_all(self, *_args, **_kwargs):
+        return []
+
+    def find(self, *_args, **_kwargs):
+        return None
+
+
+def _install_fake_transport(monkeypatch, fake_get):
+    """Point every adapter's lazy `import requests` at `fake_get`.
+
+    `bs4` is stubbed alongside it: it is an optional dependency (the
+    scraping adapters report `is_available() is False` without it), and
+    they import it at the top of `search()`. Left alone, those adapters
+    would fail on the import rather than on the request, and the test
+    would pass for the wrong reason wherever bs4 is not installed.
+    """
+    requests_stub = types.ModuleType("requests")
+    requests_stub.get = fake_get
+    monkeypatch.setitem(sys.modules, "requests", requests_stub)
+
+    bs4_stub = types.ModuleType("bs4")
+    bs4_stub.BeautifulSoup = _EmptySoup
+    monkeypatch.setitem(sys.modules, "bs4", bs4_stub)
+
+    for var, value in _SOURCE_CREDENTIALS.items():
+        monkeypatch.setenv(var, value)
+
+
+def _adapter_names():
+    return [source.name for source in all_sources()]
+
+
+def _transport_error_params():
+    params = []
+    for name in _adapter_names():
+        reason = _STILL_SWALLOWS_TRANSPORT_ERRORS.get(name)
+        marks = [pytest.mark.xfail(strict=True, reason=reason)] if reason else []
+        params.append(pytest.param(name, marks=marks, id=name))
+    return params
+
+
+@pytest.mark.parametrize("source_name", _transport_error_params())
+def test_search_propagates_transport_errors(source_name, monkeypatch):
+    def boom(*_args, **_kwargs):
+        raise TransportError("simulated connection reset")
+
+    _install_fake_transport(monkeypatch, boom)
+
+    with pytest.raises(TransportError):
+        get_source(source_name).search(
+            "ocean waves", SearchFilters(kind="any", per_page=5)
+        )
+
+
+@pytest.mark.parametrize("source_name", _adapter_names(), ids=_adapter_names())
+def test_search_returns_empty_when_the_source_has_no_results(
+    source_name, monkeypatch
+):
+    # The other half of the contract: `[]` still has to mean "nothing
+    # matched". A 200 with an empty payload must not raise.
+    _install_fake_transport(monkeypatch, lambda *_a, **_k: _EmptyOkResponse())
+
+    assert (
+        get_source(source_name).search(
+            "ocean waves", SearchFilters(kind="any", per_page=5)
+        )
+        == []
+    )

--- a/tools/video/stock_sources/dareful.py
+++ b/tools/video/stock_sources/dareful.py
@@ -66,8 +66,10 @@ class DarefulSource:
             )
             r.raise_for_status()
         except Exception as e:
+            # Contract: an empty list means "nothing matched", so a
+            # transport failure has to propagate. See `base.StockSource`.
             _log.warning("Dareful search failed: %s", e)
-            return []
+            raise
 
         soup = BeautifulSoup(r.text, "html.parser")
         out: list[Candidate] = []

--- a/tools/video/stock_sources/esa.py
+++ b/tools/video/stock_sources/esa.py
@@ -73,8 +73,10 @@ class ESASource:
             )
             r.raise_for_status()
         except Exception as e:
+            # Contract: an empty list means "nothing matched", so a
+            # transport failure has to propagate. See `base.StockSource`.
             _log.warning("ESA search failed: %s", e)
-            return []
+            raise
 
         soup = BeautifulSoup(r.text, "html.parser")
         out: list[Candidate] = []

--- a/tools/video/stock_sources/jaxa.py
+++ b/tools/video/stock_sources/jaxa.py
@@ -76,8 +76,10 @@ class JAXASource:
             )
             r.raise_for_status()
         except Exception as e:
+            # Contract: an empty list means "nothing matched", so a
+            # transport failure has to propagate. See `base.StockSource`.
             _log.warning("JAXA search failed: %s", e)
-            return []
+            raise
 
         soup = BeautifulSoup(r.text, "html.parser")
         out: list[Candidate] = []

--- a/tools/video/stock_sources/loc.py
+++ b/tools/video/stock_sources/loc.py
@@ -83,8 +83,10 @@ class LibraryOfCongressSource:
             r.raise_for_status()
             data = r.json()
         except Exception as e:
+            # Contract: an empty list means "nothing matched", so a
+            # transport failure has to propagate. See `base.StockSource`.
             _log.warning("Library of Congress search failed: %s", e)
-            return []
+            raise
 
         results = data.get("results", []) or []
         out: list[Candidate] = []

--- a/tools/video/stock_sources/mixkit.py
+++ b/tools/video/stock_sources/mixkit.py
@@ -69,8 +69,10 @@ class MixkitSource:
             )
             r.raise_for_status()
         except Exception as e:
+            # Contract: an empty list means "nothing matched", so a
+            # transport failure has to propagate. See `base.StockSource`.
             _log.warning("Mixkit search failed: %s", e)
-            return []
+            raise
 
         soup = BeautifulSoup(r.text, "html.parser")
         out: list[Candidate] = []

--- a/tools/video/stock_sources/nara.py
+++ b/tools/video/stock_sources/nara.py
@@ -86,8 +86,10 @@ class NARASource:
             r.raise_for_status()
             data = r.json()
         except Exception as e:
+            # Contract: an empty list means "nothing matched", so a
+            # transport failure has to propagate. See `base.StockSource`.
             _log.warning("NARA search failed: %s", e)
-            return []
+            raise
 
         results = data.get("results", []) or []
         out: list[Candidate] = []

--- a/tools/video/stock_sources/noaa.py
+++ b/tools/video/stock_sources/noaa.py
@@ -119,7 +119,10 @@ class NOAASource:
                 )
 
         except Exception as e:
+            # Contract: an empty list means "nothing matched", so a
+            # transport failure has to propagate. See `base.StockSource`.
             _log.warning("NOAA search failed: %s", e)
+            raise
 
         return out
 

--- a/tools/video/stock_sources/videvo.py
+++ b/tools/video/stock_sources/videvo.py
@@ -83,8 +83,10 @@ class VidevoSource:
             r.raise_for_status()
             data = r.json()
         except Exception as e:
+            # Contract: an empty list means "nothing matched", so a
+            # transport failure has to propagate. See `base.StockSource`.
             _log.warning("Videvo search failed: %s", e)
-            return []
+            raise
 
         hits = data.get("data", []) or data.get("results", []) or data.get("clips", []) or []
         out: list[Candidate] = []


### PR DESCRIPTION
## Summary

Eight stock source adapters wrap their search request in `except Exception`, log a warning, and return `[]`. But `[]` is also what a source returns when it genuinely matched nothing, so the caller cannot tell the two apart — `direct_clip_search` ends up reporting `success: True, clips_downloaded: 0, errors: []` for a run in which every request failed. That is the symptom in #511.

`base.StockSource.search` already states the rule they violate, and has since the protocol was written:

> Returns a flat list of `Candidate` objects [...] An empty list is legal (and common for niche queries). **Network errors should be raised — the corpus builder catches and logs per-source so one flaky API doesn't poison the whole run.**

Both callers already hold up their end: `direct_clip_search` and `corpus_builder` each wrap `src.search(...)` in a `try` that records `{phase, source, query, error}` and continues to the next source. The plumbing to receive the truth is already there; the adapters just never send it.

This is the first of two PRs. It fixes 8 of the 11 offending adapters and lands the contract test. The remaining three (`archive_org`, `wikimedia`, `pond5_pd`) swallow errors through a different shape — a query cascade and an API-to-web fallback — and need a different fix, so they are marked `xfail(strict=True)` here and handled in #531.

## Related issue

Refs #511

Not `Closes` — this PR does not finish the issue. #531 does.

## Changes

- **8 adapters re-raise after logging**: `dareful`, `esa`, `jaxa`, `loc`, `mixkit`, `nara`, `noaa`, `videvo`. Seven are the same two-line edit. `noaa` differs slightly — its `try` wraps the parse loop as well as the request and fell through to `return out`, so it gets a `raise` after the warning.
- The `_log.warning` is kept in all eight. It names the source in the adapter's own words, which the caller's generic error record does not.
- **New parametrized contract test** over `all_sources()`, so the rule is asserted for all 16 registered adapters rather than the 8 that happened to be wrong — a new source cannot quietly reintroduce this.
- Five adapters (`coverr`, `nasa`, `pexels`, `pixabay_video`, `unsplash`) already had no handler and were correct. They are covered by the new test, unchanged.

### ⚠️ This is a user-visible behavior change

**A run where the transport failed for every source previously reported success with zero clips. It will now surface errors.** That is the point of #511, but it changes what users see on a bad network day or when an upstream API is down, so it is worth your opinion. Nothing about a *successful* run changes — an empty result set still returns `[]` and still reports success.

## Testing

Both halves of the contract are pinned, because fixing only the first would let an adapter "pass" by raising on everything, which would break the empty-result case the corpus builder depends on:

- `test_search_propagates_transport_errors` — `requests.get` raises a distinct `TransportError`; every adapter must let it out.
- `test_search_returns_empty_when_the_source_has_no_results` — a genuine 200 with an empty payload must still return `[]`.

Results:

- Against the unfixed adapters, exactly 8 propagation cases fail and the 3 `xfail`s hold.
- With the fix: `make test` → `1422 passed, 11 skipped, 3 xfailed`, against a stashed baseline of `1393 passed, 11 skipped` on the same branch — +29 passing and +3 xfailed, which is the 32 new cases exactly.
- `make test-contracts` → `845 passed, 7 skipped`.
- `make lint` clean.

Two test details worth a look during review:

- `requests` and `bs4` are stubbed via `sys.modules`, following the fake-`requests` pattern in `tests/tools/test_atlas_video.py`. **bs4 is stubbed on purpose**: it is an optional dependency (it appears in no requirements file, and the five scraping adapters report `is_available() is False` without it) that they import at the *top* of `search()`, before the request. Left alone, those five would fail on the `ImportError` rather than on the transport and pass for the wrong reason anywhere bs4 is absent — including CI.
- The test sets the eight provider API-key env vars, because the key-gated adapters return early before issuing any request and would otherwise assert nothing.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable. — both, plus `make lint`; results above.
- [x] I updated docs/README if behavior or usage changed. — the contract lives in the `base.StockSource.search` docstring and already said errors should raise, so no doc contradicted this change; the eight adapter docstrings/comments were updated to cite it. Say the word if you'd like the documentary-montage asset-director skill to call out the new distinction between "the source errored" and "the source has nothing" — its fallback guidance currently treats both as "empty".
- [x] No unrelated files (build artifacts, local config) are included in the diff. — 9 files: 8 adapters and one test file.
