### PR TITLE
fix(CaptionOverlay): give every composition CJK-correct captions

### DIFF
--- a/remotion-composer/src/components/CaptionOverlay.tsx
+++ b/remotion-composer/src/components/CaptionOverlay.tsx
@@ -26,8 +26,10 @@ type CaptionOverlayProps = {
   highlightColor?: string;
   backgroundColor?: string;
   fontFamily?: string;
-  // Separator rendered between words. Space-delimited languages want the
-  // default " "; CJK languages (no inter-word spacing) should pass "".
+  // Separator rendered between words. Left unset, it is decided per adjacent
+  // pair by `separatorBetween`, which is what CJK captions need — a fixed
+  // string cannot be right for both sides of a script boundary. Set it to
+  // force one separator everywhere.
   wordSeparator?: string;
 };
 
@@ -36,6 +38,33 @@ interface CaptionPage {
   startMs: number;
   endMs: number;
 }
+
+// Scripts written without inter-word spaces: Han ideographs (including the
+// Extension blocks that carry rarer Traditional forms), kana, Hangul, and the
+// CJK punctuation / fullwidth blocks — the latter matter because a closing
+// mark like "。" must stay glued to the word it follows.
+const CJK_CHARACTER =
+  /^(?:[\u3000-\u303F\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uAC00-\uD7AF\uF900-\uFAFF\uFF00-\uFFEF]|[\u{20000}-\u{2FA1F}])$/u;
+
+// Array.from splits by code point, so an Extension B ideograph is compared as
+// one character rather than as half of a surrogate pair.
+const firstCharacter = (text: string): string => Array.from(text)[0] ?? "";
+const lastCharacter = (text: string): string => {
+  const characters = Array.from(text);
+  return characters[characters.length - 1] ?? "";
+};
+
+/**
+ * Separator to render between two caption tokens when none was configured.
+ *
+ * The space is dropped only when *both* sides are CJK, so a script boundary
+ * keeps the space that separates the two writing systems — "使用 OpenMontage
+ * 製作的影片" reads correctly, and space-delimited text is unchanged.
+ */
+export const separatorBetween = (left: string, right: string): string =>
+  CJK_CHARACTER.test(lastCharacter(left)) && CJK_CHARACTER.test(firstCharacter(right))
+    ? ""
+    : " ";
 
 function buildPages(words: WordCaption[], wordsPerPage: number): CaptionPage[] {
   const pages: CaptionPage[] = [];
@@ -64,7 +93,7 @@ const PageRenderer: React.FC<{
   highlightColor: string;
   backgroundColor: string;
   fontFamily: string;
-  wordSeparator: string;
+  wordSeparator?: string;
 }> = ({ page, fontSize, color, highlightColor, backgroundColor, fontFamily, wordSeparator }) => {
   const frame = useCurrentFrame();
   const { fps } = useVideoConfig();
@@ -109,6 +138,12 @@ const PageRenderer: React.FC<{
           {page.words.map((w, i) => {
             const isActive = w.startMs <= currentMs && w.endMs > currentMs;
             const isPast = w.endMs <= currentMs;
+            const next = page.words[i + 1];
+            // Computed here rather than inline so no JSX line break can
+            // reintroduce whitespace a CJK caption must not have.
+            const separator = next
+              ? wordSeparator ?? separatorBetween(w.word, next.word)
+              : "";
             return (
               <span
                 key={`${w.startMs}-${i}`}
@@ -125,7 +160,7 @@ const PageRenderer: React.FC<{
                     : "0 2px 4px rgba(0,0,0,0.5)",
                 }}
               >
-                {w.word}{i < page.words.length - 1 ? wordSeparator : ""}
+                {w.word}{separator}
               </span>
             );
           })}
@@ -143,7 +178,7 @@ export const CaptionOverlay: React.FC<CaptionOverlayProps> = ({
   highlightColor = "#22D3EE",
   backgroundColor = "rgba(15, 23, 42, 0.75)",
   fontFamily = "Space Grotesk, Inter, system-ui, sans-serif",
-  wordSeparator = " ",
+  wordSeparator,
 }) => {
   const { fps } = useVideoConfig();
   const pages = buildPages(words, wordsPerPage);

--- a/tests/contracts/test_caption_cjk_contract.py
+++ b/tests/contracts/test_caption_cjk_contract.py
@@ -1,0 +1,129 @@
+"""CJK captions must lose the inter-word space in every composition.
+
+PR #507 gave `CaptionOverlay` a `wordSeparator` prop, but it defaulted to
+`" "` and only `TalkingHead` forwarded it. `Explainer` and `CinematicRenderer`
+never passed it, so captions there kept a space between every token — the
+defect #507 set out to fix, still live on the two main composition paths.
+
+The separator is now decided per adjacent pair when the prop is unset, so a
+script boundary keeps its space ("使用 OpenMontage 製作的影片") while two CJK
+tokens are glued. An explicit `wordSeparator` still overrides.
+
+There is no JS test runner in this repo, so the wiring is asserted against the
+source the way test_remotion_video_transition_contract.py does. The character
+ranges are extracted and exercised for real, since a range table is exactly
+the kind of thing that looks right and is not.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+COMPOSER = PROJECT_ROOT / "remotion-composer" / "src"
+CAPTION_OVERLAY = COMPOSER / "components" / "CaptionOverlay.tsx"
+
+# Matches both \uXXXX and the \u{XXXXX} form the /u flag allows.
+_RANGE = re.compile(r"\\u\{?([0-9A-Fa-f]{4,6})\}?-\\u\{?([0-9A-Fa-f]{4,6})\}?")
+
+
+def _source(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _cjk_ranges() -> list[tuple[int, int]]:
+    """Parse the ranges out of the TSX, tolerating their absence.
+
+    Raising at import time would turn every assertion below into one
+    collection error, which hides which behaviour actually broke.
+    """
+    source = _source(CAPTION_OVERLAY)
+    start = source.find("const CJK_CHARACTER")
+    if start == -1:
+        return []
+    literal = source[start : source.index(";", start)]
+    return [(int(low, 16), int(high, 16)) for low, high in _RANGE.findall(literal)]
+
+
+RANGES = _cjk_ranges()
+
+
+def test_the_range_table_exists() -> None:
+    """Without this, the parametrized range tests would pass vacuously."""
+    assert RANGES, "CaptionOverlay declares no CJK character ranges"
+
+
+def _is_cjk(char: str) -> bool:
+    code = ord(char)
+    return any(low <= code <= high for low, high in RANGES)
+
+
+# --- the range table, exercised ---------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "char",
+    [
+        "阿",  # CJK Unified Ideographs
+        "聽",
+        "\u3400",  # Extension A
+        "\U00020000",  # Extension B — rarer Traditional forms live here
+        "の",  # Hiragana
+        "ス",  # Katakana
+        "한",  # Hangul
+        "。",  # CJK punctuation, must stay glued to the preceding word
+        "、",
+        "？",  # Fullwidth forms
+        "）",
+    ],
+)
+def test_character_is_recognised_as_cjk(char: str) -> None:
+    assert _is_cjk(char), f"{char!r} (U+{ord(char):04X}) should count as CJK"
+
+
+@pytest.mark.parametrize("char", ["a", "Z", "0", " ", ".", "?", "é", "—"])
+def test_latin_character_is_not_cjk(char: str) -> None:
+    assert not _is_cjk(char), f"{char!r} must not count as CJK"
+
+
+def test_range_table_reaches_past_the_basic_plane() -> None:
+    """A table stopping at U+9FFF drops the rarer Traditional forms."""
+    assert max(high for _, high in RANGES) > 0xFFFF
+
+
+# --- wiring ------------------------------------------------------------------
+
+
+def test_word_separator_no_longer_defaults_to_a_space() -> None:
+    """The default was what made every non-TalkingHead composition wrong."""
+    source = _source(CAPTION_OVERLAY)
+    assert 'wordSeparator = " "' not in source
+    assert "wordSeparator?: string;" in source
+
+
+def test_separator_is_decided_per_pair_when_the_prop_is_unset() -> None:
+    source = _source(CAPTION_OVERLAY)
+    assert "wordSeparator ?? separatorBetween(w.word, next.word)" in source
+
+
+def test_separator_is_emitted_without_intervening_jsx_whitespace() -> None:
+    """A JSX line break between the two expressions renders as a space."""
+    source = _source(CAPTION_OVERLAY)
+    assert "{w.word}{separator}" in source
+
+
+@pytest.mark.parametrize("composition", ["Explainer.tsx", "CinematicRenderer.tsx"])
+def test_composition_gets_cjk_captions_without_opting_in(composition: str) -> None:
+    """These two never passed wordSeparator; the fix must not require them to.
+
+    If a composition starts pinning the separator, this test should be updated
+    deliberately rather than the behaviour regressing silently.
+    """
+    source = _source(COMPOSER / composition)
+    call_start = source.index("<CaptionOverlay")
+    call = source[call_start : source.index("/>", call_start)]
+    assert "wordSeparator" not in call


### PR DESCRIPTION
## The defect

#507 added a `wordSeparator` prop so CJK captions could drop the inter-word space. But it defaulted to `" "`, and only `TalkingHead` forwards it:

| composition | passes `wordSeparator`? |
|---|---|
| `TalkingHead` | yes |
| `Explainer` | **no** |
| `CinematicRenderer` | **no** |

So captions on the two main composition paths still render a space between every token — the defect #507 set out to fix, still live where most videos are made.

## Why not just thread the prop through

That fixes the symptom and leaves the next composition to make the same omission. It also can't be fully right: a single string cannot serve both sides of a script boundary. `使用 OpenMontage 製作的影片` needs a space in two places and none in the others.

So when the prop is unset, the separator is decided **per adjacent pair**:

```
阿公 + 的            ->  ""     two CJK tokens are glued
使用 + OpenMontage   ->  " "    the space between scripts stays
OpenMontage + 製作   ->  " "
the + quick          ->  " "    unchanged
難熬 + 。            ->  ""     a closing mark may not open a line
```

An explicit `wordSeparator` still wins, so `TalkingHead`'s pass-through and any caller pinning a separator behave exactly as before, and space-delimited captions are untouched because `separatorBetween` returns `" "` for them.

## Details worth flagging

- **`Array.from` splits by code point**, so an Extension B ideograph is compared as one character rather than as half of a surrogate pair. Rarer Traditional forms live above U+20000; a range check stopping at U+9FFF would put a space beside them.
- The table also covers the **CJK punctuation and fullwidth blocks**, which is what keeps `。` and `？` attached to the word they follow.
- The separator is computed in the map body rather than inline, because **a JSX line break between two expressions renders as whitespace** — precisely what a CJK caption must not have.

## Coverage

No JS test runner exists here, so the wiring is asserted against the source the way `test_remotion_video_transition_contract.py` does. The character ranges are *extracted from the TSX and exercised for real* — a range table is exactly the kind of thing that looks right and is not.

Two test-design notes: parsing tolerates the ranges being absent, so a regression fails the specific assertions instead of collapsing into a single collection error that hides which behaviour broke; and a guard test fails if the table disappears entirely, since the parametrized range tests would otherwise pass vacuously.

## Verification

- 16 of the 26 cases fail on the unfixed tree. The 10 that pass are the Latin negative cases and the "composition does not opt in" checks, which should hold either way.
- The implementation was also executed under Node against 11 cases covering Han, kana, Hangul, fullwidth punctuation, Extension B in both directions, and script boundaries — all pass.
- Full suite: **1829 → 1855 passed**, 11 skipped, no regressions.
- `tsc --noEmit` clean under strict.

Companion to #538, which fixes the same assumption in the SRT/VTT path that ffmpeg burns in. The two share no files and can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)