### PR TITLE
fix(hero-title): accent the first word, allow theming, wrap at word boundaries

### DIFF
--- a/remotion-composer/src/components/HeroTitle.tsx
+++ b/remotion-composer/src/components/HeroTitle.tsx
@@ -15,6 +15,8 @@ type HeroTitleProps = {
   textColor?: string;
   /** Subtitle color. */
   subtitleColor?: string;
+  /** Font family. Pass the theme's heading font; falls back to Space Grotesk. */
+  fontFamily?: string;
   /**
    * Scrim painted behind the title so it separates from whatever is underneath.
    * Defaults to a dark wash; a light theme must pass a light one, otherwise the
@@ -32,13 +34,26 @@ export const HeroTitle: React.FC<HeroTitleProps> = ({
   accentColor = "#22D3EE",
   textColor = "#F8FAFC",
   subtitleColor = "#A78BFA",
+  fontFamily = "Space Grotesk, Inter, system-ui, sans-serif",
   scrimBackground = DEFAULT_SCRIM,
 }) => {
   const frame = useCurrentFrame();
   const { fps } = useVideoConfig();
 
-  // Staggered letter-by-letter spring
-  const titleChars = title.split("");
+  // Staggered letter-by-letter spring. Words carry the global character index
+  // so the stagger timing is identical to the previous per-character layout.
+  const titleWords = (() => {
+    let cursor = 0;
+    return title.split(" ").map((word) => {
+      const entry = { word, start: cursor };
+      cursor += word.length + 1; // + the space that was consumed by the split
+      return entry;
+    });
+  })();
+  // Accent the first word. This used to be a hardcoded `i < 8`, which cuts
+  // mid-word for any first word that is not exactly eight characters long.
+  const firstSpace = title.indexOf(" ");
+  const accentChars = firstSpace === -1 ? title.length : firstSpace;
 
   return (
     <AbsoluteFill
@@ -54,7 +69,7 @@ export const HeroTitle: React.FC<HeroTitleProps> = ({
           style={{
             fontSize: 72,
             fontWeight: 800,
-            fontFamily: "Space Grotesk, Inter, system-ui, sans-serif",
+            fontFamily,
             lineHeight: 1.2,
             display: "flex",
             justifyContent: "center",
@@ -62,30 +77,41 @@ export const HeroTitle: React.FC<HeroTitleProps> = ({
             gap: 0,
           }}
         >
-          {titleChars.map((char, i) => {
-            const delay = i * 1.2;
-            const charSpring = spring({
-              frame: frame - delay,
-              fps,
-              config: { damping: 12, stiffness: 150 },
-            });
+          {titleWords.map(({ word, start }, wi) => (
+            // One flex item per word: the container wraps between items, so a
+            // long title can no longer break in the middle of a word.
+            <span
+              key={wi}
+              style={{
+                display: "inline-block",
+                whiteSpace: "nowrap",
+                marginRight: wi < titleWords.length - 1 ? "0.28em" : 0,
+              }}
+            >
+              {word.split("").map((char, ci) => {
+                const i = start + ci;
+                const charSpring = spring({
+                  frame: frame - i * 1.2,
+                  fps,
+                  config: { damping: 12, stiffness: 150 },
+                });
 
-            return (
-              <span
-                key={i}
-                style={{
-                  display: "inline-block",
-                  opacity: charSpring,
-                  transform: `translateY(${interpolate(charSpring, [0, 1], [30, 0])}px)`,
-                  color: i < 8 ? accentColor : textColor, // Accent first word
-                  whiteSpace: char === " " ? "pre" : undefined,
-                  minWidth: char === " " ? "0.3em" : undefined,
-                }}
-              >
-                {char}
-              </span>
-            );
-          })}
+                return (
+                  <span
+                    key={ci}
+                    style={{
+                      display: "inline-block",
+                      opacity: charSpring,
+                      transform: `translateY(${interpolate(charSpring, [0, 1], [30, 0])}px)`,
+                      color: i < accentChars ? accentColor : textColor,
+                    }}
+                  >
+                    {char}
+                  </span>
+                );
+              })}
+            </span>
+          ))}
         </div>
 
         {/* Subtitle */}
@@ -94,14 +120,14 @@ export const HeroTitle: React.FC<HeroTitleProps> = ({
             style={{
               marginTop: 20,
               opacity: spring({
-                frame: frame - titleChars.length * 1.2 - 5,
+                frame: frame - title.length * 1.2 - 5,
                 fps,
                 config: { damping: 20 },
               }),
               fontSize: 28,
               fontWeight: 400,
               color: subtitleColor,
-              fontFamily: "Space Grotesk, Inter, system-ui, sans-serif",
+              fontFamily,
               letterSpacing: "0.1em",
               textTransform: "uppercase",
             }}


### PR DESCRIPTION
Three defects in `HeroTitle`, each a hardcoded assumption that only looked correct for one particular title. They surfaced together when an end card carried a longer sentence and a custom theme.

## 1. Accent cuts mid-word

```tsx
color: i < 8 ? accentColor : textColor, // Accent first word
```

The comment says "first word", the code colors the first eight *characters*. `"Nicht die Bildschirmzeit. Der Modus."` renders as `Nicht di` in the accent color and `e Bildschirmzeit…` in the text color. It only looks right when the first word happens to be eight characters long.

Now derived from the first space.

## 2. Font ignores the theme

`fontFamily` was hardcoded to `"Space Grotesk, Inter, system-ui, sans-serif"`. `Explainer` sets the theme font on the root element, but this component overrode it, so the end card silently ignored the theme's heading font. Now a prop, defaulting to the previous value so nothing changes for existing callers.

## 3. Line breaks mid-word

Each character was its own flex item inside a `flexWrap: "wrap"` container, so a line could break between any two letters — `Wohlbefin` / `den`. Short titles happened to break at spaces, which is why this went unnoticed.

Characters are now grouped per word with one flex item per word, so wrapping only happens at spaces. The per-character stagger is preserved exactly: each word carries the global character index, so the animation timing is byte-for-byte what it was.

## Compatibility

All three are backward compatible. `fontFamily` defaults to the previous hardcoded stack; the accent and wrapping fixes only change rendering where it was already wrong.

## Follow-up

Forwarding `theme.headingFont` from `Explainer` to this component is a one-line caller change that only makes sense once this lands. It is not included here to keep the PR to one file — happy to add it here or in a follow-up, whichever you prefer. Related: #549 forwards the theme font to `CaptionOverlay` and `ComparisonCard`.

## Verification

Rendered a 106-second explainer with a custom theme (Arial, dark navy, orange accent) and a nine-word end card. Before: accent broke mid-word, the card rendered in Space Grotesk, and `Wohlbefinden` split across two lines. After: all three correct, animation timing unchanged. `npx tsc --noEmit` passes.

No test is included because `remotion-composer/` currently has no JS test setup — happy to add one if you would like the harness introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)