### PR TITLE
fix: prefer native command names outside Windows in render_demo

### DIFF
--- a/render_demo.py
+++ b/render_demo.py
@@ -39,6 +39,8 @@ def discover_demos() -> dict[str, Path]:
 
 
 def find_command(*names: str) -> str | None:
+    if sys.platform != "win32":
+        names = tuple(n for n in names if not n.endswith((".cmd", ".exe")))
     for name in names:
         resolved = shutil.which(name)
         if resolved:


### PR DESCRIPTION
### Problem

`find_command` tries Windows-only names first (`"npx.cmd"`, `"npm.cmd"`). Under WSL, the Windows binaries exposed through `/mnt/c` PATH interop win over the Linux ones, and Python then fails to exec a batch file:

```
OSError: [Errno 8] Exec format error: '/mnt/c/Program Files/nodejs/npx.cmd'
```

This breaks `make demo` for every WSL user — which is notable, since WSL is a common path for Windows users who lack `make`.

### Fix

Filter `.cmd`/`.exe` candidates when not on Windows. This matches the platform check already used in `tools/video/remotion_caption_burn.py:329`, so it follows an existing convention rather than introducing a new one. Windows behaviour is unchanged. One change point fixes `node`, `npm` and `npx` together.

### Testing

Ubuntu 26.04 under WSL2, Node v22.22.1, Python 3.14.4. Before: fails at `npx` resolution. After: `npx -> /usr/bin/npx`, `npm -> /usr/bin/npm`, and `render_demo.py` renders all three demos (1920x1080, 30 fps) with the Windows PATH intact and no workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
