### PR TITLE
fix(comfyui): reject renders that are strobing stills rather than motion

### DIFF
--- a/.agents/skills/comfyui/SKILL.md
+++ b/.agents/skills/comfyui/SKILL.md
@@ -66,6 +66,7 @@ Use this skill before calling `comfyui_image`, `comfyui_video`, or `comfyui_musi
 - If models are missing, read `data.missing_models[]`; each item should include the file name, role, destination hint, and download URL when OpenMontage knows it.
 - If custom nodes are missing, ask the user to install them through ComfyUI Manager or the workflow author's documented install path, then restart ComfyUI.
 - If a long render times out locally, check ComfyUI history before retrying from scratch; the server may still have completed the prompt -- or just call again with `resume_prompt_id` set to the `prompt_id` from the timeout error.
+- `comfyui_video` checks the clip it produced and reports `data.coherence` with the mean adjacent-frame difference and its coefficient of variation. A `STROBING_STILLS` verdict fails the call: the file is structurally valid but its frames are unrelated, which almost always means the workflow's latent node is an image latent rather than a temporal one. Fix the workflow rather than retrying with a new seed -- every seed will fail the same way.
 
 ## Music (`comfyui_music`)
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -1217,6 +1217,27 @@ the ComfyUI machine. MiniMax H3 is available as an official open-weight local
 workflow; pass the official workflow exported in API format using
 `workflow_json` or `workflow_path`, plus its `output_node`.
 
+Local video generations are checked for frame coherence before they are
+reported as successful. The result carries `data.coherence` (mean
+adjacent-frame difference, its coefficient of variation, and a verdict), and a
+`STROBING_STILLS` verdict fails the call: the output is a structurally valid
+MP4 whose frames are unrelated stills rather than motion. That is what a video
+workflow produces when its empty-latent node is an image latent
+(`EmptyLatentImage`) instead of a temporal one (`EmptyHunyuanLatentVideo` and
+friends), so it is a workflow bug rather than a bad seed. The check is skipped,
+rather than failing the call, when `numpy` or `ffmpeg` is unavailable.
+
+The verdict is `STROBING_STILLS` only when **both** measurements agree: a mean
+adjacent-frame difference above `25.0` (on 8-bit greyscale frames decoded at
+104x60) **and** a coefficient of variation below `0.35`. Independent stills sit
+far above the first and far below the second, because every adjacent pair is
+equally unrelated. Requiring both is what spares a legitimately busy clip --
+hard cuts and fast action raise the mean but also raise the variation, so they
+are ruled coherent. The thresholds live in `ComfyUIVideo._assess_coherence` and
+are pinned by `tests/tools/test_comfyui_video_coherence.py`, which exercises
+coherent motion, strobing stills, a high-motion clip, and every way the check
+can fail to run.
+
 The MiniMax H3 local stack includes the pruned INT8 diffusion model, Qwen3-VL
 text encoder, video VAE, and audio VAE. OpenMontage exposes the official
 download URLs and destination folders in tool metadata rather than silently

--- a/tests/tools/test_comfyui_video_coherence.py
+++ b/tests/tools/test_comfyui_video_coherence.py
@@ -1,0 +1,299 @@
+"""Deterministic tests for the strobing-stills detector in `comfyui_video`.
+
+`ComfyUIVideo._assess_coherence()` is the only check that can catch #526: a
+workflow whose latent is an image latent emits N unrelated stills, and the
+resulting mp4 has the right frame count, duration, codec and a clean ffprobe.
+Nothing structural separates it from a real render — only the relationship
+between consecutive frames does.
+
+Because the verdict can flip a user-visible `success=True` to `success=False`,
+the threshold cannot rest on measurements taken once by hand. These tests pin
+the behaviour against synthetic frame buffers fed through a mocked ffmpeg, so
+every branch is checked without a GPU, a server, or a real video file:
+
+- coherent motion is not condemned,
+- strobing stills are caught,
+- a *high-motion* clip that is not strobing is not condemned (the false
+  positive that would matter most — an action shot failing to render),
+- and every way the check can fail to run returns None rather than a verdict,
+  because a diagnostic that cannot run must never fail a good render.
+
+The frame buffers are built with seeded generators, so the numbers below are
+reproducible: the assertions compare against the thresholds in the
+implementation, not against magic constants recorded from one run.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from tools.video.comfyui_video import ComfyUIVideo
+
+# Must match the decode size in `_assess_coherence`; the mocked ffmpeg has to
+# hand back a buffer the reshape can consume.
+W, H = 104, 60
+
+
+# ------------------------------------------------------------------
+# Synthetic clips
+# ------------------------------------------------------------------
+
+def _coherent_motion(n: int = 24) -> np.ndarray:
+    """A gradient panning across frame — small, smoothly varying differences."""
+    yy, xx = np.mgrid[0:H, 0 : W * 3]
+    base = ((np.sin(xx / 9.0) * 0.5 + 0.5) * 180 + (yy / H) * 60).astype(np.uint8)
+    rng = np.random.default_rng(7)
+    starts = np.cumsum(rng.integers(1, 4, size=n))
+    return np.stack([base[:, s : s + W] for s in starts])
+
+
+def _strobing_stills(n: int = 24) -> np.ndarray:
+    """Independent frames — every adjacent pair is equally unrelated."""
+    return np.random.default_rng(3).integers(0, 256, size=(n, H, W), dtype=np.uint8)
+
+
+def _high_motion_cuts(n: int = 24) -> np.ndarray:
+    """Hard cuts between holds: differences are large *and* wildly uneven.
+
+    This is the shape that a naive "big frame deltas means strobing" rule gets
+    wrong. The mean adjacent difference clears the strobing threshold, but the
+    variation does not, because most pairs are static and a few are total.
+    """
+    frames = []
+    value = 20
+    for i in range(n):
+        if i % 4 == 0:
+            value = 20 if value > 128 else 235
+        frames.append(np.full((H, W), value, np.uint8))
+    return np.stack(frames)
+
+
+def _raw(frames: np.ndarray) -> bytes:
+    return frames.astype(np.uint8).tobytes()
+
+
+@pytest.fixture
+def fake_ffmpeg(monkeypatch):
+    """Replace the ffmpeg decode with a canned rawvideo buffer."""
+
+    def _install(stdout: bytes, returncode: int = 0):
+        calls: list[list[str]] = []
+
+        def _run(cmd, **kwargs):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr=b"")
+
+        monkeypatch.setattr(subprocess, "run", _run)
+        return calls
+
+    return _install
+
+
+# ------------------------------------------------------------------
+# Verdicts
+# ------------------------------------------------------------------
+
+def test_coherent_motion_is_not_condemned(fake_ffmpeg, tmp_path):
+    fake_ffmpeg(_raw(_coherent_motion()))
+
+    report = ComfyUIVideo._assess_coherence(tmp_path / "clip.mp4")
+
+    assert report is not None
+    assert report["verdict"] == "COHERENT_MOTION"
+    assert report["frames_analyzed"] == 24
+    assert report["mean_abs_diff"] <= 25.0
+
+
+def test_strobing_stills_are_caught(fake_ffmpeg, tmp_path):
+    """The #526 signature: a large mean difference that barely varies."""
+    fake_ffmpeg(_raw(_strobing_stills()))
+
+    report = ComfyUIVideo._assess_coherence(tmp_path / "clip.mp4")
+
+    assert report is not None
+    assert report["verdict"] == "STROBING_STILLS"
+    assert report["mean_abs_diff"] > 25.0
+    assert report["cv"] < 0.35
+
+
+def test_high_motion_clip_is_not_a_false_positive(fake_ffmpeg, tmp_path):
+    """Both conditions must hold, so a busy clip survives.
+
+    Large differences alone are not the signal. Here the mean is far above the
+    threshold and the clip is still ruled coherent, because the differences are
+    uneven — which is what separates real cuts from independent stills.
+    """
+    fake_ffmpeg(_raw(_high_motion_cuts()))
+
+    report = ComfyUIVideo._assess_coherence(tmp_path / "clip.mp4")
+
+    assert report is not None
+    assert report["mean_abs_diff"] > 25.0, "premise: this clip really is high-motion"
+    assert report["cv"] >= 0.35
+    assert report["verdict"] == "COHERENT_MOTION"
+
+
+def test_static_clip_is_coherent(fake_ffmpeg, tmp_path):
+    """Identical frames give a zero mean, which must not divide by zero."""
+    fake_ffmpeg(_raw(np.full((24, H, W), 128, np.uint8)))
+
+    report = ComfyUIVideo._assess_coherence(tmp_path / "clip.mp4")
+
+    assert report is not None
+    assert report["mean_abs_diff"] == 0.0
+    assert report["cv"] == 0.0
+    assert report["verdict"] == "COHERENT_MOTION"
+
+
+def test_ffmpeg_is_asked_for_the_size_the_reshape_expects(fake_ffmpeg, tmp_path):
+    """The decode geometry and the buffer geometry are one contract."""
+    calls = fake_ffmpeg(_raw(_coherent_motion()))
+
+    ComfyUIVideo._assess_coherence(tmp_path / "clip.mp4")
+
+    assert len(calls) == 1
+    cmd = calls[0]
+    assert cmd[0] == "ffmpeg"
+    assert f"scale={W}:{H},format=gray" in cmd
+    assert "rawvideo" in cmd
+
+
+# ------------------------------------------------------------------
+# Every way the check can fail to run
+# ------------------------------------------------------------------
+
+def test_missing_ffmpeg_returns_no_verdict(monkeypatch, tmp_path):
+    """No decoder is not evidence of a bad render."""
+
+    def _boom(cmd, **kwargs):
+        raise FileNotFoundError("ffmpeg")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+
+    assert ComfyUIVideo._assess_coherence(tmp_path / "clip.mp4") is None
+
+
+def test_decode_timeout_returns_no_verdict(monkeypatch, tmp_path):
+    def _boom(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, 120)
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+
+    assert ComfyUIVideo._assess_coherence(tmp_path / "clip.mp4") is None
+
+
+def test_decode_failure_returns_no_verdict(fake_ffmpeg, tmp_path):
+    """ffmpeg ran, ffmpeg failed: empty stdout, no frames, no verdict."""
+    fake_ffmpeg(b"", returncode=1)
+
+    assert ComfyUIVideo._assess_coherence(tmp_path / "clip.mp4") is None
+
+
+def test_too_few_frames_returns_no_verdict(fake_ffmpeg, tmp_path):
+    """Two frames give a single difference — a distribution of one says nothing."""
+    fake_ffmpeg(_raw(_coherent_motion(n=2)))
+
+    assert ComfyUIVideo._assess_coherence(tmp_path / "clip.mp4") is None
+
+
+def test_missing_numpy_returns_no_verdict(monkeypatch, fake_ffmpeg, tmp_path):
+    """numpy is not a hard dependency of the tool; absence must be silent."""
+    fake_ffmpeg(_raw(_strobing_stills()))
+    monkeypatch.setitem(sys.modules, "numpy", None)
+
+    assert ComfyUIVideo._assess_coherence(tmp_path / "clip.mp4") is None
+
+
+# ------------------------------------------------------------------
+# The execute() failure path
+# ------------------------------------------------------------------
+
+class _StubClient:
+    """Enough of ComfyUIClient to reach the coherence check offline."""
+
+    def __init__(self, produced: Path):
+        self._produced = produced
+
+    def is_available(self) -> bool:
+        return True
+
+    def unavailable_reason(self) -> str:  # pragma: no cover - not reached
+        return "unavailable"
+
+    def check_models(self, required):
+        return list(required), []
+
+    def has_node(self, node_class: str) -> bool:
+        return True
+
+    def generate(self, workflow, **kwargs):
+        return [self._produced]
+
+
+def _t2v_tool(tmp_path: Path) -> tuple[ComfyUIVideo, Path]:
+    produced = tmp_path / "out.mp4"
+    produced.write_bytes(b"not really an mp4")
+    tool = ComfyUIVideo()
+    tool._client = _StubClient(produced)
+    return tool, produced
+
+
+def _t2v_inputs(produced: Path) -> dict:
+    return {
+        "prompt": "a slow dolly through a forest",
+        "operation": "text_to_video",
+        "output_path": str(produced),
+        "seed": 42,
+    }
+
+
+def test_execute_fails_when_the_render_is_strobing_stills(fake_ffmpeg, tmp_path):
+    """A structurally valid file that strobes must not report success.
+
+    This is the whole point of the check: before it, `comfyui_video` returned
+    `success=True` for the #526 output because every structural signal was
+    fine. The failure has to name the cause -- an image latent where a temporal
+    one belongs -- or the user is left debugging the encoder.
+    """
+    tool, produced = _t2v_tool(tmp_path)
+    fake_ffmpeg(_raw(_strobing_stills()))
+
+    result = tool.execute(_t2v_inputs(produced))
+
+    assert result.success is False
+    assert "unrelated stills" in result.error
+    assert "latent" in result.error
+    assert result.data["coherence"]["verdict"] == "STROBING_STILLS"
+    # The artifact is still reported: the file exists and the user may want to
+    # look at it to confirm the diagnosis.
+    assert result.artifacts == [str(produced)]
+
+
+def test_execute_succeeds_when_the_render_is_coherent(fake_ffmpeg, tmp_path):
+    tool, produced = _t2v_tool(tmp_path)
+    fake_ffmpeg(_raw(_coherent_motion()))
+
+    result = tool.execute(_t2v_inputs(produced))
+
+    assert result.success is True
+    assert result.data["coherence"]["verdict"] == "COHERENT_MOTION"
+
+
+def test_execute_succeeds_when_the_check_cannot_run(monkeypatch, tmp_path):
+    """No ffmpeg, no verdict, no failure -- and no `coherence` key to mislead."""
+    tool, produced = _t2v_tool(tmp_path)
+
+    def _boom(cmd, **kwargs):
+        raise FileNotFoundError("ffmpeg")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+
+    result = tool.execute(_t2v_inputs(produced))
+
+    assert result.success is True
+    assert "coherence" not in result.data

--- a/tools/video/comfyui_video.py
+++ b/tools/video/comfyui_video.py
@@ -8,6 +8,7 @@ via the ``workflow_json`` input.
 from __future__ import annotations
 
 import json
+import subprocess
 import time
 from pathlib import Path
 from typing import Any
@@ -579,6 +580,32 @@ class ComfyUIVideo(BaseTool):
                     "duration_seconds": round(num_frames / 16, 2),
                 }
             )
+        coherence = self._assess_coherence(paths[0])
+        if coherence:
+            result_data["coherence"] = coherence
+            if coherence.get("verdict") == "STROBING_STILLS":
+                return ToolResult(
+                    success=False,
+                    error=(
+                        "Generated video is a sequence of unrelated stills, not "
+                        "motion (mean adjacent-frame difference "
+                        f"{coherence['mean_abs_diff']:.1f} with coefficient of "
+                        f"variation {coherence['cv']:.2f}). This is what a video "
+                        "model produces when its latent is an image latent "
+                        "rather than a temporal one -- check that the workflow's "
+                        "latent node is EmptyHunyuanLatentVideo (or the "
+                        "model-appropriate video latent) with `length` set to "
+                        "the frame count and `batch_size` 1. The file itself is "
+                        "structurally valid, which is why ffprobe accepts it."
+                    ),
+                    data=result_data,
+                    artifacts=[str(p) for p in paths],
+                    cost_usd=self.estimate_cost(inputs),
+                    duration_seconds=round(time.time() - start, 2),
+                    seed=seed,
+                    model=model_name,
+                )
+
         return ToolResult(
             success=True,
             data=result_data,
@@ -588,6 +615,63 @@ class ComfyUIVideo(BaseTool):
             seed=seed,
             model=model_name,
         )
+
+    @staticmethod
+    def _assess_coherence(path: Path) -> dict[str, Any] | None:
+        """Is this actually motion, or a strobe of unrelated frames?
+
+        The failure this catches is invisible to every structural check: a
+        workflow whose latent is an image latent emits N independent stills, and
+        the resulting mp4 has the right frame count, the right duration, the
+        right codec and a clean ffprobe. Only the relationship between
+        consecutive frames tells them apart.
+
+        Purely numerical -- it says nothing about what the frames depict.
+        Decode to small greyscale, take the mean absolute difference between
+        each adjacent pair, and look at the distribution: coherent motion gives
+        small, smoothly varying differences, while independent stills give
+        large ones that barely vary, because every pair is equally unrelated.
+
+        Returns None when the check cannot run (no ffmpeg, no numpy, too few
+        frames). A diagnostic that cannot run must never fail a good render.
+        """
+        try:
+            import numpy as np
+        except ImportError:
+            return None
+
+        w, h = 104, 60
+        try:
+            proc = subprocess.run(
+                ["ffmpeg", "-v", "error", "-i", str(path),
+                 "-vf", f"scale={w}:{h},format=gray", "-f", "rawvideo", "-"],
+                capture_output=True, check=False, timeout=120,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+
+        buf = np.frombuffer(proc.stdout, dtype=np.uint8)
+        n = buf.size // (w * h)
+        if n < 3:
+            return None
+        frames = buf[: n * w * h].reshape(n, h, w).astype(np.int16)
+        diffs = np.abs(np.diff(frames, axis=0)).mean(axis=(1, 2))
+        mean = float(diffs.mean())
+        cv = float(diffs.std() / mean) if mean else 0.0
+
+        # Thresholds separate two populations measured on this failure: coherent
+        # WAN 2.2 clips run mean 3.5-9 with cv 0.18-0.59, while 81 independent
+        # stills land far higher with a very low cv -- every pair is equally
+        # unrelated, so the differences barely vary. Both conditions must hold,
+        # so a legitimately busy clip (high mean, high cv) is not condemned.
+        strobing = mean > 25.0 and cv < 0.35
+        return {
+            "frames_analyzed": int(n),
+            "mean_abs_diff": round(mean, 2),
+            "median_abs_diff": round(float(np.median(diffs)), 2),
+            "cv": round(cv, 3),
+            "verdict": "STROBING_STILLS" if strobing else "COHERENT_MOTION",
+        }
 
     # ------------------------------------------------------------------
     # Workflow builders


### PR DESCRIPTION
## Summary

Split out of #527 at review request. That PR now contains the WAN 2.2 workflow/builder repair alone; this one carries the runtime check and the tests that pin it.

`comfyui_video` cannot currently tell a real render from a broken one. A video workflow whose latent is an image latent emits N independent stills, and the resulting MP4 has the right frame count, the right duration, the right codec and a clean `ffprobe` — so every structural signal in the tool is satisfied and the call returns `success=True` on a clip that is unusable. That is exactly how #526 stayed invisible. Only the relationship between *consecutive* frames separates the two cases.

This adds `ComfyUIVideo._assess_coherence()`: decode the tool's own output to small greyscale, take the mean absolute difference between adjacent frame pairs, and look at the distribution. Coherent motion gives small, smoothly varying differences; independent stills give large ones that barely vary, because every pair is equally unrelated.

**This branch is based on `main` and is independent of #527** — the two touch disjoint regions of `comfyui_video.py` and can be reviewed, merged or dropped in either order.

## Changes

- `ComfyUIVideo._assess_coherence()` — the measurement. Purely numerical; it says nothing about what the frames depict.
- `ComfyUIVideo.execute()` — a `STROBING_STILLS` verdict fails the call with an error naming the likely cause; the artifact path is still reported so the user can look at the file and confirm.
- `data.coherence` carries the mean, the median, the coefficient of variation and the verdict on success as well as failure.
- `tests/tools/test_comfyui_video_coherence.py` — 13 tests, no GPU, no server, no real MP4.
- `docs/PROVIDERS.md` / `.agents/skills/comfyui/SKILL.md` — the payload, the failure mode, and both thresholds.

## On the failure policy

Your review asked for the threshold, the unavailable-decoder behavior and the false-positive boundary to be verified rather than asserted. All three are now pinned by tests that feed synthetic frame buffers through a mocked `subprocess.run`:

| Case | mean | cv | verdict |
|---|---|---|---|
| coherent motion (panning gradient) | 12.65 | 0.435 | `COHERENT_MOTION` |
| independent stills | 85.57 | 0.007 | `STROBING_STILLS` |
| high-motion hard cuts between holds | 46.74 | 1.897 | `COHERENT_MOTION` |
| fully static clip | 0.0 | 0.0 | `COHERENT_MOTION` (no division by zero) |

The third row is the false positive that would matter most — an action shot failing to render — and it is why **both** conditions must hold. Hard cuts raise the mean well past `25.0`, but they also raise the variation well past `0.35`, so they are ruled coherent.

Every way the check can fail to run returns `None` rather than a verdict: missing `ffmpeg`, decode timeout, non-zero exit, fewer than three frames, missing `numpy`. A diagnostic that cannot run must never fail a good render — and in that case there is no `coherence` key in `data` at all, rather than a misleading one.

Through `execute()` with the client stubbed: a strobing render fails and still reports its artifact, a coherent render succeeds, and a render whose check could not run succeeds cleanly.

The frame buffers come from seeded generators, and the assertions compare against the thresholds in the implementation rather than against constants recorded from one run — so changing a threshold fails the tests instead of silently drifting past them.

## Notes for review

- **Thresholds are documented, not just measured.** `docs/PROVIDERS.md` states both numbers (mean adjacent-frame difference > `25.0` on 8-bit greyscale decoded at 104x60, coefficient of variation < `0.35`), why both must hold, and where they live. A user-visible hard failure should not rest on numbers a reader can only find by opening the source.
- **Empirical basis.** On an RTX 5090 (ComfyUI 0.17.0, WAN 2.2 14B FP8 + LightX2V 4-step), the #526 workflow scores mean 38.71 / cv 0.183 and the repaired one 4.78 / cv 0.172. Thirteen further real WAN takes generated during testing scored means of 3.0–9.1.
- **It runs on all `comfyui_video` outputs, including custom workflows.** That seemed right — the failure is not specific to the bundled graph — but I am happy to scope it to bundled workflows only, or to make it warn rather than fail, if you would rather custom workflows were left alone.

## Testing

- `make lint` — clean.
- `make test` — 1842 passed, 11 skipped, 3 xfailed (skips and xfails are the pre-existing opt-in/live/fixture-dependent ones, unrelated to this change).
- `pytest tests/tools/test_comfyui_video_coherence.py tests/contracts/test_comfyui_tools.py -q` — 132 passed, on `main` without #527.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [x] I updated docs/README if behavior or usage changed.
- [x] No unrelated files (build artifacts, local config) are included in the diff.
