### PR TITLE
fix(subtitle_gen): stop inserting a space between every CJK token

### DIFF
--- a/tests/tools/test_subtitle_gen_cjk.py
+++ b/tests/tools/test_subtitle_gen_cjk.py
@@ -1,0 +1,136 @@
+"""Regression tests: CJK captions must not get a space between every token.
+
+The transcriber emits one token per word, and `subtitle_gen` joined them with
+`" "`. That is right for space-delimited languages and wrong for Chinese,
+Japanese and Korean, which are written without inter-word spaces — a
+Traditional Chinese cue came out as "阿公 的 助聽器 已經 戴 了 十五 年"
+instead of "阿公的助聽器已經戴了十五年".
+
+`CaptionOverlay` gained a `wordSeparator` prop for the Remotion side
+(PR #507), but the SRT/VTT path that ffmpeg burns in was untouched.
+
+The space survives at a script boundary, so mixed text keeps reading
+correctly, and output for space-delimited languages is byte-identical.
+"""
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.subtitle.subtitle_gen import (  # noqa: E402
+    SubtitleGen,
+    join_caption_tokens,
+)
+
+
+def _cue_texts(tokens: list[str], **inputs) -> list[str]:
+    words = [
+        {"word": w, "start": i * 0.4, "end": (i + 1) * 0.4}
+        for i, w in enumerate(tokens)
+    ]
+    segments = [
+        {
+            "start": 0.0,
+            "end": len(tokens) * 0.4,
+            "text": "".join(tokens),
+            "words": words,
+        }
+    ]
+    cues = SubtitleGen()._build_cues(segments, inputs.get("max_words", 8), 42)
+    return [c["text"] for c in cues]
+
+
+# --- join_caption_tokens ----------------------------------------------------
+
+
+def test_two_cjk_tokens_are_glued():
+    assert join_caption_tokens(["阿公", "的", "助聽器"]) == "阿公的助聽器"
+
+
+def test_space_survives_at_a_script_boundary():
+    assert join_caption_tokens(["使用", "OpenMontage", "製作"]) == "使用 OpenMontage 製作"
+
+
+def test_latin_tokens_keep_their_spaces():
+    assert join_caption_tokens(["the", "quick", "fox"]) == "the quick fox"
+
+
+def test_fullwidth_punctuation_stays_glued():
+    # A stranded "。" at the start of a line is a Chinese typography error.
+    assert join_caption_tokens(["難熬", "。"]) == "難熬。"
+    assert join_caption_tokens(["真的", "嗎", "？"]) == "真的嗎？"
+
+
+def test_kana_and_hangul_are_treated_as_cjk():
+    assert join_caption_tokens(["日本語", "の", "字幕"]) == "日本語の字幕"
+    assert join_caption_tokens(["한국어", "자막"]) == "한국어자막"
+
+
+def test_extension_b_ideographs_are_treated_as_cjk():
+    # U+20000 onwards carries rarer Traditional forms; a range check that
+    # stopped at U+9FFF would put a space beside them.
+    rare = "\U00020000"
+    assert join_caption_tokens([rare, "字"]) == f"{rare}字"
+
+
+def test_rendered_forms_do_not_decide_spacing():
+    # Karaoke markup must not make a CJK neighbour look like Latin.
+    assert (
+        join_caption_tokens(["阿公", "的"], ["<b>阿公</b>", "的"]) == "<b>阿公</b>的"
+    )
+
+
+def test_empty_input_is_empty():
+    assert join_caption_tokens([]) == ""
+
+
+# --- end to end through the tool -------------------------------------------
+
+
+def test_chinese_cues_have_no_inter_token_spaces():
+    texts = _cue_texts("阿公 的 助聽器 已經 戴 了 十五 年".split())
+    assert texts == ["阿公的助聽器已經戴了十五年"]
+
+
+def test_english_cues_are_unchanged():
+    texts = _cue_texts("the quick brown fox jumps".split())
+    assert texts == ["the quick brown fox jumps"]
+
+
+def test_mixed_script_cue_keeps_the_boundary_space():
+    texts = _cue_texts("使用 OpenMontage 製作 的 影片".split())
+    assert texts == ["使用 OpenMontage 製作的影片"]
+
+
+def test_karaoke_srt_does_not_reintroduce_spaces():
+    words = [
+        {"word": w, "start": i * 0.4, "end": (i + 1) * 0.4}
+        for i, w in enumerate(["阿公", "的", "助聽器"])
+    ]
+    cues = [{"index": 1, "start": 0.0, "end": 1.2, "text": "阿公的助聽器", "words": words}]
+
+    srt = SubtitleGen()._render_srt(cues, "karaoke")
+
+    assert "<b>阿公</b>的助聽器" in srt
+    assert "阿公 的" not in srt
+
+
+def test_corrections_rebuild_segment_text_without_spaces():
+    segments = [
+        {
+            "start": 0.0,
+            "end": 1.2,
+            "text": "阿公的助聽氣",
+            "words": [
+                {"word": "阿公", "start": 0.0, "end": 0.4},
+                {"word": "的", "start": 0.4, "end": 0.8},
+                {"word": "助聽氣", "start": 0.8, "end": 1.2},
+            ],
+        }
+    ]
+
+    fixed = SubtitleGen()._apply_corrections(segments, {"助聽氣": "助聽器"})
+
+    assert fixed[0]["text"] == "阿公的助聽器"

--- a/tools/subtitle/subtitle_gen.py
+++ b/tools/subtitle/subtitle_gen.py
@@ -23,6 +23,57 @@ from tools.base_tool import (
 )
 
 
+# Scripts written without inter-word spaces. Han ideographs (including the
+# Extension blocks that carry rarer Traditional forms), kana, Hangul, and the
+# CJK punctuation / fullwidth blocks — the latter matter because a closing
+# mark like "。" must stay glued to the word it follows.
+_CJK_RANGES: tuple[tuple[int, int], ...] = (
+    (0x3000, 0x303F),    # CJK symbols and punctuation
+    (0x3040, 0x30FF),    # Hiragana, Katakana
+    (0x3400, 0x4DBF),    # CJK Unified Ideographs Extension A
+    (0x4E00, 0x9FFF),    # CJK Unified Ideographs
+    (0xAC00, 0xD7AF),    # Hangul syllables
+    (0xF900, 0xFAFF),    # CJK Compatibility Ideographs
+    (0xFF00, 0xFFEF),    # Fullwidth and halfwidth forms
+    (0x20000, 0x2FA1F),  # CJK Unified Ideographs Extension B and later
+)
+
+
+def _is_cjk(char: str) -> bool:
+    code = ord(char)
+    return any(low <= code <= high for low, high in _CJK_RANGES)
+
+
+def join_caption_tokens(
+    tokens: list[str], rendered: list[str] | None = None
+) -> str:
+    """Join caption tokens the way each script actually writes them.
+
+    Whisper emits one token per word, and joining them with a space is right
+    for space-delimited languages but wrong for CJK, where it puts a gap
+    between every character. The space is dropped only when *both* sides are
+    CJK, so mixed text such as "使用 OpenMontage 製作" keeps the space that
+    separates the scripts.
+
+    ``rendered`` supplies substitute forms to emit — a karaoke highlighter
+    passes ``<b>word</b>`` — while spacing is still decided from the plain
+    tokens.
+    """
+    out = tokens if rendered is None else rendered
+    if not tokens:
+        return ""
+    result = out[0]
+    for i in range(1, len(tokens)):
+        previous, current = tokens[i - 1], tokens[i]
+        glue = (
+            ""
+            if previous and current and _is_cjk(previous[-1]) and _is_cjk(current[0])
+            else " "
+        )
+        result += glue + out[i]
+    return result
+
+
 class SubtitleGen(BaseTool):
     name = "subtitle_gen"
     version = "0.1.0"
@@ -152,7 +203,7 @@ class SubtitleGen(BaseTool):
                     w["word"] = corr[stripped] + trailing
             # Also fix segment-level text
             if "text" in seg and words:
-                seg["text"] = " ".join(w["word"] for w in words)
+                seg["text"] = join_caption_tokens([w["word"] for w in words])
             elif "text" in seg:
                 for wrong, right in corr.items():
                     import re as _re
@@ -190,9 +241,12 @@ class SubtitleGen(BaseTool):
         buf: list[dict] = []
         buf_text = ""
 
+        def buffer_text(entries: list[dict]) -> str:
+            return join_caption_tokens([e["word"].strip() for e in entries])
+
         for w in all_words:
             word_text = w["word"].strip()
-            candidate = f"{buf_text} {word_text}".strip() if buf_text else word_text
+            candidate = buffer_text(buf + [w])
 
             if buf and (len(buf) >= max_words or len(candidate) > max_chars):
                 cues.append({
@@ -209,7 +263,7 @@ class SubtitleGen(BaseTool):
                 buf_text = ""
 
             buf.append(w)
-            buf_text = f"{buf_text} {word_text}".strip() if buf_text else word_text
+            buf_text = buffer_text(buf)
 
         # Flush remaining
         if buf:
@@ -255,13 +309,12 @@ class SubtitleGen(BaseTool):
                     lines.append(
                         f"{self._ts_srt(word_info['start'])} --> {self._ts_srt(word_info['end'])}"
                     )
-                    parts = []
-                    for wj, w in enumerate(words):
-                        if wj == wi:
-                            parts.append(f"<b>{w['word']}</b>")
-                        else:
-                            parts.append(w["word"])
-                    lines.append(" ".join(parts))
+                    plain = [w["word"] for w in words]
+                    parts = [
+                        f"<b>{word}</b>" if wj == wi else word
+                        for wj, word in enumerate(plain)
+                    ]
+                    lines.append(join_caption_tokens(plain, parts))
                     lines.append("")
         else:
             for cue in cues:
@@ -293,13 +346,12 @@ class SubtitleGen(BaseTool):
                     lines.append(
                         f"{self._ts_vtt(word_info['start'])} --> {self._ts_vtt(word_info['end'])}"
                     )
-                    parts = []
-                    for wj, w in enumerate(words):
-                        if wj == wi:
-                            parts.append(f"<b>{w['word']}</b>")
-                        else:
-                            parts.append(w["word"])
-                    lines.append(" ".join(parts))
+                    plain = [w["word"] for w in words]
+                    parts = [
+                        f"<b>{word}</b>" if wj == wi else word
+                        for wj, word in enumerate(plain)
+                    ]
+                    lines.append(join_caption_tokens(plain, parts))
                     lines.append("")
         else:
             for cue in cues:


### PR DESCRIPTION
## The defect

The transcriber emits one token per word and `subtitle_gen` joined them with `" "`. That is correct for space-delimited languages and wrong for Chinese, Japanese and Korean, which are written without inter-word spaces.

Real output from `SubtitleGen` on Traditional Chinese input:

```
1  阿公 的 助聽器 已經 戴 了 十五 年
2  了 。 家人 不在 的 那 幾 個
3  小時 最 難熬 。
```

It should read `阿公的助聽器已經戴了十五年`. Note also the `。` stranded at the start of cue 2 — Chinese typography does not allow a closing mark to open a line.

#507 gave `CaptionOverlay` a `wordSeparator` prop for the Remotion side. This is the **SRT/VTT path — what ffmpeg burns into the video** — and it was untouched.

## The repair

`join_caption_tokens()` drops the space only when **both** neighbours are CJK, so a script boundary keeps the space that separates the two writing systems:

```
使用 OpenMontage 製作的影片
```

It replaces all five hardcoded joins:

| Site | What it builds |
|---|---|
| `_apply_corrections` | the rebuilt segment text after a word correction |
| `_build_cues` ×2 | the candidate and committed cue buffer text |
| `_render_srt` / `_render_vtt` | the karaoke line with the active word in `<b>` |

The karaoke path decides spacing from the **plain** tokens and emits the marked-up ones, so a `<b>` wrapper cannot make a CJK neighbour look like Latin.

The range table covers Han ideographs including Extension A and **Extension B and later** — rarer Traditional forms live above U+20000, so a check stopping at U+9FFF would put a space beside them — plus kana, Hangul, and the CJK punctuation and fullwidth blocks. Those last two are what keep `。` and `？` glued to the word they follow.

## Deliberately left alone

`max_chars_per_line` counts a fullwidth character as one column when it occupies two, so a CJK line can be twice as wide as the setting suggests. In practice `max_words_per_cue` binds first for CJK, and changing the width model is a segmentation decision rather than part of removing the spurious spaces.

## Verification

Behavioural assertions, unfixed tree → fixed tree:

```
FAIL -> PASS   Chinese cue has no inter-token spaces
PASS -> PASS   English cue unchanged
FAIL -> PASS   mixed script keeps the boundary space
FAIL -> PASS   karaoke markup does not reintroduce a space
```

- SRT and VTT output for English is **byte-identical** before and after, across all three highlight styles (`none`, `word_by_word`, `karaoke`).
- Full suite: **1829 → 1842 passed**, 11 skipped, no regressions.
- `make lint`: passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)