### PR TITLE
fix(captions): keep word spacing in caption overlay

### DIFF
--- a/remotion-composer/src/components/CaptionOverlay.tsx
+++ b/remotion-composer/src/components/CaptionOverlay.tsx
@@ -125,7 +125,16 @@ const PageRenderer: React.FC<{
                     : "0 2px 4px rgba(0,0,0,0.5)",
                 }}
               >
-                {w.word}{i < page.words.length - 1 ? wordSeparator : ""}
+                {/* A plain trailing space inside an inline-block span is
+                    trimmed by the browser, so words run together. A
+                    non-breaking space survives it. CJK (separator "")
+                    is unaffected. */}
+                {w.word}
+                {i < page.words.length - 1
+                  ? wordSeparator === " "
+                    ? "\u00A0"
+                    : wordSeparator
+                  : ""}
               </span>
             );
           })}


### PR DESCRIPTION
## Problem

Every caption rendered as one run-on string — `Mediamalaufbautundmalauslaugt:` instead of `Media mal aufbaut und mal auslaugt:`.

`PageRenderer` puts each word in its own `inline-block` span and appends the separator *inside* that span:

```tsx
{w.word}{i < page.words.length - 1 ? wordSeparator : ""}
```

Browsers trim trailing whitespace at the end of an inline-block box, so the separator never rendered. The parent's `whiteSpace: "pre-wrap"` does not help, because the child overrides it with `nowrap`.

This affects every space-delimited language. The CJK path happened to be correct only because it passes `wordSeparator=""`.

## Fix

Emit a non-breaking space when the separator is a plain space. It survives the trim, and `nowrap` keeps each word unbroken as before. Callers passing `""` (CJK) are untouched.

## Verification

Rendered a 95-second German explainer before and after; captions go from run-on to correctly spaced, with no change to line wrapping or the word-highlight timing. `npx tsc --noEmit` passes.

No test is included because `remotion-composer/` currently has no JS test setup (no test script, no test files) — happy to add one if you would like the harness introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)