### PR TITLE
Fix video_trimmer cutting the wrong range

### DIFF
--- a/tools/video/video_trimmer.py
+++ b/tools/video/video_trimmer.py
@@ -70,7 +70,15 @@ class VideoTrimmer(BaseTool):
                     },
                 },
             },
-            "codec": {"type": "string", "default": "copy"},
+            "codec": {
+                "type": "string",
+                "default": "auto",
+                "description": (
+                    "auto: stream copy when cutting from 0, otherwise libx264 so the "
+                    "in/out points are frame-accurate. Pass copy explicitly to force the "
+                    "fast path — it snaps the cut to the nearest keyframe."
+                ),
+            },
         },
     }
 
@@ -109,20 +117,32 @@ class VideoTrimmer(BaseTool):
 
         start_s = inputs.get("start_seconds", 0)
         end_s = inputs.get("end_seconds")
-        codec = inputs.get("codec", "copy")
+        codec = inputs.get("codec", "auto")
         output_path = Path(
             inputs.get("output_path", str(input_path.with_stem(f"{input_path.stem}_cut")))
         )
 
-        cmd = [
-            "ffmpeg", "-y",
-            "-i", str(input_path),
-            "-ss", str(start_s),
-        ]
+        # Stream copy can only start on a keyframe, so a cut that starts partway
+        # into the source snaps to the nearest one and returns the wrong range.
+        # Cutting from zero has no such problem, so copy stays the fast path there.
+        if codec == "auto":
+            codec = "copy" if float(start_s) == 0 else "libx264"
+
+        # -ss must precede -i: as an output option it makes ffmpeg keep the
+        # source timestamps, so the clip's frames start at their original PTS
+        # instead of zero. Subtitles and overlays timed from 0 then land
+        # outside the clip's timeline and never render.
+        cmd = ["ffmpeg", "-y", "-ss", str(start_s), "-i", str(input_path)]
+        # -t (duration) rather than -to: with an input-side -ss the output
+        # timeline restarts at zero, so -to would be measured from the seek
+        # point and cut the wrong length.
         if end_s is not None:
-            cmd.extend(["-to", str(end_s)])
+            cmd.extend(["-t", str(max(0, float(end_s) - float(start_s)))])
         if codec == "copy":
-            cmd.extend(["-c", "copy"])
+            # Stream copy can only start on a keyframe, so the cut snaps to the
+            # nearest one at or before start_seconds. make_zero rebases the
+            # timestamps so the clip still starts at 0.
+            cmd.extend(["-c", "copy", "-avoid_negative_ts", "make_zero"])
         else:
             cmd.extend(["-c:v", codec, "-c:a", "aac"])
         cmd.append(str(output_path))
@@ -188,6 +208,7 @@ class VideoTrimmer(BaseTool):
 
         # First, cut each segment to a temp file if start/end are specified
         temp_files: list[Path] = []
+        list_path: Path | None = None
         temp_dir = output_path.parent / ".concat_tmp"
         temp_dir.mkdir(parents=True, exist_ok=True)
 
@@ -202,12 +223,17 @@ class VideoTrimmer(BaseTool):
 
                 if seg_start is not None or seg_end is not None:
                     temp_path = temp_dir / f"seg_{i:04d}{seg_input.suffix}"
-                    cmd = ["ffmpeg", "-y", "-i", str(seg_input)]
+                    # Same seek ordering as _cut: -ss belongs before -i so the
+                    # segment's timestamps restart at zero. The concat demuxer
+                    # requires every segment to share codec parameters, so this
+                    # stays a stream copy and the cut still snaps to a keyframe.
+                    cmd = ["ffmpeg", "-y"]
                     if seg_start is not None:
                         cmd.extend(["-ss", str(seg_start)])
+                    cmd.extend(["-i", str(seg_input)])
                     if seg_end is not None:
-                        cmd.extend(["-to", str(seg_end)])
-                    cmd.extend(["-c", "copy", str(temp_path)])
+                        cmd.extend(["-t", str(max(0, float(seg_end) - float(seg_start or 0)))])
+                    cmd.extend(["-c", "copy", "-avoid_negative_ts", "make_zero", str(temp_path)])
                     self.run_command(cmd)
                     temp_files.append(temp_path)
                 else:
@@ -244,7 +270,7 @@ class VideoTrimmer(BaseTool):
             for tf in temp_files:
                 if tf.parent == temp_dir and tf.exists():
                     tf.unlink()
-            if list_path.exists():
+            if list_path is not None and list_path.exists():
                 list_path.unlink()
             if temp_dir.exists():
                 try:


### PR DESCRIPTION
`_cut` built the command as `-i input -ss N -to M`. As an *output* option `-ss` makes ffmpeg keep the source timestamps, and a stream copy can only start on a keyframe, so on a 60s source a request for 2-12s produced a clip holding **8-18s**, with frames sitting at PTS 8.0-18.0.

The knock-on effect is silent. Subtitles authored from zero land in a window where the clip has no frames, so `burn_subtitles` reports success and hands back a video with no captions in it. That is how I found this — chasing missing subtitles in `clip-factory`.

### Changes

- `-ss` moved ahead of `-i`, so the clip's timeline starts at zero
- `-to` replaced with `-t`: with an input-side `-ss` the duration is measured from the seek point, so `-to` cut the wrong length
- default codec `copy` → `auto`: cutting from zero stays a fast stream copy, cutting from the middle re-encodes so the in/out points are frame-accurate. `copy` can still be requested explicitly, and the schema now documents the keyframe trade-off
- the same seek ordering is fixed in `_concat`'s per-segment cut
- `_concat`'s `finally` block dereferenced `list_path` before assignment, so any failure before that line surfaced as `UnboundLocalError` instead of the real error

### Verification

| case | before | after |
|---|---|---|
| default, cut from middle (2-12s) | PTS 8.0, 10.06s, content 8-18s | PTS 0.0, exactly 10.000s, content 2-12s |
| default, cut from zero | — | PTS 0.08, 10.10s (fast stream copy) |
| `codec: copy` explicitly | — | PTS 0.08, 12.10s — documented trade-off |

Subtitles now burn visibly onto a clip cut with the defaults. `pytest tests/` passes.