### PR TITLE
Fix the vintage_film color_grade profile never rendering

### DIFF
--- a/tools/enhancement/color_grade.py
+++ b/tools/enhancement/color_grade.py
@@ -56,7 +56,13 @@ PROFILES = {
     "vintage_film": {
         "description": "Faded film look with grain texture and warm tint",
         "vf": (
-            "colorbalance=rs=0.06:gs=0.03:bs=-0.03:ms=0.03:mh=-0.02,"
+            # colorbalance takes per-range channel options — rs/gs/bs (shadows),
+            # rm/gm/bm (midtones), rh/gh/bh (highlights). "ms" and "mh" are not
+            # options at all, so ffmpeg rejected the whole filter chain with
+            # "Error applying option 'ms' to filter 'colorbalance'" and this
+            # profile could never render. Warm midtones + cooler highlights keep
+            # the intended faded-film tint.
+            "colorbalance=rs=0.06:gs=0.03:bs=-0.03:rm=0.03:bh=-0.02,"
             "curves=all='0/0.06 0.25/0.25 0.5/0.50 0.75/0.74 1/0.94',"
             "eq=saturation=0.85:contrast=0.95"
         ),


### PR DESCRIPTION
The `vintage_film` profile passes `ms` and `mh` to the `colorbalance` filter, which has no such options — channels are `rs`/`gs`/`bs` (shadows), `rm`/`gm`/`bm` (midtones) and `rh`/`gh`/`bh` (highlights).

ffmpeg rejects the whole chain:

```
Error applying option 'ms' to filter 'colorbalance': Option not found
```

So this profile could never render, and `color_grade` surfaced only a generic `FFmpeg failed: Command '['ffmpeg', ...]'` with the cause buried in a truncated repr.

### Change

Replaced with `rm=0.03:bh=-0.02` — warm midtones, slightly cool highlights — which keeps the intended faded-film tint.

### Verification

Every profile was exercised through ffmpeg on a real frame:

```
cinematic_warm     OK
cinematic_cool     OK
moody_dark         OK
bright_clean       OK
vintage_film       BROKEN -> OK
high_contrast      OK
neutral            OK
```

Then used for real: four Pexels clips graded with `vintage_film` and stitched into a montage — the tint is consistent across mixed sources. `pytest tests/` passes.