### PR TITLE
fix(screen_capture_selector): declare fallbacks by tool name

### DIFF
--- a/tests/contracts/test_fallback_tool_names.py
+++ b/tests/contracts/test_fallback_tool_names.py
@@ -1,0 +1,86 @@
+"""Every declared fallback must name a tool the registry can resolve.
+
+`registry.find_fallback()` looks each name up with `registry.get()`, which is
+keyed by tool *name*. `screen_capture_selector` built its list from
+`_providers()`, a dict keyed by `tool.provider`, so it advertised `["cap",
+"ffmpeg"]` — neither of which is a tool name. `find_fallback()` returned None
+even with both `cap_recorder` and `screen_recorder` AVAILABLE, and preflight
+("Check `fallback_tools` for unavailable tools", AGENT_GUIDE.md) had nothing
+to look up.
+
+`get_info()` republishes the list into the support envelope, described in
+tool_registry as "the primary report the orchestrator uses", so an
+unresolvable name propagates to every consumer of that report.
+
+The registry is iterated rather than named so a newly added tool is covered
+the moment it is discovered.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.base_tool import ToolStatus  # noqa: E402
+from tools.tool_registry import registry  # noqa: E402
+
+
+def _declared_fallbacks() -> list[tuple[str, str]]:
+    registry.discover()
+    pairs: list[tuple[str, str]] = []
+    for name, tool in sorted(registry._tools.items()):
+        declared = list(tool.fallback_tools or [])
+        if tool.fallback and tool.fallback not in declared:
+            declared.append(tool.fallback)
+        pairs.extend((name, fb) for fb in declared)
+    return pairs
+
+
+FALLBACKS = _declared_fallbacks()
+
+
+def test_some_tools_declare_a_fallback() -> None:
+    """Guard against the parametrized test below silently covering nothing."""
+    assert FALLBACKS
+
+
+@pytest.mark.parametrize(("tool", "fallback"), FALLBACKS, ids=lambda v: str(v))
+def test_declared_fallback_names_a_registered_tool(tool: str, fallback: str) -> None:
+    registry.discover()
+    assert registry.get(fallback) is not None, (
+        f"{tool} declares fallback {fallback!r}, which is not a registered "
+        f"tool name — registry.find_fallback({tool!r}) cannot resolve it"
+    )
+
+
+def test_selector_falls_back_while_a_provider_is_available() -> None:
+    """The end the defect was actually visible from.
+
+    Availability is derived from the capability, not from `fallback_tools` —
+    reading the list under test to decide whether to assert on it is how this
+    defect stays invisible: unresolvable names look like "no providers".
+    """
+    registry.discover()
+
+    for selector, capability in (
+        ("screen_capture_selector", "screen_capture"),
+        ("tts_selector", "tts"),
+        ("image_selector", "image_generation"),
+        ("video_selector", "video_generation"),
+    ):
+        if registry.get(selector) is None:
+            continue
+        providers = [
+            t for t in registry.get_by_capability(capability)
+            if t.name != selector and t.get_status() == ToolStatus.AVAILABLE
+        ]
+        if not providers:
+            continue
+
+        assert registry.find_fallback(selector) is not None, (
+            f"{selector} has available providers "
+            f"{[t.name for t in providers]} but find_fallback returned None"
+        )

--- a/tools/capture/screen_capture_selector.py
+++ b/tools/capture/screen_capture_selector.py
@@ -138,7 +138,10 @@ class ScreenCaptureSelector(BaseTool):
 
     @property
     def fallback_tools(self) -> list[str]:
-        return list(self._providers().keys())
+        # Tool names, not the provider keys `_providers()` is indexed by:
+        # registry.find_fallback() resolves these through registry.get(),
+        # which is keyed by tool name. This matches tts/image/video_selector.
+        return [t.name for t in self._providers().values()]
 
     def get_status(self) -> ToolStatus:
         providers = self._providers()


### PR DESCRIPTION
## The defect

`fallback_tools` was built from `_providers()`, a dict keyed by `tool.provider`, so the selector advertised `["cap", "ffmpeg"]`. Neither is a tool name — and `registry.find_fallback()` resolves each entry through `registry.get()`, which is keyed by name.

```
screen_recorder  available   provider='ffmpeg'
cap_recorder     available   provider='cap'

registry.find_fallback("screen_capture_selector")  ->  None
registry.find_fallback("tts_selector")             ->  <OpenAITTS ...>
```

Both providers are AVAILABLE and the fallback chain still resolves to nothing.

It is the only capability selector with this problem — the other three return `[t.name for t in ...]`:

| selector | fallbacks that resolve | fallbacks that don't |
|---|---|---|
| `tts_selector` | 10 | 0 |
| `image_selector` | 16 | 0 |
| `video_selector` | 27 | 0 |
| `screen_capture_selector` | **0** | `cap`, `ffmpeg` |

The blast radius is wider than `find_fallback`: `get_info()` republishes the list into the support envelope — "the primary report the orchestrator uses", per `tool_registry` — and AGENT_GUIDE.md's preflight step tells the agent to *"Check `fallback_tools` for unavailable tools"*, which it cannot look up.

## The repair

`_providers()` stays keyed by provider, since `get_status()` and `execute()` index it that way. Only the fallback list maps to `.name`.

## Coverage

`tests/contracts/test_fallback_tool_names.py` iterates the registry rather than naming tools, so a newly added tool is covered the moment it is discovered.

One note on how the behavioural test is written: it derives availability from the **capability**, not from `fallback_tools`. Reading the list under test to decide whether to assert on it is exactly how this defect stayed invisible — unresolvable names look identical to "no providers configured", so the assertion silently skips. My first draft had that hole and passed on the unfixed tree.

## Verification

- 3 cases fail on the unfixed tree; all 225 pass after.
- Full suite: **1829 → 2054 passed**, 11 skipped, no regressions.
- `make lint`: passed.

Independent of #538 — no overlapping files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)