### PR TITLE
fix(piper_tts): pass --data-dir so downloaded voices are found

### DIFF
--- a/tools/audio/piper_tts.py
+++ b/tools/audio/piper_tts.py
@@ -124,6 +124,7 @@ class PiperTTS(BaseTool):
             [
                 "piper",
                 "--model", inputs.get("model", "en_US-lessac-medium"),
+                "--data-dir", str(Path.home() / ".piper" / "models"),
                 "--speaker", str(inputs.get("speaker_id", 0)),
                 "--length-scale", str(inputs.get("length_scale", 1.0)),
                 "--sentence-silence", str(inputs.get("sentence_silence", 0.3)),


### PR DESCRIPTION
## Problem

`PiperTTS.get_status()` only checks that the `piper` CLI binary is on `PATH`, and the tool's own `install_instructions` tell users to download a voice with:

```
piper --download-dir ~/.piper/models --model en_US-lessac-medium
```

But `_generate()` never passes `--data-dir` to the `piper` subprocess call — it only passes `--model <bare-voice-name>`. The `piper` CLI's default voice search path is the current working directory only, so unless the process happens to be run from inside `~/.piper/models`, the tool fails with `Unable to find voice: en_US-lessac-medium (use piper.download_voices)` — even though `get_status()` reports `AVAILABLE` and the user followed the documented setup exactly.

## Fix

Pass `--data-dir` pointing at the same `~/.piper/models` path the tool's own `install_instructions` already tell users to download into:

```diff
 "piper",
 "--model", inputs.get("model", "en_US-lessac-medium"),
+"--data-dir", str(Path.home() / ".piper" / "models"),
 "--speaker", str(inputs.get("speaker_id", 0)),
```

This is additive — an extra search directory — so it doesn't change behavior for anyone already passing an absolute `--model` path.

## How found

Ran the `animated-explainer` pipeline end-to-end on a fresh Windows machine for a new user's first video. Piper reported `AVAILABLE` (binary + `piper-tts` pip package present) and the voice had been downloaded per the documented instructions, but generation failed until this fix was applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)