### PR TITLE
fix(schemas): accept the values AGENT_GUIDE mandates

### DIFF
--- a/schemas/artifacts/decision_log.schema.json
+++ b/schemas/artifacts/decision_log.schema.json
@@ -39,6 +39,7 @@
               "concept_selection",
               "voice_selection",
               "capability_extension",
+              "approval_policy",
               "playbook_override",
               "visual_accuracy_check"
             ],

--- a/schemas/artifacts/proposal_packet.schema.json
+++ b/schemas/artifacts/proposal_packet.schema.json
@@ -169,7 +169,7 @@
           "type": "object",
           "description": "Resolved music plan from the proposal stage",
           "properties": {
-            "source_type": { "type": "string", "enum": ["user_library", "ai_generated", "bring_your_own", "none"] },
+            "source_type": { "type": "string", "enum": ["user_library", "royalty_free_search", "ai_generated", "bring_your_own", "none"], "description": "Where the track comes from. royalty_free_search covers a track fetched through a music_search tool such as pixabay_music, which AGENT_GUIDE.md requires the music plan to offer and which user_library (the user's own music_library/ folder) does not describe." },
             "track_path": { "type": "string", "description": "Path to selected track, if known" },
             "provider": { "type": "string", "description": "Music generation provider, if AI-generated" },
             "mood_direction": { "type": "string", "description": "Music mood description from research" },

--- a/tests/contracts/test_artifact_schema_vocabulary.py
+++ b/tests/contracts/test_artifact_schema_vocabulary.py
@@ -1,0 +1,127 @@
+"""The artifact schemas must accept the values AGENT_GUIDE mandates.
+
+AGENT_GUIDE.md is binding on the agent, but nothing checked that the artifact
+schemas can express what it requires. Where they cannot, the agent has to
+either drop the record or file it under an unrelated value — and the audit
+trail then says something that did not happen. Reported as calesthio/OpenMontage#493.
+
+Two cases, both grounded in an explicit instruction rather than in taste:
+
+- `decision_log` had no `approval_policy` category, though AGENT_GUIDE.md
+  names it as the one mechanism that makes full-run pre-authorization count.
+- `proposal_packet` had no `source_type` for a track fetched through a
+  `music_search` tool, though AGENT_GUIDE.md requires the music plan to offer
+  royalty-free search — and `pixabay_music` serves it with no API key.
+
+The category test derives its expectations from AGENT_GUIDE.md itself, so a
+future instruction naming a new category fails here instead of silently
+becoming unrecordable.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+SCHEMAS = PROJECT_ROOT / "schemas" / "artifacts"
+AGENT_GUIDE = PROJECT_ROOT / "AGENT_GUIDE.md"
+
+# AGENT_GUIDE writes a mandated decision category as `category: "name"`.
+_CATEGORY = re.compile(r'category:\s*"([a-z_]+)"')
+
+
+def _schema(name: str) -> dict:
+    return json.loads((SCHEMAS / f"{name}.schema.json").read_text(encoding="utf-8"))
+
+
+def _decision_categories() -> list[str]:
+    return _schema("decision_log")["properties"]["decisions"]["items"]["properties"][
+        "category"
+    ]["enum"]
+
+
+def _guide_categories() -> list[str]:
+    return sorted(set(_CATEGORY.findall(AGENT_GUIDE.read_text(encoding="utf-8"))))
+
+
+GUIDE_CATEGORIES = _guide_categories()
+
+
+def test_agent_guide_names_some_categories() -> None:
+    """Without this the parametrized test below could pass vacuously."""
+    assert GUIDE_CATEGORIES, "no `category: \"...\"` mandates found in AGENT_GUIDE.md"
+
+
+@pytest.mark.parametrize("category", GUIDE_CATEGORIES)
+def test_mandated_category_is_recordable(category: str) -> None:
+    assert category in _decision_categories(), (
+        f"AGENT_GUIDE.md mandates decision_log category {category!r}, but the "
+        f"schema enum rejects it, so the agent cannot record it truthfully"
+    )
+
+
+def test_a_pre_authorization_entry_validates() -> None:
+    """The end the defect was visible from: writing the entry the guide asks for."""
+    artifact = {
+        "version": "1.0",
+        "project_id": "probe",
+        "decisions": [
+            {
+                "decision_id": "d1",
+                "stage": "idea",
+                "category": "approval_policy",
+                "subject": "Full-run pre-authorization",
+                "options_considered": [
+                    {
+                        "option_id": "per_gate",
+                        "label": "Approve at every gate",
+                        "score": 0.4,
+                        "reason": "Default; the user stops at each stage.",
+                    },
+                    {
+                        "option_id": "full_run",
+                        "label": "Full-run pre-authorization",
+                        "score": 1.0,
+                        "reason": "The user authorized the whole run up front.",
+                    },
+                ],
+                "selected": "full_run",
+                "reason": "User approved the whole run up front.",
+            }
+        ],
+    }
+
+    Draft202012Validator(_schema("decision_log")).validate(artifact)
+
+
+def _source_types() -> list[str]:
+    packet = _schema("proposal_packet")
+    return packet["properties"]["production_plan"]["properties"]["music_source"][
+        "properties"
+    ]["source_type"]["enum"]
+
+
+def test_a_searched_royalty_free_track_can_be_described() -> None:
+    """`user_library` means the user's own music_library/ folder, so a track
+    fetched through a music_search tool had no honest value."""
+    assert "royalty_free_search" in _source_types()
+
+
+def test_the_royalty_free_option_is_actually_reachable() -> None:
+    """Guard against adding an enum value for a path nothing implements."""
+    import logging
+
+    logging.disable(logging.CRITICAL)
+    from tools.tool_registry import registry
+
+    registry.discover()
+    assert registry.get_by_capability("music_search"), (
+        "no tool serves the music_search capability, so royalty_free_search "
+        "would describe a path that does not exist"
+    )


### PR DESCRIPTION
Addresses items 1 and 2 of #493.

## The defect

AGENT_GUIDE.md is binding on the agent, but nothing checked that the artifact schemas can express what it requires. Where they cannot, the agent must drop the record or file it under an unrelated value — and the audit trail then says something that did not happen. Neither case fails loudly.

### 1. `approval_policy` was unrecordable

AGENT_GUIDE.md:592 names exactly one mechanism for full-run pre-authorization:

> explicit full-run pre-authorization **must** be recorded as a `decision_log` entry (`category: "approval_policy"`) to count

`decision_log.schema.json` restricted `category` to 16 values and `approval_policy` was not among them.

The guide names three categories in that form. The other two — `composition_mode`, `voice_selection` — are already in the enum, so exactly one mandate was unrecordable. Without it, every later gate is technically a violation of the per-gate rule.

### 2. A searched royalty-free track had no honest `source_type`

AGENT_GUIDE.md:536 makes royalty-free search a required option of the music plan:

> **Royalty-free search:** Check `registry.get_by_capability("music_search")` for configured search/download tools.

But `proposal_packet.schema.json` offered only `user_library / ai_generated / bring_your_own / none`. `user_library` means the user's own `music_library/` folder, so a track fetched through a `music_search` tool could not be described.

This is not hypothetical — it is the out-of-the-box path:

```
freesound_music      unavailable    needs key = False
pixabay_music        available      needs key = False
```

## Coverage

`tests/contracts/test_artifact_schema_vocabulary.py` derives the expected categories **from AGENT_GUIDE.md itself** rather than from a copied list, so a future instruction naming a new category fails here instead of silently becoming unrecordable.

Two guards, both learned from writing this kind of test badly before:

- a test fails if the extraction finds nothing, since the parametrized test would otherwise pass vacuously;
- the royalty-free value is checked against the registry, so the enum cannot come to describe a path nothing implements.

The behavioural test writes the entry the guide asks for and validates it against the schema, rather than only asserting the enum contains a string.

## Scope

#493 lists five mismatches. This PR takes two:

| item | status |
|---|---|
| 1. `approval_policy` missing | **fixed here** |
| 2. no royalty-free `source_type` | **fixed here** |
| 3. `research_brief` missing the animation research-director's fields | left to open PR #492, which is already editing that schema |
| 4. no music entry offset in `edit_decisions.audio` | needs a field design, not an enum value |
| 5. atelier silently ignored on HyperFrames | **already fixed on current main** — `_render_via_hyperframes` now routes an authored workspace before the stock cut requirements |

Item 5 was the most serious one in the report, so it is worth noting it reproduces as fixed.

## Verification

- 3 cases fail on the unfixed tree; all 7 pass after.
- Full suite: **1829 → 1836 passed**, 11 skipped, no regressions.
- `make lint`: passed.

Independent of #538, #539 and #540 — no overlapping files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)