### PR TITLE
feat(composition): support vertical formats via props

### DIFF
--- a/remotion-composer/src/Root.tsx
+++ b/remotion-composer/src/Root.tsx
@@ -129,7 +129,14 @@ const calculateMetadata: CalculateMetadataFunction<ExplainerProps> = async ({
   }
   const lastEnd = Math.max(...cuts.map((c) => c.out_seconds || 0));
   // Add 1 second padding for final fade
-  return { durationInFrames: Math.ceil((lastEnd + 1) * 30) };
+  // Optional dimensions from props (e.g. 1080x1350 for 4:5 social formats).
+  // When absent, the composition keeps its 1920x1080 default.
+  const w = (props as Record<string, unknown>).width as number | undefined;
+  const h = (props as Record<string, unknown>).height as number | undefined;
+  return {
+    durationInFrames: Math.ceil((lastEnd + 1) * 30),
+    ...(w && h ? { width: Math.round(w), height: Math.round(h) } : {}),
+  };
 };
 
 export const Root: React.FC = () => {

--- a/remotion-composer/src/components/StatReveal.tsx
+++ b/remotion-composer/src/components/StatReveal.tsx
@@ -12,7 +12,7 @@ interface StatRevealProps {
   accentColor?: string;
   /** Label color. Defaults to near-white; pass the theme's textColor on light themes. */
   textColor?: string;
-  position?: "center" | "bottom-right" | "right";
+  position?: "center" | "bottom-right" | "right" | "top-left" | "top-right";
 }
 
 export const StatReveal: React.FC<StatRevealProps> = ({
@@ -49,11 +49,17 @@ export const StatReveal: React.FC<StatRevealProps> = ({
 
   const opacity = Math.min(spring({ frame, fps, config: { damping: 20 } }), fadeOut);
 
+  // top-left/top-right added for portrait formats: the vertical centre lands
+  // on faces there, and the bottom-right corner collides with the caption band.
   const positionStyles: React.CSSProperties =
     position === "center"
       ? { justifyContent: "center", alignItems: "center" }
       : position === "right"
       ? { justifyContent: "center", alignItems: "flex-end", paddingRight: 80 }
+      : position === "top-left"
+      ? { justifyContent: "flex-start", alignItems: "flex-start", padding: 80 }
+      : position === "top-right"
+      ? { justifyContent: "flex-start", alignItems: "flex-end", padding: 80 }
       : { justifyContent: "flex-end", alignItems: "flex-end", padding: 80 };
 
   return (
@@ -62,7 +68,8 @@ export const StatReveal: React.FC<StatRevealProps> = ({
         style={{
           opacity,
           transform: `scale(${scale})`,
-          textAlign: position === "center" ? "center" : "right",
+          textAlign:
+            position === "center" ? "center" : position === "top-left" ? "left" : "right",
         }}
       >
         <div


### PR DESCRIPTION
## Motivation

The `Explainer` composition is fixed at 1920x1080. Producing a 4:5 or 9:16 cut for social feeds means either editing `Root.tsx` by hand or cropping the finished render — and cropping destroys the caption and overlay layout, which is anchored to the 16:9 frame.

## Changes

**`Root.tsx`** — `calculateMetadata` reads optional `width` / `height` from props. Omitting them keeps the 1920x1080 default, so every existing props file renders byte-identically.

```json
{ "width": 1080, "height": 1350, "cuts": [...] }
```

**`StatReveal`** — adds `top-left` and `top-right` positions. In portrait the existing options leave no usable anchor: `right` is vertically centred and lands on the subject's face, `bottom-right` collides with the caption band, and `center` covers the subject. Text alignment follows the chosen position.

`Overlay.position` in `Explainer` is already typed as `string`, so the new values flow through from props without further changes.

## Verification

Rendered the same props file at 1920x1080 and at 1080x1350. The 16:9 output is unchanged; the 4:5 output composes correctly with stats anchored top-left, clear of both faces and captions. `npx tsc --noEmit` passes.

No test is included because `remotion-composer/` currently has no JS test setup — happy to add one if you would like the harness introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)