### PR TITLE
Fix remotion_caption_burn: render aborted, then words ran together

### DIFF
--- a/remotion-composer/src/components/CaptionOverlay.tsx
+++ b/remotion-composer/src/components/CaptionOverlay.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from "react";
 import {
   AbsoluteFill,
   Sequence,
@@ -110,23 +111,30 @@ const PageRenderer: React.FC<{
             const isActive = w.startMs <= currentMs && w.endMs > currentMs;
             const isPast = w.endMs <= currentMs;
             return (
-              <span
-                key={`${w.startMs}-${i}`}
-                style={{
-                  // Keep each word unbroken so lines wrap only at word
-                  // boundaries. For space-delimited text this matches the
-                  // previous behavior; for CJK it prevents mid-word breaks.
-                  display: "inline-block",
-                  whiteSpace: "nowrap",
-                  color: isActive ? highlightColor : isPast ? color : `${color}99`,
-                  transition: "none", // CSS transitions forbidden in Remotion
-                  textShadow: isActive
-                    ? `0 0 20px ${highlightColor}66, 0 2px 4px rgba(0,0,0,0.5)`
-                    : "0 2px 4px rgba(0,0,0,0.5)",
-                }}
-              >
-                {w.word}{i < page.words.length - 1 ? wordSeparator : ""}
-              </span>
+              // The separator sits outside the word span on purpose. Inside an
+              // inline-block with white-space: nowrap a trailing space is
+              // collapsed away, which ran every word together ("tellsyouabout").
+              // The parent span uses pre-wrap, so out here the space both
+              // renders and gives the line a legal wrap point.
+              <Fragment key={`${w.startMs}-${i}`}>
+                <span
+                  style={{
+                    // Keep each word unbroken so lines wrap only at word
+                    // boundaries. For space-delimited text this matches the
+                    // previous behavior; for CJK it prevents mid-word breaks.
+                    display: "inline-block",
+                    whiteSpace: "nowrap",
+                    color: isActive ? highlightColor : isPast ? color : `${color}99`,
+                    transition: "none", // CSS transitions forbidden in Remotion
+                    textShadow: isActive
+                      ? `0 0 20px ${highlightColor}66, 0 2px 4px rgba(0,0,0,0.5)`
+                      : "0 2px 4px rgba(0,0,0,0.5)",
+                  }}
+                >
+                  {w.word}
+                </span>
+                {i < page.words.length - 1 ? wordSeparator : ""}
+              </Fragment>
             );
           })}
         </span>

--- a/tools/video/remotion_caption_burn.py
+++ b/tools/video/remotion_caption_burn.py
@@ -312,7 +312,11 @@ class RemotionCaptionBurn(BaseTool):
 
         # Build props JSON
         props = {
-            "videoSrc": f"public/talking-head/{video_filename}",
+            # staticFile() resolves relative to remotion-composer/public/, so the
+            # prefix must not be repeated here — Remotion rejects it outright with
+            # "Do not include the public/ prefix when using staticFile()" and the
+            # render dies before a single frame is written.
+            "videoSrc": f"talking-head/{video_filename}",
             "captions": captions,
             "overlays": overlays or [],
             "wordsPerPage": words_per_page,


### PR DESCRIPTION
Two independent faults on the word-level caption path — the one thing short vertical video cannot ship without, since most of it is watched with the sound off.

### 1. The render never started

The props carried `"public/talking-head/<file>"`, but `staticFile()` resolves relative to `remotion-composer/public/` and rejects a repeated prefix outright:

```
TypeError: Do not include the public/ prefix when using staticFile()
  - got "public/talking-head/reel_raw.mp4"
```

The render died before a single frame. Prefix removed.

### 2. Words rendered with no spaces

With that fixed, captions came out as `tellsyouabout` instead of `tells you about`.

The separator sat inside the per-word span, which is `display: inline-block` with `white-space: nowrap` — a trailing space in such a box is collapsed away. Moved it out into the parent span, which already uses `pre-wrap`, so it both renders and gives the line a legal wrap point. Each word still cannot break mid-way, so the CJK behaviour the `wordSeparator` option was added for is unchanged.

`Fragment` is imported explicitly since the file relies on the automatic JSX runtime and has no `React` binding.

### Verification

End to end: 1920x1080 stock footage → `auto_reframe` (face-tracked) → 1080x1920 → narration → `transcriber` → `remotion_caption_burn`.

Before: `tellsyouabout` / `morethanperfection.` / `isalreadytalking`
After: `tells you about` / `more than perfection.` / `is already talking`, with the active word highlighted.

`tsc --noEmit` clean, `pytest tests/` passes.