### PR TITLE
Fix three broken video tools, add gemini_tts

### DIFF
--- a/remotion-composer/src/components/CaptionOverlay.tsx
+++ b/remotion-composer/src/components/CaptionOverlay.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from "react";
 import {
   AbsoluteFill,
   Sequence,
@@ -110,23 +111,30 @@ const PageRenderer: React.FC<{
             const isActive = w.startMs <= currentMs && w.endMs > currentMs;
             const isPast = w.endMs <= currentMs;
             return (
-              <span
-                key={`${w.startMs}-${i}`}
-                style={{
-                  // Keep each word unbroken so lines wrap only at word
-                  // boundaries. For space-delimited text this matches the
-                  // previous behavior; for CJK it prevents mid-word breaks.
-                  display: "inline-block",
-                  whiteSpace: "nowrap",
-                  color: isActive ? highlightColor : isPast ? color : `${color}99`,
-                  transition: "none", // CSS transitions forbidden in Remotion
-                  textShadow: isActive
-                    ? `0 0 20px ${highlightColor}66, 0 2px 4px rgba(0,0,0,0.5)`
-                    : "0 2px 4px rgba(0,0,0,0.5)",
-                }}
-              >
-                {w.word}{i < page.words.length - 1 ? wordSeparator : ""}
-              </span>
+              // The separator sits outside the word span on purpose. Inside an
+              // inline-block with white-space: nowrap a trailing space is
+              // collapsed away, which ran every word together ("tellsyouabout").
+              // The parent span uses pre-wrap, so out here the space both
+              // renders and gives the line a legal wrap point.
+              <Fragment key={`${w.startMs}-${i}`}>
+                <span
+                  style={{
+                    // Keep each word unbroken so lines wrap only at word
+                    // boundaries. For space-delimited text this matches the
+                    // previous behavior; for CJK it prevents mid-word breaks.
+                    display: "inline-block",
+                    whiteSpace: "nowrap",
+                    color: isActive ? highlightColor : isPast ? color : `${color}99`,
+                    transition: "none", // CSS transitions forbidden in Remotion
+                    textShadow: isActive
+                      ? `0 0 20px ${highlightColor}66, 0 2px 4px rgba(0,0,0,0.5)`
+                      : "0 2px 4px rgba(0,0,0,0.5)",
+                  }}
+                >
+                  {w.word}
+                </span>
+                {i < page.words.length - 1 ? wordSeparator : ""}
+              </Fragment>
             );
           })}
         </span>

--- a/tests/contracts/test_phase3_contracts.py
+++ b/tests/contracts/test_phase3_contracts.py
@@ -697,6 +697,7 @@ class TestCapabilityMetadata:
             "elevenlabs",
             "fish_audio",
             "fal.ai",
+            "gemini",
             "google_tts",
             "kling_official",
             "openai",

--- a/tools/audio/gemini_tts.py
+++ b/tools/audio/gemini_tts.py
@@ -1,0 +1,263 @@
+"""Gemini Text-to-Speech provider tool.
+
+Speech synthesis through the Gemini API (generativelanguage.googleapis.com).
+
+Unlike `google_tts`, which targets Google Cloud Text-to-Speech, this tool works
+with a plain AI Studio API key: Cloud TTS rejects API keys outright
+("API keys are not supported by this API"), while the Gemini API accepts them.
+Reach for this when GOOGLE_API_KEY is all that is configured; prefer
+`google_tts` when a service account is available and the wider Cloud voice
+catalogue is needed.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import struct
+import time
+from pathlib import Path
+from typing import Any
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+
+class GeminiTTS(BaseTool):
+    name = "gemini_tts"
+    version = "0.1.0"
+    tier = ToolTier.VOICE
+    capability = "tts"
+    provider = "gemini"
+    stability = ToolStability.BETA
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = []
+    install_instructions = (
+        "Set GOOGLE_API_KEY (or GEMINI_API_KEY) to an AI Studio API key.\n"
+        "  Get one at https://aistudio.google.com/apikey — no Google Cloud project,\n"
+        "  billing account or service account needed.\n"
+        "  The same key also unlocks google_imagen and gemini_omni_video."
+    )
+    fallback = "piper_tts"
+    fallback_tools = ["google_tts", "openai_tts", "piper_tts"]
+    agent_skills = ["text-to-speech"]
+
+    capabilities = ["text_to_speech", "voice_selection", "multilingual"]
+    supports = {
+        "voice_cloning": False,
+        "multilingual": True,
+        "offline": False,
+        "native_audio": True,
+        "ssml": False,
+    }
+    best_for = [
+        "TTS when only an AI Studio API key is configured",
+        "quick narration drafts without Google Cloud setup",
+        "style direction through plain-language prompts",
+    ]
+    not_good_for = [
+        "SSML markup — the Gemini API has no SSML input",
+        "the full 700+ voice Cloud catalogue — use google_tts",
+        "fully offline production — use piper_tts",
+    ]
+
+    # Prebuilt voice names accepted by the Gemini speech models.
+    VOICES = [
+        "Zephyr", "Puck", "Charon", "Kore", "Fenrir", "Leda", "Orus", "Aoede",
+        "Callirrhoe", "Autonoe", "Enceladus", "Iapetus", "Umbriel", "Algieba",
+        "Despina", "Erinome", "Algenib", "Rasalgethi", "Laomedeia", "Achernar",
+        "Alnilam", "Schedar", "Gacrux", "Pulcherrima", "Achird", "Zubenelgenubi",
+        "Vindemiatrix", "Sadachbia", "Sadaltager", "Sulafat",
+    ]
+
+    DEFAULT_MODEL = "gemini-3.1-flash-tts-preview"
+
+    input_schema = {
+        "type": "object",
+        "required": ["text"],
+        "properties": {
+            "text": {"type": "string", "description": "Text to convert to speech"},
+            "voice": {
+                "type": "string",
+                "default": "Kore",
+                "enum": VOICES,
+                "description": "Prebuilt Gemini voice name.",
+            },
+            "model": {
+                "type": "string",
+                "default": DEFAULT_MODEL,
+                "description": (
+                    "Gemini speech model. The default is resolved against the live "
+                    "model list, so a retired preview name falls back automatically."
+                ),
+            },
+            "style": {
+                "type": "string",
+                "description": (
+                    "Optional delivery direction in plain language, e.g. "
+                    "'read this slowly and warmly'. Prepended to the text as a prompt."
+                ),
+            },
+            "output_path": {"type": "string"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=50, network_required=True
+    )
+    retry_policy = RetryPolicy(max_retries=2, retryable_errors=["rate_limit", "timeout"])
+    idempotency_key_fields = ["text", "voice", "model", "style"]
+    side_effects = ["writes a WAV file to output_path", "calls the Gemini API"]
+    user_visible_verification = ["Listen to generated audio for natural speech quality"]
+
+    _API_ROOT = "https://generativelanguage.googleapis.com/v1beta"
+
+    # ---- Credentials ----
+
+    @staticmethod
+    def _api_key() -> str | None:
+        for var in ("GEMINI_API_KEY", "GOOGLE_API_KEY"):
+            value = os.environ.get(var)
+            if value:
+                return value
+        return None
+
+    def get_status(self) -> ToolStatus:
+        return ToolStatus.AVAILABLE if self._api_key() else ToolStatus.UNAVAILABLE
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        return 2.0 + len(inputs.get("text", "")) / 200.0
+
+    # ---- Model resolution ----
+
+    def _resolve_model(self, requested: str, api_key: str) -> str:
+        """Return `requested` if the key can see it, else any other speech model.
+
+        Google retires preview model names without notice, and a stale default
+        would otherwise surface as a bare 404.
+        """
+        import requests
+
+        try:
+            response = requests.get(
+                f"{self._API_ROOT}/models",
+                headers={"x-goog-api-key": api_key},
+                timeout=30,
+            )
+            response.raise_for_status()
+            names = [m["name"].split("/")[-1] for m in response.json().get("models", [])]
+        except Exception:
+            return requested
+
+        if requested in names:
+            return requested
+        speech = [n for n in names if "tts" in n.lower()]
+        return speech[0] if speech else requested
+
+    # ---- PCM -> WAV ----
+
+    @staticmethod
+    def _pcm_to_wav(pcm: bytes, sample_rate: int, channels: int = 1) -> bytes:
+        """Wrap raw little-endian 16-bit PCM in a WAV container.
+
+        The API returns headerless PCM (audio/L16), which most players and
+        ffmpeg filters will not open without an explicit format hint.
+        """
+        bits = 16
+        byte_rate = sample_rate * channels * bits // 8
+        block_align = channels * bits // 8
+        header = b"RIFF" + struct.pack("<I", 36 + len(pcm)) + b"WAVEfmt "
+        header += struct.pack("<IHHIIHH", 16, 1, channels, sample_rate, byte_rate, block_align, bits)
+        header += b"data" + struct.pack("<I", len(pcm))
+        return header + pcm
+
+    @staticmethod
+    def _sample_rate_from_mime(mime: str, default: int = 24000) -> int:
+        for part in mime.split(";"):
+            part = part.strip()
+            if part.startswith("rate="):
+                try:
+                    return int(part[5:])
+                except ValueError:
+                    return default
+        return default
+
+    # ---- Execution ----
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        import requests
+
+        api_key = self._api_key()
+        if not api_key:
+            return ToolResult(
+                success=False,
+                error="No Gemini API key found. " + self.install_instructions,
+            )
+
+        text = inputs["text"]
+        voice = inputs.get("voice", "Kore")
+        style = inputs.get("style")
+        model = self._resolve_model(inputs.get("model", self.DEFAULT_MODEL), api_key)
+        prompt = f"{style}: {text}" if style else text
+
+        payload = {
+            "contents": [{"parts": [{"text": prompt}]}],
+            "generationConfig": {
+                "responseModalities": ["AUDIO"],
+                "speechConfig": {
+                    "voiceConfig": {"prebuiltVoiceConfig": {"voiceName": voice}}
+                },
+            },
+        }
+
+        start = time.time()
+        try:
+            response = requests.post(
+                f"{self._API_ROOT}/models/{model}:generateContent",
+                headers={"x-goog-api-key": api_key, "Content-Type": "application/json"},
+                json=payload,
+                timeout=180,
+            )
+            response.raise_for_status()
+            part = response.json()["candidates"][0]["content"]["parts"][0]["inlineData"]
+        except Exception as exc:
+            safe_error = str(exc).replace(api_key, "[REDACTED]")
+            return ToolResult(success=False, error=f"Gemini TTS failed: {safe_error}")
+
+        mime = part.get("mimeType", "audio/L16;rate=24000")
+        sample_rate = self._sample_rate_from_mime(mime)
+        audio = self._pcm_to_wav(base64.b64decode(part["data"]), sample_rate)
+
+        output_path = Path(inputs.get("output_path", "tts_output.wav"))
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(audio)
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": self.provider,
+                "voice": voice,
+                "model": model,
+                "text_length": len(text),
+                "output": str(output_path),
+                "format": "WAV",
+                "sample_rate": sample_rate,
+                "duration_seconds": round(len(audio) / (sample_rate * 2), 2),
+            },
+            artifacts=[str(output_path)],
+            model=f"gemini-tts/{model}/{voice}",
+            duration_seconds=round(time.time() - start, 2),
+        )

--- a/tools/audio/google_tts.py
+++ b/tools/audio/google_tts.py
@@ -187,22 +187,27 @@ class GoogleTTS(BaseTool):
         return round(char_count * rate_per_char, 4)
 
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
-        # Prefer an API key (cheapest path); otherwise mint a Bearer token from
-        # the service-account JSON. This is what makes
-        # GOOGLE_APPLICATION_CREDENTIALS actually work for TTS.
+        # Prefer the service account. Cloud TTS rejects bare API keys outright
+        # ("API keys are not supported by this API. Expected OAuth2 access
+        # token..."), so preferring a key here meant that configuring
+        # GOOGLE_APPLICATION_CREDENTIALS had no effect whenever GOOGLE_API_KEY
+        # was also set — the tool reported AVAILABLE and then failed with 401.
+        # An API key only works when it comes from a Cloud project with the
+        # Text-to-Speech API enabled, so it stays as the fallback.
         api_key = self._get_api_key()
         bearer_token: str | None = None
-        if not api_key:
-            if service_account_configured():
-                try:
-                    bearer_token, _ = get_access_token()
-                except RuntimeError as exc:
+        if service_account_configured():
+            try:
+                bearer_token, _ = get_access_token()
+                api_key = None
+            except RuntimeError as exc:
+                if not api_key:
                     return ToolResult(success=False, error=str(exc))
-            else:
-                return ToolResult(
-                    success=False,
-                    error="No Google credentials found. " + self.install_instructions,
-                )
+        elif not api_key:
+            return ToolResult(
+                success=False,
+                error="No Google credentials found. " + self.install_instructions,
+            )
 
         start = time.time()
         try:

--- a/tools/enhancement/color_grade.py
+++ b/tools/enhancement/color_grade.py
@@ -56,7 +56,13 @@ PROFILES = {
     "vintage_film": {
         "description": "Faded film look with grain texture and warm tint",
         "vf": (
-            "colorbalance=rs=0.06:gs=0.03:bs=-0.03:ms=0.03:mh=-0.02,"
+            # colorbalance takes per-range channel options — rs/gs/bs (shadows),
+            # rm/gm/bm (midtones), rh/gh/bh (highlights). "ms" and "mh" are not
+            # options at all, so ffmpeg rejected the whole filter chain with
+            # "Error applying option 'ms' to filter 'colorbalance'" and this
+            # profile could never render. Warm midtones + cooler highlights keep
+            # the intended faded-film tint.
+            "colorbalance=rs=0.06:gs=0.03:bs=-0.03:rm=0.03:bh=-0.02,"
             "curves=all='0/0.06 0.25/0.25 0.5/0.50 0.75/0.74 1/0.94',"
             "eq=saturation=0.85:contrast=0.95"
         ),

--- a/tools/video/remotion_caption_burn.py
+++ b/tools/video/remotion_caption_burn.py
@@ -312,7 +312,11 @@ class RemotionCaptionBurn(BaseTool):
 
         # Build props JSON
         props = {
-            "videoSrc": f"public/talking-head/{video_filename}",
+            # staticFile() resolves relative to remotion-composer/public/, so the
+            # prefix must not be repeated here — Remotion rejects it outright with
+            # "Do not include the public/ prefix when using staticFile()" and the
+            # render dies before a single frame is written.
+            "videoSrc": f"talking-head/{video_filename}",
             "captions": captions,
             "overlays": overlays or [],
             "wordsPerPage": words_per_page,

--- a/tools/video/video_trimmer.py
+++ b/tools/video/video_trimmer.py
@@ -70,7 +70,15 @@ class VideoTrimmer(BaseTool):
                     },
                 },
             },
-            "codec": {"type": "string", "default": "copy"},
+            "codec": {
+                "type": "string",
+                "default": "auto",
+                "description": (
+                    "auto: stream copy when cutting from 0, otherwise libx264 so the "
+                    "in/out points are frame-accurate. Pass copy explicitly to force the "
+                    "fast path — it snaps the cut to the nearest keyframe."
+                ),
+            },
         },
     }
 
@@ -109,20 +117,32 @@ class VideoTrimmer(BaseTool):
 
         start_s = inputs.get("start_seconds", 0)
         end_s = inputs.get("end_seconds")
-        codec = inputs.get("codec", "copy")
+        codec = inputs.get("codec", "auto")
         output_path = Path(
             inputs.get("output_path", str(input_path.with_stem(f"{input_path.stem}_cut")))
         )
 
-        cmd = [
-            "ffmpeg", "-y",
-            "-i", str(input_path),
-            "-ss", str(start_s),
-        ]
+        # Stream copy can only start on a keyframe, so a cut that starts partway
+        # into the source snaps to the nearest one and returns the wrong range.
+        # Cutting from zero has no such problem, so copy stays the fast path there.
+        if codec == "auto":
+            codec = "copy" if float(start_s) == 0 else "libx264"
+
+        # -ss must precede -i: as an output option it makes ffmpeg keep the
+        # source timestamps, so the clip's frames start at their original PTS
+        # instead of zero. Subtitles and overlays timed from 0 then land
+        # outside the clip's timeline and never render.
+        cmd = ["ffmpeg", "-y", "-ss", str(start_s), "-i", str(input_path)]
+        # -t (duration) rather than -to: with an input-side -ss the output
+        # timeline restarts at zero, so -to would be measured from the seek
+        # point and cut the wrong length.
         if end_s is not None:
-            cmd.extend(["-to", str(end_s)])
+            cmd.extend(["-t", str(max(0, float(end_s) - float(start_s)))])
         if codec == "copy":
-            cmd.extend(["-c", "copy"])
+            # Stream copy can only start on a keyframe, so the cut snaps to the
+            # nearest one at or before start_seconds. make_zero rebases the
+            # timestamps so the clip still starts at 0.
+            cmd.extend(["-c", "copy", "-avoid_negative_ts", "make_zero"])
         else:
             cmd.extend(["-c:v", codec, "-c:a", "aac"])
         cmd.append(str(output_path))
@@ -188,6 +208,7 @@ class VideoTrimmer(BaseTool):
 
         # First, cut each segment to a temp file if start/end are specified
         temp_files: list[Path] = []
+        list_path: Path | None = None
         temp_dir = output_path.parent / ".concat_tmp"
         temp_dir.mkdir(parents=True, exist_ok=True)
 
@@ -202,12 +223,17 @@ class VideoTrimmer(BaseTool):
 
                 if seg_start is not None or seg_end is not None:
                     temp_path = temp_dir / f"seg_{i:04d}{seg_input.suffix}"
-                    cmd = ["ffmpeg", "-y", "-i", str(seg_input)]
+                    # Same seek ordering as _cut: -ss belongs before -i so the
+                    # segment's timestamps restart at zero. The concat demuxer
+                    # requires every segment to share codec parameters, so this
+                    # stays a stream copy and the cut still snaps to a keyframe.
+                    cmd = ["ffmpeg", "-y"]
                     if seg_start is not None:
                         cmd.extend(["-ss", str(seg_start)])
+                    cmd.extend(["-i", str(seg_input)])
                     if seg_end is not None:
-                        cmd.extend(["-to", str(seg_end)])
-                    cmd.extend(["-c", "copy", str(temp_path)])
+                        cmd.extend(["-t", str(max(0, float(seg_end) - float(seg_start or 0)))])
+                    cmd.extend(["-c", "copy", "-avoid_negative_ts", "make_zero", str(temp_path)])
                     self.run_command(cmd)
                     temp_files.append(temp_path)
                 else:
@@ -244,7 +270,7 @@ class VideoTrimmer(BaseTool):
             for tf in temp_files:
                 if tf.parent == temp_dir and tf.exists():
                     tf.unlink()
-            if list_path.exists():
+            if list_path is not None and list_path.exists():
                 list_path.unlink()
             if temp_dir.exists():
                 try:


### PR DESCRIPTION
Four fixes found while running `clip-factory` and `documentary-montage` end to end on macOS (Apple Silicon, Python 3.10, ffmpeg 9.0.1). Each one was reproduced, fixed, and then verified by rendering real output rather than by checking tool status.

The common thread: every tool below reported `AVAILABLE` and then failed — three of them silently.

### 1. `video_trimmer` cut the wrong range

`_cut` built `-i input -ss N -to M`. As an *output* option `-ss` keeps the source timestamps, and a stream copy can only start on a keyframe, so on a 60s source a request for 2-12s returned a clip holding **8-18s**, with frames at PTS 8.0-18.0.

The knock-on effect is silent: subtitles authored from zero land in a window with no frames, so `burn_subtitles` reports success and returns a video with no captions.

`-ss` moved ahead of `-i`, `-to` replaced with `-t`, and the default codec is now `auto` — cutting from zero stays a fast stream copy, cutting from the middle re-encodes so boundaries are frame-accurate. The same seek ordering is fixed in `_concat`, whose `finally` block also dereferenced `list_path` before assignment and masked every earlier error as `UnboundLocalError`.

### 2. `vintage_film` could never render

The profile passed `ms` and `mh` to `colorbalance`, which has no such options. ffmpeg rejected the whole chain with `Error applying option 'ms' to filter 'colorbalance'`, and the tool surfaced only a generic `FFmpeg failed`. All seven profiles were exercised through ffmpeg; the other six are fine.

### 3. `remotion_caption_burn` aborted, then ran words together

The props carried `public/talking-head/<file>`, but `staticFile()` resolves relative to `remotion-composer/public/` and rejects a repeated prefix — the render died before a single frame.

With that fixed, captions rendered as `tellsyouabout`. The separator sat inside the per-word span, which is `display: inline-block` with `white-space: nowrap`, so its trailing space was collapsed. Moved out to the parent span (which uses `pre-wrap`), where it renders and gives the line a legal wrap point. Words still cannot break mid-way, so CJK behaviour is unchanged.

### 4. `google_tts` could not use a service account, and a new `gemini_tts`

Cloud TTS does not accept API keys at all — `texttospeech.googleapis.com` answers `401 API keys are not supported by this API`. But `google_tts` preferred an API key over the service account as the "cheapest path", so setting `GOOGLE_APPLICATION_CREDENTIALS` did nothing whenever `GOOGLE_API_KEY` was also present. The service account now wins; the key stays as fallback for Cloud projects with Text-to-Speech enabled.

That still leaves anyone holding only an AI Studio key without TTS, so this adds `gemini_tts`, which goes through `generativelanguage.googleapis.com`: no Cloud project, billing account or service account required. 30 prebuilt voices, plain-language style direction, and it wraps the API's headerless PCM into WAV itself. The preview model name is resolved against the live model list, since Google retires those without notice — `gemini-2.5-flash` already returns "no longer available to new users" for new keys.

### Verification

- `pytest tests/` — 1829 passed, 12 skipped, 3 xfailed (`gemini` added to the TTS provider inventory in the contract tests)
- `tsc --noEmit` clean
- End to end: 1920x1080 stock footage → `auto_reframe` (face-tracked) → 1080x1920 → `gemini_tts` narration → `transcriber` → `remotion_caption_burn`, captions legible with the active word highlighted
- `documentary-montage`: four Pexels clips → uniform `vintage_film` grade → `video_stitch` with crossfades → music bed

Happy to split this into four PRs if you would rather review them separately.