### PR TITLE
feat(pipeline): validate manifest semantics

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -63,7 +63,7 @@ Each tool's `agent_skills[]` field bridges Layer 1 → Layer 3. See `skills/INDE
 | `config.yaml` | Global configuration |
 | `lib/config_model.py` | Runtime config loader (Pydantic) |
 | `lib/checkpoint.py` | Checkpoint writer/reader |
-| `lib/pipeline_loader.py` | Pipeline manifest loader + helpers |
+| `lib/pipeline_loader.py` | Pipeline manifest loader, schema + semantic validation, and helpers |
 | `lib/media_profiles.py` | Platform-specific render profiles |
 | `styles/playbook_loader.py` | Style playbook loader + validator + design intelligence (color/type/a11y) |
 | `tools/base_tool.py` | ToolContract base class |

--- a/lib/pipeline_loader.py
+++ b/lib/pipeline_loader.py
@@ -6,12 +6,15 @@ Loads and validates pipeline YAML manifests from pipeline_defs/.
 from __future__ import annotations
 
 import json
+from collections import Counter
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Optional
 
 import yaml
 import jsonschema
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
 PIPELINE_DEFS_DIR = Path(__file__).resolve().parent.parent / "pipeline_defs"
 SCHEMA_PATH = (
     Path(__file__).resolve().parent.parent
@@ -21,8 +24,16 @@ SCHEMA_PATH = (
 )
 
 
-from functools import lru_cache
+class PipelineSemanticError(ValueError):
+    """Raised when a schema-valid pipeline contains contradictory references."""
 
+    def __init__(self, pipeline_name: str, errors: list[str]) -> None:
+        self.pipeline_name = pipeline_name
+        self.errors = tuple(errors)
+        details = "\n".join(f"- {error}" for error in errors)
+        super().__init__(
+            f"Pipeline {pipeline_name!r} failed semantic validation:\n{details}"
+        )
 
 @lru_cache(maxsize=1)
 def _load_manifest_schema() -> dict:
@@ -66,8 +77,109 @@ def load_pipeline(name: str, defs_dir: Optional[Path] = None) -> dict[str, Any]:
 
     schema = _load_manifest_schema()
     jsonschema.validate(instance=manifest, schema=schema)
+    _validate_pipeline_semantics(
+        manifest,
+        repo_root=defs_dir.parent if defs_dir != PIPELINE_DEFS_DIR else REPO_ROOT,
+    )
 
     return manifest
+
+
+def _validate_pipeline_semantics(
+    manifest: dict[str, Any],
+    *,
+    repo_root: Path,
+) -> None:
+    """Validate cross-field invariants that JSON Schema cannot express.
+
+    The pipeline loader is the seam for manifest correctness, so callers get
+    structural and semantic validation from the same unchanged interface.
+    """
+    errors: list[str] = []
+    stages = manifest["stages"]
+    stage_names = [stage["name"] for stage in stages]
+
+    for stage_name, count in sorted(Counter(stage_names).items()):
+        if count < 2:
+            continue
+        errors.append(f"duplicate stage name: {stage_name}")
+
+    artifact_owners: dict[str, list[tuple[int, str]]] = {}
+    for index, stage in enumerate(stages):
+        sub_stage_names = [sub_stage["name"] for sub_stage in stage.get("sub_stages", [])]
+        for sub_stage_name, count in sorted(Counter(sub_stage_names).items()):
+            if count < 2:
+                continue
+            errors.append(
+                f"stage {stage['name']!r} has duplicate sub-stage name: {sub_stage_name}"
+            )
+
+        for artifact in stage.get("produces", []):
+            artifact_owners.setdefault(artifact, []).append((index, stage["name"]))
+
+    for artifact, owners in sorted(artifact_owners.items()):
+        if len(owners) > 1:
+            owner_names = ", ".join(owner_name for _, owner_name in owners)
+            errors.append(
+                f"artifact {artifact!r} has multiple producing stages: {owner_names}"
+            )
+
+    for index, stage in enumerate(stages):
+        for artifact in stage.get("required_artifacts_in", []):
+            invalid_owners = [
+                owner_name
+                for owner_index, owner_name in artifact_owners.get(artifact, [])
+                if owner_index >= index
+            ]
+            if invalid_owners:
+                errors.append(
+                    f"stage {stage['name']!r} requires artifact {artifact!r} before "
+                    f"its producer: {', '.join(invalid_owners)}"
+                )
+
+        tools_available = set(stage.get("tools_available", []))
+        for tool_field in ("required_tools", "optional_tools"):
+            missing_tools = sorted(set(stage.get(tool_field, [])) - tools_available)
+            if missing_tools:
+                errors.append(
+                    f"stage {stage['name']!r} lists {', '.join(missing_tools)} in "
+                    f"{tool_field} but not tools_available"
+                )
+
+    declared_skills = set(manifest.get("required_skills", []))
+    referenced_skills = {
+        stage["skill"] for stage in stages if stage.get("skill")
+    }
+    orchestration_skill = manifest.get("orchestration", {}).get("skill")
+    if orchestration_skill:
+        referenced_skills.add(orchestration_skill)
+
+    for skill in sorted(referenced_skills - declared_skills):
+        errors.append(f"referenced skill {skill!r} is not listed in required_skills")
+
+    for skill in sorted(declared_skills | referenced_skills):
+        skill_path = Path(skill)
+        if skill_path.suffix != ".md":
+            skill_path = skill_path.with_suffix(".md")
+        if not (repo_root / "skills" / skill_path).is_file():
+            errors.append(f"skill path does not exist: skills/{skill_path.as_posix()}")
+
+    artifact_names = {
+        artifact
+        for stage in stages
+        for field in ("required_artifacts_in", "optional_artifacts_in", "produces")
+        for artifact in stage.get(field, [])
+    }
+    for artifact in sorted(artifact_names):
+        schema_path = repo_root / "schemas" / "artifacts" / f"{artifact}.schema.json"
+        if not schema_path.is_file():
+            errors.append(
+                f"artifact {artifact!r} has no schema at "
+                f"schemas/artifacts/{artifact}.schema.json"
+            )
+
+    if errors:
+        raise PipelineSemanticError(manifest.get("name", "unknown"), errors)
 
 
 def list_pipelines(defs_dir: Optional[Path] = None) -> list[str]:

--- a/pipeline_defs/screen-demo.yaml
+++ b/pipeline_defs/screen-demo.yaml
@@ -107,6 +107,7 @@ stages:
     tools_available:
       - transcriber
       - scene_detect
+      - audio_enhance
     checkpoint_required: true
     human_approval_default: true
     review_focus:

--- a/schemas/pipelines/pipeline_manifest.schema.json
+++ b/schemas/pipelines/pipeline_manifest.schema.json
@@ -131,6 +131,24 @@
         "analysis_tools": { "type": "array", "items": { "type": "string" } }
       }
     },
+    "production_modes": {
+      "type": "array",
+      "description": "Alternative production paths that the idea stage may select.",
+      "items": {
+        "type": "object",
+        "required": ["name", "description", "required_tools", "best_for"],
+        "properties": {
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "required_tools": { "type": "array", "items": { "type": "string" } },
+          "optional_tools": { "type": "array", "items": { "type": "string" } },
+          "scene_type": { "type": "string" },
+          "agent_skills": { "type": "array", "items": { "type": "string" } },
+          "best_for": { "type": "array", "items": { "type": "string" } }
+        },
+        "additionalProperties": false
+      }
+    },
     "metadata": { "type": "object" },
     "orchestration": {
       "type": "object",

--- a/tests/contracts/test_pipeline_semantic_validation.py
+++ b/tests/contracts/test_pipeline_semantic_validation.py
@@ -1,0 +1,158 @@
+"""Semantic contracts for declarative pipeline manifests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from lib.pipeline_loader import PipelineSemanticError, list_pipelines, load_pipeline
+
+
+def _write_pipeline_repo(
+    tmp_path: Path,
+    *,
+    stages: list[dict],
+    required_skills: list[str] | None = None,
+) -> Path:
+    """Create the smallest repository layout accepted by load_pipeline."""
+    required_skills = required_skills or ["pipelines/test/director"]
+    defs_dir = tmp_path / "pipeline_defs"
+    defs_dir.mkdir()
+
+    for skill in required_skills:
+        skill_path = tmp_path / "skills" / Path(skill).with_suffix(".md")
+        skill_path.parent.mkdir(parents=True, exist_ok=True)
+        skill_path.write_text("# Test skill\n", encoding="utf-8")
+
+    artifact_names = {
+        artifact
+        for stage in stages
+        for field in ("required_artifacts_in", "optional_artifacts_in", "produces")
+        for artifact in stage.get(field, [])
+    }
+    schema_dir = tmp_path / "schemas" / "artifacts"
+    schema_dir.mkdir(parents=True)
+    for artifact in artifact_names:
+        (schema_dir / f"{artifact}.schema.json").write_text(
+            json.dumps({"type": "object"}),
+            encoding="utf-8",
+        )
+
+    manifest = {
+        "name": "test-pipeline",
+        "version": "1.0",
+        "required_skills": required_skills,
+        "stages": stages,
+    }
+    (defs_dir / "test-pipeline.yaml").write_text(
+        yaml.safe_dump(manifest, sort_keys=False),
+        encoding="utf-8",
+    )
+    return defs_dir
+
+
+def _valid_stages() -> list[dict]:
+    return [
+        {
+            "name": "script",
+            "skill": "pipelines/test/director",
+            "produces": ["script"],
+            "required_tools": ["writer"],
+            "tools_available": ["writer"],
+        },
+        {
+            "name": "compose",
+            "skill": "pipelines/test/director",
+            "required_artifacts_in": ["script"],
+            "produces": ["render_report"],
+            "tools_available": [],
+        },
+    ]
+
+
+def test_all_repository_pipeline_manifests_are_semantically_valid() -> None:
+    for pipeline_name in list_pipelines():
+        load_pipeline(pipeline_name)
+
+
+def test_load_pipeline_accepts_consistent_cross_references(tmp_path: Path) -> None:
+    defs_dir = _write_pipeline_repo(tmp_path, stages=_valid_stages())
+
+    manifest = load_pipeline("test-pipeline", defs_dir)
+
+    assert manifest["name"] == "test-pipeline"
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected_error"),
+    [
+        (
+            lambda stages: stages.append(
+                {
+                    "name": "script",
+                    "skill": "pipelines/test/director",
+                    "tools_available": [],
+                }
+            ),
+            "duplicate stage name: script",
+        ),
+        (
+            lambda stages: stages[1]["produces"].append("script"),
+            "artifact 'script' has multiple producing stages",
+        ),
+        (
+            lambda stages: stages[0].update(
+                {"required_artifacts_in": ["render_report"]}
+            ),
+            "requires artifact 'render_report' before its producer",
+        ),
+        (
+            lambda stages: stages[0]["required_tools"].append("missing_tool"),
+            "missing_tool in required_tools but not tools_available",
+        ),
+    ],
+)
+def test_load_pipeline_rejects_cross_field_conflicts(
+    tmp_path: Path,
+    mutate,
+    expected_error: str,
+) -> None:
+    stages = _valid_stages()
+    mutate(stages)
+    defs_dir = _write_pipeline_repo(tmp_path, stages=stages)
+
+    with pytest.raises(PipelineSemanticError, match=expected_error):
+        load_pipeline("test-pipeline", defs_dir)
+
+
+def test_load_pipeline_rejects_undeclared_stage_skill(tmp_path: Path) -> None:
+    stages = _valid_stages()
+    stages[1]["skill"] = "pipelines/test/compose-director"
+    defs_dir = _write_pipeline_repo(tmp_path, stages=stages)
+    compose_skill = tmp_path / "skills" / "pipelines" / "test" / "compose-director.md"
+    compose_skill.write_text("# Compose skill\n", encoding="utf-8")
+
+    with pytest.raises(
+        PipelineSemanticError,
+        match="referenced skill 'pipelines/test/compose-director' is not listed",
+    ):
+        load_pipeline("test-pipeline", defs_dir)
+
+
+def test_load_pipeline_rejects_missing_skill_file(tmp_path: Path) -> None:
+    defs_dir = _write_pipeline_repo(tmp_path, stages=_valid_stages())
+    (tmp_path / "skills" / "pipelines" / "test" / "director.md").unlink()
+
+    with pytest.raises(PipelineSemanticError, match="skill path does not exist"):
+        load_pipeline("test-pipeline", defs_dir)
+
+
+def test_load_pipeline_rejects_missing_artifact_schema(tmp_path: Path) -> None:
+    defs_dir = _write_pipeline_repo(tmp_path, stages=_valid_stages())
+    (tmp_path / "schemas" / "artifacts" / "script.schema.json").unlink()
+
+    with pytest.raises(PipelineSemanticError, match="artifact 'script' has no schema"):
+        load_pipeline("test-pipeline", defs_dir)


### PR DESCRIPTION
## Summary

Add fail-fast semantic validation to the existing pipeline manifest loader so schema-valid manifests cannot contain contradictory cross-field references.

## Related issue

N/A

## Changes

- reject duplicate stage/sub-stage names, ambiguous artifact producers, and forward artifact dependencies
- verify stage/orchestration skills are declared and resolve to files
- verify referenced artifacts have schemas and required/optional tools are present in `tools_available`
- aggregate all semantic findings in `PipelineSemanticError`
- bring the existing screen-demo manifest/schema back into contract
- add repository-wide and focused contract coverage

## Testing

- `python -m pytest tests/contracts/test_pipeline_semantic_validation.py -q` — 9 passed
- `python -m pytest tests/contracts -q` — 854 passed, 7 skipped
- `python -m py_compile lib/pipeline_loader.py`
- Full `tests/` collection was also attempted on Windows; the pre-existing FFmpeg QA fixture stopped during narration concatenation under a non-ASCII local path before test execution.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [x] I updated docs/README if behavior or usage changed.
- [x] No unrelated files (build artifacts, local config) are included in the diff.