### PR TITLE
fix(stock-sources): raise from the query cascades and the pond5 fallback

### DIFF
--- a/tests/tools/test_stock_source_adapters.py
+++ b/tests/tools/test_stock_source_adapters.py
@@ -4,6 +4,7 @@ import types
 import pytest
 
 from tools.video.stock_sources import SearchFilters, all_sources, get_source
+from tools.video.stock_sources.archive_org import _METADATA_URL
 from tools.video.stock_sources.unsplash import _build_download_url, _orientation_for_unsplash
 from tools.video.stock_sources.wikimedia import (
     _build_search_queries,
@@ -105,32 +106,26 @@ _SOURCE_CREDENTIALS = {
     "VIDEVO_API_KEY": "test-videvo",
 }
 
-# Adapters that still swallow transport failures, recorded as known
-# defects rather than encoded as expected behavior. `strict=True` means
-# the suite fails the moment one of them is fixed and left in this map.
-_STILL_SWALLOWS_TRANSPORT_ERRORS = {
-    "archive_org": "#511 follow-up: query cascade continues past a failed strategy",
-    "wikimedia": "#511 follow-up: query cascade continues past a failed strategy",
-    "pond5_pd": "#511 follow-up: API failure falls through to the web fallback",
-}
-
 
 class TransportError(Exception):
     """Distinct failure type so the assertion cannot pass by accident."""
 
 
-class _EmptyOkResponse:
-    """A genuine 200 that simply carries no results."""
+class _OkResponse:
+    """A genuine 200 carrying `payload` (empty by default)."""
 
     status_code = 200
-    text = "<html><body></body></html>"
     content = b""
+
+    def __init__(self, payload=None, text="<html><body></body></html>"):
+        self._payload = payload if payload is not None else {}
+        self.text = text
 
     def raise_for_status(self):
         return None
 
     def json(self):
-        return {}
+        return self._payload
 
     def __enter__(self):
         return self
@@ -183,16 +178,7 @@ def _adapter_names():
     return [source.name for source in all_sources()]
 
 
-def _transport_error_params():
-    params = []
-    for name in _adapter_names():
-        reason = _STILL_SWALLOWS_TRANSPORT_ERRORS.get(name)
-        marks = [pytest.mark.xfail(strict=True, reason=reason)] if reason else []
-        params.append(pytest.param(name, marks=marks, id=name))
-    return params
-
-
-@pytest.mark.parametrize("source_name", _transport_error_params())
+@pytest.mark.parametrize("source_name", _adapter_names(), ids=_adapter_names())
 def test_search_propagates_transport_errors(source_name, monkeypatch):
     def boom(*_args, **_kwargs):
         raise TransportError("simulated connection reset")
@@ -211,7 +197,7 @@ def test_search_returns_empty_when_the_source_has_no_results(
 ):
     # The other half of the contract: `[]` still has to mean "nothing
     # matched". A 200 with an empty payload must not raise.
-    _install_fake_transport(monkeypatch, lambda *_a, **_k: _EmptyOkResponse())
+    _install_fake_transport(monkeypatch, lambda *_a, **_k: _OkResponse())
 
     assert (
         get_source(source_name).search(
@@ -219,3 +205,161 @@ def test_search_returns_empty_when_the_source_has_no_results(
         )
         == []
     )
+
+
+# ---------------------------------------------------------------------
+# Cascade and fallback semantics (issue #511, second half)
+#
+# `archive_org` and `wikimedia` walk a query cascade, and `pond5_pd`
+# falls back from its API to a web scraper. All three are *designed* to
+# absorb a failure and keep going, which is why they could not take the
+# plain re-raise the other eight got. The rule they follow instead: a
+# partial failure is fine, but returning `[]` means the source itself
+# said "nothing" — so it requires having actually heard that.
+# ---------------------------------------------------------------------
+
+_ARCHIVE_DOC = {
+    "identifier": "ocean-waves",
+    "title": "Ocean waves",
+    "description": "Waves breaking on a shore",
+    "collection": "prelinger",
+}
+
+_ARCHIVE_METADATA = {
+    "files": [
+        {
+            "format": "h.264",
+            "name": "ocean-waves.mp4",
+            "size": str(8 * 1024 * 1024),
+            "length": "12.0",
+            "width": "1920",
+            "height": "1080",
+        }
+    ]
+}
+
+_WIKIMEDIA_PAGE = {
+    "pageid": 42,
+    "index": 1,
+    "title": "File:Ocean waves.webm",
+    "canonicalurl": "https://commons.wikimedia.org/wiki/File:Ocean_waves.webm",
+    "imageinfo": [
+        {
+            "mime": "video/webm",
+            "width": 1920,
+            "height": 1080,
+            "duration": 12.0,
+            "url": "https://upload.wikimedia.org/ocean-waves.webm",
+            "descriptionurl": "https://commons.wikimedia.org/wiki/File:Ocean_waves.webm",
+            "extmetadata": {},
+        }
+    ],
+}
+
+
+def test_archive_org_cascade_survives_one_failed_strategy(monkeypatch):
+    # The cascade exists precisely so a weak strategy can be skipped.
+    # A failed one must not become an error as long as a later strategy
+    # gets an answer.
+    searches = []
+
+    def fake_get(url, **_kwargs):
+        if url.startswith(_METADATA_URL):
+            return _OkResponse(_ARCHIVE_METADATA)
+        searches.append(url)
+        if len(searches) == 1:
+            raise TransportError("first strategy died")
+        return _OkResponse({"response": {"docs": [_ARCHIVE_DOC]}})
+
+    _install_fake_transport(monkeypatch, fake_get)
+
+    out = get_source("archive_org").search(
+        "ocean waves", SearchFilters(kind="video", per_page=5)
+    )
+
+    assert [c.source_id for c in out] == ["ocean-waves"]
+    assert len(searches) == 2
+
+
+def test_wikimedia_cascade_survives_one_failed_strategy(monkeypatch):
+    calls = []
+
+    def fake_get(url, **_kwargs):
+        calls.append(url)
+        if len(calls) == 1:
+            raise TransportError("first strategy died")
+        return _OkResponse({"query": {"pages": {"42": _WIKIMEDIA_PAGE}}})
+
+    _install_fake_transport(monkeypatch, fake_get)
+
+    out = get_source("wikimedia").search(
+        "ocean waves", SearchFilters(kind="video", per_page=5)
+    )
+
+    assert [c.source_id for c in out] == ["42"]
+    assert len(calls) == 2
+
+
+def test_archive_org_raises_when_every_item_fetch_fails(monkeypatch):
+    # The search request lands, so the cascade knows the query matched
+    # items — it just can't hydrate any of them. `[]` here would claim
+    # Archive.org has nothing, which is the opposite of what happened.
+    def fake_get(url, **_kwargs):
+        if url.startswith(_METADATA_URL):
+            raise TransportError("metadata endpoint down")
+        return _OkResponse({"response": {"docs": [_ARCHIVE_DOC]}})
+
+    _install_fake_transport(monkeypatch, fake_get)
+
+    with pytest.raises(TransportError):
+        get_source("archive_org").search(
+            "ocean waves", SearchFilters(kind="video", per_page=5)
+        )
+
+
+def test_archive_org_returns_empty_when_no_item_has_a_usable_file(monkeypatch):
+    # Every request lands and every item is inspected — the items just
+    # hold nothing playable. That is a real answer, so it stays `[]`.
+    def fake_get(url, **_kwargs):
+        if url.startswith(_METADATA_URL):
+            return _OkResponse({"files": [{"format": "JPEG", "name": "cover.jpg"}]})
+        return _OkResponse({"response": {"docs": [_ARCHIVE_DOC]}})
+
+    _install_fake_transport(monkeypatch, fake_get)
+
+    assert (
+        get_source("archive_org").search(
+            "ocean waves", SearchFilters(kind="video", per_page=5)
+        )
+        == []
+    )
+
+
+def test_pond5_raises_when_the_web_fallback_cannot_run(monkeypatch):
+    def boom(*_args, **_kwargs):
+        raise TransportError("pond5 api down")
+
+    _install_fake_transport(monkeypatch, boom)
+    source = get_source("pond5_pd")
+
+    # The fallback is still a stub, so it reports that it could not run
+    # and the API's error is what the caller has to see.
+    assert source._search_web_fallback("ocean waves", "video", SearchFilters()) is None
+    with pytest.raises(TransportError):
+        source.search("ocean waves", SearchFilters(kind="video", per_page=5))
+
+
+def test_pond5_stays_quiet_when_the_web_fallback_can_run(monkeypatch):
+    # The other half of "raise only when both paths fail": once the
+    # fallback is implemented, an API outage it covers for is not an
+    # error the caller needs to hear about.
+    def boom(*_args, **_kwargs):
+        raise TransportError("pond5 api down")
+
+    _install_fake_transport(monkeypatch, boom)
+    source = get_source("pond5_pd")
+    monkeypatch.setattr(
+        type(source), "_search_web_fallback", lambda *_a, **_k: []
+    )
+
+    assert source.search("ocean waves", SearchFilters(kind="video", per_page=5)) == []

--- a/tools/video/stock_sources/archive_org.py
+++ b/tools/video/stock_sources/archive_org.py
@@ -134,12 +134,23 @@ class ArchiveOrgSource:
         why a cascade is needed — pure OR-join is too noisy, pure
         phrase-proximity is too strict, no single strategy wins across
         the documentary query space.
+
+        An individual strategy is allowed to fail — that is what the
+        cascade is for. But `[]` is the answer for "Archive.org has
+        nothing", so returning it requires having actually heard that
+        from the API. If nothing in this call got an answer, the last
+        error is raised instead. See `base.StockSource`.
         """
         kind = (filters.kind or "video").lower()
         if kind not in ("video", "any"):
             return []
 
         import requests  # lazy
+
+        # True once a strategy has run end to end without erroring —
+        # the one thing that makes an empty return honest.
+        answered = False
+        last_error: Optional[Exception] = None
 
         for _label, solr_q in self._build_queries(query):
             params = [
@@ -161,21 +172,38 @@ class ArchiveOrgSource:
                 r = requests.get(_SEARCH_URL, params=params, timeout=30)
                 r.raise_for_status()
                 data = r.json()
-            except Exception:
+            except Exception as e:
                 # One strategy's network/parse error shouldn't kill the
                 # whole cascade — try the next one.
+                last_error = e
                 continue
             docs = (data.get("response") or {}).get("docs", []) or []
             if not docs:
+                answered = True
                 continue
 
             out: list[Candidate] = []
+            hydrate_failed = False
             for doc in docs:
-                cand = self._hydrate_candidate(doc, filters)
+                try:
+                    cand = self._hydrate_candidate(doc, filters)
+                except Exception as e:
+                    # One bad item shouldn't poison the strategy, but it
+                    # also isn't evidence that the item was unusable.
+                    hydrate_failed = True
+                    last_error = e
+                    continue
                 if cand is not None:
                     out.append(cand)
             if out:
                 return out
+            if not hydrate_failed:
+                # Every doc was inspected and none was usable — the
+                # strategy completed, it just found nothing.
+                answered = True
+
+        if not answered and last_error is not None:
+            raise last_error
 
         return []
 
@@ -322,16 +350,13 @@ class ArchiveOrgSource:
         if not identifier:
             return None
 
-        try:
-            r = requests.get(f"{_METADATA_URL}/{identifier}", timeout=30)
-            r.raise_for_status()
-            meta = r.json()
-        except Exception:
-            # Swallow per-item fetch failures — one bad item shouldn't
-            # poison the whole search. Alternative would be to raise and
-            # have corpus_builder catch per-source, but at this layer we
-            # can keep going.
-            return None
+        # Per-item fetch failures propagate. `search()` tolerates them
+        # one at a time — one bad item shouldn't poison the whole
+        # search — but it needs to tell them apart from "this item has
+        # no usable files", which is what `None` means here.
+        r = requests.get(f"{_METADATA_URL}/{identifier}", timeout=30)
+        r.raise_for_status()
+        meta = r.json()
 
         files = meta.get("files") or []
         picked = _pick_video_file(files)

--- a/tools/video/stock_sources/pond5_pd.py
+++ b/tools/video/stock_sources/pond5_pd.py
@@ -92,7 +92,14 @@ class Pond5PublicDomainSource:
             data = r.json()
         except Exception as e:
             _log.warning("Pond5 PD search failed (API), trying web fallback: %s", e)
-            return self._search_web_fallback(query, kind, filters)
+            fallback = self._search_web_fallback(query, kind, filters)
+            if fallback is None:
+                # Both paths are dead: the API errored and the web
+                # fallback has nothing to offer. `[]` would read as
+                # "Pond5 has nothing", so surface the API error
+                # instead. See `base.StockSource`.
+                raise
+            return fallback
 
         results = data.get("results", []) or data.get("items", []) or []
         return self._parse_results(results, kind, filters)
@@ -162,14 +169,20 @@ class Pond5PublicDomainSource:
 
     def _search_web_fallback(
         self, query: str, kind: str, filters: SearchFilters
-    ) -> list[Candidate]:
+    ) -> list[Candidate] | None:
         """Fallback: parse Pond5 free page HTML for public domain clips.
 
         Used when the API endpoint is unavailable or returns errors.
-        Returns empty list if HTML parsing fails — does not raise.
+
+        Returns `None` when the fallback could not run at all, which
+        tells `search()` to surface the API error it was standing in
+        for. A list — including an empty one — means the fallback did
+        run and this is Pond5's answer.
+
+        Not implemented yet, so today it always returns `None`.
         """
-        _log.info("Pond5 PD: web fallback not implemented, returning empty")
-        return []
+        _log.info("Pond5 PD: web fallback not implemented")
+        return None
 
     def download(self, candidate: Candidate, out_path: Path) -> Path:
         import requests

--- a/tools/video/stock_sources/wikimedia.py
+++ b/tools/video/stock_sources/wikimedia.py
@@ -64,8 +64,19 @@ class WikimediaSource:
         The cascade (see ``_build_search_queries``) tries strict first,
         then narrows to 2 distinctive tokens, then to 1 — returning the
         first non-empty video result set.
+
+        An individual strategy is allowed to fail — that is what the
+        cascade is for. But `[]` is the answer for "Commons has
+        nothing", so returning it requires having actually heard that
+        from the API. If no strategy got an answer, the last error is
+        raised instead. See `base.StockSource`.
         """
         import requests  # lazy
+
+        # True once a strategy has run end to end without erroring —
+        # the one thing that makes an empty return honest.
+        answered = False
+        last_error: Exception | None = None
 
         for _label, search_text in _build_search_queries(query, filters.kind):
             params = {
@@ -91,8 +102,11 @@ class WikimediaSource:
                 )
                 r.raise_for_status()
                 data = r.json()
-            except Exception:
+            except Exception as e:
+                last_error = e
                 continue
+
+            answered = True
             pages = list(((data.get("query") or {}).get("pages") or {}).values())
             if not pages:
                 continue
@@ -105,6 +119,9 @@ class WikimediaSource:
                     out.append(cand)
             if out:
                 return out
+
+        if not answered and last_error is not None:
+            raise last_error
 
         return []
 


### PR DESCRIPTION
## Summary

The remaining three adapters from #511. The eight in #530 took a plain re-raise; these three could not, because all of them are *designed* to absorb a failure and keep going:

| Adapter | Shape |
|---|---|
| `archive_org`, `wikimedia` | a query cascade that walks strategies until one produces results, skipping any that error |
| `pond5_pd` | an API call that falls back to a web scraper when it fails |

Making them raise on the first error would have deleted the resilience they were built for. The rule they follow instead:

> A partial failure is fine. But `[]` is the answer for "this source has nothing", so returning it requires having actually heard that from the source.

**Rebased onto `main` now that #530 has landed — this branch is self-contained.** The diff is 4 files and 2 commits: `fix(stock-sources): raise from the cascades and the pond5 fallback` and `test(stock-sources): cover the cascade and fallback semantics`. It was originally stacked on #530 because its test commit deletes the `xfail(strict=True)` map that #530 introduced; with #530 in `main` that map is simply there to delete, so no stacking is needed.

## Related issue

Refs #511

Together with #530 this covers all 11 adapters the issue describes. Merging both closes it.

## Changes

- **`archive_org`, `wikimedia` — cascades.** Both now track whether any strategy ran end to end without erroring (`answered`). A failed strategy is still skipped exactly as before. If none of them got through, the last error is raised instead of being reported as an empty result set.
- **`archive_org` — stage 2.** Not in the issue's original sweep and worth a look. `_hydrate_candidate` swallowed its per-item metadata fetch failure and returned `None` — which is also what it returns for "this item has no usable files". So a search whose first request landed and whose every item fetch then failed still reported an empty search: the same defect as #511, one stage later. The fetch now propagates and `search()` catches it per item, so one bad item still doesn't poison the strategy, but a strategy that hydrated nothing *and* saw failures no longer counts as an answer.
- **`pond5_pd` — fallback.** `_search_web_fallback` now returns `None` for "could not run", as distinct from `[]` for "ran, found nothing", and `search()` re-raises the API error when the fallback has nothing to offer. The fallback is still an unimplemented stub, so in practice an API failure always surfaces today; once someone implements it, an outage it genuinely covers for correctly stays quiet. Happy to swap the sentinel for an exception if you'd rather the fallback signal failure that way.
- The three `xfail(strict=True)` entries from #530 are gone, so all 16 adapters now pass its parametrized contract pair with no exceptions carved out.

### ⚠️ Same user-visible behavior change as #530

**Runs that previously reported success with zero clips will now surface errors.** Successful runs are unchanged — an empty result set still returns `[]` and still reports success.

## Testing

Six new tests. Three fail against the unfixed adapters:

- `archive_org` raises when every item fetch fails
- `pond5_pd` raises when the web fallback cannot run
- plus the two cascade adapters and `pond5_pd` in #530's parametrized propagation test

The other three pin behavior that had to survive the change and pass both before and after, which is the point:

- both cascades still absorb a failed strategy when a later one gets an answer
- `archive_org` still returns `[]` when every item was inspected and none held a playable file
- `pond5_pd` stays quiet when the fallback can run — standing in for the fallback once it exists

`_EmptyOkResponse` becomes `_OkResponse(payload)` so a test can hand back a real search or metadata body. The empty-result case is the default and is unchanged.

Results:

- Against the unfixed adapters, 5 of the unmarked cases fail; with the fix the file is `44 passed`, no xfails.
- `make test` → `1431 passed, 11 skipped`, up from `1425` on #530's branch — the 3 former xfails now pass, plus 6 new tests.
- `make test-contracts` → `845 passed, 7 skipped`.
- `make lint` clean.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable. — both, plus `make lint`; results above.
- [x] I updated docs/README if behavior or usage changed. — the contract lives in the `base.StockSource.search` docstring and already said errors should raise; the `search()` docstrings of both cascade adapters and the `_search_web_fallback` docstring were updated to spell out the new rule. No user-facing doc described the old behavior.
- [x] No unrelated files (build artifacts, local config) are included in the diff. — 4 files: 3 adapters and one test file.