### PR TITLE
Define Hub Studio to OpenMontage cutover

### DIFF
--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -1,0 +1,31 @@
+# OpenMontage runner deployment
+
+The runner is a loopback-only bridge for the Hub. It does not expose Backlot
+and it does not start, shell out to, or otherwise bypass the OpenMontage
+pipeline/approval protocol.
+
+Install the unit and its root-readable token file:
+
+```bash
+install -d -m 0700 /etc/openmontage
+install -m 0600 /dev/null /etc/openmontage/runner.env
+# Add exactly: OPENMONTAGE_RUNNER_TOKEN=<long random value>
+install -m 0644 deploy/systemd/openmontage-runner.service /etc/systemd/system/openmontage-runner.service
+systemctl daemon-reload
+systemctl enable --now openmontage-runner.service
+```
+
+The Hub runner client sends that value as `Authorization: Bearer …` over its
+local service boundary. Do not put it in the Hub repository, browser code, or
+OpenMontage project directories. Confirm the listener stays local with
+`ss -ltnp | grep 4751`; the expected bind is `127.0.0.1:4751`.
+
+The three authenticated operations are:
+
+- `POST /api/v1/runs` — initialize one fixed-root project workspace.
+- `GET /api/v1/runs/{project_id}` — derive checkpoint/render status.
+- `POST /api/v1/runs/{project_id}/cancel` — record a cooperative cancellation
+  request; it never kills a process or invokes a shell.
+
+`GET /api/v1/health` is intentionally unauthenticated only for local service
+supervision; it exposes no run data.

--- a/deploy/systemd/openmontage-runner.service
+++ b/deploy/systemd/openmontage-runner.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=OpenMontage authenticated local runner (127.0.0.1:4751)
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/root/openmontage
+Environment=PYTHONUNBUFFERED=1
+EnvironmentFile=/etc/openmontage/runner.env
+UMask=0077
+ExecStart=/root/openmontage/.venv/bin/python -m runner --port 4751
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/HUB-STUDIO-CUTOVER-SPEC.md
+++ b/docs/HUB-STUDIO-CUTOVER-SPEC.md
@@ -1,0 +1,124 @@
+# Hub Studio → OpenMontage cutover
+
+**Status:** implementation-ready design; no Hub code has been changed by this
+document.  **Owner:** the Hub publisher owns the implementation and release.
+
+## Intent
+
+Replace the existing single-asset, Kie-only Studio generation path with
+OpenMontage production runs while preserving the Hub as the authenticated,
+manager-only cockpit and the source of record for the user's request history.
+OpenMontage owns pipeline execution, artifacts, review state, and rendering.
+
+This is a cutover of the **Generate** workflow, not a deletion of the existing
+media library.  Historical `studio_generations` and `generated_audio` records
+remain readable during and after the cutover.
+
+## Current boundary (verified 2026-08-25)
+
+| Concern | Existing Hub boundary | Cutover boundary |
+| --- | --- | --- |
+| UI / auth | `/studio/generate` and `/studio/media`, manager+ | Hub stays the cockpit and auth authority |
+| submission | `POST /api/v1/studio/generate` | New OpenMontage-run submission endpoint |
+| generation | `routers/studio_generate.py` calls `acall_kie_async()` inline | OpenMontage pipeline runs asynchronously |
+| history | `studio_generations`, `generated_audio` | Existing rows remain legacy history; a new run table links to an OpenMontage project |
+| assets/renders | Kie result URLs and legacy `/root/livewell-media*` stores | `/root/openmontage/projects/<project-id>/` canonical run artifacts |
+| production board | none | Backlot at loopback `127.0.0.1:4750` |
+
+The old implementation is deliberately not removed in the first release:
+`/root/dev/app_fastapi/routers/studio_generate.py` and
+`/root/dev/app_fastapi/routers/media_studio.py` are still the only callers of
+the legacy Kie dispatcher and library.  The historical media directories are
+dormant and are not a current runnable engine.
+
+## Target shape
+
+```text
+Hub manager UI
+  -> Hub API (session/role/audit + durable run record)
+  -> OpenMontage runner adapter (local, authenticated service boundary)
+  -> OpenMontage project workspace + Backlot
+  -> Hub polls/receives normalized run status and serves approved artifact links
+```
+
+The Hub must not mount OpenMontage's `.env` or call individual media providers.
+Provider selection occurs only inside the OpenMontage pipeline after proposal
+selection.  OpenMontage's non-Twilio/non-ElevenLabs AI calls must use the
+already-established OmniRoute routing policy rather than create a second
+provider-key surface.  This needs a dedicated OpenMontage provider adapter;
+do not silently reuse the current local `.env` provider keys in production.
+
+## Minimum Hub-owned implementation
+
+1. Add `openmontage_runs` through the next append-only Hub migration. Required
+   columns: `id`, `project_id` (unique), `requested_by`, `pipeline_type`,
+   `title`, `brief_json`, `status`, `current_stage`, `backlot_url`,
+   `render_url`, `error`, `created_at`, `updated_at`, `completed_at`.
+2. Add `POST /api/v1/studio/openmontage/runs` (manager+) which validates a
+   pipeline, creates the Hub row, then asks the runner to initialize the
+   matching OpenMontage project.  Return `202` with the Hub run id and the
+   Backlot project URL; do not perform a video generation inline.
+3. Add `GET /api/v1/studio/openmontage/runs/{id}` and a paginated list endpoint.
+   They return normalized status only; Hub reads no arbitrary files from the
+   OpenMontage filesystem.
+4. Add a Hub-owned background reconciler/webhook consumer that ingests a
+   narrow runner status payload (`project_id`, stage, status, approved render
+   path, error).  It must reject paths outside the configured OpenMontage
+   export root.
+5. Add `/studio/openmontage` as the new manager-only entry.  It submits a
+   brief, shows pipeline/stage status, and links to the project Backlot view.
+   Leave `/studio/generate` and `/studio/media` visible as **Legacy Generate**
+   and **Legacy Media** until cutover evidence is complete.
+
+## Minimum OpenMontage-owned implementation
+
+1. Keep Backlot loopback-only. It is an observer, not the authorization layer.
+2. Add a small runner API/service with exactly three authenticated operations:
+   `create_run`, `get_run_status`, and `cancel_run`.  It initializes projects
+   using `lib.checkpoint.init_project`; it never accepts an arbitrary output
+   directory or shell command.
+3. Make pipeline stages resume from checkpoints. A run reaches generation only
+   after the normal proposal/approval process; the service cannot bypass those
+   rules.
+4. Add an OmniRoute-backed provider adapter and make cloud generation depend
+   on it. Keep Remotion/FFmpeg/HyperFrames local rendering direct.
+5. Export only approved final artifacts through one configured export root and
+   return relative artifact identifiers to Hub, never host filesystem paths.
+
+## Exact Hub implementation locations
+
+| Purpose | Owner-scoped target |
+| --- | --- |
+| routes | `app_fastapi/routers/studio_openmontage.py` (new) and registration in `app_fastapi/main.py` |
+| request/response models | `app_fastapi/schemas/openmontage.py` (new) |
+| persistence | next `M####` in `app_fastapi/db_migrations.py` |
+| runner client | `app_fastapi/services/openmontage/client.py` (new) |
+| async reconciliation | `app_fastapi/workers/tasks/openmontage.py` plus `workers/cron.py` |
+| UI | `frontend/src/routes/studio/openmontage/+page.svelte` and generated API schema/client |
+| navigation | `app_fastapi/nav_manifest.py`; retain legacy links during transition |
+| tests | focused FastAPI router/client/worker tests plus page test |
+
+## Release sequence
+
+1. Deploy the runner and prove a local Remotion run and Backlot status read.
+2. Deploy Hub read/write run records and the new page with the legacy routes
+   unchanged.  Prove create → project initialized → status visible.
+3. Enable one non-paid/local pipeline end-to-end, then one OmniRoute-routed
+   cloud asset path with explicit user approval.
+4. Mark the Kie Generate entry legacy only after production proof.  Do not
+   migrate or delete historical rows; add a legacy badge and redirect new
+   multi-asset work to OpenMontage.
+5. Only after a separate retention/export receipt, archive the dormant legacy
+   media stores and remove the Kie-only dispatcher.  That is a later Hub
+   publisher task, not an OpenMontage deployment action.
+
+## Acceptance evidence
+
+- Manager-authenticated Hub request creates one `openmontage_runs` row and one
+  matching OpenMontage `projects/<project_id>/project.json`.
+- Backlot reports the same project and status; a valid completed local render
+  is available through the Hub run detail.
+- A cloud generation request has an OmniRoute trace and no direct OpenMontage
+  provider key in the deployed runner environment.
+- Legacy `/studio/generate` history remains readable; no historical media is
+  deleted during the release.

--- a/docs/HUB-STUDIO-CUTOVER-SPEC.md
+++ b/docs/HUB-STUDIO-CUTOVER-SPEC.md
@@ -5,10 +5,15 @@ document.  **Owner:** the Hub publisher owns the implementation and release.
 
 ## Intent
 
-Replace the existing single-asset, Kie-only Studio generation path with
+Replace the existing single-asset, Kie-only Studio generation *workflow* with
 OpenMontage production runs while preserving the Hub as the authenticated,
 manager-only cockpit and the source of record for the user's request history.
 OpenMontage owns pipeline execution, artifacts, review state, and rendering.
+
+This does **not** retire Kie. Kie remains an OmniRoute-backed provider and model
+catalog, including image generation. The cutover changes the Hub Studio
+orchestration path; it does not remove Kie from Hub, OmniRoute, or other image
+and media features.
 
 This is a cutover of the **Generate** workflow, not a deletion of the existing
 media library.  Historical `studio_generations` and `generated_audio` records
@@ -27,8 +32,9 @@ remain readable during and after the cutover.
 
 The old implementation is deliberately not removed in the first release:
 `/root/dev/app_fastapi/routers/studio_generate.py` and
-`/root/dev/app_fastapi/routers/media_studio.py` are still the only callers of
-the legacy Kie dispatcher and library.  The historical media directories are
+`/root/dev/app_fastapi/routers/media_studio.py` remain the legacy Studio callers
+of the Kie-backed generation workflow and library. Kie itself remains available
+to other Hub routes through OmniRoute. The historical media directories are
 dormant and are not a current runnable engine.
 
 ## Target shape
@@ -105,12 +111,14 @@ do not silently reuse the current local `.env` provider keys in production.
    unchanged.  Prove create → project initialized → status visible.
 3. Enable one non-paid/local pipeline end-to-end, then one OmniRoute-routed
    cloud asset path with explicit user approval.
-4. Mark the Kie Generate entry legacy only after production proof.  Do not
-   migrate or delete historical rows; add a legacy badge and redirect new
-   multi-asset work to OpenMontage.
+4. Mark the old Studio Generate entry legacy only after production proof. Do not
+   migrate or delete historical rows; add a legacy badge and direct new
+   multi-asset work to OpenMontage. This does not disable Kie image generation
+   or its model catalog elsewhere in Hub.
 5. Only after a separate retention/export receipt, archive the dormant legacy
-   media stores and remove the Kie-only dispatcher.  That is a later Hub
-   publisher task, not an OpenMontage deployment action.
+   media stores and retire the old *Studio-specific* Kie-only dispatcher path.
+   Do not remove the shared Kie provider integration or its OmniRoute catalog.
+   That is a later Hub publisher task, not an OpenMontage deployment action.
 
 ## Acceptance evidence
 

--- a/docs/OMNIROUTE-ADAPTER-PLAN.md
+++ b/docs/OMNIROUTE-ADAPTER-PLAN.md
@@ -1,0 +1,268 @@
+# OmniRoute-Backed Cloud Provider Adapter for OpenMontage
+
+**Status:** plan only — no implementation. Written to satisfy
+`docs/HUB-STUDIO-CUTOVER-SPEC.md`'s "Minimum OpenMontage-owned implementation"
+item 4: *"Add an OmniRoute-backed provider adapter and make cloud generation
+depend on it. Keep Remotion/FFmpeg/HyperFrames local rendering direct."*
+
+---
+
+## Requirement recap (from the cutover spec)
+
+- The Hub must not mount OpenMontage's `.env` or call individual media
+  providers directly. Provider selection happens only inside the OpenMontage
+  pipeline, after proposal selection.
+- "OpenMontage's non-Twilio/non-ElevenLabs AI calls must use the
+  already-established OmniRoute routing policy rather than create a second
+  provider-key surface." Twilio and ElevenLabs are explicitly carved out and
+  keep their current direct-key path (`ELEVENLABS_API_KEY` in `.env`).
+- Kie remains an OmniRoute-backed provider and model catalog, including image
+  generation — it is not being retired, only re-routed.
+- Acceptance evidence requires: "A cloud generation request has an OmniRoute
+  trace and no direct OpenMontage provider key in the deployed runner
+  environment."
+
+## What was confirmed on this box (2026-08-26)
+
+- OmniRoute is reachable at `http://127.0.0.1:20128`, loopback-only, health at
+  `GET /api/monitoring/health` (confirmed `"status":"healthy"`, version
+  `3.8.49`).
+- It exposes an OpenAI-compatible surface: `GET /v1/models` (catalog, not live
+  capability — see gotcha below) and a completions path shaped
+  `/v1/providers/{provider_id}/chat/completions` per the documented Hermes
+  consumer contract (`/root/.hermes/specs/omniroute/v1/hermes-consumer-contract.json`).
+- Credential handling in the established pattern: a bearer token resolved
+  **at request time** from Infisical (`HERMES_OMNIROUTE_CONSUMER_API_KEY` under
+  `/nodes/livewell`), held in process memory only — never written to a
+  persistent env file, never logged, never placed in argv.
+- **Gotcha (do not re-trip this):** `/v1/models` reflects OmniRoute's
+  *configured* catalog, not live per-provider capability. An adapter must not
+  infer "Kie image generation is available" from a model ID appearing in that
+  list; it must treat a real dispatch (or a documented, versioned capability
+  endpoint if OmniRoute exposes one) as the source of truth, and must handle a
+  configured-but-unavailable model as a normal runtime failure, not a bug.
+- What is **not yet confirmed** on this box: the exact request/response shape
+  OmniRoute uses for *media* (image/video) generation as opposed to chat/text
+  completions. The one written contract found (`hermes-consumer-contract.json`)
+  documents an `openai_compatible` chat-completions transport used today for
+  LLM routing (Kimi, Claude, Codex, DeepSeek, xAI, etc.). Whether Kie's image
+  models ride the same `/v1/providers/{provider_id}/chat/completions` shape
+  (e.g., as a multimodal/tool-call response) or a distinct OmniRoute route is
+  an open question — **the implementer must confirm this against the live
+  OmniRoute API and/or OmniRoute's own docs before writing the HTTP layer**,
+  not assume either shape. This plan is written so that confirmation is the
+  first implementation step, isolated behind one client class.
+
+## Design
+
+### Architecture
+
+```
+OpenMontage pipeline agent
+    |
+    v
+image_selector / video_selector / tts_selector  (existing selectors)
+    |
+    v
+omniroute_image / omniroute_video / (omniroute_kie_* as needed)   (new tools)
+    |
+    v
+lib/providers/omniroute_client.py   (new shared client)
+    |
+    v
+OmniRoute  http://127.0.0.1:20128   (loopback, OpenAI-compatible, no direct
+                                      provider key held by OpenMontage)
+```
+
+Remotion/FFmpeg/HyperFrames composition and local rendering (`hyperframes_compose`,
+`video_compose`, `remotion_caption_burn`, etc.) are untouched — they already run
+direct/local and the spec explicitly says to keep them that way.
+
+### New files
+
+```
+lib/
+  providers/
+    omniroute_client.py     # shared client: health check, auth, dispatch, error mapping
+    omniroute_models.py      # typed request/response dataclasses per confirmed shape
+tools/
+  graphics/
+    omniroute_image.py       # capability="image_generation", provider="omniroute"
+  video/
+    omniroute_video.py       # capability="video_generation", provider="omniroute"
+docs/
+  OMNIROUTE-ADAPTER-PLAN.md  # this file
+tests/
+  contracts/
+    test_omniroute_tools.py  # tool-contract tests against a stubbed OmniRoute
+```
+
+`lib/providers/__init__.py` already exists (currently empty) — this is where
+the shared client lands, following the same "shared client + thin BaseTool
+subclasses" split used by `tools/_comfyui/client.py` (see
+`docs/comfyui-adapter-plan.md`).
+
+Kie-specific dispatch, if it turns out to need its own request shape distinct
+from a generic "omniroute image/video" tool, becomes `tools/graphics/omniroute_kie_image.py`
+/ `tools/video/omniroute_kie_video.py` reusing the same shared client — kept as
+a fork point rather than assumed up front, since the exact Kie routing shape
+through OmniRoute is the open question above.
+
+### Shared client: `lib/providers/omniroute_client.py`
+
+```python
+class OmniRouteError(Exception):
+    """Raised on a non-2xx OmniRoute response or a health/version mismatch."""
+
+class OmniRouteClient:
+    """Thin client for OpenMontage's OmniRoute-backed cloud generation calls."""
+
+    def __init__(self, base_url: str | None = None):
+        # Loopback default; never accept a non-loopback override in production
+        # config the way the runner's host bind is hardcoded to 127.0.0.1.
+        self.base_url = base_url or os.environ.get(
+            "OPENMONTAGE_OMNIROUTE_URL", "http://127.0.0.1:20128"
+        )
+
+    def _token(self) -> str:
+        """Resolve the bearer token at call time. Same pattern as the Hermes
+        consumer contract: Infisical read at request time, held in memory
+        only, never persisted to .env or logs. No fallback to a static env
+        var checked into .env.example."""
+
+    def health(self) -> dict:
+        """GET /api/monitoring/health. Raise OmniRouteError unless status is
+        'healthy'. Callers (get_status()/dry_run()) use this, not a bare
+        socket check, so a degraded-but-listening OmniRoute reports
+        DEGRADED/UNAVAILABLE correctly instead of AVAILABLE."""
+
+    def generate_image(self, *, prompt: str, model: str, **params) -> dict:
+        """Dispatch one image generation request. Request/response shape is
+        the confirmed-first-step above — implemented only after that shape is
+        verified live, not guessed."""
+
+    def generate_video(self, *, prompt: str, model: str, **params) -> dict:
+        """Same contract as generate_image for video models."""
+```
+
+Design choices carried over deliberately from the runner and ComfyUI adapter
+precedent:
+
+- **No direct provider key ever held by this client or its tools.** `dependencies`
+  on the new `BaseTool` subclasses declare no `env:<PROVIDER>_API_KEY` entries;
+  the only environment dependency is whatever names the OmniRoute consumer
+  token (resolved via the vault rail, per `AGENTS.md` — "Use Infisical/vault
+  rails for secrets; do not create ad-hoc env copies").
+- **Loopback-only, matching the runner's own posture.** `runner/__main__.py`
+  hardcodes `host="127.0.0.1"`; this client's default `base_url` follows the
+  same convention and is not meant to be pointed at a non-loopback address in
+  the deployed config.
+- **Health is a distinct call from dispatch**, so `get_status()` can report
+  `DEGRADED` (OmniRoute up, provider circuit open / model exhausted) versus
+  `UNAVAILABLE` (OmniRoute unreachable) versus `AVAILABLE`, the same
+  three-state contract every other `BaseTool` already exposes.
+- **Errors carry an OmniRoute trace id** (whatever correlation id the response
+  includes) into `ToolResult.data`, both so operators can find the call in
+  OmniRoute's own logs and so the cutover's acceptance evidence
+  ("a cloud generation request has an OmniRoute trace") is satisfiable without
+  extra plumbing.
+
+### Tool specifications
+
+#### `omniroute_image` — Image generation
+
+| Field | Value |
+|-------|-------|
+| capability | `image_generation` |
+| provider | `omniroute` |
+| runtime | `API` |
+| tier | `GENERATE` |
+| stability | `EXPERIMENTAL` (until the live request shape is confirmed and one real generation has round-tripped) |
+| dependencies | none of the `env:*` kind — only requires OmniRoute reachability + vault-resolved token |
+| fallback_tools | existing direct-key tools (`flux_image`, `openai_image`, `kling_official_image`, etc.) stay as-is and as fallback; nothing about them changes in this plan |
+| cost | reported from OmniRoute's own response if it returns metered cost; otherwise `estimate_cost()` uses the same per-model cost table `tools/cost_tracker.py` already loads |
+
+#### `omniroute_video` — Video generation
+
+Same shape as above, `capability="video_generation"`.
+
+**`execute()` flow (both tools), matching the existing `BaseTool` contract:**
+
+1. `client.health()` — fail fast with a clear `ToolResult(success=False, ...)`
+   if OmniRoute itself is down, rather than letting a raw connection error
+   surface.
+2. Build the provider-specific request body per the confirmed shape.
+3. `client.generate_image(...)` / `client.generate_video(...)`.
+4. Download/save the returned artifact into the caller-provided `output_path`
+   (same convention every other generation tool in `tools/video/` and
+   `tools/graphics/` already follows).
+5. Return `ToolResult` with `model`, `cost_usd`, and the OmniRoute trace id in
+   `data`.
+
+### Registry and selector integration
+
+No changes needed beyond adding the two files under `tools/graphics/` and
+`tools/video/` — `tool_registry.discover()` already walks those packages via
+`pkgutil.walk_packages`, and `image_selector`/`video_selector` already pick up
+any tool through `registry.get_by_capability(...)`. This mirrors exactly what
+`docs/comfyui-adapter-plan.md` did for its own registry/selector section — no
+new integration surface is being invented here.
+
+### Configuration
+
+```bash
+# .env — OpenMontage-side, no provider key added here
+OPENMONTAGE_OMNIROUTE_URL=http://127.0.0.1:20128   # optional; this is the default
+```
+
+No `OMNIROUTE_API_KEY`-shaped entry belongs in `.env` or `.env.example`: the
+token is vault-resolved at request time, exactly like the Hermes consumer
+contract's `HERMES_OMNIROUTE_CONSUMER_API_KEY` binding. If OpenMontage's
+process identity needs its own distinct Infisical secret (rather than reusing
+the Hermes one), that is a vault-provisioning decision for whoever owns the
+Infisical rail on this box, not something this adapter should invent an ad-hoc
+copy of.
+
+### What this deliberately does not change
+
+- Twilio and ElevenLabs keep their current direct-key path — the spec
+  excludes them by name.
+- Kie stays a real provider/model catalog; this plan does not remove or
+  duplicate `docs/PROVIDERS.md`'s Kie entry, it only adds the routing layer in
+  front of dispatch for calls the cutover spec scopes to OmniRoute.
+- Remotion/FFmpeg/HyperFrames local rendering is untouched.
+- No other existing direct-key tool (`kling_video`, `fal_elevenlabs_music`,
+  `runway_video`, etc.) is modified, deprecated, or rewired by this plan. They
+  remain available as fallback tools exactly as they are today.
+
+## Implementation scope (estimate)
+
+| Component | Files | Estimated size |
+|-----------|-------|-----------------|
+| Shared client | `lib/providers/omniroute_client.py` | ~150 lines |
+| Typed request/response models | `lib/providers/omniroute_models.py` | ~60 lines |
+| Image tool | `tools/graphics/omniroute_image.py` | ~120 lines |
+| Video tool | `tools/video/omniroute_video.py` | ~130 lines |
+| Tests (stubbed OmniRoute) | `tests/contracts/test_omniroute_tools.py` | ~150 lines |
+| Docs | `docs/OMNIROUTE-ADAPTER-PLAN.md` | this file |
+
+No changes to: `base_tool.py`, `runner/server.py`, any pipeline definition,
+Backlot, or any existing direct-key provider tool.
+
+## Open questions to resolve before writing code
+
+1. **Confirm the live media-generation request/response shape against
+   OmniRoute itself** (or its docs) before writing `omniroute_client.py`'s
+   `generate_image`/`generate_video` bodies — do not assume the chat-completions
+   shape carries over to image/video without checking.
+2. **Confirm which Infisical secret path/name OpenMontage should read** for its
+   own OmniRoute consumer token — reuse `HERMES_OMNIROUTE_CONSUMER_API_KEY`
+   under `/nodes/livewell`, or provision a distinct OpenMontage-scoped secret.
+   This is a vault-ownership call, not an OpenMontage code decision.
+3. **Confirm whether OmniRoute reports metered cost per call** (so
+   `estimate_cost()`/`ToolResult.cost_usd` can use the authoritative number)
+   or whether OpenMontage's own per-model cost table remains the source of
+   truth for budget governance.
+4. **EXPERIMENTAL → BETA promotion criteria**: same convention as every other
+   tool here — promote once one real generation has round-tripped end-to-end
+   and been reviewed, not on code completion alone.

--- a/docs/POST-LIFT-E2E-PREFLIGHT.md
+++ b/docs/POST-LIFT-E2E-PREFLIGHT.md
@@ -1,0 +1,178 @@
+# OpenMontage Post-Lift Preflight and End-to-End Proof
+
+**Status:** prepared during the maintenance freeze. Nothing in this document
+was executed as a service start — `openmontage-runner.service` stays
+inactive/disabled until the freeze lifts. Every check below is read-only
+(config audit, file/permission checks, module import, health GET against the
+already-running Backlot) or an explicit static analysis of `runner/server.py`
+and `runner/__main__.py`.
+
+Verified: 2026-08-26.
+
+---
+
+## Part 1 — Preflight checklist
+
+| # | Item | Check performed | Result |
+|---|------|------------------|--------|
+| 1 | Runner code present | `/root/openmontage/runner/server.py`, `__main__.py`, `__init__.py` exist | **PASS** |
+| 2 | Runner imports cleanly | `python -c "from runner import server; server.create_app()"` in the venv | **PASS** — app builds, routes: `/api/v1/health`, `/api/v1/runs`, `/api/v1/runs/{project_id}`, `/api/v1/runs/{project_id}/cancel` |
+| 3 | venv has runtime deps (fastapi, uvicorn, pydantic) | `pip list` in `.venv` | **PASS** — fastapi 0.141.1, uvicorn 0.52.4, pydantic 2.13.4 |
+| 4 | venv has test deps (pytest) | installed this session via `.venv/bin/python -m pip install -r requirements-dev.txt` | **PASS** — pytest 9.1.1, pytest-asyncio 1.4.0 |
+| 5 | Focused runner test suite passes | `pytest tests/runner/ -v` | **PASS** — 4/4 (`test_create_run_initializes_fixed_canonical_project_root`, `test_auth_and_path_input_are_rejected`, `test_status_derives_checkpoint_then_approved_render`, `test_cancel_is_cooperative_and_terminal_runs_are_not_cancelled`) |
+| 6 | Loopback-only bind confirmed in code | `runner/__main__.py` line 14: `uvicorn.run("runner.server:app", host="127.0.0.1", port=args.port, ...)` — hardcoded, not env-overridable | **PASS** |
+| 7 | Port default correct | `--port` defaults to `OPENMONTAGE_RUNNER_PORT` env or `4751` | **PASS** |
+| 8 | Port currently dark (freeze respected) | `ss -ltnp \| grep 4751` | **PASS (expected)** — nothing listening |
+| 9 | systemd unit installed | `/etc/systemd/system/openmontage-runner.service` | **PASS** — present, byte-identical to `deploy/systemd/openmontage-runner.service` in the repo |
+| 10 | systemd unit inactive/disabled (freeze respected) | `systemctl is-active` / `is-enabled openmontage-runner.service` | **PASS (expected)** — `inactive` / `disabled` |
+| 11 | Token file present, correctly scoped | `/etc/openmontage/runner.env` | **PASS** — exists, mode `600`, owner `root:root`, contains exactly one `OPENMONTAGE_RUNNER_TOKEN=` line (value not read/printed here) |
+| 12 | Token not duplicated into repo `.env` | `grep OPENMONTAGE_RUNNER .env` | **PASS** — no match; token lives only in the root-only `/etc/openmontage/runner.env`, consistent with the systemd `EnvironmentFile` design |
+| 13 | `PROJECTS_DIR` resolves and is writable | `lib.paths.PROJECTS_DIR` resolves to `/root/openmontage/projects`, exists, writable | **PASS** |
+| 14 | `pipeline_defs/` has a minimal smoke pipeline | `pipeline_defs/framework-smoke.yaml` present | **PASS** — this is the pipeline the E2E test in Part 2 uses |
+| 15 | Backlot already up (dependency of the runner's value, not the runner itself) | `curl 127.0.0.1:4750/api/health` | **PASS** — `{"ok":true,"app":"backlot"}`, service `active`/`enabled` |
+| 16 | OpenMontage repo commit state | `git status` / `git log ragnar/main..HEAD` | **PASS** — working tree clean; the 3 locally-ahead commits are already present on `ragnar/main` (owner's fork) — see drift note below |
+| 17 | Render toolchain — ffmpeg | `ffmpeg -version` | **PASS** — ffmpeg 6.1.1-3ubuntu5 (libx264, libx265, libvpx present) |
+| 18 | Render toolchain — Remotion node deps | `npm ls --depth=0` in `remotion-composer/` | **PASS** — no missing/unmet deps reported |
+| 19 | Render toolchain — headless Chromium for Remotion | `node_modules/.remotion/chrome-headless-shell` | **PASS** — already downloaded, no first-run fetch needed |
+| 20 | Render toolchain — GPU | `nvidia-smi` | **N/A (no GPU on this box)** — CPU-bound Remotion/FFmpeg rendering only; GPU-only local tools (`local_diffusion`, `wan_video`, etc.) will correctly report `UNAVAILABLE`, which is expected and does not block the E2E proof (framework-smoke does not require them) |
+| 21 | Disk space | `df -h /` | **CAUTION** — 40G free of 387G (90% used). Not a blocker for one smoke render, but leave a margin note for whoever runs a longer/heavier render batch after lift |
+| 22 | OmniRoute cloud adapter | see `docs/OMNIROUTE-ADAPTER-PLAN.md` | **NOT STARTED (by design)** — plan-only per task scope; local rendering does not depend on it |
+
+### Drift note (item 16)
+
+`origin` (`git remote -v`) is `github.com/calesthio/OpenMontage` — the
+upstream project, not the owner's. `ragnar` is `github.com/ragnar-claude/OpenMontage`
+— the owner's fork. `HEAD` and `ragnar/main` are the same commit
+(`9cb3f209fdaa2585b5b17d16a0f863522da45d25`); the "3 commits ahead" is only
+relative to `origin/main`, which is expected and correct — those commits
+should not be pushed to `origin` (not the owner's repo), and no push to
+`ragnar` was needed because they are already there.
+
+### One remaining pre-lift confirmation
+
+Item 11 confirms the token *file* is correctly shaped, but its *value* was
+deliberately not read or compared in this pass (never print secrets to a
+report). Before running Part 2's Step 3, whoever executes it should confirm
+`/etc/openmontage/runner.env`'s `OPENMONTAGE_RUNNER_TOKEN` value is the one
+they intend to send as the bearer token — this doc does not and should not
+embed it.
+
+---
+
+## Part 2 — Post-lift end-to-end proof plan
+
+Run only after the maintenance freeze is explicitly lifted. Every step below
+is one command; nothing here should require debugging if Part 1 stayed green.
+
+### Step 1 — Start the runner (the one action this preflight deliberately did not take)
+
+```bash
+systemctl daemon-reload   # picks up the unit if anything changed since install
+systemctl enable --now openmontage-runner.service
+```
+
+### Step 2 — Confirm the runner is up and loopback-only
+
+```bash
+systemctl is-active openmontage-runner.service      # expect: active
+ss -ltnp | grep 4751                                # expect: 127.0.0.1:4751 only, no 0.0.0.0/::
+curl -s http://127.0.0.1:4750/api/health             # Backlot, expect: {"ok":true,"app":"backlot"}
+curl -s http://127.0.0.1:4751/api/v1/health          # Runner, expect: {"ok":true}
+```
+
+### Step 3 — Submit one test render through the runner API directly
+
+(This exercises the same path the Hub's future runner client will use —
+`docs/HUB-STUDIO-CUTOVER-SPEC.md`'s "Release sequence" step 1: "Deploy the
+runner and prove a local Remotion run and Backlot status read.")
+
+```bash
+TOKEN=$(grep -oP '(?<=^OPENMONTAGE_RUNNER_TOKEN=).*' /etc/openmontage/runner.env)
+
+curl -s -X POST http://127.0.0.1:4751/api/v1/runs \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"project_id":"e2e-smoke-01","title":"E2E smoke","pipeline_type":"framework-smoke"}'
+# expect: 201, {"project_id":"e2e-smoke-01","status":"initialized",...}
+
+curl -s http://127.0.0.1:4751/api/v1/runs/e2e-smoke-01 \
+  -H "Authorization: Bearer ${TOKEN}"
+# expect: status progresses initialized -> in_progress -> ready/completed as
+# the pipeline agent advances checkpoints (the runner itself does not drive
+# this — see Step 4)
+```
+
+### Step 4 — Advance the pipeline to a completed render
+
+The runner only initializes the project and reports derived status; it does
+not execute pipeline stages itself (`runner/server.py`'s own docstring: *"The
+runner is an adapter for the Hub, not a second orchestrator... Pipeline agents
+remain responsible for progressing work through the normal checkpoint and
+approval protocol."*). Drive `projects/e2e-smoke-01` through the
+`framework-smoke` pipeline's stages via the normal OpenMontage agent/checkpoint
+flow until a `compose`/`publish` checkpoint is `completed` and
+`projects/e2e-smoke-01/renders/final.mp4` (or `.webm`/`.mov`) exists.
+
+```bash
+# Re-check status after the pipeline reaches compose/publish:
+curl -s http://127.0.0.1:4751/api/v1/runs/e2e-smoke-01 \
+  -H "Authorization: Bearer ${TOKEN}"
+# expect: {"status":"completed","render_id":"renders/final.mp4",...}
+```
+
+### Step 5 — Verify Backlot reconciliation
+
+```bash
+curl -s http://127.0.0.1:4750/api/health              # still healthy
+# Backlot's own project/board view should show e2e-smoke-01 with the same
+# stage/status the runner just reported — Backlot is a read-only observer of
+# the same checkpoint files, so this is a cross-check, not a second source of
+# truth. Confirm by whatever Backlot board endpoint/UI lists projects (check
+# backlot/ router paths at lift time if the exact listing route isn't already
+# known).
+```
+
+### Step 6 — Verify the delivered artifact
+
+```bash
+ls -la /root/openmontage/projects/e2e-smoke-01/renders/
+file /root/openmontage/projects/e2e-smoke-01/renders/final.mp4
+ffprobe -v error -show_format -show_streams \
+  /root/openmontage/projects/e2e-smoke-01/renders/final.mp4
+# expect: a valid, playable container with at least one video stream
+```
+
+### Step 7 — Exercise cancellation (cooperative, non-destructive)
+
+Optional but cheap — proves the third authenticated operation before Hub
+integration work begins:
+
+```bash
+curl -s -X POST http://127.0.0.1:4751/api/v1/runs/e2e-smoke-01/cancel \
+  -H "Authorization: Bearer ${TOKEN}"
+# expect: 409 if the run already reached completed/failed/cancelled (correct
+# behavior per test_cancel_is_cooperative_and_terminal_runs_are_not_cancelled);
+# run this against a still-in-progress run if you want to see the 200 path.
+```
+
+### Step 8 — Clean up the smoke project (optional)
+
+```bash
+rm -rf /root/openmontage/projects/e2e-smoke-01
+```
+
+### Acceptance criteria (mirrors the cutover spec's "Acceptance evidence")
+
+- [ ] Runner active, loopback-only (`127.0.0.1:4751`), health `200`.
+- [ ] `POST /api/v1/runs` created one `projects/<id>/project.json`.
+- [ ] Pipeline advanced through checkpoints to a `compose`/`publish` completion
+      without the runner itself executing any stage.
+- [ ] `GET /api/v1/runs/<id>` derived `status:"completed"` and a `render_id`.
+- [ ] Backlot's own view of the same project agrees with the runner's derived
+      status.
+- [ ] The artifact at `projects/<id>/renders/final.mp4` is a valid, playable
+      video file.
+- [ ] No direct provider key was required for this specific proof (it exercises
+      local Remotion/FFmpeg rendering only, per the cutover spec's phased
+      "Release sequence" — cloud/OmniRoute generation is proved separately
+      once `docs/OMNIROUTE-ADAPTER-PLAN.md` is implemented).

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -1,0 +1,1 @@
+"""Authenticated, local-only API boundary for OpenMontage production runs."""

--- a/runner/__main__.py
+++ b/runner/__main__.py
@@ -1,0 +1,19 @@
+"""Run the loopback-only OpenMontage runner service."""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="openmontage-runner")
+    parser.add_argument("--port", type=int, default=int(os.environ.get("OPENMONTAGE_RUNNER_PORT", "4751")))
+    args = parser.parse_args(argv)
+    import uvicorn
+    uvicorn.run("runner.server:app", host="127.0.0.1", port=args.port, log_level="warning")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runner/server.py
+++ b/runner/server.py
@@ -1,0 +1,237 @@
+"""Small, deliberately bounded OpenMontage runner service.
+
+The runner is an adapter for the Hub, not a second orchestrator.  It only
+creates canonical project workspaces, derives their state from checkpoints and
+approved renders, and records a cooperative cancellation request.  Pipeline
+agents remain responsible for progressing work through the normal checkpoint
+and approval protocol.
+"""
+
+from __future__ import annotations
+
+import hmac
+import json
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from fastapi import Depends, FastAPI, Header, HTTPException, status
+from pydantic import BaseModel, Field
+
+from lib.checkpoint import get_pipeline_stages, init_project
+from lib.paths import PROJECTS_DIR
+
+API_PREFIX = "/api/v1"
+PROJECT_ID_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,62})$")
+CONTROL_FILENAME = "runner_control.json"
+APPROVED_RENDER_NAMES = ("final.mp4", "final.webm", "final.mov")
+
+
+class CreateRunRequest(BaseModel):
+    """The only information the runner accepts to initialize a run."""
+
+    project_id: str = Field(min_length=1, max_length=63)
+    title: str = Field(min_length=1, max_length=240)
+    pipeline_type: str = Field(min_length=1, max_length=80)
+    style_playbook: str | None = Field(default=None, max_length=80)
+
+
+class RunResponse(BaseModel):
+    project_id: str
+    status: str
+    current_stage: str | None = None
+    render_id: str | None = None
+    error: str | None = None
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _token() -> str:
+    token = os.environ.get("OPENMONTAGE_RUNNER_TOKEN", "")
+    if not token:
+        raise HTTPException(status_code=503, detail="runner authentication is not configured")
+    return token
+
+
+def require_auth(authorization: str | None = Header(default=None)) -> None:
+    """Require a bearer token without exposing token content in errors/logs."""
+
+    expected = _token()
+    scheme, _, supplied = (authorization or "").partition(" ")
+    if scheme.lower() != "bearer" or not supplied or not hmac.compare_digest(supplied, expected):
+        raise HTTPException(status_code=401, detail="unauthorized")
+
+
+def _validate_project_id(project_id: str) -> str:
+    if not PROJECT_ID_RE.fullmatch(project_id):
+        raise HTTPException(
+            status_code=422,
+            detail="project_id must be lowercase kebab-case (1-63 characters)",
+        )
+    return project_id
+
+
+def _project_dir(project_id: str, *, require_exists: bool = True) -> Path:
+    _validate_project_id(project_id)
+    root = PROJECTS_DIR.resolve()
+    path = (root / project_id).resolve()
+    if path.parent != root:
+        # Defensive even though validation makes traversal impossible.
+        raise HTTPException(status_code=400, detail="invalid project id")
+    if require_exists and not path.is_dir():
+        raise HTTPException(status_code=404, detail="unknown project")
+    return path
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _control_path(project_dir: Path) -> Path:
+    return project_dir / CONTROL_FILENAME
+
+
+def _is_cancelled(project_dir: Path) -> bool:
+    control = _read_json(_control_path(project_dir))
+    return bool(control and control.get("cancel_requested_at"))
+
+
+def _latest_checkpoint(project_dir: Path) -> dict[str, Any] | None:
+    paths = sorted(project_dir.glob("checkpoint_*.json"), key=lambda p: p.stat().st_mtime_ns, reverse=True)
+    for path in paths:
+        checkpoint = _read_json(path)
+        if checkpoint:
+            return checkpoint
+    return None
+
+
+def _approved_render(project_dir: Path, checkpoint: dict[str, Any] | None) -> str | None:
+    """Return a project-relative identifier only after compose/publish completed."""
+
+    completed = {
+        p.stem.removeprefix("checkpoint_")
+        for p in project_dir.glob("checkpoint_*.json")
+        if (_read_json(p) or {}).get("status") == "completed"
+    }
+    if not {"compose", "publish"}.intersection(completed):
+        return None
+    for name in APPROVED_RENDER_NAMES:
+        candidate = project_dir / "renders" / name
+        if candidate.is_file():
+            return f"renders/{name}"
+    return None
+
+
+def derive_status(project_dir: Path) -> RunResponse:
+    """Derive normalized state from canonical checkpoint/render files only."""
+
+    marker = _read_json(project_dir / "project.json") or {}
+    checkpoint = _latest_checkpoint(project_dir)
+    current_stage = checkpoint.get("stage") if checkpoint else None
+    checkpoint_status = checkpoint.get("status") if checkpoint else None
+    render_id = _approved_render(project_dir, checkpoint)
+
+    if _is_cancelled(project_dir):
+        run_status = "cancelled"
+    elif render_id:
+        run_status = "completed"
+    elif checkpoint_status in {"failed", "error"}:
+        run_status = "failed"
+    elif checkpoint_status == "awaiting_human":
+        run_status = "awaiting_human"
+    elif checkpoint_status == "in_progress":
+        run_status = "in_progress"
+    elif checkpoint_status == "completed":
+        pipeline_type = marker.get("pipeline_type")
+        stages = get_pipeline_stages(pipeline_type) if isinstance(pipeline_type, str) else []
+        completed = {
+            p.stem.removeprefix("checkpoint_")
+            for p in project_dir.glob("checkpoint_*.json")
+            if (_read_json(p) or {}).get("status") == "completed"
+        }
+        run_status = "completed" if stages and set(stages).issubset(completed) else "ready"
+    else:
+        run_status = "initialized"
+
+    error = checkpoint.get("error") if checkpoint and isinstance(checkpoint.get("error"), str) else None
+    return RunResponse(
+        project_id=str(marker.get("project_id") or project_dir.name),
+        status=run_status,
+        current_stage=current_stage if isinstance(current_stage, str) else None,
+        render_id=render_id,
+        error=error,
+    )
+
+
+def _write_cancel_request(project_dir: Path) -> None:
+    """Atomically record cooperative cancellation; never kills a process."""
+
+    payload = {"version": "1.0", "cancel_requested_at": _now()}
+    destination = _control_path(project_dir)
+    temporary = destination.with_suffix(".json.tmp")
+    temporary.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    os.replace(temporary, destination)
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="OpenMontage Runner", docs_url=None, redoc_url=None)
+
+    @app.get(f"{API_PREFIX}/health")
+    def health() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.post(f"{API_PREFIX}/runs", response_model=RunResponse, status_code=status.HTTP_201_CREATED)
+    def create_run(request: CreateRunRequest, _: None = Depends(require_auth)) -> RunResponse:
+        project_id = _validate_project_id(request.project_id)
+        try:
+            # Validate before filesystem mutation: an unknown pipeline must not
+            # leave a half-created directory behind.
+            get_pipeline_stages(request.pipeline_type)
+            pipeline_known = (Path(__file__).resolve().parents[1] / "pipeline_defs" / f"{request.pipeline_type}.yaml").is_file()
+            if not pipeline_known:
+                raise ValueError("unknown pipeline")
+        except Exception:
+            raise HTTPException(status_code=422, detail="unknown pipeline_type") from None
+        project_dir = _project_dir(project_id, require_exists=False)
+        if project_dir.exists():
+            marker = _read_json(project_dir / "project.json")
+            if marker:
+                raise HTTPException(status_code=409, detail="project_id already exists")
+            raise HTTPException(status_code=409, detail="project directory already exists")
+        try:
+            init_project(
+                project_id,
+                title=request.title,
+                pipeline_type=request.pipeline_type,
+                pipeline_dir=PROJECTS_DIR,
+                style_playbook=request.style_playbook,
+            )
+        except Exception as exc:
+            raise HTTPException(status_code=422, detail=f"project initialization failed: {exc}") from None
+        return derive_status(project_dir)
+
+    @app.get(f"{API_PREFIX}/runs/{{project_id}}", response_model=RunResponse)
+    def get_run_status(project_id: str, _: None = Depends(require_auth)) -> RunResponse:
+        return derive_status(_project_dir(project_id))
+
+    @app.post(f"{API_PREFIX}/runs/{{project_id}}/cancel", response_model=RunResponse)
+    def cancel_run(project_id: str, _: None = Depends(require_auth)) -> RunResponse:
+        project_dir = _project_dir(project_id)
+        current = derive_status(project_dir)
+        if current.status in {"completed", "failed", "cancelled"}:
+            raise HTTPException(status_code=409, detail=f"cannot cancel a {current.status} run")
+        _write_cancel_request(project_dir)
+        return derive_status(project_dir)
+
+    return app
+
+
+app = create_app()

--- a/tests/runner/test_server.py
+++ b/tests/runner/test_server.py
@@ -1,0 +1,80 @@
+"""Focused contract tests for the bounded OpenMontage runner API."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from runner import server as runner
+
+
+@pytest.fixture
+def projects_root(tmp_path, monkeypatch) -> Path:
+    root = tmp_path / "projects"
+    root.mkdir()
+    monkeypatch.setattr(runner, "PROJECTS_DIR", root)
+    monkeypatch.setenv("OPENMONTAGE_RUNNER_TOKEN", "runner-test-token")
+    return root
+
+
+@pytest.fixture
+def client(projects_root):
+    return TestClient(runner.create_app())
+
+
+def _headers() -> dict[str, str]:
+    return {"Authorization": "Bearer runner-test-token"}
+
+
+def _create(client, project_id="local-demo"):
+    return client.post(
+        "/api/v1/runs",
+        headers=_headers(),
+        json={"project_id": project_id, "title": "Local demo", "pipeline_type": "framework-smoke"},
+    )
+
+
+def test_create_run_initializes_fixed_canonical_project_root(client, projects_root):
+    response = _create(client)
+    assert response.status_code == 201
+    assert response.json() == {
+        "project_id": "local-demo", "status": "initialized",
+        "current_stage": None, "render_id": None, "error": None,
+    }
+    assert (projects_root / "local-demo" / "project.json").is_file()
+    assert (projects_root / "local-demo" / "artifacts").is_dir()
+    assert not (projects_root / "outside").exists()
+
+
+def test_auth_and_path_input_are_rejected(client):
+    forbidden = client.post("/api/v1/runs", json={"project_id": "x", "title": "X", "pipeline_type": "framework-smoke"})
+    assert forbidden.status_code == 401
+    unsafe = _create(client, "../outside")
+    assert unsafe.status_code == 422
+
+
+def test_status_derives_checkpoint_then_approved_render(client, projects_root):
+    assert _create(client).status_code == 201
+    project = projects_root / "local-demo"
+    (project / "checkpoint_research.json").write_text(json.dumps({"stage": "research", "status": "awaiting_human"}), encoding="utf-8")
+    waiting = client.get("/api/v1/runs/local-demo", headers=_headers())
+    assert waiting.json()["status"] == "awaiting_human"
+    (project / "checkpoint_compose.json").write_text(json.dumps({"stage": "compose", "status": "completed"}), encoding="utf-8")
+    (project / "renders").mkdir(exist_ok=True)
+    (project / "renders" / "final.mp4").write_bytes(b"render")
+    done = client.get("/api/v1/runs/local-demo", headers=_headers())
+    assert done.json()["status"] == "completed"
+    assert done.json()["render_id"] == "renders/final.mp4"
+
+
+def test_cancel_is_cooperative_and_terminal_runs_are_not_cancelled(client, projects_root):
+    assert _create(client).status_code == 201
+    cancelled = client.post("/api/v1/runs/local-demo/cancel", headers=_headers())
+    assert cancelled.status_code == 200
+    assert cancelled.json()["status"] == "cancelled"
+    assert (projects_root / "local-demo" / "runner_control.json").is_file()
+    again = client.post("/api/v1/runs/local-demo/cancel", headers=_headers())
+    assert again.status_code == 409


### PR DESCRIPTION
Adds the actionable Hub-owned cutover specification: authenticated Studio cockpit, OpenMontage runner boundary, safe staged migration, legacy retention, and OmniRoute-only cloud adapter routing.