### PR TITLE
Add Comfy Cloud as a hosted backend for the ComfyUI tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,7 +137,8 @@ AZURE_SPEECH_REGION=
 # Get a key at https://platform.comfy.org
 COMFY_CLOUD_API_KEY=
 # Force a backend for the comfyui_* tools: local | cloud | auto (default auto).
-# auto prefers a reachable local server and falls back to Comfy Cloud.
+# Under auto, a configured local server always wins — set COMFYUI_SERVER_URL
+# and this key together and the key is ignored. Set this to "cloud" to override.
 COMFYUI_BACKEND=
 # Optional: point comfyui_music at its own local ComfyUI instance.
 COMFYUI_MUSIC_SERVER_URL=

--- a/.env.example
+++ b/.env.example
@@ -132,3 +132,10 @@ AZURE_SPEECH_REGION=
 # --- Avatar (local installs) ---
 # WAV2LIP_PATH=              # Path to cloned Wav2Lip repo (for lip sync)
 # SADTALKER_PATH=            # Path to cloned SadTalker repo (for talking head avatars)
+
+# ComfyUI Cloud (hosted ComfyUI — alternative to running your own server).
+# Get a key at https://platform.comfy.org
+COMFY_CLOUD_API_KEY=
+# Force a backend for the comfyui_* tools: local | cloud | auto (default auto).
+# auto prefers a reachable local server and falls back to Comfy Cloud.
+COMFYUI_BACKEND=

--- a/.env.example
+++ b/.env.example
@@ -139,3 +139,5 @@ COMFY_CLOUD_API_KEY=
 # Force a backend for the comfyui_* tools: local | cloud | auto (default auto).
 # auto prefers a reachable local server and falls back to Comfy Cloud.
 COMFYUI_BACKEND=
+# Optional: point comfyui_music at its own local ComfyUI instance.
+COMFYUI_MUSIC_SERVER_URL=

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -78,6 +78,10 @@ VIDEO_GEN_LOCAL_MODEL=       # wan2.2-ti2v-5b, wan2.1-1.3b, wan2.1-14b, hunyuan-
 # COMFYUI (optional overrides; localhost:8188 is the default)
 COMFYUI_SERVER_URL=          # Local ComfyUI server for shared workflows
 COMFYUI_VIDEO_SERVER_URL=    # Optional video-specific ComfyUI server
+
+# COMFY CLOUD (hosted ComfyUI — no server of your own required)
+COMFY_CLOUD_API_KEY=         # Key from https://platform.comfy.org
+COMFYUI_BACKEND=             # local | cloud | auto (default auto = local)
 ```
 
 ---
@@ -1201,6 +1205,51 @@ piper --download-dir ~/.piper/models --model en_US-lessac-medium
 **Available voices:** ~30 English voices plus voices for German, French, Spanish, Italian, and other languages. Lower variety than cloud providers but completely free and offline.
 
 **Quality:** Good for drafts, internal videos, and budget projects. For client-facing narration, use ElevenLabs or Google TTS.
+
+---
+
+### Comfy Cloud — Hosted ComfyUI Backend
+
+**Tools:** `comfyui_image`, `comfyui_video`, `comfyui_music` (same tools, second backend)
+
+**Env vars:** `COMFY_CLOUD_API_KEY` (required), `COMFYUI_BACKEND` (optional)
+
+Comfy Cloud runs the same bundled workflows on hosted GPUs, so no local
+ComfyUI install or model download is needed. Every bundled graph is
+supported: FLUX 2 text-to-image, WAN 2.2 text-to-video and image-to-video,
+and ACE-Step music.
+
+Select it per call with `backend: "cloud"`, or globally with
+`COMFYUI_BACKEND=cloud`:
+
+```bash
+COMFY_CLOUD_API_KEY=your_key_here
+COMFYUI_BACKEND=cloud
+```
+
+**`auto` never picks Comfy Cloud.** Cloud is metered, so it is opt-in only —
+an unreachable local server is reported as a fault rather than silently
+becoming a paid run. `auto` means local.
+
+**Cost:** billed as Comfy Cloud GPU hours, not per image. The bundled
+workflows carry flat per-run estimates (`$0.05` image and music, `$0.25`
+video). Actual billing comes from the workspace usage records; open-weight
+workflows bill GPU time that no per-node estimate covers, so treat the
+estimate as a floor rather than a quote.
+
+**Model differences:** the hosted catalog carries the stock FLUX 2 build
+rather than the NVFP4 quantization the local graph names (that quant targets
+Blackwell-class local hardware). The adapter swaps the filename
+automatically and reports the model that actually ran. WAN 2.2 and ACE-Step
+are byte-identical across both backends.
+
+**Errors worth knowing:** `402` means the workspace is out of credits and
+`429` means the subscription is inactive. Both look like throttling and
+neither is retryable — the tools surface them as explicit blockers.
+
+**End-to-end demo:** `scripts/comfy_cloud_e2e.py` exercises all four bundled
+workflows and composes the results into one video. It defaults to a free dry
+run; `--live` performs real generations.
 
 ---
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -78,6 +78,8 @@ VIDEO_GEN_LOCAL_MODEL=       # wan2.2-ti2v-5b, wan2.1-1.3b, wan2.1-14b, hunyuan-
 # COMFYUI (optional overrides; localhost:8188 is the default)
 COMFYUI_SERVER_URL=          # Local ComfyUI server for shared workflows
 COMFYUI_VIDEO_SERVER_URL=    # Optional video-specific ComfyUI server
+COMFYUI_IMAGE_SERVER_URL=    # Optional image-specific ComfyUI server
+COMFYUI_MUSIC_SERVER_URL=    # Optional music-specific ComfyUI server
 
 # COMFY CLOUD (hosted ComfyUI — no server of your own required)
 COMFY_CLOUD_API_KEY=         # Key from https://platform.comfy.org

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -83,7 +83,7 @@ COMFYUI_MUSIC_SERVER_URL=    # Optional music-specific ComfyUI server
 
 # COMFY CLOUD (hosted ComfyUI — no server of your own required)
 COMFY_CLOUD_API_KEY=         # Key from https://platform.comfy.org
-COMFYUI_BACKEND=             # local | cloud | auto (default auto = local)
+COMFYUI_BACKEND=             # local | cloud | auto (default auto; local wins when both are set)
 ```
 
 ---
@@ -1229,9 +1229,20 @@ COMFY_CLOUD_API_KEY=your_key_here
 COMFYUI_BACKEND=cloud
 ```
 
-**`auto` never picks Comfy Cloud.** Cloud is metered, so it is opt-in only —
-an unreachable local server is reported as a fault rather than silently
-becoming a paid run. `auto` means local.
+**A configured local server always wins.** `auto` resolves by what is set:
+
+| `COMFYUI_SERVER_URL` | `COMFY_CLOUD_API_KEY` | backend |
+|---|---|---|
+| set | — | local |
+| set | set | **local** — the cloud key is ignored |
+| — | set | cloud |
+| — | — | local |
+
+Cloud is metered and a local server is not, so once someone has stood one up,
+silently billing them for a hosted run would be the wrong default: an
+unreachable local server is a fault to report, not a reason to spend. With no
+local server configured, a cloud key is an unambiguous statement of intent.
+Set `COMFYUI_BACKEND=cloud` (or pass `backend: "cloud"`) to force cloud anyway.
 
 **Cost:** billed as Comfy Cloud GPU hours, not per image. The bundled
 workflows carry flat per-run estimates (`$0.05` image and music, `$0.25`

--- a/scripts/comfy_cloud_backlot.py
+++ b/scripts/comfy_cloud_backlot.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+"""'The Backlot' — a Comfy Cloud showcase spot for OpenMontage.
+
+A 30-second commercial whose premise is the product's own metaphor: a studio
+backlot that fills itself with worlds. It is also a coverage harness — every
+surface the Comfy Cloud adapter supports is used to make one of the shots, so
+a successful render is proof the whole integration works:
+
+    flux2-txt2img      stills for the animated shots
+    wan22-i2v-4step    animates those stills
+    wan22-t2v-4step    one pure text-to-video shot
+    ace-step-1-t2a     the score
+    custom workflow    the voiceover, via the ElevenLabs partner node
+    model_family       one hero shot through a hosted partner video node
+
+Run the shoot (spends Comfy Cloud credits):
+
+    python scripts/comfy_cloud_backlot.py --stage shoot
+
+Then assemble:
+
+    python scripts/comfy_cloud_backlot.py --stage cut
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from lib.env_loader import load_env  # noqa: E402
+
+load_env(ROOT)
+
+from lib.checkpoint import init_project  # noqa: E402
+from tools.tool_registry import registry  # noqa: E402
+
+PROJECT = "comfy-cloud-backlot"
+BACKEND = "cloud"
+
+# A consistent grade across every shot is what keeps generated footage from
+# reading as a pile of unrelated clips: one palette, one lens, one hour.
+LOOK = (
+    "anamorphic cinema still, 2.39:1 framing, deep teal shadows and warm "
+    "sodium practicals, volumetric haze, fine 35mm grain, shallow depth of "
+    "field, no text, no watermark"
+)
+
+# WAN 2.2 i2v wants a moving subject. Given a landscape and an instruction to
+# move, it will invent one — crew walking through an "empty" soundstage, a
+# dune buggy cresting an "untouched" ridge. Two things are needed together:
+# a negative that names the inventions, and a motion prompt that gives the
+# model something legitimate to animate (camera, dust, water, light).
+NO_SUBJECTS = (
+    "people, person, human figures, crew, extras, actors, silhouettes of "
+    "people, walking figures, faces, hands, vehicles, car, truck, motorcycle, "
+    "dune buggy, quad bike, aircraft, animals, birds, tracks in the sand, "
+    "text, logos, watermark"
+)
+
+SHOTS: list[dict[str, Any]] = [
+    {
+        "id": "01_stage_empty",
+        "mode": "i2v",
+        "still": (
+            "An empty film soundstage before dawn, vast dark volume, a single "
+            "work light on a stand throwing one cone of light across bare "
+            "concrete, dust suspended in the beam, cable coiled, nothing built "
+            "yet, " + LOOK
+        ),
+        "motion": (
+            "Locked-off camera, no camera move. Only dust drifting slowly "
+            "through the beam and the light flickering once. The room stays "
+            "completely empty and still."
+        ),
+        "negative": NO_SUBJECTS,
+    },
+    {
+        "id": "02_desert",
+        "mode": "i2v",
+        "still": (
+            "Endless sand dunes at first light, long blue shadows down the "
+            "ridgelines, a thin band of warm sun on the crests, wind lifting a "
+            "veil of sand, " + LOOK
+        ),
+        "motion": (
+            "The aerial camera drifts slowly forward over the dune ridge. The "
+            "only movement is wind lifting sand off the crest and the shadows "
+            "creeping. The desert is completely deserted and nothing enters "
+            "the frame."
+        ),
+        "negative": NO_SUBJECTS + ", buildings, roads, footprints, structures",
+    },
+    {
+        "id": "03_ocean_partner",
+        "mode": "partner",
+        "model_family": "seedance_2.5",
+        "prompt": (
+            "A black basalt sea cliff taking a heavy storm swell, tower of "
+            "white spray rising in slow motion, cold blue light through rain, "
+            "anamorphic cinema, volumetric haze, 35mm grain"
+        ),
+    },
+    {
+        "id": "04_city",
+        "mode": "i2v",
+        "still": (
+            "A narrow city street at night in heavy rain, neon signage bleeding "
+            "red and cyan into wet asphalt, steam rising from a grate, one "
+            "figure silhouetted far down the block, " + LOOK
+        ),
+        "motion": (
+            "The camera dollies slowly down the wet street. Only rain, steam "
+            "and the rippling neon reflections move. No one approaches the "
+            "camera and nothing else enters the frame."
+        ),
+        # The still deliberately holds one distant silhouette; keep that and
+        # suppress the crowd WAN would otherwise invent around it.
+        "negative": (
+            "crowds, groups of people, extras walking toward camera, faces, "
+            "text, logos, watermark"
+        ),
+    },
+    {
+        "id": "05_stage_full",
+        "mode": "t2v",
+        # "Flooded with light" + "lamps" first produced a theatre auditorium
+        # full of red seats. The finale has to be the SAME room as shot 01, so
+        # the prompt now names the soundstage's architecture explicitly and the
+        # negative rules out the performance venue WAN kept reaching for.
+        "prompt": (
+            "An empty film soundstage at night, vast industrial volume, bare "
+            "polished concrete floor, black soundproofed walls, exposed steel "
+            "lighting grid overhead. Enormous studio lamps ignite one after "
+            "another down the length of the empty room, haze catching every "
+            "beam. Completely empty floor, no seating of any kind, "
+            "anamorphic cinema, deep teal shadows, warm practicals, 35mm grain"
+        ),
+        "negative": (
+            NO_SUBJECTS
+            + ", theatre, auditorium, cinema seats, rows of chairs, red seats, "
+            "audience, proscenium stage, curtains, concert hall, balcony"
+        ),
+    },
+]
+
+TITLE_TEXT = "OpenMontage"
+SUBTITLE_TEXT = "now running on Comfy Cloud"
+
+
+def project_dir() -> Path:
+    return Path(
+        init_project(
+            PROJECT, title="The Backlot", pipeline_type="cinematic"
+        )
+    )
+
+
+def shoot(only: str | None = None, force: bool = False) -> int:
+    registry.discover()
+    image = registry._tools["comfyui_image"]
+    video = registry._tools["comfyui_video"]
+    music = registry._tools["comfyui_music"]
+    root = project_dir()
+    log: list[dict[str, Any]] = []
+
+    def done(path: Path) -> bool:
+        """Skip assets already on disk — reruns should not re-buy generations."""
+        if path.exists() and path.stat().st_size > 0 and not force:
+            print(f"  [skip] {path.name} already present")
+            log.append({"asset": path.name, "success": True,
+                        "bytes": path.stat().st_size, "error": None,
+                        "skipped": True})
+            return True
+        return False
+
+    def record(name: str, result, path: Path) -> bool:
+        ok = bool(result.success and path.exists())
+        size = path.stat().st_size if path.exists() else 0
+        print(f"  [{'ok ' if ok else 'FAIL'}] {name}  {size:,} bytes")
+        if not ok:
+            print(f"         {result.error}")
+        log.append({"asset": name, "success": ok, "bytes": size,
+                    "error": None if ok else result.error})
+        return ok
+
+    for shot in SHOTS:
+        if only and only != shot["id"]:
+            continue
+        print(f"\n=== {shot['id']}  ({shot['mode']})")
+        clip = root / f"assets/video/{shot['id']}.mp4"
+
+        if shot["mode"] == "i2v":
+            still = root / f"assets/images/{shot['id']}.png"
+            if not done(still):
+                record(
+                f"{shot['id']} still",
+                image.execute({
+                    "prompt": shot["still"], "width": 1280, "height": 720,
+                    "steps": 20, "backend": BACKEND, "output_path": str(still),
+                }),
+                still,
+                )
+            if not still.exists():
+                continue
+            if done(clip):
+                continue
+            record(
+                f"{shot['id']} clip",
+                video.execute({
+                    "operation": "image_to_video", "prompt": shot["motion"],
+                    "negative_prompt": shot.get("negative", ""),
+                    "reference_image_path": str(still),
+                    "width": 704, "height": 400, "num_frames": 81,
+                    "backend": BACKEND, "timeout_seconds": 2400,
+                    "output_path": str(clip),
+                }),
+                clip,
+            )
+
+        elif shot["mode"] == "t2v":
+            if done(clip):
+                continue
+            record(
+                f"{shot['id']} clip",
+                video.execute({
+                    "operation": "text_to_video", "prompt": shot["prompt"],
+                    "negative_prompt": shot.get("negative", ""),
+                    "width": 832, "height": 480, "num_frames": 81,
+                    "backend": BACKEND, "timeout_seconds": 2400,
+                    "output_path": str(clip),
+                }),
+                clip,
+            )
+
+        elif shot["mode"] == "partner":
+            if done(clip):
+                continue
+            record(
+                f"{shot['id']} clip (partner {shot['model_family']})",
+                video.execute({
+                    "operation": "text_to_video", "prompt": shot["prompt"],
+                    "model_family": shot["model_family"],
+                    "duration": 5, "resolution": "720p",
+                    "backend": BACKEND, "timeout_seconds": 2400,
+                    "output_path": str(clip),
+                }),
+                clip,
+            )
+
+    if not only:
+        print("\n=== score  (ace-step)")
+        score = root / "assets/music/backlot_score.mp3"
+        if not done(score):
+            record(
+            "score",
+            music.execute({
+                "prompt": (
+                    "cinematic trailer score, slow swelling low strings, deep "
+                    "sub pulse every two bars, distant choir pad, one bright "
+                    "piano figure entering late, hopeful resolve, instrumental"
+                ),
+                "duration_seconds": 32, "steps": 50, "backend": BACKEND,
+                "timeout_seconds": 1800, "output_path": str(score),
+                }),
+                score,
+            )
+
+    (root / "artifacts" / "shoot_log.json").write_text(json.dumps(log, indent=2))
+    failed = [entry for entry in log if not entry["success"]]
+    print(f"\n{len(log) - len(failed)}/{len(log)} assets produced")
+    return 1 if failed else 0
+
+
+def _pick_font(size: int):
+    """Return a real typeface, falling back to PIL's bitmap default."""
+    from PIL import ImageFont
+
+    for path in (
+        "/System/Library/Fonts/HelveticaNeue.ttc",
+        "/System/Library/Fonts/Avenir Next.ttc",
+        "/System/Library/Fonts/Supplemental/Futura.ttc",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+    ):
+        if Path(path).exists():
+            try:
+                return ImageFont.truetype(path, size)
+            except OSError:
+                continue
+    return ImageFont.load_default()
+
+
+def _render_end_card(dest: Path, size: tuple[int, int] = (1280, 536)) -> Path:
+    """Draw the end card: product name over the spot's own shadow colour."""
+    from PIL import Image, ImageDraw
+
+    img = Image.new("RGB", size, (7, 11, 14))
+    draw = ImageDraw.Draw(img)
+    w, h = size
+
+    title_font = _pick_font(76)
+    sub_font = _pick_font(24)
+
+    title_box = draw.textbbox((0, 0), TITLE_TEXT, font=title_font)
+    sub_box = draw.textbbox((0, 0), SUBTITLE_TEXT, font=sub_font)
+    title_h = title_box[3] - title_box[1]
+    sub_h = sub_box[3] - sub_box[1]
+
+    # Stack the three elements and centre the stack, rather than positioning
+    # each from the middle — otherwise the rule lands inside the title's
+    # descenders and reads as an underline.
+    gap_above_rule, gap_below_rule = 34, 26
+    stack_h = title_h + gap_above_rule + 1 + gap_below_rule + sub_h
+    y = (h - stack_h) / 2
+
+    def centered(text, font, top, fill, box):
+        draw.text(((w - (box[2] - box[0])) / 2 - box[0], top - box[1]),
+                  text, font=font, fill=fill)
+
+    centered(TITLE_TEXT, title_font, y, (240, 244, 246), title_box)
+    rule_y = y + title_h + gap_above_rule
+    rule_w = 132
+    draw.rectangle(
+        [((w - rule_w) / 2, rule_y), ((w + rule_w) / 2, rule_y + 1)],
+        fill=(52, 179, 196),
+    )
+    centered(SUBTITLE_TEXT, sub_font, rule_y + 1 + gap_below_rule,
+             (126, 186, 197), sub_box)
+
+    img.save(dest)
+    return dest
+
+
+def _ff(args: list[str]) -> None:
+    proc = subprocess.run(["ffmpeg", "-v", "error", "-y", *args],
+                          capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip()[:800])
+
+
+# Cut timing. The voiceover is a single take, so the edit is timed around it
+# rather than the other way round: shots are cut to SHOT_LEN, and VO_DELAY is
+# set so the take's last line ("OpenMontage. Now running on Comfy Cloud.")
+# lands on the end card instead of being stranded a shot early.
+SHOT_LEN = 4.0
+CARD_LEN = 4.0
+VO_DELAY = 3.2
+
+
+def cut() -> int:
+    """Assemble the spot: graded clips, VO, score, and an end card."""
+    root = project_dir()
+    work = root / "assets" / "cut"
+    work.mkdir(parents=True, exist_ok=True)
+
+    clips = [root / f"assets/video/{s['id']}.mp4" for s in SHOTS]
+    have = [c for c in clips if c.exists()]
+    if not have:
+        print("No clips found — run --stage shoot first.")
+        return 1
+
+    # Normalize to one 2.39:1 anamorphic frame with a short dip-to-black on
+    # each cut, so the shots read as one piece rather than a reel.
+    norm: list[Path] = []
+    for i, clip in enumerate(have):
+        out = work / f"n{i:02d}.mp4"
+        _ff([
+            "-i", str(clip),
+            "-vf",
+            (f"scale=1280:536:force_original_aspect_ratio=increase,"
+             f"crop=1280:536,fps=24,setsar=1,"
+             f"fade=t=in:st=0:d=0.3,fade=t=out:st={SHOT_LEN - 0.3:.2f}:d=0.3,"
+             "format=yuv420p"),
+            "-an", "-c:v", "libx264", "-crf", "18", "-t", f"{SHOT_LEN}", str(out),
+        ])
+        norm.append(out)
+
+    # End card. This ffmpeg build has no drawtext filter compiled in, so the
+    # type is rendered to a PNG with PIL and used as a still source — which
+    # also gives real font control rather than drawtext's defaults.
+    card_png = work / "card.png"
+    _render_end_card(card_png)
+    card = work / "card.mp4"
+    _ff([
+        "-loop", "1", "-i", str(card_png), "-t", f"{CARD_LEN}",
+        "-vf", "fps=24,format=yuv420p,fade=t=in:st=0:d=0.8",
+        "-c:v", "libx264", "-crf", "18", str(card),
+    ])
+    norm.append(card)
+
+    concat = work / "list.txt"
+    concat.write_text("\n".join(f"file '{p.name}'" for p in norm))
+    silent = work / "silent.mp4"
+    _ff(["-f", "concat", "-safe", "0", "-i", str(concat),
+         "-c:v", "libx264", "-crf", "18", str(silent)])
+
+    vo = root / "assets/audio/vo.mp3"
+    score = root / "assets/music/backlot_score.mp3"
+    final = root / "renders/final.mp4"
+    final.parent.mkdir(parents=True, exist_ok=True)
+
+    total = SHOT_LEN * (len(norm) - 1) + CARD_LEN
+    if vo.exists() and score.exists():
+        # Duck the score under the voiceover, then let it come back up and
+        # carry the end card on its own.
+        _ff([
+            "-i", str(silent), "-i", str(vo), "-i", str(score),
+            "-filter_complex",
+            (f"[1:a]adelay={int(VO_DELAY * 1000)}|{int(VO_DELAY * 1000)},"
+             f"volume=1.0[vo];"
+             f"[2:a]atrim=0:{total:.2f},volume=0.34,"
+             f"afade=t=in:st=0:d=1.5,afade=t=out:st={total - 2.5:.2f}:d=2.5[bed];"
+             "[bed][vo]amix=inputs=2:duration=first:dropout_transition=0,"
+             "dynaudnorm=f=200[a]"),
+            "-map", "0:v", "-map", "[a]",
+            "-c:v", "copy", "-c:a", "aac", "-b:a", "192k",
+            "-shortest", str(final),
+        ])
+    else:
+        _ff(["-i", str(silent), "-c", "copy", str(final)])
+
+    print(f"Final cut: {final}  ({final.stat().st_size:,} bytes)")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--stage", choices=["shoot", "cut"], required=True)
+    parser.add_argument("--only", help="Shoot a single shot id")
+    parser.add_argument("--force", action="store_true",
+                        help="Regenerate even if the asset already exists")
+    args = parser.parse_args()
+    return shoot(args.only, args.force) if args.stage == "shoot" else cut()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/comfy_cloud_e2e.py
+++ b/scripts/comfy_cloud_e2e.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Comfy Cloud adapter E2E demo.
+
+Exercises every bundled ComfyUI workflow against the Comfy Cloud backend and
+assembles the results into one finished video, so the whole adapter surface is
+proven end to end rather than tool by tool:
+
+    flux2-txt2img    -> comfyui_image   (FLUX 2)
+    wan22-t2v-4step  -> comfyui_video   (WAN 2.2 text-to-video)
+    wan22-i2v-4step  -> comfyui_video   (WAN 2.2 image-to-video, fed the
+                                         FLUX still — also covers upload_image)
+    ace-step-1-t2a   -> comfyui_music   (ACE-Step)
+
+Default mode is a no-cost dry run that verifies discovery, backend resolution,
+model availability, and cost estimates without submitting anything. ``--live``
+runs the four real generations, which consume Comfy Cloud GPU credits.
+
+    python scripts/comfy_cloud_e2e.py            # dry run, free
+    python scripts/comfy_cloud_e2e.py --live     # real generations, costs money
+
+Requires COMFY_CLOUD_API_KEY in .env. See docs/PROVIDERS.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from lib.env_loader import load_env  # noqa: E402
+
+load_env(ROOT)
+
+from lib.checkpoint import init_project  # noqa: E402
+from tools._comfyui.client import resolve_backend  # noqa: E402
+from tools.tool_registry import registry  # noqa: E402
+
+
+DEFAULT_PROJECT = "comfy-cloud-demo"
+
+SUBJECT = "a lone lighthouse on a black basalt cliff at dusk, fog over the water"
+
+STEPS: list[dict[str, Any]] = [
+    {
+        "key": "image",
+        "tool": "comfyui_image",
+        "workflow": "flux2-txt2img",
+        "label": "FLUX 2 still",
+        "rel": "assets/images/lighthouse.png",
+        "inputs": {
+            "prompt": (
+                "A lone lighthouse on a black basalt cliff at dusk, low fog "
+                "rolling over the water, single warm beam cutting the blue "
+                "haze, cinematic wide shot, photographic"
+            ),
+            "width": 1280,
+            "height": 720,
+            "steps": 20,
+            "seed": 7,
+        },
+    },
+    {
+        "key": "t2v",
+        "tool": "comfyui_video",
+        "workflow": "wan22-t2v-4step",
+        "label": "WAN 2.2 text-to-video",
+        "rel": "assets/video/t2v_lighthouse.mp4",
+        "inputs": {
+            "operation": "text_to_video",
+            "prompt": (
+                "Slow aerial push toward a lighthouse on a black cliff at "
+                "dusk, fog drifting across the water, beam sweeping through "
+                "haze, cinematic"
+            ),
+            "width": 832,
+            "height": 480,
+            "num_frames": 81,
+            "seed": 11,
+            "timeout_seconds": 2400,
+        },
+    },
+    {
+        "key": "i2v",
+        "tool": "comfyui_video",
+        "workflow": "wan22-i2v-4step",
+        "label": "WAN 2.2 image-to-video",
+        "rel": "assets/video/i2v_lighthouse.mp4",
+        # Consumes the FLUX still produced by the first step.
+        "reference_from": "image",
+        "inputs": {
+            "operation": "image_to_video",
+            "prompt": (
+                "The fog drifts slowly across the water and the lighthouse "
+                "beam sweeps through the haze, gentle camera drift"
+            ),
+            "width": 640,
+            "height": 640,
+            "num_frames": 81,
+            "seed": 13,
+            "timeout_seconds": 2400,
+        },
+    },
+    {
+        "key": "music",
+        "tool": "comfyui_music",
+        "workflow": "ace-step-1-t2a",
+        "label": "ACE-Step score",
+        "rel": "assets/music/fog_theme.mp3",
+        "inputs": {
+            "prompt": (
+                "slow cinematic ambient, low strings, distant foghorn, sparse "
+                "piano, melancholy maritime atmosphere, instrumental"
+            ),
+            "duration_seconds": 20,
+            "steps": 50,
+            "seed": 23,
+            "timeout_seconds": 1800,
+        },
+    },
+]
+
+
+def preflight(backend: str) -> int:
+    """Report discovery, backend resolution, and readiness. Spends nothing."""
+    print(f"\nBackend resolved: {backend}")
+    if backend != "cloud":
+        print(
+            "  note: no Comfy Cloud backend selected. Set COMFY_CLOUD_API_KEY "
+            "and COMFYUI_BACKEND=cloud, or pass --backend cloud."
+        )
+
+    failures = 0
+    print("\nTool readiness")
+    for tool_name in ("comfyui_image", "comfyui_video", "comfyui_music"):
+        tool = registry._tools.get(tool_name)
+        if tool is None:
+            print(f"  {tool_name:15} NOT DISCOVERED")
+            failures += 1
+            continue
+        # Report readiness for the backend this run will actually use.
+        # tool.get_status() answers for the tool's ambient default, which
+        # can differ when COMFYUI_BACKEND is set — printing both side by
+        # side would read as a contradiction.
+        client = tool._client_for(backend)
+        cost = tool.estimate_cost({"backend": backend})
+        ok = client.is_available()
+        print(
+            f"  {tool_name:15} backend={client.backend:5} "
+            f"reachable={ok!s:5} est=${cost:.2f}"
+        )
+        if not ok:
+            print(f"    {client.unavailable_reason().splitlines()[0]}")
+            failures += 1
+    return failures
+
+
+def run_step(step: dict[str, Any], project_dir: Path, backend: str) -> dict[str, Any]:
+    """Execute one generation step and return a manifest entry."""
+    tool = registry._tools[step["tool"]]
+    out = project_dir / step["rel"]
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    inputs = dict(step["inputs"])
+    inputs["backend"] = backend
+    inputs["output_path"] = str(out)
+    if step.get("reference_from"):
+        ref = project_dir / next(
+            s["rel"] for s in STEPS if s["key"] == step["reference_from"]
+        )
+        if not ref.exists():
+            raise RuntimeError(
+                f"{step['key']} needs {ref}, which the earlier step did not produce."
+            )
+        inputs["reference_image_path"] = str(ref)
+
+    print(f"\n=== {step['label']}  ({step['workflow']})")
+    started = datetime.now(timezone.utc)
+    result = tool.execute(inputs)
+    elapsed = (datetime.now(timezone.utc) - started).total_seconds()
+
+    if not result.success:
+        print(f"  FAILED: {result.error}")
+        return {
+            "step": step["key"],
+            "workflow": step["workflow"],
+            "tool": step["tool"],
+            "success": False,
+            "error": result.error,
+            "elapsed_seconds": round(elapsed, 1),
+        }
+
+    size = out.stat().st_size if out.exists() else 0
+    print(f"  ok  {out}  ({size:,} bytes, {elapsed:.0f}s)")
+    return {
+        "step": step["key"],
+        "workflow": step["workflow"],
+        "tool": step["tool"],
+        "success": True,
+        "output": str(out.relative_to(project_dir)),
+        "bytes": size,
+        "elapsed_seconds": round(elapsed, 1),
+        "model": result.data.get("model"),
+        "backend": result.data.get("backend", backend),
+    }
+
+
+def compose(project_dir: Path) -> dict[str, Any]:
+    """Concatenate both clips and lay the generated score underneath.
+
+    Uses FFmpeg directly: the point of this script is the ComfyUI Cloud
+    adapter, not the composition runtimes, and FFmpeg is always available.
+    """
+    t2v = project_dir / "assets/video/t2v_lighthouse.mp4"
+    i2v = project_dir / "assets/video/i2v_lighthouse.mp4"
+    music = project_dir / "assets/music/fog_theme.mp3"
+    final = project_dir / "renders/final.mp4"
+    final.parent.mkdir(parents=True, exist_ok=True)
+
+    missing = [p.name for p in (t2v, i2v, music) if not p.exists()]
+    if missing:
+        return {"success": False, "error": f"missing inputs: {', '.join(missing)}"}
+
+    # Normalize both clips to a common size/fps, concat, then mix the score
+    # in and fade it out over the tail.
+    cmd = [
+        "ffmpeg", "-v", "error", "-y",
+        "-i", str(t2v),
+        "-i", str(i2v),
+        "-i", str(music),
+        "-filter_complex",
+        (
+            "[0:v]scale=832:480:force_original_aspect_ratio=decrease,"
+            "pad=832:480:(ow-iw)/2:(oh-ih)/2,fps=16,setsar=1[v0];"
+            "[1:v]scale=832:480:force_original_aspect_ratio=decrease,"
+            "pad=832:480:(ow-iw)/2:(oh-ih)/2,fps=16,setsar=1[v1];"
+            "[v0][v1]concat=n=2:v=1:a=0[v];"
+            "[2:a]atrim=0:10.125,afade=t=out:st=8.1:d=2[a]"
+        ),
+        "-map", "[v]", "-map", "[a]",
+        "-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "20",
+        "-c:a", "aac", "-shortest",
+        str(final),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        return {"success": False, "error": proc.stderr.strip()[:500]}
+    return {
+        "success": True,
+        "output": str(final.relative_to(project_dir)),
+        "bytes": final.stat().st_size,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project", default=DEFAULT_PROJECT)
+    parser.add_argument(
+        "--backend", default="cloud", choices=["cloud", "local", "auto"]
+    )
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Run the real generations. Consumes Comfy Cloud credits.",
+    )
+    args = parser.parse_args()
+
+    registry.discover()
+    backend = resolve_backend(args.backend)
+
+    failures = preflight(backend)
+    if not args.live:
+        print(
+            "\nDry run complete — nothing was submitted and no credits were "
+            "spent.\nRe-run with --live to generate."
+        )
+        return 1 if failures else 0
+    if failures:
+        print("\nPreflight failed; not spending credits. Fix the above first.")
+        return 1
+
+    project_dir = Path(
+        init_project(
+            args.project,
+            title="Comfy Cloud Adapter Demo",
+            pipeline_type="animated-explainer",
+        )
+    )
+
+    manifest = [run_step(step, project_dir, backend) for step in STEPS]
+
+    print("\n=== Compose")
+    render = compose(project_dir)
+    print(f"  {'ok  ' + render['output'] if render['success'] else render['error']}")
+
+    summary = {
+        "project": args.project,
+        "backend": backend,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "steps": manifest,
+        "render": render,
+    }
+    report = project_dir / "artifacts" / "comfy_cloud_e2e.json"
+    report.write_text(json.dumps(summary, indent=2))
+    print(f"\nReport: {report}")
+
+    failed = [m for m in manifest if not m["success"]]
+    print(
+        f"\n{len(manifest) - len(failed)}/{len(manifest)} workflows succeeded"
+        + (f" — failed: {', '.join(m['step'] for m in failed)}" if failed else "")
+    )
+    return 1 if failed or not render["success"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/comfy_cloud_e2e.py
+++ b/scripts/comfy_cloud_e2e.py
@@ -41,7 +41,7 @@ from lib.env_loader import load_env  # noqa: E402
 load_env(ROOT)
 
 from lib.checkpoint import init_project  # noqa: E402
-from tools._comfyui.client import resolve_backend  # noqa: E402
+from tools._comfyui.cloud_client import resolve_backend  # noqa: E402
 from tools.tool_registry import registry  # noqa: E402
 
 

--- a/tests/contracts/conftest.py
+++ b/tests/contracts/conftest.py
@@ -7,6 +7,21 @@ import pytest
 from tools.tool_registry import ToolRegistry
 
 
+@pytest.fixture(autouse=True)
+def neutral_backend_env(monkeypatch) -> None:
+    """Pin provider-selecting env vars so contract tests are deterministic.
+
+    A developer's real ``.env`` can route the ComfyUI tools at Comfy Cloud
+    (``COMFYUI_BACKEND=cloud``), which would otherwise change what these
+    tests observe -- server URLs, cost estimates -- depending on whose
+    machine they run on. Contract tests assert the default local contract,
+    so the ambient values are cleared here. Tests that mean to exercise the
+    cloud path set the backend explicitly.
+    """
+    for var in ("COMFYUI_BACKEND", "COMFY_CLOUD_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+
 @pytest.fixture()
 def isolated_tool_registry(monkeypatch) -> ToolRegistry:
     """Provide a registry singleton replacement scoped to one test."""

--- a/tests/contracts/test_comfyui_local_server.py
+++ b/tests/contracts/test_comfyui_local_server.py
@@ -1,0 +1,323 @@
+"""End-to-end tests for the LOCAL ComfyUI path against a fake ComfyUI server.
+
+The Comfy Cloud work refactored code shared by both backends — `is_available`,
+`list_models`/`has_node` (now routed through `_object_info`), `submit`,
+`_history_entry`, `download` and `upload_image` all gained branches. Mocked
+unit tests can pin the branch that was taken, but they cannot prove the local
+path still speaks the protocol correctly end to end, and not everyone
+reviewing this has a GPU box to point it at.
+
+So this stands up a real HTTP server implementing ComfyUI's local REST
+contract and drives the three tools against it for real: URL construction,
+headers, polling, artifact discovery and download all execute unmodified.
+The session network guard permits loopback precisely for fixtures like this.
+
+What the fake deliberately does NOT do is accept an X-API-Key or an /api
+prefix — if the cloud branch ever leaks into the local path, these fail.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from tools.audio.comfyui_music import ComfyUIMusic
+from tools.graphics.comfyui_image import ComfyUIImage
+from tools.video.comfyui_video import ComfyUIVideo
+
+# Every model filename the three bundled workflows ask for.
+_INSTALLED_MODELS = [
+    "flux2-dev-nvfp4.safetensors",
+    "mistral_3_small_flux2_fp4_mixed.safetensors",
+    "flux2-vae.safetensors",
+    "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+    "wan2.2_t2v_high_noise_14B_fp8_scaled.safetensors",
+    "wan2.2_t2v_low_noise_14B_fp8_scaled.safetensors",
+    "wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors",
+    "wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors",
+    "wan_2.1_vae.safetensors",
+    "wan2.2_t2v_lightx2v_4steps_lora_v1.1_high_noise.safetensors",
+    "wan2.2_t2v_lightx2v_4steps_lora_v1.1_low_noise.safetensors",
+    "wan2.2_i2v_lightx2v_4steps_lora_v1_high_noise.safetensors",
+    "wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors",
+    "ace_step_v1_3.5b.safetensors",
+]
+
+# Which media key a Save* node reports its artifact under, mirroring ComfyUI.
+_SAVE_NODE_KEYS = {
+    "SaveImage": "images",
+    "SaveVideo": "gifs",
+    "SaveAudioMP3": "audio",
+    "SaveAudio": "audio",
+}
+
+_ARTIFACT_BYTES = b"OPENMONTAGE-FAKE-ARTIFACT-PAYLOAD" * 4
+
+
+class _State:
+    """Everything the fake server records, for assertions."""
+
+    def __init__(self) -> None:
+        self.paths: list[str] = []
+        self.saw_auth_header = False
+        self.submitted: list[dict] = []
+        self.uploads: list[str] = []
+        self.outputs: dict[str, dict] = {}
+
+
+def _node_defs(node_class: str) -> dict:
+    field = {
+        "CheckpointLoaderSimple": "ckpt_name",
+        "UNETLoader": "unet_name",
+        "VAELoader": "vae_name",
+        "CLIPLoader": "clip_name",
+        "LoraLoaderModelOnly": "lora_name",
+    }.get(node_class, "value")
+    return {node_class: {"input": {"required": {field: [_INSTALLED_MODELS, {}]}}}}
+
+
+def _make_handler(state: _State):
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *args):  # keep pytest output clean
+            pass
+
+        def _record(self) -> None:
+            state.paths.append(self.path)
+            if self.headers.get("X-API-Key"):
+                state.saw_auth_header = True
+
+        def _send(self, payload, status=200, raw=False):
+            body = payload if raw else json.dumps(payload).encode()
+            self.send_response(status)
+            self.send_header(
+                "Content-Type",
+                "application/octet-stream" if raw else "application/json",
+            )
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):  # noqa: N802
+            self._record()
+            route = urlparse(self.path).path
+            if route == "/system_stats":
+                return self._send({"system": {"comfyui_version": "fake"}})
+            if route.startswith("/object_info/"):
+                return self._send(_node_defs(route.rsplit("/", 1)[1]))
+            if route.startswith("/history/"):
+                prompt_id = route.rsplit("/", 1)[1]
+                entry = state.outputs.get(prompt_id)
+                # ComfyUI returns {} until the job finishes; returning the
+                # entry immediately keeps the test fast while still exercising
+                # the "entry appears means done" contract the local path uses.
+                return self._send({prompt_id: entry} if entry else {})
+            if route == "/view":
+                return self._send(_ARTIFACT_BYTES, raw=True)
+            return self._send({"error": "not found"}, status=404)
+
+        def do_POST(self):  # noqa: N802
+            self._record()
+            route = urlparse(self.path).path
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length) if length else b""
+
+            if route == "/prompt":
+                payload = json.loads(body)
+                state.submitted.append(payload)
+                prompt_id = f"fake-{len(state.submitted)}"
+                workflow = payload.get("prompt", {})
+                outputs = {}
+                for node_id, node in workflow.items():
+                    key = _SAVE_NODE_KEYS.get(node.get("class_type", ""))
+                    if key:
+                        outputs[node_id] = {key: [{
+                            "filename": f"{node_id}_00001.bin",
+                            "subfolder": "",
+                            "type": "output",
+                        }]}
+                state.outputs[prompt_id] = {
+                    "outputs": outputs,
+                    "status": {"status_str": "success", "completed": True,
+                               "messages": []},
+                    "meta": {},
+                }
+                return self._send({"prompt_id": prompt_id})
+
+            if route == "/upload/image":
+                name = f"uploaded_{len(state.uploads)}.png"
+                state.uploads.append(name)
+                return self._send({"name": name, "subfolder": ""})
+
+            return self._send({"error": "not found"}, status=404)
+
+    return Handler
+
+
+@pytest.fixture()
+def fake_comfyui(monkeypatch):
+    """Run a fake local ComfyUI and point the tools at it."""
+    state = _State()
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _make_handler(state))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    url = f"http://127.0.0.1:{server.server_address[1]}"
+
+    monkeypatch.setenv("COMFYUI_SERVER_URL", url)
+    monkeypatch.setenv("COMFYUI_BACKEND", "local")
+    for var in ("COMFYUI_IMAGE_SERVER_URL", "COMFYUI_VIDEO_SERVER_URL",
+                "COMFYUI_MUSIC_SERVER_URL", "COMFY_CLOUD_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    try:
+        yield state, url
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+class TestLocalDiscovery:
+
+    def test_tools_report_available_against_a_local_server(self, fake_comfyui):
+        for cls in (ComfyUIImage, ComfyUIVideo, ComfyUIMusic):
+            tool = cls()
+            assert tool._client.backend == "local"
+            assert tool._client.is_available() is True
+            assert tool.get_status().value == "available", cls.__name__
+
+    def test_model_discovery_uses_the_per_node_route(self, fake_comfyui):
+        state, _ = fake_comfyui
+        tool = ComfyUIImage()
+        found, missing = tool._client.check_models(
+            ["flux2-dev-nvfp4.safetensors", "not-installed.safetensors"]
+        )
+        assert found == ["flux2-dev-nvfp4.safetensors"]
+        assert missing == ["not-installed.safetensors"]
+        assert any(p.startswith("/object_info/") for p in state.paths)
+        assert not any(p.startswith("/api/") for p in state.paths)
+
+    def test_missing_models_degrade_rather_than_fail(self, fake_comfyui, monkeypatch):
+        monkeypatch.setitem(
+            __import__("tools.graphics.comfyui_image", fromlist=["x"]).__dict__,
+            "_REQUIRED_MODELS", ["absent.safetensors"],
+        )
+        assert ComfyUIImage().get_status().value == "degraded"
+
+
+class TestLocalGeneration:
+    """The whole local cycle: submit, poll, locate artifact, download."""
+
+    def test_image_writes_a_real_file(self, fake_comfyui, tmp_path):
+        state, _ = fake_comfyui
+        out = tmp_path / "img.png"
+        result = ComfyUIImage().execute({
+            "prompt": "a lighthouse", "width": 512, "height": 512, "seed": 3,
+            "output_path": str(out), "timeout_seconds": 15,
+        })
+        assert result.success, result.error
+        assert out.read_bytes() == _ARTIFACT_BYTES
+        assert result.cost_usd == 0.0
+        assert result.data["model"] == "flux2-dev-nvfp4"
+
+        submitted = state.submitted[0]["prompt"]
+        assert submitted["4"]["inputs"]["text"] == "a lighthouse"
+        assert submitted["7"]["inputs"]["noise_seed"] == 3
+        # Local must keep the NVFP4 filename — the swap is cloud-only.
+        assert submitted["1"]["inputs"]["unet_name"] == "flux2-dev-nvfp4.safetensors"
+        assert "extra_data" not in state.submitted[0]
+        assert state.saw_auth_header is False
+
+    def test_text_to_video_writes_a_real_file(self, fake_comfyui, tmp_path):
+        state, _ = fake_comfyui
+        out = tmp_path / "clip.mp4"
+        result = ComfyUIVideo().execute({
+            "operation": "text_to_video", "prompt": "waves", "seed": 5,
+            "output_path": str(out), "timeout_seconds": 15,
+        })
+        assert result.success, result.error
+        assert out.read_bytes() == _ARTIFACT_BYTES
+        submitted = state.submitted[0]["prompt"]
+        assert submitted["2"]["inputs"]["text"] == "waves"
+        assert submitted["12"]["inputs"]["noise_seed"] == 5
+
+    def test_image_to_video_uploads_the_reference(self, fake_comfyui, tmp_path):
+        state, _ = fake_comfyui
+        ref = tmp_path / "ref.png"
+        ref.write_bytes(b"\x89PNG\r\n\x1a\n" + b"0" * 32)
+        out = tmp_path / "clip.mp4"
+
+        result = ComfyUIVideo().execute({
+            "operation": "image_to_video", "prompt": "drift",
+            "reference_image_path": str(ref), "seed": 7,
+            "output_path": str(out), "timeout_seconds": 15,
+        })
+        assert result.success, result.error
+        assert out.read_bytes() == _ARTIFACT_BYTES
+        assert state.uploads, "reference image was never uploaded"
+        submitted = state.submitted[0]["prompt"]
+        assert submitted["97"]["inputs"]["image"] == state.uploads[0]
+
+    def test_music_writes_a_real_file(self, fake_comfyui, tmp_path):
+        out = tmp_path / "track.mp3"
+        result = ComfyUIMusic().execute({
+            "prompt": "ambient drone", "duration_seconds": 10, "seed": 11,
+            "output_path": str(out), "timeout_seconds": 15,
+        })
+        assert result.success, result.error
+        assert out.read_bytes() == _ARTIFACT_BYTES
+        assert result.cost_usd == 0.0
+
+    def test_custom_workflow_with_output_node(self, fake_comfyui, tmp_path):
+        """The override contract must keep working on local."""
+        out = tmp_path / "custom.png"
+        workflow = {
+            "1": {"class_type": "SaveImage",
+                  "inputs": {"filename_prefix": "custom"}},
+        }
+        result = ComfyUIImage().execute({
+            "prompt": "unused by the custom graph",
+            "workflow_json": json.dumps(workflow),
+            "output_node": "1",
+            "output_path": str(out), "timeout_seconds": 15, "timeout_seconds": 15,
+        })
+        assert result.success, result.error
+        assert out.read_bytes() == _ARTIFACT_BYTES
+
+    def test_custom_workflow_without_output_node_is_rejected(self, fake_comfyui):
+        result = ComfyUIImage().execute({
+            "prompt": "x", "workflow_json": "{}",
+        })
+        assert result.success is False
+        assert "output_node" in result.error
+
+
+class TestLocalStaysLocal:
+    """Guard against the cloud branch leaking into the local path."""
+
+    def test_no_api_prefix_and_no_auth_header_anywhere(self, fake_comfyui, tmp_path):
+        state, _ = fake_comfyui
+        ComfyUIImage().execute({
+            "prompt": "x", "output_path": str(tmp_path / "a.png"),
+            "timeout_seconds": 15,
+        })
+        ComfyUIMusic().execute({
+            "prompt": "y", "output_path": str(tmp_path / "b.mp3"),
+            "timeout_seconds": 15,
+        })
+        assert state.paths, "the fake server was never contacted"
+        assert not any(p.startswith("/api/") for p in state.paths)
+        assert state.saw_auth_header is False
+        assert all("extra_data" not in s for s in state.submitted)
+
+    def test_unreachable_local_server_reports_a_local_reason(self, monkeypatch):
+        monkeypatch.setenv("COMFYUI_SERVER_URL", "http://127.0.0.1:1")
+        monkeypatch.setenv("COMFYUI_BACKEND", "local")
+        monkeypatch.delenv("COMFY_CLOUD_API_KEY", raising=False)
+        tool = ComfyUIImage()
+        assert tool._client.is_available() is False
+        reason = tool._client.unavailable_reason()
+        assert "127.0.0.1:1" in reason
+        assert "Comfy Cloud" not in reason

--- a/tests/contracts/test_comfyui_tools.py
+++ b/tests/contracts/test_comfyui_tools.py
@@ -1635,3 +1635,42 @@ class TestBackendSurfaceOnTools:
         patched = apply_backend_models(
             workflow, workflow_key="flux2-txt2img", backend="local")
         assert patched["1"]["inputs"]["unet_name"] == "flux2-dev-nvfp4.safetensors"
+
+
+class TestSetupMetadataMentionsCloud:
+    """AGENT_GUIDE has agents build the setup menu from this metadata.
+
+    If install_instructions only describes standing up a local server, a
+    user with no GPU is told to install ComfyUI and never learns a cloud key
+    is an option — the provider menu would be accurate but incomplete.
+    """
+
+    def test_install_instructions_offer_the_cloud_path(self):
+        for cls in (ComfyUIImage, ComfyUIVideo, ComfyUIMusic):
+            text = cls.install_instructions
+            assert "COMFY_CLOUD_API_KEY" in text, cls.__name__
+            assert "platform.comfy.org" in text, cls.__name__
+            # and must still explain precedence, or users will assume the
+            # key alone switches them over
+            assert "COMFYUI_BACKEND" in text, cls.__name__
+
+    def test_setup_offer_carries_the_hosted_alternative(self):
+        from tools._comfyui.metadata import COMFYUI_SETUP_OFFER
+
+        alt = COMFYUI_SETUP_OFFER["alternative"]
+        assert alt["env_var"] == "COMFY_CLOUD_API_KEY"
+        assert alt["kind"] == "hosted"
+        # Cost honesty is a review-guide requirement for paid providers.
+        assert "metered" in alt["billing"]
+
+    def test_supports_flags_declare_the_cloud_backend(self):
+        for cls in (ComfyUIImage, ComfyUIVideo, ComfyUIMusic):
+            assert cls.supports.get("comfy_cloud_backend") is True, cls.__name__
+
+    def test_local_setup_offer_is_unchanged(self):
+        """The hosted option is additive — it must not displace the local one."""
+        from tools._comfyui.metadata import COMFYUI_SETUP_OFFER
+
+        assert COMFYUI_SETUP_OFFER["kind"] == "local_server"
+        assert COMFYUI_SETUP_OFFER["env_var"] == "COMFYUI_SERVER_URL"
+        assert COMFYUI_SETUP_OFFER["health_check"] == "GET /system_stats"

--- a/tests/contracts/test_comfyui_tools.py
+++ b/tests/contracts/test_comfyui_tools.py
@@ -385,7 +385,7 @@ class TestClientHelpers:
         client = ComfyUIClient("http://comfy.test")
         seen = {}
 
-        def fake_post(url, json=None, timeout=None):
+        def fake_post(url, json=None, timeout=None, headers=None):
             seen.update(json)
             return type("R", (), {
                 "raise_for_status": lambda self: None,
@@ -1303,3 +1303,393 @@ class TestCustomWorkflowSelectorEligibility:
                 "workflow_model_stack",
             ):
                 assert field in props, f"{selector.name} missing {field}"
+
+
+class TestCloudBackend:
+    """Contract for the Comfy Cloud transport inside ComfyUIClient."""
+
+    def test_auto_never_selects_cloud(self, monkeypatch):
+        """Cloud is metered, so it must never be chosen implicitly."""
+        from tools._comfyui.client import resolve_backend
+
+        monkeypatch.setenv("COMFY_CLOUD_API_KEY", "present-but-not-enough")
+        monkeypatch.delenv("COMFYUI_BACKEND", raising=False)
+        assert resolve_backend() == "local"
+        assert resolve_backend("auto") == "local"
+
+    def test_env_var_and_argument_opt_in_to_cloud(self, monkeypatch):
+        from tools._comfyui.client import resolve_backend
+
+        assert resolve_backend("cloud") == "cloud"
+        monkeypatch.setenv("COMFYUI_BACKEND", "cloud")
+        assert resolve_backend() == "cloud"
+        # An explicit argument still wins over the env var.
+        assert resolve_backend("local") == "local"
+
+    def test_invalid_backend_rejected(self):
+        from tools._comfyui.client import resolve_backend
+
+        with pytest.raises(ValueError):
+            resolve_backend("gpu-farm")
+
+    def test_cloud_client_uses_api_prefix_and_auth_header(self, monkeypatch):
+        from tools._comfyui.client import ComfyUIClient
+
+        monkeypatch.setenv("COMFY_CLOUD_API_KEY", "k-123")
+        client = ComfyUIClient(backend="cloud")
+        assert client.is_cloud is True
+        assert client.server_url == "https://cloud.comfy.org/api"
+        assert client._headers == {"X-API-Key": "k-123"}
+
+    def test_local_client_sends_no_auth_header(self, monkeypatch):
+        from tools._comfyui.client import ComfyUIClient
+
+        monkeypatch.setenv("COMFYUI_SERVER_URL", "http://box:8188")
+        client = ComfyUIClient(backend="local")
+        assert client.is_cloud is False
+        assert client.server_url == "http://box:8188"
+        assert client._headers == {}
+
+    def test_cloud_unavailable_without_key(self, monkeypatch):
+        from tools._comfyui.client import ComfyUIClient
+
+        monkeypatch.delenv("COMFY_CLOUD_API_KEY", raising=False)
+        client = ComfyUIClient(backend="cloud")
+        assert client.is_available() is False
+        assert "COMFY_CLOUD_API_KEY" in client.unavailable_reason()
+
+    def test_normalizer_maps_job_record_to_local_shape(self):
+        """The job record's execution_status IS the local status dict.
+
+        Reading the flat record's top-level ``status`` instead would yield
+        the bare string "completed", and the caller's
+        ``status_str == "error"`` check would never fire.
+        """
+        from tools._comfyui.client import ComfyUIClient
+
+        job = {
+            "id": "abc",
+            "status": "completed",
+            "execution_status": {
+                "status_str": "success",
+                "completed": True,
+                "messages": [["execution_start", {}]],
+            },
+            "execution_meta": {"215": {"node_id": "215"}},
+            "outputs": {
+                "215": {"audio": [{"filename": "a.mp3", "subfolder": "audio",
+                                   "type": "output"}]}
+            },
+        }
+        entry = ComfyUIClient._normalize_cloud_job(job)
+        assert entry["status"]["status_str"] == "success"
+        assert entry["meta"] == {"215": {"node_id": "215"}}
+        assert entry["outputs"]["215"]["audio"][0]["filename"] == "a.mp3"
+
+    def test_normalizer_preserves_failure_signal(self):
+        from tools._comfyui.client import ComfyUIClient
+
+        entry = ComfyUIClient._normalize_cloud_job(
+            {
+                "status": "completed",
+                "execution_status": {"status_str": "error", "messages": ["boom"]},
+                "outputs": {},
+            }
+        )
+        assert entry["status"]["status_str"] == "error"
+
+    @pytest.mark.parametrize(
+        "code,needle",
+        [
+            (401, "COMFY_CLOUD_API_KEY"),
+            (402, "out of credits"),
+            (429, "subscription is inactive"),
+        ],
+    )
+    def test_billing_and_auth_errors_are_explicit_blockers(self, code, needle):
+        """402 and 429 look like throttling; retrying them can never work."""
+        from tools._comfyui.client import ComfyUIClient, ComfyUIError
+
+        client = ComfyUIClient(backend="cloud")
+        resp = type("R", (), {
+            "status_code": code,
+            "json": lambda self: {"code": "X", "message": "nope"},
+            "text": "nope",
+        })()
+        with pytest.raises(ComfyUIError) as exc:
+            client._raise_for_cloud_error(resp)
+        assert needle in str(exc.value)
+
+    def test_cloud_swaps_models_the_hosted_catalog_actually_has(self):
+        """Cloud has no NVFP4 build; the graph must name what exists there."""
+        from tools._comfyui.metadata import apply_backend_models, backend_models
+
+        workflow = {
+            "1": {"class_type": "UNETLoader",
+                  "inputs": {"unet_name": "flux2-dev-nvfp4.safetensors"}},
+            "3": {"class_type": "VAELoader",
+                  "inputs": {"vae_name": "flux2-vae.safetensors"}},
+        }
+        patched = apply_backend_models(
+            workflow, workflow_key="flux2-txt2img", backend="cloud"
+        )
+        assert patched["1"]["inputs"]["unet_name"] == "flux2-dev.safetensors"
+        assert patched["3"]["inputs"]["vae_name"] == "flux2-vae.safetensors"
+
+        required = backend_models(
+            ["flux2-dev-nvfp4.safetensors"],
+            workflow_key="flux2-txt2img",
+            backend="cloud",
+        )
+        assert required == ["flux2-dev.safetensors"]
+
+    def test_local_backend_leaves_workflow_untouched(self):
+        from tools._comfyui.metadata import apply_backend_models
+
+        workflow = {
+            "1": {"class_type": "UNETLoader",
+                  "inputs": {"unet_name": "flux2-dev-nvfp4.safetensors"}},
+        }
+        patched = apply_backend_models(
+            workflow, workflow_key="flux2-txt2img", backend="local"
+        )
+        assert patched["1"]["inputs"]["unet_name"] == "flux2-dev-nvfp4.safetensors"
+
+    def test_tools_expose_backend_input(self):
+        for cls in (ComfyUIImage, ComfyUIVideo, ComfyUIMusic):
+            prop = cls.input_schema["properties"]["backend"]
+            assert prop["enum"] == ["local", "cloud", "auto"]
+            assert prop["default"] == "auto"
+
+    def test_cloud_runs_cost_money_local_is_free(self, monkeypatch):
+        monkeypatch.setenv("COMFY_CLOUD_API_KEY", "k")
+        for cls in (ComfyUIImage, ComfyUIVideo, ComfyUIMusic):
+            tool = cls()
+            assert tool.estimate_cost({"backend": "local"}) == 0.0
+            assert tool.estimate_cost({"backend": "cloud"}) > 0.0
+
+
+class TestPartnerNodeGraphs:
+    """Partner API nodes have tighter input ranges than the local graphs."""
+
+    def test_partner_seed_is_clamped_to_int32(self):
+        """random_seed() draws UINT32; partner nodes reject anything over INT32_MAX."""
+        from pathlib import Path
+
+        workflow, _ = ComfyUIVideo._build_partner_t2v(
+            {"prompt": "a wave", "duration": 5},
+            4_161_237_130,  # a real UINT32 seed that failed validation
+            Path("out.mp4"),
+            "seedance_2.5",
+        )
+        assert workflow["1"]["inputs"]["seed"] <= 2_147_483_647
+
+    def test_partner_seed_left_alone_when_already_in_range(self):
+        from pathlib import Path
+
+        workflow, _ = ComfyUIVideo._build_partner_t2v(
+            {"prompt": "a wave"}, 42, Path("out.mp4"), "seedance_2.5"
+        )
+        assert workflow["1"]["inputs"]["seed"] == 42
+
+    def test_cloud_submit_carries_partner_credential(self, monkeypatch):
+        """Partner nodes read the key from extra_data, not the header."""
+        from tools._comfyui.client import ComfyUIClient
+
+        monkeypatch.setenv("COMFY_CLOUD_API_KEY", "k-777")
+        client = ComfyUIClient(backend="cloud")
+        seen = {}
+
+        def fake_post(url, json=None, timeout=None, headers=None):
+            seen.update(json or {})
+            return type("R", (), {
+                "status_code": 200,
+                "raise_for_status": lambda self: None,
+                "json": lambda self: {"prompt_id": "p1"},
+            })()
+
+        monkeypatch.setattr("tools._comfyui.client.requests.post", fake_post)
+        client.submit({"1": {"inputs": {}}})
+        assert seen["extra_data"] == {"api_key_comfy_org": "k-777"}
+
+    def test_local_submit_sends_no_extra_data(self, monkeypatch):
+        from tools._comfyui.client import ComfyUIClient
+
+        client = ComfyUIClient(backend="local")
+        seen = {}
+
+        def fake_post(url, json=None, timeout=None, headers=None):
+            seen.update(json or {})
+            return type("R", (), {
+                "status_code": 200,
+                "raise_for_status": lambda self: None,
+                "json": lambda self: {"prompt_id": "p1"},
+            })()
+
+        monkeypatch.setattr("tools._comfyui.client.requests.post", fake_post)
+        client.submit({"1": {"inputs": {}}})
+        assert "extra_data" not in seen
+
+    def test_failed_job_error_names_the_node(self):
+        """A failed cloud job has no execution_status — detail is elsewhere."""
+        from tools._comfyui.client import _describe_cloud_error
+        import json as _json
+
+        payload = {"error_message": _json.dumps({
+            "exception_message": "Unauthorized: Please login first to use this node.",
+            "node_id": "208", "node_type": "ElevenLabsTextToSpeech",
+        })}
+        described = _describe_cloud_error(payload)
+        assert "ElevenLabsTextToSpeech" in described
+        assert "Unauthorized" in described
+
+    def test_failed_status_is_terminal(self):
+        """'failed' is undocumented but real; polling it forever is a hang."""
+        from tools._comfyui.client import _CLOUD_TERMINAL
+
+        assert "failed" in _CLOUD_TERMINAL
+
+    def test_partner_model_uses_flattened_dynamic_combo_keys(self):
+        """COMFY_DYNAMICCOMBO_V3 takes the combo key plus `model.<name>` siblings.
+
+        Nesting the parameters in a dict passes submit-time validation and
+        then dies at execution with "missing 1 required positional argument".
+        """
+        from pathlib import Path
+
+        workflow, _ = ComfyUIVideo._build_partner_t2v(
+            {"prompt": "a wave"}, 1, Path("o.mp4"), "seedance_2.5"
+        )
+        node = workflow["1"]["inputs"]
+        assert node["model"] == "Seedance 2.5"
+        assert node["model.prompt"] == "a wave"
+        assert not isinstance(node["model"], dict)
+
+    def test_seedance_25_sends_required_output_format(self):
+        """The 2.5 variant requires output_format; omitting it fails validation."""
+        from pathlib import Path
+
+        workflow, _ = ComfyUIVideo._build_partner_t2v(
+            {"prompt": "a wave"}, 1, Path("o.mp4"), "seedance_2.5"
+        )
+        assert workflow["1"]["inputs"]["model.output_format"] == "mp4"
+
+    def test_every_partner_family_flattens(self):
+        from pathlib import Path
+
+        for family in ("gemini_omni_flash", "seedance_2.5", "minimax_h3_api"):
+            workflow, out = ComfyUIVideo._build_partner_t2v(
+                {"prompt": "x"}, 1, Path("o.mp4"), family
+            )
+            node = workflow["1"]["inputs"]
+            assert isinstance(node["model"], str), family
+            assert any(k.startswith("model.") for k in node), family
+            assert out == "2"
+
+    def test_negative_prompt_appends_rather_than_replaces(self):
+        """The bundled quality negative must survive a caller's additions."""
+        from pathlib import Path
+
+        tool = ComfyUIVideo()
+        base, _ = tool._build_t2v({"prompt": "x"}, 1, Path("o.mp4"))
+        stock = base["3"]["inputs"]["text"]
+
+        merged, _ = tool._build_t2v(
+            {"prompt": "x", "negative_prompt": "people, crew"}, 1, Path("o.mp4")
+        )
+        text = merged["3"]["inputs"]["text"]
+        assert text.startswith(stock)
+        assert "people, crew" in text
+
+    def test_negative_prompt_optional(self):
+        from pathlib import Path
+
+        tool = ComfyUIVideo()
+        a, _ = tool._build_t2v({"prompt": "x"}, 1, Path("o.mp4"))
+        b, _ = tool._build_t2v({"prompt": "x", "negative_prompt": ""}, 1, Path("o.mp4"))
+        assert a["3"]["inputs"]["text"] == b["3"]["inputs"]["text"]
+
+
+class TestObjectInfoRouting:
+    """`_object_info` is shared by both backends — local must not regress.
+
+    Cloud 404s the per-node route and only answers the full ~10 MB
+    `/api/object_info`, so the two backends fetch differently. These tests
+    pin that the local path still uses the cheap per-node request it always
+    did, and that cloud fetches the big payload only once.
+    """
+
+    @staticmethod
+    def _fake_get(calls, payload):
+        def _get(url, headers=None, timeout=None, params=None):
+            calls.append(url)
+            return type("R", (), {
+                "status_code": 200,
+                "raise_for_status": lambda self: None,
+                "json": lambda self: payload,
+            })()
+        return _get
+
+    def test_local_still_uses_per_node_route(self, monkeypatch):
+        from tools._comfyui.client import ComfyUIClient
+
+        calls: list[str] = []
+        monkeypatch.setattr(
+            "tools._comfyui.client.requests.get",
+            self._fake_get(calls, {"UNETLoader": {"input": {"required": {
+                "unet_name": [["a.safetensors"]]}}}}),
+        )
+        client = ComfyUIClient(backend="local", server_url="http://box:8188")
+        client.list_models()
+        assert all(url.startswith("http://box:8188/object_info/") for url in calls)
+        assert "http://box:8188/object_info/UNETLoader" in calls
+
+    def test_cloud_fetches_full_object_info_once(self, monkeypatch):
+        from tools._comfyui.client import ComfyUIClient
+
+        monkeypatch.setenv("COMFY_CLOUD_API_KEY", "k")
+        calls: list[str] = []
+        monkeypatch.setattr(
+            "tools._comfyui.client.requests.get",
+            self._fake_get(calls, {"UNETLoader": {"input": {"required": {
+                "unet_name": [["a.safetensors"]]}}}}),
+        )
+        client = ComfyUIClient(backend="cloud")
+        client.list_models()
+        client.has_node("UNETLoader")
+        client.check_models(["a.safetensors"])
+
+        assert calls, "cloud made no request"
+        assert all(url.endswith("/api/object_info") for url in calls)
+        # Memoized: five model groups plus two later lookups, one fetch.
+        assert len(calls) == 1, f"object_info fetched {len(calls)} times"
+
+    def test_cloud_has_node_false_for_absent_class(self, monkeypatch):
+        from tools._comfyui.client import ComfyUIClient
+
+        monkeypatch.setenv("COMFY_CLOUD_API_KEY", "k")
+        monkeypatch.setattr(
+            "tools._comfyui.client.requests.get",
+            self._fake_get([], {"UNETLoader": {}}),
+        )
+        client = ComfyUIClient(backend="cloud")
+        assert client.has_node("UNETLoader") is True
+        assert client.has_node("NoSuchNode") is False
+
+
+class TestRecoveryHints:
+    def test_cloud_hint_points_at_jobs_not_history(self, monkeypatch):
+        """Cloud has no /history route — sending users there 404s."""
+        from tools._comfyui.client import ComfyUIClient
+
+        monkeypatch.setenv("COMFY_CLOUD_API_KEY", "k")
+        hint = ComfyUIClient(backend="cloud").recovery_hint("p1")
+        assert "/api/jobs/p1" in hint
+        assert "/history/" not in hint
+
+    def test_local_hint_unchanged(self, monkeypatch):
+        from tools._comfyui.client import ComfyUIClient
+
+        monkeypatch.setenv("COMFYUI_SERVER_URL", "http://box:8188")
+        hint = ComfyUIClient(backend="local").recovery_hint("p1")
+        assert hint == "GET http://box:8188/history/p1"

--- a/tests/contracts/test_comfyui_tools.py
+++ b/tests/contracts/test_comfyui_tools.py
@@ -1305,155 +1305,296 @@ class TestCustomWorkflowSelectorEligibility:
                 assert field in props, f"{selector.name} missing {field}"
 
 
-class TestCloudBackend:
-    """Contract for the Comfy Cloud transport inside ComfyUIClient."""
+class TestBackendResolution:
+    """A configured local server always wins; a lone cloud key means cloud."""
 
-    def test_auto_never_selects_cloud(self, monkeypatch):
-        """Cloud is metered, so it must never be chosen implicitly."""
-        from tools._comfyui.client import resolve_backend
+    @pytest.mark.parametrize(
+        "local_url,cloud_key,expected",
+        [
+            ("http://box:8188", None, "local"),
+            ("http://box:8188", "k", "local"),   # both set -> cloud is ignored
+            (None, "k", "cloud"),
+            (None, None, "local"),
+        ],
+    )
+    def test_auto_resolution_table(self, monkeypatch, local_url, cloud_key, expected):
+        from tools._comfyui.cloud_client import resolve_backend
 
-        monkeypatch.setenv("COMFY_CLOUD_API_KEY", "present-but-not-enough")
         monkeypatch.delenv("COMFYUI_BACKEND", raising=False)
+        for var in ("COMFYUI_SERVER_URL", "COMFYUI_IMAGE_SERVER_URL",
+                    "COMFYUI_VIDEO_SERVER_URL", "COMFYUI_MUSIC_SERVER_URL",
+                    "COMFY_CLOUD_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+        if local_url:
+            monkeypatch.setenv("COMFYUI_SERVER_URL", local_url)
+        if cloud_key:
+            monkeypatch.setenv("COMFY_CLOUD_API_KEY", cloud_key)
+        assert resolve_backend() == expected
+
+    def test_a_per_capability_local_url_also_counts_as_configured(self, monkeypatch):
+        from tools._comfyui.cloud_client import resolve_backend
+
+        monkeypatch.delenv("COMFYUI_BACKEND", raising=False)
+        monkeypatch.delenv("COMFYUI_SERVER_URL", raising=False)
+        monkeypatch.setenv("COMFYUI_VIDEO_SERVER_URL", "http://gpu:8188")
+        monkeypatch.setenv("COMFY_CLOUD_API_KEY", "k")
         assert resolve_backend() == "local"
-        assert resolve_backend("auto") == "local"
 
-    def test_env_var_and_argument_opt_in_to_cloud(self, monkeypatch):
-        from tools._comfyui.client import resolve_backend
+    def test_explicit_argument_and_env_override(self, monkeypatch):
+        from tools._comfyui.cloud_client import resolve_backend
 
+        monkeypatch.setenv("COMFYUI_SERVER_URL", "http://box:8188")
         assert resolve_backend("cloud") == "cloud"
         monkeypatch.setenv("COMFYUI_BACKEND", "cloud")
         assert resolve_backend() == "cloud"
-        # An explicit argument still wins over the env var.
         assert resolve_backend("local") == "local"
 
     def test_invalid_backend_rejected(self):
-        from tools._comfyui.client import resolve_backend
+        from tools._comfyui.cloud_client import resolve_backend
 
         with pytest.raises(ValueError):
             resolve_backend("gpu-farm")
 
-    def test_cloud_client_uses_api_prefix_and_auth_header(self, monkeypatch):
+    def test_factory_returns_the_right_class(self, monkeypatch):
+        from tools._comfyui.client import ComfyUIClient
+        from tools._comfyui.cloud_client import ComfyCloudClient, make_client
+
+        monkeypatch.setenv("COMFY_CLOUD_API_KEY", "k")
+        assert isinstance(make_client("image", "cloud"), ComfyCloudClient)
+        local = make_client("image", "local")
+        assert isinstance(local, ComfyUIClient)
+        assert not isinstance(local, ComfyCloudClient)
+
+
+class TestLocalClientKnowsNothingOfCloud:
+    """The point of the subclass split: the local client is cloud-free."""
+
+    def test_local_client_source_never_mentions_cloud(self):
+        from pathlib import Path
+        import tools._comfyui.client as mod
+
+        source = Path(mod.__file__).read_text().lower()
+        for term in ("comfy_cloud_api_key", "x-api-key", "extra_data",
+                     "cloud.comfy.org", "/api/"):
+            assert term not in source, f"local client references {term!r}"
+
+    def test_local_client_defaults(self, monkeypatch):
         from tools._comfyui.client import ComfyUIClient
 
-        monkeypatch.setenv("COMFY_CLOUD_API_KEY", "k-123")
-        client = ComfyUIClient(backend="cloud")
-        assert client.is_cloud is True
-        assert client.server_url == "https://cloud.comfy.org/api"
-        assert client._headers == {"X-API-Key": "k-123"}
-
-    def test_local_client_sends_no_auth_header(self, monkeypatch):
-        from tools._comfyui.client import ComfyUIClient
-
-        monkeypatch.setenv("COMFYUI_SERVER_URL", "http://box:8188")
-        client = ComfyUIClient(backend="local")
+        monkeypatch.setenv("COMFY_CLOUD_API_KEY", "k")
+        client = ComfyUIClient(server_url="http://box:8188")
+        assert client.backend == "local"
         assert client.is_cloud is False
         assert client.server_url == "http://box:8188"
-        assert client._headers == {}
+        assert client.recovery_hint("p1") == "GET http://box:8188/history/p1"
 
-    def test_cloud_unavailable_without_key(self, monkeypatch):
-        from tools._comfyui.client import ComfyUIClient
+
+class TestCloudClient:
+
+    def test_api_prefix_and_auth_header(self, monkeypatch):
+        from tools._comfyui.cloud_client import ComfyCloudClient
+
+        monkeypatch.setenv("COMFY_CLOUD_API_KEY", "k-123")
+        client = ComfyCloudClient()
+        assert client.is_cloud is True
+        assert client.backend == "cloud"
+        assert client.server_url == "https://cloud.comfy.org/api"
+        assert client._headers == {"X-API-Key": "k-123"}
+        assert "/api/jobs/p1" in client.recovery_hint("p1")
+
+    def test_unavailable_without_key(self, monkeypatch):
+        from tools._comfyui.cloud_client import ComfyCloudClient
 
         monkeypatch.delenv("COMFY_CLOUD_API_KEY", raising=False)
-        client = ComfyUIClient(backend="cloud")
+        client = ComfyCloudClient()
         assert client.is_available() is False
         assert "COMFY_CLOUD_API_KEY" in client.unavailable_reason()
 
     def test_normalizer_maps_job_record_to_local_shape(self):
-        """The job record's execution_status IS the local status dict.
+        """execution_status IS the local status dict — a rename, not a translation.
 
-        Reading the flat record's top-level ``status`` instead would yield
-        the bare string "completed", and the caller's
-        ``status_str == "error"`` check would never fire.
+        Reading the flat record's top-level `status` yields the bare string
+        "completed", and the caller's status_str == "error" check would
+        never fire.
         """
-        from tools._comfyui.client import ComfyUIClient
+        from tools._comfyui.cloud_client import ComfyCloudClient
 
-        job = {
-            "id": "abc",
+        entry = ComfyCloudClient.normalize_job({
             "status": "completed",
-            "execution_status": {
-                "status_str": "success",
-                "completed": True,
-                "messages": [["execution_start", {}]],
-            },
+            "execution_status": {"status_str": "success", "completed": True,
+                                 "messages": [["execution_start", {}]]},
             "execution_meta": {"215": {"node_id": "215"}},
-            "outputs": {
-                "215": {"audio": [{"filename": "a.mp3", "subfolder": "audio",
-                                   "type": "output"}]}
-            },
-        }
-        entry = ComfyUIClient._normalize_cloud_job(job)
+            "outputs": {"215": {"audio": [{"filename": "a.mp3",
+                                           "subfolder": "audio",
+                                           "type": "output"}]}},
+        })
         assert entry["status"]["status_str"] == "success"
         assert entry["meta"] == {"215": {"node_id": "215"}}
         assert entry["outputs"]["215"]["audio"][0]["filename"] == "a.mp3"
 
     def test_normalizer_preserves_failure_signal(self):
-        from tools._comfyui.client import ComfyUIClient
+        from tools._comfyui.cloud_client import ComfyCloudClient
 
-        entry = ComfyUIClient._normalize_cloud_job(
-            {
-                "status": "completed",
-                "execution_status": {"status_str": "error", "messages": ["boom"]},
-                "outputs": {},
-            }
-        )
+        entry = ComfyCloudClient.normalize_job({
+            "status": "completed",
+            "execution_status": {"status_str": "error", "messages": ["boom"]},
+            "outputs": {},
+        })
         assert entry["status"]["status_str"] == "error"
 
-    @pytest.mark.parametrize(
-        "code,needle",
-        [
-            (401, "COMFY_CLOUD_API_KEY"),
-            (402, "out of credits"),
-            (429, "subscription is inactive"),
-        ],
-    )
+    @pytest.mark.parametrize("code,needle", [
+        (401, "COMFY_CLOUD_API_KEY"),
+        (402, "out of credits"),
+        (429, "subscription is inactive"),
+    ])
     def test_billing_and_auth_errors_are_explicit_blockers(self, code, needle):
         """402 and 429 look like throttling; retrying them can never work."""
-        from tools._comfyui.client import ComfyUIClient, ComfyUIError
+        from tools._comfyui.client import ComfyUIError
+        from tools._comfyui.cloud_client import ComfyCloudClient
 
-        client = ComfyUIClient(backend="cloud")
         resp = type("R", (), {
             "status_code": code,
             "json": lambda self: {"code": "X", "message": "nope"},
             "text": "nope",
         })()
         with pytest.raises(ComfyUIError) as exc:
-            client._raise_for_cloud_error(resp)
+            ComfyCloudClient()._raise_for_error(resp)
         assert needle in str(exc.value)
 
-    def test_cloud_swaps_models_the_hosted_catalog_actually_has(self):
-        """Cloud has no NVFP4 build; the graph must name what exists there."""
-        from tools._comfyui.metadata import apply_backend_models, backend_models
+    def test_failed_job_error_names_the_node(self):
+        from tools._comfyui.cloud_client import describe_cloud_error
 
-        workflow = {
-            "1": {"class_type": "UNETLoader",
-                  "inputs": {"unet_name": "flux2-dev-nvfp4.safetensors"}},
-            "3": {"class_type": "VAELoader",
-                  "inputs": {"vae_name": "flux2-vae.safetensors"}},
-        }
-        patched = apply_backend_models(
-            workflow, workflow_key="flux2-txt2img", backend="cloud"
+        described = describe_cloud_error({"error_message": json.dumps({
+            "exception_message": "Unauthorized: Please login first to use this node.",
+            "node_id": "208", "node_type": "ElevenLabsTextToSpeech",
+        })})
+        assert "ElevenLabsTextToSpeech" in described
+        assert "Unauthorized" in described
+
+    def test_failed_status_is_terminal(self):
+        """'failed' is undocumented but real; polling it forever is a hang."""
+        from tools._comfyui.cloud_client import CLOUD_TERMINAL
+
+        assert "failed" in CLOUD_TERMINAL
+
+    def test_submit_carries_the_partner_credential(self, monkeypatch):
+        """Partner nodes read the key from extra_data, not the header."""
+        from tools._comfyui.cloud_client import ComfyCloudClient
+
+        monkeypatch.setenv("COMFY_CLOUD_API_KEY", "k-777")
+        seen = {}
+
+        def fake_post(url, json=None, timeout=None, headers=None):
+            seen.update(json or {})
+            return type("R", (), {
+                "status_code": 200,
+                "raise_for_status": lambda self: None,
+                "json": lambda self: {"prompt_id": "p1"},
+            })()
+
+        monkeypatch.setattr(
+            "tools._comfyui.cloud_client.requests.post", fake_post)
+        ComfyCloudClient().submit({"1": {"inputs": {}}})
+        assert seen["extra_data"] == {"api_key_comfy_org": "k-777"}
+
+    def test_object_info_is_fetched_once(self, monkeypatch):
+        """Cloud only serves the full ~10MB payload — memoize it."""
+        from tools._comfyui.cloud_client import ComfyCloudClient
+
+        monkeypatch.setenv("COMFY_CLOUD_API_KEY", "k")
+        calls = []
+
+        def fake_get(url, headers=None, timeout=None, params=None):
+            calls.append(url)
+            return type("R", (), {
+                "status_code": 200,
+                "raise_for_status": lambda self: None,
+                "json": lambda self: {"UNETLoader": {"input": {"required": {
+                    "unet_name": [["a.safetensors"]]}}}},
+            })()
+
+        monkeypatch.setattr("tools._comfyui.cloud_client.requests.get", fake_get)
+        client = ComfyCloudClient()
+        client.list_models()
+        client.has_node("UNETLoader")
+        client.check_models(["a.safetensors"])
+        assert all(u.endswith("/api/object_info") for u in calls)
+        assert len(calls) == 1, f"object_info fetched {len(calls)} times"
+
+
+class TestPartnerNodeGraphs:
+    """Partner API nodes have tighter input ranges than the local graphs."""
+
+    def test_partner_seed_is_clamped_to_int32(self):
+        """random_seed() draws UINT32; partner nodes cap at INT32_MAX."""
+        workflow, _ = ComfyUIVideo._build_partner_t2v(
+            {"prompt": "a wave", "duration": 5},
+            4_161_237_130,  # a real UINT32 seed that failed validation
+            Path("out.mp4"),
+            "seedance_2.5",
         )
-        assert patched["1"]["inputs"]["unet_name"] == "flux2-dev.safetensors"
-        assert patched["3"]["inputs"]["vae_name"] == "flux2-vae.safetensors"
+        assert workflow["1"]["inputs"]["seed"] <= 2_147_483_647
 
-        required = backend_models(
-            ["flux2-dev-nvfp4.safetensors"],
-            workflow_key="flux2-txt2img",
-            backend="cloud",
+    def test_partner_seed_left_alone_when_already_in_range(self):
+        workflow, _ = ComfyUIVideo._build_partner_t2v(
+            {"prompt": "a wave"}, 42, Path("out.mp4"), "seedance_2.5"
         )
-        assert required == ["flux2-dev.safetensors"]
+        assert workflow["1"]["inputs"]["seed"] == 42
 
-    def test_local_backend_leaves_workflow_untouched(self):
-        from tools._comfyui.metadata import apply_backend_models
+    def test_model_uses_flattened_dynamic_combo_keys(self):
+        """COMFY_DYNAMICCOMBO_V3 takes the combo key plus `model.<name>`.
 
-        workflow = {
-            "1": {"class_type": "UNETLoader",
-                  "inputs": {"unet_name": "flux2-dev-nvfp4.safetensors"}},
-        }
-        patched = apply_backend_models(
-            workflow, workflow_key="flux2-txt2img", backend="local"
+        Nesting the parameters passes submit-time validation and then dies
+        at execution with "missing 1 required positional argument".
+        """
+        workflow, _ = ComfyUIVideo._build_partner_t2v(
+            {"prompt": "a wave"}, 1, Path("o.mp4"), "seedance_2.5"
         )
-        assert patched["1"]["inputs"]["unet_name"] == "flux2-dev-nvfp4.safetensors"
+        node = workflow["1"]["inputs"]
+        assert node["model"] == "Seedance 2.5"
+        assert node["model.prompt"] == "a wave"
+        assert not isinstance(node["model"], dict)
+
+    def test_seedance_25_sends_required_output_format(self):
+        workflow, _ = ComfyUIVideo._build_partner_t2v(
+            {"prompt": "a wave"}, 1, Path("o.mp4"), "seedance_2.5"
+        )
+        assert workflow["1"]["inputs"]["model.output_format"] == "mp4"
+
+    def test_every_partner_family_flattens(self):
+        for family in ("gemini_omni_flash", "seedance_2.5", "minimax_h3_api"):
+            workflow, out = ComfyUIVideo._build_partner_t2v(
+                {"prompt": "x"}, 1, Path("o.mp4"), family
+            )
+            node = workflow["1"]["inputs"]
+            assert isinstance(node["model"], str), family
+            assert any(k.startswith("model.") for k in node), family
+            assert out == "2"
+
+
+class TestNegativePrompt:
+
+    def test_appends_rather_than_replaces(self):
+        """The bundled quality negative must survive a caller's additions."""
+        tool = ComfyUIVideo()
+        base, _ = tool._build_t2v({"prompt": "x"}, 1, Path("o.mp4"))
+        stock = base["3"]["inputs"]["text"]
+
+        merged, _ = tool._build_t2v(
+            {"prompt": "x", "negative_prompt": "people, crew"}, 1, Path("o.mp4")
+        )
+        text = merged["3"]["inputs"]["text"]
+        assert text.startswith(stock)
+        assert "people, crew" in text
+
+    def test_optional(self):
+        tool = ComfyUIVideo()
+        a, _ = tool._build_t2v({"prompt": "x"}, 1, Path("o.mp4"))
+        b, _ = tool._build_t2v({"prompt": "x", "negative_prompt": ""}, 1, Path("o.mp4"))
+        assert a["3"]["inputs"]["text"] == b["3"]["inputs"]["text"]
+
+
+class TestBackendSurfaceOnTools:
 
     def test_tools_expose_backend_input(self):
         for cls in (ComfyUIImage, ComfyUIVideo, ComfyUIMusic):
@@ -1468,228 +1609,29 @@ class TestCloudBackend:
             assert tool.estimate_cost({"backend": "local"}) == 0.0
             assert tool.estimate_cost({"backend": "cloud"}) > 0.0
 
+    def test_cloud_swaps_models_the_hosted_catalog_has(self):
+        """Cloud has no NVFP4 build; the graph must name what exists there."""
+        from tools._comfyui.metadata import apply_backend_models, backend_models
 
-class TestPartnerNodeGraphs:
-    """Partner API nodes have tighter input ranges than the local graphs."""
+        workflow = {
+            "1": {"class_type": "UNETLoader",
+                  "inputs": {"unet_name": "flux2-dev-nvfp4.safetensors"}},
+            "3": {"class_type": "VAELoader",
+                  "inputs": {"vae_name": "flux2-vae.safetensors"}},
+        }
+        patched = apply_backend_models(
+            workflow, workflow_key="flux2-txt2img", backend="cloud")
+        assert patched["1"]["inputs"]["unet_name"] == "flux2-dev.safetensors"
+        assert patched["3"]["inputs"]["vae_name"] == "flux2-vae.safetensors"
+        assert backend_models(["flux2-dev-nvfp4.safetensors"],
+                              workflow_key="flux2-txt2img",
+                              backend="cloud") == ["flux2-dev.safetensors"]
 
-    def test_partner_seed_is_clamped_to_int32(self):
-        """random_seed() draws UINT32; partner nodes reject anything over INT32_MAX."""
-        from pathlib import Path
+    def test_local_backend_leaves_workflow_untouched(self):
+        from tools._comfyui.metadata import apply_backend_models
 
-        workflow, _ = ComfyUIVideo._build_partner_t2v(
-            {"prompt": "a wave", "duration": 5},
-            4_161_237_130,  # a real UINT32 seed that failed validation
-            Path("out.mp4"),
-            "seedance_2.5",
-        )
-        assert workflow["1"]["inputs"]["seed"] <= 2_147_483_647
-
-    def test_partner_seed_left_alone_when_already_in_range(self):
-        from pathlib import Path
-
-        workflow, _ = ComfyUIVideo._build_partner_t2v(
-            {"prompt": "a wave"}, 42, Path("out.mp4"), "seedance_2.5"
-        )
-        assert workflow["1"]["inputs"]["seed"] == 42
-
-    def test_cloud_submit_carries_partner_credential(self, monkeypatch):
-        """Partner nodes read the key from extra_data, not the header."""
-        from tools._comfyui.client import ComfyUIClient
-
-        monkeypatch.setenv("COMFY_CLOUD_API_KEY", "k-777")
-        client = ComfyUIClient(backend="cloud")
-        seen = {}
-
-        def fake_post(url, json=None, timeout=None, headers=None):
-            seen.update(json or {})
-            return type("R", (), {
-                "status_code": 200,
-                "raise_for_status": lambda self: None,
-                "json": lambda self: {"prompt_id": "p1"},
-            })()
-
-        monkeypatch.setattr("tools._comfyui.client.requests.post", fake_post)
-        client.submit({"1": {"inputs": {}}})
-        assert seen["extra_data"] == {"api_key_comfy_org": "k-777"}
-
-    def test_local_submit_sends_no_extra_data(self, monkeypatch):
-        from tools._comfyui.client import ComfyUIClient
-
-        client = ComfyUIClient(backend="local")
-        seen = {}
-
-        def fake_post(url, json=None, timeout=None, headers=None):
-            seen.update(json or {})
-            return type("R", (), {
-                "status_code": 200,
-                "raise_for_status": lambda self: None,
-                "json": lambda self: {"prompt_id": "p1"},
-            })()
-
-        monkeypatch.setattr("tools._comfyui.client.requests.post", fake_post)
-        client.submit({"1": {"inputs": {}}})
-        assert "extra_data" not in seen
-
-    def test_failed_job_error_names_the_node(self):
-        """A failed cloud job has no execution_status — detail is elsewhere."""
-        from tools._comfyui.client import _describe_cloud_error
-        import json as _json
-
-        payload = {"error_message": _json.dumps({
-            "exception_message": "Unauthorized: Please login first to use this node.",
-            "node_id": "208", "node_type": "ElevenLabsTextToSpeech",
-        })}
-        described = _describe_cloud_error(payload)
-        assert "ElevenLabsTextToSpeech" in described
-        assert "Unauthorized" in described
-
-    def test_failed_status_is_terminal(self):
-        """'failed' is undocumented but real; polling it forever is a hang."""
-        from tools._comfyui.client import _CLOUD_TERMINAL
-
-        assert "failed" in _CLOUD_TERMINAL
-
-    def test_partner_model_uses_flattened_dynamic_combo_keys(self):
-        """COMFY_DYNAMICCOMBO_V3 takes the combo key plus `model.<name>` siblings.
-
-        Nesting the parameters in a dict passes submit-time validation and
-        then dies at execution with "missing 1 required positional argument".
-        """
-        from pathlib import Path
-
-        workflow, _ = ComfyUIVideo._build_partner_t2v(
-            {"prompt": "a wave"}, 1, Path("o.mp4"), "seedance_2.5"
-        )
-        node = workflow["1"]["inputs"]
-        assert node["model"] == "Seedance 2.5"
-        assert node["model.prompt"] == "a wave"
-        assert not isinstance(node["model"], dict)
-
-    def test_seedance_25_sends_required_output_format(self):
-        """The 2.5 variant requires output_format; omitting it fails validation."""
-        from pathlib import Path
-
-        workflow, _ = ComfyUIVideo._build_partner_t2v(
-            {"prompt": "a wave"}, 1, Path("o.mp4"), "seedance_2.5"
-        )
-        assert workflow["1"]["inputs"]["model.output_format"] == "mp4"
-
-    def test_every_partner_family_flattens(self):
-        from pathlib import Path
-
-        for family in ("gemini_omni_flash", "seedance_2.5", "minimax_h3_api"):
-            workflow, out = ComfyUIVideo._build_partner_t2v(
-                {"prompt": "x"}, 1, Path("o.mp4"), family
-            )
-            node = workflow["1"]["inputs"]
-            assert isinstance(node["model"], str), family
-            assert any(k.startswith("model.") for k in node), family
-            assert out == "2"
-
-    def test_negative_prompt_appends_rather_than_replaces(self):
-        """The bundled quality negative must survive a caller's additions."""
-        from pathlib import Path
-
-        tool = ComfyUIVideo()
-        base, _ = tool._build_t2v({"prompt": "x"}, 1, Path("o.mp4"))
-        stock = base["3"]["inputs"]["text"]
-
-        merged, _ = tool._build_t2v(
-            {"prompt": "x", "negative_prompt": "people, crew"}, 1, Path("o.mp4")
-        )
-        text = merged["3"]["inputs"]["text"]
-        assert text.startswith(stock)
-        assert "people, crew" in text
-
-    def test_negative_prompt_optional(self):
-        from pathlib import Path
-
-        tool = ComfyUIVideo()
-        a, _ = tool._build_t2v({"prompt": "x"}, 1, Path("o.mp4"))
-        b, _ = tool._build_t2v({"prompt": "x", "negative_prompt": ""}, 1, Path("o.mp4"))
-        assert a["3"]["inputs"]["text"] == b["3"]["inputs"]["text"]
-
-
-class TestObjectInfoRouting:
-    """`_object_info` is shared by both backends — local must not regress.
-
-    Cloud 404s the per-node route and only answers the full ~10 MB
-    `/api/object_info`, so the two backends fetch differently. These tests
-    pin that the local path still uses the cheap per-node request it always
-    did, and that cloud fetches the big payload only once.
-    """
-
-    @staticmethod
-    def _fake_get(calls, payload):
-        def _get(url, headers=None, timeout=None, params=None):
-            calls.append(url)
-            return type("R", (), {
-                "status_code": 200,
-                "raise_for_status": lambda self: None,
-                "json": lambda self: payload,
-            })()
-        return _get
-
-    def test_local_still_uses_per_node_route(self, monkeypatch):
-        from tools._comfyui.client import ComfyUIClient
-
-        calls: list[str] = []
-        monkeypatch.setattr(
-            "tools._comfyui.client.requests.get",
-            self._fake_get(calls, {"UNETLoader": {"input": {"required": {
-                "unet_name": [["a.safetensors"]]}}}}),
-        )
-        client = ComfyUIClient(backend="local", server_url="http://box:8188")
-        client.list_models()
-        assert all(url.startswith("http://box:8188/object_info/") for url in calls)
-        assert "http://box:8188/object_info/UNETLoader" in calls
-
-    def test_cloud_fetches_full_object_info_once(self, monkeypatch):
-        from tools._comfyui.client import ComfyUIClient
-
-        monkeypatch.setenv("COMFY_CLOUD_API_KEY", "k")
-        calls: list[str] = []
-        monkeypatch.setattr(
-            "tools._comfyui.client.requests.get",
-            self._fake_get(calls, {"UNETLoader": {"input": {"required": {
-                "unet_name": [["a.safetensors"]]}}}}),
-        )
-        client = ComfyUIClient(backend="cloud")
-        client.list_models()
-        client.has_node("UNETLoader")
-        client.check_models(["a.safetensors"])
-
-        assert calls, "cloud made no request"
-        assert all(url.endswith("/api/object_info") for url in calls)
-        # Memoized: five model groups plus two later lookups, one fetch.
-        assert len(calls) == 1, f"object_info fetched {len(calls)} times"
-
-    def test_cloud_has_node_false_for_absent_class(self, monkeypatch):
-        from tools._comfyui.client import ComfyUIClient
-
-        monkeypatch.setenv("COMFY_CLOUD_API_KEY", "k")
-        monkeypatch.setattr(
-            "tools._comfyui.client.requests.get",
-            self._fake_get([], {"UNETLoader": {}}),
-        )
-        client = ComfyUIClient(backend="cloud")
-        assert client.has_node("UNETLoader") is True
-        assert client.has_node("NoSuchNode") is False
-
-
-class TestRecoveryHints:
-    def test_cloud_hint_points_at_jobs_not_history(self, monkeypatch):
-        """Cloud has no /history route — sending users there 404s."""
-        from tools._comfyui.client import ComfyUIClient
-
-        monkeypatch.setenv("COMFY_CLOUD_API_KEY", "k")
-        hint = ComfyUIClient(backend="cloud").recovery_hint("p1")
-        assert "/api/jobs/p1" in hint
-        assert "/history/" not in hint
-
-    def test_local_hint_unchanged(self, monkeypatch):
-        from tools._comfyui.client import ComfyUIClient
-
-        monkeypatch.setenv("COMFYUI_SERVER_URL", "http://box:8188")
-        hint = ComfyUIClient(backend="local").recovery_hint("p1")
-        assert hint == "GET http://box:8188/history/p1"
+        workflow = {"1": {"class_type": "UNETLoader",
+                          "inputs": {"unet_name": "flux2-dev-nvfp4.safetensors"}}}
+        patched = apply_backend_models(
+            workflow, workflow_key="flux2-txt2img", backend="local")
+        assert patched["1"]["inputs"]["unet_name"] == "flux2-dev-nvfp4.safetensors"

--- a/tools/_comfyui/client.py
+++ b/tools/_comfyui/client.py
@@ -18,6 +18,64 @@ from typing import Any, Callable
 import requests
 
 
+CLOUD_BASE_URL = "https://cloud.comfy.org"
+
+#: Terminal values of ``GET /api/job/{id}/status`` on Comfy Cloud.
+#: ``failed`` is not in the published list but is what the API actually
+#: returns for a node that raised — omitting it would poll a dead job until
+#: the caller's timeout.
+_CLOUD_TERMINAL = {
+    "success",
+    "error",
+    "failed",
+    "non_retryable_error",
+    "lost",
+    "cancelled",
+}
+
+
+def _describe_cloud_error(payload: dict) -> str:
+    """Extract a readable cause from a failed Comfy Cloud job status payload.
+
+    ``error_message`` is a JSON *string* holding the node id, node type and
+    exception. Falls back to the raw text when it isn't parseable.
+    """
+    raw = payload.get("error_message")
+    if not raw:
+        return ""
+    try:
+        detail = json.loads(raw) if isinstance(raw, str) else raw
+    except (ValueError, TypeError):
+        return str(raw)[:300]
+    node = detail.get("node_type") or detail.get("node_id")
+    message = str(detail.get("exception_message", "")).strip()
+    return f"Node {node}: {message}" if node else message[:300]
+
+
+def resolve_backend(explicit: str | None = None) -> str:
+    """Resolve which ComfyUI backend to use: ``"local"`` or ``"cloud"``.
+
+    Order of precedence:
+
+    1. an explicit ``backend`` argument (``"local"`` / ``"cloud"``),
+    2. the ``COMFYUI_BACKEND`` env var (same values, plus ``"auto"``),
+    3. ``auto`` — always local.
+
+    ``auto`` never selects cloud. Cloud is metered, so choosing it must be
+    a deliberate act: an unreachable local server is a fault to report, not
+    a reason to start spending the user's credits. Opt in per call with
+    ``backend="cloud"``, or globally with ``COMFYUI_BACKEND=cloud``.
+    """
+    choice = (explicit or os.environ.get("COMFYUI_BACKEND") or "auto").strip().lower()
+    if choice in ("local", "cloud"):
+        return choice
+    if choice != "auto":
+        raise ValueError(
+            f"Invalid backend {choice!r}. Expected 'local', 'cloud', or 'auto'."
+        )
+    return "local"
+
+
 class ComfyUIError(Exception):
     """Raised when ComfyUI returns an error or times out.
 
@@ -43,7 +101,10 @@ class ComfyUIClient:
     """
 
     def __init__(
-        self, server_url: str | None = None, capability: str | None = None
+        self,
+        server_url: str | None = None,
+        capability: str | None = None,
+        backend: str | None = None,
     ) -> None:
         """*capability*, if given (e.g. ``"image"``, ``"video"``), lets a
         per-capability env var (``COMFYUI_{CAPABILITY}_SERVER_URL``) point
@@ -51,18 +112,44 @@ class ComfyUIClient:
         video generation are split across separate servers/GPUs. Falls back
         to the shared ``COMFYUI_SERVER_URL`` when the capability-specific
         var isn't set, so single-server setups need no extra configuration.
+
+        *backend* selects the transport: ``"local"`` (a ComfyUI server you
+        run) or ``"cloud"`` (Comfy Cloud, authenticated with
+        ``COMFY_CLOUD_API_KEY``). Pass ``None`` to take the value verbatim
+        without auto-resolution -- callers that want ``auto`` should call
+        :func:`resolve_backend` first. Cloud puts the ``/api`` prefix into
+        ``server_url``, so every route below is shared between backends.
         """
         self.capability = capability
         self._capability_env_var = (
             f"COMFYUI_{capability.upper()}_SERVER_URL" if capability else None
         )
-        resolved = (
-            server_url or self._capability_url() or os.environ.get("COMFYUI_SERVER_URL")
-        )
-        self.server_url = (resolved or "http://localhost:8188").rstrip("/")
+        self.backend = (backend or "local").strip().lower()
+        self._headers: dict[str, str] = {}
+        self._object_info_cache: dict[str, Any] | None = None
+
+        if self.backend == "cloud":
+            base = (
+                os.environ.get("COMFY_CLOUD_BASE_URL") or CLOUD_BASE_URL
+            ).rstrip("/")
+            self.server_url = f"{base}/api"
+            api_key = os.environ.get("COMFY_CLOUD_API_KEY", "")
+            if api_key:
+                self._headers = {"X-API-Key": api_key}
+        else:
+            resolved = (
+                server_url
+                or self._capability_url()
+                or os.environ.get("COMFYUI_SERVER_URL")
+            )
+            self.server_url = (resolved or "http://localhost:8188").rstrip("/")
         # Scopes websocket execution events to this client (see wait_ws) and
         # is echoed back on /prompt so the server targets messages to us.
         self.client_id = str(uuid.uuid4())
+
+    @property
+    def is_cloud(self) -> bool:
+        return self.backend == "cloud"
 
     def _capability_url(self) -> str | None:
         if self._capability_env_var:
@@ -80,6 +167,16 @@ class ComfyUIClient:
 
     def unavailable_reason(self) -> str:
         """Human-readable explanation of why the server can't be reached."""
+        if self.is_cloud:
+            if not os.environ.get("COMFY_CLOUD_API_KEY"):
+                return (
+                    "Comfy Cloud selected but COMFY_CLOUD_API_KEY is not set.\n"
+                    "Get a key at https://platform.comfy.org and add it to .env."
+                )
+            return (
+                f"Comfy Cloud not reachable at {self.server_url}.\n"
+                "Check the key is valid and the workspace subscription is active."
+            )
         env_var_hint = self._capability_env_var or "COMFYUI_SERVER_URL"
         if self._capability_env_var:
             env_var_hint += " (or the shared COMFYUI_SERVER_URL)"
@@ -96,12 +193,54 @@ class ComfyUIClient:
         )
 
     def is_available(self) -> bool:
-        """Return True if the ComfyUI server is reachable."""
+        """Return True if the ComfyUI backend is reachable."""
+        # Cloud has no /system_stats; /api/user is the cheap authenticated ping.
+        probe = "/user" if self.is_cloud else "/system_stats"
+        if self.is_cloud and not os.environ.get("COMFY_CLOUD_API_KEY"):
+            return False
         try:
-            resp = requests.get(f"{self.server_url}/system_stats", timeout=5)
+            resp = requests.get(
+                f"{self.server_url}{probe}", headers=self._headers, timeout=10
+            )
             return resp.status_code == 200
         except Exception:
             return False
+
+    # ------------------------------------------------------------------
+    # Errors
+    # ------------------------------------------------------------------
+
+    def _raise_for_cloud_error(self, resp: requests.Response) -> None:
+        """Turn a Comfy Cloud error response into a ComfyUIError.
+
+        Cloud uses two envelope shapes: validation errors return
+        ``{"error": {"message", "type"}}`` while auth/billing errors return
+        ``{"code", "message"}``. 402 and 429 both look like throttling and
+        are not -- retrying either can never succeed, so they are surfaced
+        as explicit blockers.
+        """
+        if resp.status_code < 400:
+            return
+        try:
+            body = resp.json()
+        except Exception:
+            body = {}
+        detail = (
+            (body.get("error") or {}).get("message")
+            if isinstance(body.get("error"), dict)
+            else None
+        ) or body.get("message") or resp.text[:300]
+
+        hints = {
+            401: "COMFY_CLOUD_API_KEY is missing or invalid.",
+            402: "Comfy Cloud workspace is out of credits — add credits to continue.",
+            429: "Comfy Cloud subscription is inactive — reactivate it to continue.",
+        }
+        hint = hints.get(resp.status_code)
+        msg = f"Comfy Cloud HTTP {resp.status_code}: {detail}"
+        if hint:
+            msg = f"{msg}\n{hint}"
+        raise ComfyUIError(msg)
 
     # ------------------------------------------------------------------
     # Model discovery
@@ -130,11 +269,7 @@ class ComfyUIClient:
         result: dict[str, list[str]] = {}
         for node_class, (field, group) in node_to_key.items():
             try:
-                resp = requests.get(
-                    f"{self.server_url}/object_info/{node_class}", timeout=10
-                )
-                resp.raise_for_status()
-                data = resp.json()
+                data = self._object_info(node_class)
                 options = (
                     data.get(node_class, {})
                     .get("input", {})
@@ -146,6 +281,30 @@ class ComfyUIClient:
             except Exception:
                 result[group] = []
         return result
+
+    def _object_info(self, node_class: str) -> dict:
+        """Return ``{node_class: definition}`` for *node_class*.
+
+        Local ComfyUI serves a per-node route. Comfy Cloud does not -- it
+        404s ``/object_info/{node_class}`` and only answers the full
+        ``/api/object_info``, which is ~10 MB across ~3,700 node classes.
+        Fetch that once per client and slice it.
+        """
+        if not self.is_cloud:
+            resp = requests.get(
+                f"{self.server_url}/object_info/{node_class}", timeout=10
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+        if self._object_info_cache is None:
+            resp = requests.get(
+                f"{self.server_url}/object_info", headers=self._headers, timeout=180
+            )
+            self._raise_for_cloud_error(resp)
+            self._object_info_cache = resp.json()
+        cache = self._object_info_cache or {}
+        return {node_class: cache[node_class]} if node_class in cache else {}
 
     def check_models(self, required: list[str]) -> tuple[list[str], list[str]]:
         """Check which of *required* model filenames are available.
@@ -163,11 +322,7 @@ class ComfyUIClient:
     def has_node(self, node_class: str) -> bool:
         """Return whether the connected server exposes a node class."""
         try:
-            response = requests.get(
-                f"{self.server_url}/object_info/{node_class}", timeout=10
-            )
-            response.raise_for_status()
-            return node_class in response.json()
+            return node_class in self._object_info(node_class)
         except Exception:
             return False
 
@@ -177,11 +332,30 @@ class ComfyUIClient:
 
     def submit(self, workflow: dict) -> str:
         """Queue a workflow for execution.  Returns the ``prompt_id``."""
+        payload: dict[str, Any] = {
+            "prompt": workflow,
+            "client_id": self.client_id,
+        }
+        if self.is_cloud:
+            # Partner API nodes (ElevenLabs, Kling, Veo, Recraft, ...) run
+            # inside the graph but bill through the Comfy account, and they
+            # read the credential from extra_data — not the request header.
+            # Without this they fail at execution with "Unauthorized: Please
+            # login first to use this node."
+            key = os.environ.get("COMFY_CLOUD_API_KEY")
+            if key:
+                payload["extra_data"] = {"api_key_comfy_org": key}
+
         resp = requests.post(
             f"{self.server_url}/prompt",
-            json={"prompt": workflow, "client_id": self.client_id},
+            json=payload,
+            headers=self._headers,
             timeout=30,
         )
+        if self.is_cloud:
+            # Cloud rejects invalid graphs and auth/billing problems with
+            # envelopes that carry no node_errors — map them first.
+            self._raise_for_cloud_error(resp)
         try:
             data = resp.json()
         except ValueError:
@@ -215,14 +389,80 @@ class ComfyUIClient:
             f"The job is very likely still running on the ComfyUI server "
             f"(local/custom workflows on modest GPUs routinely exceed the "
             f"client wait) — it was not cancelled. Poll "
-            f"GET {{server_url}}/history/{prompt_id} directly, or call "
+            f"{self.recovery_hint(prompt_id)} directly, or call "
             f"generate()/execute() again with a longer timeout and this "
             f"prompt_id to resume waiting without resubmitting.",
             prompt_id=prompt_id,
         )
 
+    def recovery_hint(self, prompt_id: str) -> str:
+        """The request a caller can run by hand to check on a job.
+
+        Backend-specific: cloud has no ``/history`` route, so telling a cloud
+        user to poll it sends them somewhere that 404s.
+        """
+        if self.is_cloud:
+            return f"GET {self.server_url}/jobs/{prompt_id} (with X-API-Key)"
+        return f"GET {self.server_url}/history/{prompt_id}"
+
+    @staticmethod
+    def _normalize_cloud_job(job: dict) -> dict:
+        """Map a Comfy Cloud ``/api/jobs/{id}`` record to the local shape.
+
+        The flat record's top-level ``status`` is a bare string
+        (``"completed"``), but ``execution_status`` beside it is already the
+        local ``{status_str, completed, messages}`` dict -- so this is a
+        rename, not a translation. Without it, the caller's
+        ``status_str == "error"`` check reads every failure as a success.
+        """
+        return {
+            "outputs": job.get("outputs", {}),
+            "status": job.get("execution_status", {}),
+            "meta": job.get("execution_meta", {}),
+        }
+
+    def _cloud_history_entry(self, prompt_id: str) -> dict | None:
+        """Cloud equivalent of :meth:`_history_entry`.
+
+        Local ComfyUI treats "a history entry exists" as "the job is done".
+        Cloud publishes explicit states, and a queued job already has a
+        record -- so the terminal state must be read before the outputs.
+        """
+        resp = requests.get(
+            f"{self.server_url}/job/{prompt_id}/status",
+            headers=self._headers,
+            timeout=20,
+        )
+        self._raise_for_cloud_error(resp)
+        payload = resp.json()
+        state = str(payload.get("status", ""))
+        if state not in _CLOUD_TERMINAL:
+            return None
+        if state != "success":
+            # A failed job has no execution_status at all — the detail lives
+            # in error_message on this payload, as a JSON string. Surface the
+            # node and exception rather than a bare "job failed".
+            raise ComfyUIError(
+                f"Comfy Cloud job {state}. {_describe_cloud_error(payload)}".strip(),
+                prompt_id=prompt_id,
+            )
+
+        job = requests.get(
+            f"{self.server_url}/jobs/{prompt_id}", headers=self._headers, timeout=30
+        )
+        self._raise_for_cloud_error(job)
+        entry = self._normalize_cloud_job(job.json())
+        status = entry.get("status", {})
+        if status.get("status_str") == "error":
+            raise ComfyUIError(
+                f"Execution error: {status.get('messages', [])}", prompt_id=prompt_id
+            )
+        return entry
+
     def _history_entry(self, prompt_id: str) -> dict | None:
         """Return a completed history entry, or ``None`` while it is absent."""
+        if self.is_cloud:
+            return self._cloud_history_entry(prompt_id)
         resp = requests.get(f"{self.server_url}/history/{prompt_id}", timeout=10)
         resp.raise_for_status()
         entry = resp.json().get(prompt_id)
@@ -357,6 +597,12 @@ class ComfyUIClient:
         fallback gets whatever's left of *timeout*, not a fresh budget, so a
         mid-wait websocket drop can't double the caller's worst-case wait.
         """
+        # Cloud's websocket needs token auth and a different event contract;
+        # REST polling is already the supported fallback path, so cloud takes
+        # it directly rather than carrying a second websocket implementation.
+        if self.is_cloud:
+            return self.poll(prompt_id, timeout=timeout, interval=interval)
+
         started = time.time()
         try:
             return self.wait_ws(
@@ -383,8 +629,23 @@ class ComfyUIClient:
                 "subfolder": subfolder,
                 "type": folder_type,
             },
+            headers=self._headers,
+            # Cloud answers with a 302 to a short-lived signed storage URL
+            # that must be fetched WITHOUT the auth header, so the redirect
+            # is followed by hand rather than by requests.
+            allow_redirects=not self.is_cloud,
             timeout=120,
         )
+        if self.is_cloud and resp.status_code in (301, 302, 303, 307, 308):
+            location = resp.headers.get("Location")
+            if not location:
+                raise ComfyUIError(
+                    f"Comfy Cloud returned {resp.status_code} for {filename} "
+                    "with no Location header."
+                )
+            resp = requests.get(location, timeout=300)
+        elif self.is_cloud:
+            self._raise_for_cloud_error(resp)
         resp.raise_for_status()
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_bytes(resp.content)
@@ -399,8 +660,11 @@ class ComfyUIClient:
             resp = requests.post(
                 f"{self.server_url}/upload/image",
                 files={"image": (name, f, "image/png")},
-                timeout=30,
+                headers=self._headers,
+                timeout=60,
             )
+        if self.is_cloud:
+            self._raise_for_cloud_error(resp)
         resp.raise_for_status()
         return resp.json()["name"]
 

--- a/tools/_comfyui/client.py
+++ b/tools/_comfyui/client.py
@@ -18,64 +18,6 @@ from typing import Any, Callable
 import requests
 
 
-CLOUD_BASE_URL = "https://cloud.comfy.org"
-
-#: Terminal values of ``GET /api/job/{id}/status`` on Comfy Cloud.
-#: ``failed`` is not in the published list but is what the API actually
-#: returns for a node that raised — omitting it would poll a dead job until
-#: the caller's timeout.
-_CLOUD_TERMINAL = {
-    "success",
-    "error",
-    "failed",
-    "non_retryable_error",
-    "lost",
-    "cancelled",
-}
-
-
-def _describe_cloud_error(payload: dict) -> str:
-    """Extract a readable cause from a failed Comfy Cloud job status payload.
-
-    ``error_message`` is a JSON *string* holding the node id, node type and
-    exception. Falls back to the raw text when it isn't parseable.
-    """
-    raw = payload.get("error_message")
-    if not raw:
-        return ""
-    try:
-        detail = json.loads(raw) if isinstance(raw, str) else raw
-    except (ValueError, TypeError):
-        return str(raw)[:300]
-    node = detail.get("node_type") or detail.get("node_id")
-    message = str(detail.get("exception_message", "")).strip()
-    return f"Node {node}: {message}" if node else message[:300]
-
-
-def resolve_backend(explicit: str | None = None) -> str:
-    """Resolve which ComfyUI backend to use: ``"local"`` or ``"cloud"``.
-
-    Order of precedence:
-
-    1. an explicit ``backend`` argument (``"local"`` / ``"cloud"``),
-    2. the ``COMFYUI_BACKEND`` env var (same values, plus ``"auto"``),
-    3. ``auto`` — always local.
-
-    ``auto`` never selects cloud. Cloud is metered, so choosing it must be
-    a deliberate act: an unreachable local server is a fault to report, not
-    a reason to start spending the user's credits. Opt in per call with
-    ``backend="cloud"``, or globally with ``COMFYUI_BACKEND=cloud``.
-    """
-    choice = (explicit or os.environ.get("COMFYUI_BACKEND") or "auto").strip().lower()
-    if choice in ("local", "cloud"):
-        return choice
-    if choice != "auto":
-        raise ValueError(
-            f"Invalid backend {choice!r}. Expected 'local', 'cloud', or 'auto'."
-        )
-    return "local"
-
-
 class ComfyUIError(Exception):
     """Raised when ComfyUI returns an error or times out.
 
@@ -91,7 +33,13 @@ class ComfyUIError(Exception):
 
 
 class ComfyUIClient:
-    """Client for the ComfyUI REST API.
+    """Client for a ComfyUI server you run yourself.
+
+    Comfy Cloud is a *subclass* (``tools._comfyui.cloud_client``), not a
+    branch inside these methods: its protocol differs enough that inlining
+    it would put an ``if is_cloud`` in every request, and the local path is
+    the one most users depend on and the hardest to regression-test. Nothing
+    in this class knows cloud exists.
 
     The protocol is simple and battle-tested:
       1. POST /prompt           → queue a workflow, get a prompt_id
@@ -100,11 +48,12 @@ class ComfyUIClient:
       4. POST /upload/image     → stage a local image for I2V workflows
     """
 
+    #: Which transport this client speaks. Subclasses override.
+    backend = "local"
+    is_cloud = False
+
     def __init__(
-        self,
-        server_url: str | None = None,
-        capability: str | None = None,
-        backend: str | None = None,
+        self, server_url: str | None = None, capability: str | None = None
     ) -> None:
         """*capability*, if given (e.g. ``"image"``, ``"video"``), lets a
         per-capability env var (``COMFYUI_{CAPABILITY}_SERVER_URL``) point
@@ -112,44 +61,18 @@ class ComfyUIClient:
         video generation are split across separate servers/GPUs. Falls back
         to the shared ``COMFYUI_SERVER_URL`` when the capability-specific
         var isn't set, so single-server setups need no extra configuration.
-
-        *backend* selects the transport: ``"local"`` (a ComfyUI server you
-        run) or ``"cloud"`` (Comfy Cloud, authenticated with
-        ``COMFY_CLOUD_API_KEY``). Pass ``None`` to take the value verbatim
-        without auto-resolution -- callers that want ``auto`` should call
-        :func:`resolve_backend` first. Cloud puts the ``/api`` prefix into
-        ``server_url``, so every route below is shared between backends.
         """
         self.capability = capability
         self._capability_env_var = (
             f"COMFYUI_{capability.upper()}_SERVER_URL" if capability else None
         )
-        self.backend = (backend or "local").strip().lower()
-        self._headers: dict[str, str] = {}
-        self._object_info_cache: dict[str, Any] | None = None
-
-        if self.backend == "cloud":
-            base = (
-                os.environ.get("COMFY_CLOUD_BASE_URL") or CLOUD_BASE_URL
-            ).rstrip("/")
-            self.server_url = f"{base}/api"
-            api_key = os.environ.get("COMFY_CLOUD_API_KEY", "")
-            if api_key:
-                self._headers = {"X-API-Key": api_key}
-        else:
-            resolved = (
-                server_url
-                or self._capability_url()
-                or os.environ.get("COMFYUI_SERVER_URL")
-            )
-            self.server_url = (resolved or "http://localhost:8188").rstrip("/")
+        resolved = (
+            server_url or self._capability_url() or os.environ.get("COMFYUI_SERVER_URL")
+        )
+        self.server_url = (resolved or "http://localhost:8188").rstrip("/")
         # Scopes websocket execution events to this client (see wait_ws) and
         # is echoed back on /prompt so the server targets messages to us.
         self.client_id = str(uuid.uuid4())
-
-    @property
-    def is_cloud(self) -> bool:
-        return self.backend == "cloud"
 
     def _capability_url(self) -> str | None:
         if self._capability_env_var:
@@ -167,16 +90,6 @@ class ComfyUIClient:
 
     def unavailable_reason(self) -> str:
         """Human-readable explanation of why the server can't be reached."""
-        if self.is_cloud:
-            if not os.environ.get("COMFY_CLOUD_API_KEY"):
-                return (
-                    "Comfy Cloud selected but COMFY_CLOUD_API_KEY is not set.\n"
-                    "Get a key at https://platform.comfy.org and add it to .env."
-                )
-            return (
-                f"Comfy Cloud not reachable at {self.server_url}.\n"
-                "Check the key is valid and the workspace subscription is active."
-            )
         env_var_hint = self._capability_env_var or "COMFYUI_SERVER_URL"
         if self._capability_env_var:
             env_var_hint += " (or the shared COMFYUI_SERVER_URL)"
@@ -192,55 +105,17 @@ class ComfyUIClient:
             f"Check that ComfyUI is running and the URL is correct."
         )
 
+    def recovery_hint(self, prompt_id: str) -> str:
+        """The request a caller can run by hand to check on a job."""
+        return f"GET {self.server_url}/history/{prompt_id}"
+
     def is_available(self) -> bool:
-        """Return True if the ComfyUI backend is reachable."""
-        # Cloud has no /system_stats; /api/user is the cheap authenticated ping.
-        probe = "/user" if self.is_cloud else "/system_stats"
-        if self.is_cloud and not os.environ.get("COMFY_CLOUD_API_KEY"):
-            return False
+        """Return True if the ComfyUI server is reachable."""
         try:
-            resp = requests.get(
-                f"{self.server_url}{probe}", headers=self._headers, timeout=10
-            )
+            resp = requests.get(f"{self.server_url}/system_stats", timeout=5)
             return resp.status_code == 200
         except Exception:
             return False
-
-    # ------------------------------------------------------------------
-    # Errors
-    # ------------------------------------------------------------------
-
-    def _raise_for_cloud_error(self, resp: requests.Response) -> None:
-        """Turn a Comfy Cloud error response into a ComfyUIError.
-
-        Cloud uses two envelope shapes: validation errors return
-        ``{"error": {"message", "type"}}`` while auth/billing errors return
-        ``{"code", "message"}``. 402 and 429 both look like throttling and
-        are not -- retrying either can never succeed, so they are surfaced
-        as explicit blockers.
-        """
-        if resp.status_code < 400:
-            return
-        try:
-            body = resp.json()
-        except Exception:
-            body = {}
-        detail = (
-            (body.get("error") or {}).get("message")
-            if isinstance(body.get("error"), dict)
-            else None
-        ) or body.get("message") or resp.text[:300]
-
-        hints = {
-            401: "COMFY_CLOUD_API_KEY is missing or invalid.",
-            402: "Comfy Cloud workspace is out of credits — add credits to continue.",
-            429: "Comfy Cloud subscription is inactive — reactivate it to continue.",
-        }
-        hint = hints.get(resp.status_code)
-        msg = f"Comfy Cloud HTTP {resp.status_code}: {detail}"
-        if hint:
-            msg = f"{msg}\n{hint}"
-        raise ComfyUIError(msg)
 
     # ------------------------------------------------------------------
     # Model discovery
@@ -269,7 +144,11 @@ class ComfyUIClient:
         result: dict[str, list[str]] = {}
         for node_class, (field, group) in node_to_key.items():
             try:
-                data = self._object_info(node_class)
+                resp = requests.get(
+                    f"{self.server_url}/object_info/{node_class}", timeout=10
+                )
+                resp.raise_for_status()
+                data = resp.json()
                 options = (
                     data.get(node_class, {})
                     .get("input", {})
@@ -281,30 +160,6 @@ class ComfyUIClient:
             except Exception:
                 result[group] = []
         return result
-
-    def _object_info(self, node_class: str) -> dict:
-        """Return ``{node_class: definition}`` for *node_class*.
-
-        Local ComfyUI serves a per-node route. Comfy Cloud does not -- it
-        404s ``/object_info/{node_class}`` and only answers the full
-        ``/api/object_info``, which is ~10 MB across ~3,700 node classes.
-        Fetch that once per client and slice it.
-        """
-        if not self.is_cloud:
-            resp = requests.get(
-                f"{self.server_url}/object_info/{node_class}", timeout=10
-            )
-            resp.raise_for_status()
-            return resp.json()
-
-        if self._object_info_cache is None:
-            resp = requests.get(
-                f"{self.server_url}/object_info", headers=self._headers, timeout=180
-            )
-            self._raise_for_cloud_error(resp)
-            self._object_info_cache = resp.json()
-        cache = self._object_info_cache or {}
-        return {node_class: cache[node_class]} if node_class in cache else {}
 
     def check_models(self, required: list[str]) -> tuple[list[str], list[str]]:
         """Check which of *required* model filenames are available.
@@ -322,7 +177,11 @@ class ComfyUIClient:
     def has_node(self, node_class: str) -> bool:
         """Return whether the connected server exposes a node class."""
         try:
-            return node_class in self._object_info(node_class)
+            response = requests.get(
+                f"{self.server_url}/object_info/{node_class}", timeout=10
+            )
+            response.raise_for_status()
+            return node_class in response.json()
         except Exception:
             return False
 
@@ -332,30 +191,11 @@ class ComfyUIClient:
 
     def submit(self, workflow: dict) -> str:
         """Queue a workflow for execution.  Returns the ``prompt_id``."""
-        payload: dict[str, Any] = {
-            "prompt": workflow,
-            "client_id": self.client_id,
-        }
-        if self.is_cloud:
-            # Partner API nodes (ElevenLabs, Kling, Veo, Recraft, ...) run
-            # inside the graph but bill through the Comfy account, and they
-            # read the credential from extra_data — not the request header.
-            # Without this they fail at execution with "Unauthorized: Please
-            # login first to use this node."
-            key = os.environ.get("COMFY_CLOUD_API_KEY")
-            if key:
-                payload["extra_data"] = {"api_key_comfy_org": key}
-
         resp = requests.post(
             f"{self.server_url}/prompt",
-            json=payload,
-            headers=self._headers,
+            json={"prompt": workflow, "client_id": self.client_id},
             timeout=30,
         )
-        if self.is_cloud:
-            # Cloud rejects invalid graphs and auth/billing problems with
-            # envelopes that carry no node_errors — map them first.
-            self._raise_for_cloud_error(resp)
         try:
             data = resp.json()
         except ValueError:
@@ -389,80 +229,14 @@ class ComfyUIClient:
             f"The job is very likely still running on the ComfyUI server "
             f"(local/custom workflows on modest GPUs routinely exceed the "
             f"client wait) — it was not cancelled. Poll "
-            f"{self.recovery_hint(prompt_id)} directly, or call "
+            f"GET {{server_url}}/history/{prompt_id} directly, or call "
             f"generate()/execute() again with a longer timeout and this "
             f"prompt_id to resume waiting without resubmitting.",
             prompt_id=prompt_id,
         )
 
-    def recovery_hint(self, prompt_id: str) -> str:
-        """The request a caller can run by hand to check on a job.
-
-        Backend-specific: cloud has no ``/history`` route, so telling a cloud
-        user to poll it sends them somewhere that 404s.
-        """
-        if self.is_cloud:
-            return f"GET {self.server_url}/jobs/{prompt_id} (with X-API-Key)"
-        return f"GET {self.server_url}/history/{prompt_id}"
-
-    @staticmethod
-    def _normalize_cloud_job(job: dict) -> dict:
-        """Map a Comfy Cloud ``/api/jobs/{id}`` record to the local shape.
-
-        The flat record's top-level ``status`` is a bare string
-        (``"completed"``), but ``execution_status`` beside it is already the
-        local ``{status_str, completed, messages}`` dict -- so this is a
-        rename, not a translation. Without it, the caller's
-        ``status_str == "error"`` check reads every failure as a success.
-        """
-        return {
-            "outputs": job.get("outputs", {}),
-            "status": job.get("execution_status", {}),
-            "meta": job.get("execution_meta", {}),
-        }
-
-    def _cloud_history_entry(self, prompt_id: str) -> dict | None:
-        """Cloud equivalent of :meth:`_history_entry`.
-
-        Local ComfyUI treats "a history entry exists" as "the job is done".
-        Cloud publishes explicit states, and a queued job already has a
-        record -- so the terminal state must be read before the outputs.
-        """
-        resp = requests.get(
-            f"{self.server_url}/job/{prompt_id}/status",
-            headers=self._headers,
-            timeout=20,
-        )
-        self._raise_for_cloud_error(resp)
-        payload = resp.json()
-        state = str(payload.get("status", ""))
-        if state not in _CLOUD_TERMINAL:
-            return None
-        if state != "success":
-            # A failed job has no execution_status at all — the detail lives
-            # in error_message on this payload, as a JSON string. Surface the
-            # node and exception rather than a bare "job failed".
-            raise ComfyUIError(
-                f"Comfy Cloud job {state}. {_describe_cloud_error(payload)}".strip(),
-                prompt_id=prompt_id,
-            )
-
-        job = requests.get(
-            f"{self.server_url}/jobs/{prompt_id}", headers=self._headers, timeout=30
-        )
-        self._raise_for_cloud_error(job)
-        entry = self._normalize_cloud_job(job.json())
-        status = entry.get("status", {})
-        if status.get("status_str") == "error":
-            raise ComfyUIError(
-                f"Execution error: {status.get('messages', [])}", prompt_id=prompt_id
-            )
-        return entry
-
     def _history_entry(self, prompt_id: str) -> dict | None:
         """Return a completed history entry, or ``None`` while it is absent."""
-        if self.is_cloud:
-            return self._cloud_history_entry(prompt_id)
         resp = requests.get(f"{self.server_url}/history/{prompt_id}", timeout=10)
         resp.raise_for_status()
         entry = resp.json().get(prompt_id)
@@ -597,12 +371,6 @@ class ComfyUIClient:
         fallback gets whatever's left of *timeout*, not a fresh budget, so a
         mid-wait websocket drop can't double the caller's worst-case wait.
         """
-        # Cloud's websocket needs token auth and a different event contract;
-        # REST polling is already the supported fallback path, so cloud takes
-        # it directly rather than carrying a second websocket implementation.
-        if self.is_cloud:
-            return self.poll(prompt_id, timeout=timeout, interval=interval)
-
         started = time.time()
         try:
             return self.wait_ws(
@@ -629,23 +397,8 @@ class ComfyUIClient:
                 "subfolder": subfolder,
                 "type": folder_type,
             },
-            headers=self._headers,
-            # Cloud answers with a 302 to a short-lived signed storage URL
-            # that must be fetched WITHOUT the auth header, so the redirect
-            # is followed by hand rather than by requests.
-            allow_redirects=not self.is_cloud,
             timeout=120,
         )
-        if self.is_cloud and resp.status_code in (301, 302, 303, 307, 308):
-            location = resp.headers.get("Location")
-            if not location:
-                raise ComfyUIError(
-                    f"Comfy Cloud returned {resp.status_code} for {filename} "
-                    "with no Location header."
-                )
-            resp = requests.get(location, timeout=300)
-        elif self.is_cloud:
-            self._raise_for_cloud_error(resp)
         resp.raise_for_status()
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_bytes(resp.content)
@@ -660,11 +413,8 @@ class ComfyUIClient:
             resp = requests.post(
                 f"{self.server_url}/upload/image",
                 files={"image": (name, f, "image/png")},
-                headers=self._headers,
-                timeout=60,
+                timeout=30,
             )
-        if self.is_cloud:
-            self._raise_for_cloud_error(resp)
         resp.raise_for_status()
         return resp.json()["name"]
 

--- a/tools/_comfyui/cloud_client.py
+++ b/tools/_comfyui/cloud_client.py
@@ -1,0 +1,390 @@
+"""Comfy Cloud transport for the ComfyUI tools.
+
+Comfy Cloud runs real ComfyUI behind an ``/api`` prefix and an ``X-API-Key``
+header, so most of :class:`~tools._comfyui.client.ComfyUIClient` applies
+verbatim. Five things genuinely differ, and each is overridden here rather
+than branched inside the local client — the local path is what most users
+depend on and the hardest for a reviewer to regression-test, so it is left
+untouched:
+
+* **health** — there is no ``/system_stats``; ``/api/user`` is the ping.
+* **polling** — local treats "a history entry exists" as done. Cloud
+  publishes explicit states and a queued job already has a record, so the
+  terminal state must be read before the outputs.
+* **outputs** — ``/api/jobs/{id}`` is flat and its top-level ``status`` is
+  the bare string ``"completed"``. The local-shaped dict sits beside it
+  under ``execution_status``, so the mapping is a three-key rename. Reading
+  the top-level field instead makes every failure look like a success.
+* **download** — ``/api/view`` 302s to a short-lived signed URL that must be
+  fetched *without* the auth header.
+* **node metadata** — the per-node ``/object_info/{class}`` route 404s; only
+  the full ~10MB payload is served, so it is fetched once and memoized.
+
+Partner API nodes (ElevenLabs, Kling, Veo, Recraft, ...) additionally read
+the account credential from the submit payload's ``extra_data``, not from
+the request header.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from pathlib import Path
+from typing import Any, Callable
+
+import requests
+
+from tools._comfyui.client import ComfyUIClient, ComfyUIError
+
+CLOUD_BASE_URL = "https://cloud.comfy.org"
+
+#: Terminal values of ``GET /api/job/{id}/status``. ``failed`` is not in the
+#: published list but is what the API returns for a node that raised —
+#: omitting it polls a dead job until the caller's timeout.
+CLOUD_TERMINAL = {
+    "success",
+    "error",
+    "failed",
+    "non_retryable_error",
+    "lost",
+    "cancelled",
+}
+
+
+def describe_cloud_error(payload: dict) -> str:
+    """Readable cause from a failed job's status payload.
+
+    A failed job has no ``execution_status`` at all; the detail lives in
+    ``error_message`` as a JSON *string*.
+    """
+    raw = payload.get("error_message")
+    if not raw:
+        return ""
+    try:
+        detail = json.loads(raw) if isinstance(raw, str) else raw
+    except (ValueError, TypeError):
+        return str(raw)[:300]
+    node = detail.get("node_type") or detail.get("node_id")
+    message = str(detail.get("exception_message", "")).strip()
+    return f"Node {node}: {message}" if node else message[:300]
+
+
+class ComfyCloudClient(ComfyUIClient):
+    """ComfyUIClient speaking Comfy Cloud's hosted API."""
+
+    backend = "cloud"
+    is_cloud = True
+
+    def __init__(self, capability: str | None = None, **_ignored: Any) -> None:
+        # Deliberately does not call super().__init__: the base resolves a
+        # local server URL from env vars that mean nothing here.
+        self.capability = capability
+        self._capability_env_var = None
+        self._object_info_cache: dict[str, Any] | None = None
+        base = (os.environ.get("COMFY_CLOUD_BASE_URL") or CLOUD_BASE_URL).rstrip("/")
+        self.server_url = f"{base}/api"
+        key = os.environ.get("COMFY_CLOUD_API_KEY", "")
+        self._headers = {"X-API-Key": key} if key else {}
+        self.client_id = str(uuid.uuid4())
+
+    # ------------------------------------------------------------------
+    # Health
+    # ------------------------------------------------------------------
+
+    @property
+    def is_default_url(self) -> bool:
+        return False
+
+    def unavailable_reason(self) -> str:
+        if not os.environ.get("COMFY_CLOUD_API_KEY"):
+            return (
+                "Comfy Cloud selected but COMFY_CLOUD_API_KEY is not set.\n"
+                "Get a key at https://platform.comfy.org and add it to .env."
+            )
+        return (
+            f"Comfy Cloud not reachable at {self.server_url}.\n"
+            "Check the key is valid and the workspace subscription is active."
+        )
+
+    def is_available(self) -> bool:
+        if not os.environ.get("COMFY_CLOUD_API_KEY"):
+            return False
+        try:
+            resp = requests.get(
+                f"{self.server_url}/user", headers=self._headers, timeout=10
+            )
+            return resp.status_code == 200
+        except Exception:
+            return False
+
+    def recovery_hint(self, prompt_id: str) -> str:
+        # Cloud has no /history route; sending a user there 404s.
+        return f"GET {self.server_url}/jobs/{prompt_id} (with X-API-Key)"
+
+    # ------------------------------------------------------------------
+    # Errors
+    # ------------------------------------------------------------------
+
+    def _raise_for_error(self, resp: requests.Response) -> None:
+        """Map a Cloud error response onto ComfyUIError.
+
+        Two envelope shapes are in play: validation errors return
+        ``{"error": {...}}`` while auth and billing errors return
+        ``{"code", "message"}``. 402 and 429 both look like throttling and
+        neither is retryable, so they are named explicitly.
+        """
+        if resp.status_code < 400:
+            return
+        try:
+            body = resp.json()
+        except Exception:
+            body = {}
+        detail = (
+            (body.get("error") or {}).get("message")
+            if isinstance(body.get("error"), dict)
+            else None
+        ) or body.get("message") or resp.text[:300]
+        hint = {
+            401: "COMFY_CLOUD_API_KEY is missing or invalid.",
+            402: "Comfy Cloud workspace is out of credits — add credits to continue.",
+            429: "Comfy Cloud subscription is inactive — reactivate it to continue.",
+        }.get(resp.status_code)
+        msg = f"Comfy Cloud HTTP {resp.status_code}: {detail}"
+        raise ComfyUIError(f"{msg}\n{hint}" if hint else msg)
+
+    # ------------------------------------------------------------------
+    # Node metadata
+    # ------------------------------------------------------------------
+
+    def _object_info(self, node_class: str) -> dict:
+        if self._object_info_cache is None:
+            resp = requests.get(
+                f"{self.server_url}/object_info", headers=self._headers, timeout=180
+            )
+            self._raise_for_error(resp)
+            self._object_info_cache = resp.json()
+        cache = self._object_info_cache or {}
+        return {node_class: cache[node_class]} if node_class in cache else {}
+
+    def list_models(self) -> dict[str, list[str]]:
+        node_to_key = {
+            "CheckpointLoaderSimple": ("ckpt_name", "checkpoints"),
+            "UNETLoader": ("unet_name", "diffusion_models"),
+            "VAELoader": ("vae_name", "vae"),
+            "CLIPLoader": ("clip_name", "clip"),
+            "LoraLoaderModelOnly": ("lora_name", "loras"),
+        }
+        result: dict[str, list[str]] = {}
+        for node_class, (field, group) in node_to_key.items():
+            try:
+                options = (
+                    self._object_info(node_class)
+                    .get(node_class, {})
+                    .get("input", {})
+                    .get("required", {})
+                    .get(field, [[]])[0]
+                )
+                result[group] = options if isinstance(options, list) else []
+            except Exception:
+                result[group] = []
+        return result
+
+    def has_node(self, node_class: str) -> bool:
+        try:
+            return node_class in self._object_info(node_class)
+        except Exception:
+            return False
+
+    # ------------------------------------------------------------------
+    # Core cycle
+    # ------------------------------------------------------------------
+
+    def submit(self, workflow: dict) -> str:
+        payload: dict[str, Any] = {
+            "prompt": workflow,
+            "client_id": self.client_id,
+        }
+        key = os.environ.get("COMFY_CLOUD_API_KEY")
+        if key:
+            # Partner API nodes bill through the Comfy account and read the
+            # credential from here, not the header. Without it they fail at
+            # execution with "Unauthorized: Please login first to use this node."
+            payload["extra_data"] = {"api_key_comfy_org": key}
+
+        resp = requests.post(
+            f"{self.server_url}/prompt",
+            json=payload,
+            headers=self._headers,
+            timeout=30,
+        )
+        self._raise_for_error(resp)
+        try:
+            data = resp.json()
+        except ValueError:
+            data = {}
+        if data.get("node_errors"):
+            raise ComfyUIError(f"Node errors: {json.dumps(data['node_errors'])}")
+        prompt_id = data.get("prompt_id")
+        if not prompt_id:
+            raise ComfyUIError(f"No prompt_id in response: {data}")
+        return prompt_id
+
+    def _history_entry(self, prompt_id: str) -> dict | None:
+        resp = requests.get(
+            f"{self.server_url}/job/{prompt_id}/status",
+            headers=self._headers,
+            timeout=20,
+        )
+        self._raise_for_error(resp)
+        payload = resp.json()
+        state = str(payload.get("status", ""))
+        if state not in CLOUD_TERMINAL:
+            return None
+        if state != "success":
+            raise ComfyUIError(
+                f"Comfy Cloud job {state}. {describe_cloud_error(payload)}".strip(),
+                prompt_id=prompt_id,
+            )
+
+        job = requests.get(
+            f"{self.server_url}/jobs/{prompt_id}", headers=self._headers, timeout=30
+        )
+        self._raise_for_error(job)
+        entry = self.normalize_job(job.json())
+        status = entry.get("status", {})
+        if status.get("status_str") == "error":
+            raise ComfyUIError(
+                f"Execution error: {status.get('messages', [])}", prompt_id=prompt_id
+            )
+        return entry
+
+    @staticmethod
+    def normalize_job(job: dict) -> dict:
+        """Map a ``/api/jobs/{id}`` record onto the local history shape.
+
+        ``execution_status`` is already the local
+        ``{status_str, completed, messages}`` dict, so this is a rename, not
+        a translation. Using the flat record's top-level ``status`` instead
+        yields the bare string ``"completed"`` and the caller's
+        ``status_str == "error"`` check would never fire.
+        """
+        return {
+            "outputs": job.get("outputs", {}),
+            "status": job.get("execution_status", {}),
+            "meta": job.get("execution_meta", {}),
+        }
+
+    def _wait(
+        self,
+        prompt_id: str,
+        *,
+        timeout: int,
+        interval: int,
+        on_progress: Callable[[dict], None] | None = None,
+    ) -> dict:
+        # Cloud's websocket needs token auth and a different event contract.
+        # REST polling is already the supported fallback, so it is used
+        # directly rather than carrying a second websocket implementation.
+        return self.poll(prompt_id, timeout=timeout, interval=interval)
+
+    def download(
+        self,
+        filename: str,
+        subfolder: str,
+        dest: Path,
+        folder_type: str = "output",
+    ) -> Path:
+        resp = requests.get(
+            f"{self.server_url}/view",
+            params={
+                "filename": filename,
+                "subfolder": subfolder,
+                "type": folder_type,
+            },
+            headers=self._headers,
+            allow_redirects=False,
+            timeout=120,
+        )
+        if resp.status_code in (301, 302, 303, 307, 308):
+            location = resp.headers.get("Location")
+            if not location:
+                raise ComfyUIError(
+                    f"Comfy Cloud returned {resp.status_code} for {filename} "
+                    "with no Location header."
+                )
+            # The signed storage URL rejects the auth header — fetch it bare.
+            resp = requests.get(location, timeout=300)
+        else:
+            self._raise_for_error(resp)
+        resp.raise_for_status()
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(resp.content)
+        return dest
+
+    def upload_image(self, local_path: Path, name: str) -> str:
+        with open(local_path, "rb") as handle:
+            resp = requests.post(
+                f"{self.server_url}/upload/image",
+                files={"image": (name, handle, "image/png")},
+                headers=self._headers,
+                timeout=60,
+            )
+        self._raise_for_error(resp)
+        resp.raise_for_status()
+        return resp.json()["name"]
+
+
+def resolve_backend(explicit: str | None = None) -> str:
+    """Decide which ComfyUI transport to use: ``"local"`` or ``"cloud"``.
+
+    Resolution, in order:
+
+    1. an explicit ``backend`` argument (``"local"`` / ``"cloud"``),
+    2. ``COMFYUI_BACKEND`` (same values, plus ``"auto"``),
+    3. auto, which is decided by what is configured:
+
+       ==========================  ==========================  =======
+       local server URL            COMFY_CLOUD_API_KEY          result
+       ==========================  ==========================  =======
+       set                         --                           local
+       set                         set                          local
+       --                          set                          cloud
+       --                          --                           local
+       ==========================  ==========================  =======
+
+    A configured local server always wins. Cloud is metered and a local
+    server is not, so when someone has gone to the trouble of standing one
+    up, silently billing them for a hosted run would be the wrong default —
+    an unreachable local server is a fault to report, not a reason to spend.
+    With no local server configured at all, a cloud key is an unambiguous
+    statement of intent and is used.
+    """
+    choice = (explicit or os.environ.get("COMFYUI_BACKEND") or "auto").strip().lower()
+    if choice in ("local", "cloud"):
+        return choice
+    if choice != "auto":
+        raise ValueError(
+            f"Invalid backend {choice!r}. Expected 'local', 'cloud', or 'auto'."
+        )
+    local_configured = any(
+        os.environ.get(var)
+        for var in (
+            "COMFYUI_SERVER_URL",
+            "COMFYUI_IMAGE_SERVER_URL",
+            "COMFYUI_VIDEO_SERVER_URL",
+            "COMFYUI_MUSIC_SERVER_URL",
+        )
+    )
+    if local_configured:
+        return "local"
+    return "cloud" if os.environ.get("COMFY_CLOUD_API_KEY") else "local"
+
+
+def make_client(
+    capability: str | None = None, backend: str | None = None
+) -> ComfyUIClient:
+    """Return the client for *backend*, resolving ``auto`` first."""
+    if resolve_backend(backend) == "cloud":
+        return ComfyCloudClient(capability=capability)
+    return ComfyUIClient(capability=capability)

--- a/tools/_comfyui/metadata.py
+++ b/tools/_comfyui/metadata.py
@@ -18,6 +18,27 @@ COMFYUI_SETUP_OFFER: dict[str, Any] = {
         "free local video generation through ComfyUI workflows",
         "community workflow_json/workflow_path execution",
     ],
+    # Comfy Cloud is the alternative to standing a server up at all. It is a
+    # 1-minute env-var fix with no GPU, but it is metered — surfaced here so
+    # the provider menu can offer it rather than only telling users to
+    # install ComfyUI.
+    "alternative": {
+        "kind": "hosted",
+        "name": "Comfy Cloud",
+        "fix_complexity": "1-minute env-var, no local GPU",
+        "env_var": "COMFY_CLOUD_API_KEY",
+        "signup_url": "https://platform.comfy.org",
+        "billing": "metered — Comfy Cloud GPU hours plus any paid API nodes",
+        "precedence": (
+            "A configured local server wins; set COMFYUI_BACKEND=cloud to "
+            "force cloud when both are present."
+        ),
+        "what_it_unlocks": [
+            "the same bundled FLUX 2 / WAN 2.2 / ACE-Step workflows on hosted GPUs",
+            "no model downloads and no local GPU requirement",
+            "partner API nodes (ElevenLabs, Kling, Veo, Recraft, ...)",
+        ],
+    },
     # Optional: point image/video generation at separate ComfyUI instances
     # (e.g. different GPUs). Each overrides COMFYUI_SERVER_URL for its own
     # tool only; single-server setups can ignore this entirely.

--- a/tools/_comfyui/metadata.py
+++ b/tools/_comfyui/metadata.py
@@ -226,6 +226,47 @@ BUNDLED_MODEL_STACKS: dict[str, list[dict[str, Any]]] = {
 }
 
 
+#: Model filenames that differ between a self-hosted ComfyUI and Comfy Cloud.
+#: Keyed by bundled workflow, then ``local name -> cloud name``.
+CLOUD_MODEL_OVERRIDES: dict[str, dict[str, str]] = {
+    # The bundled graph asks for the NVFP4 quantization, which exists for
+    # Blackwell-class local hardware. The hosted catalog carries the stock
+    # bf16 build instead; everything else in the stack is identical.
+    "flux2-txt2img": {
+        "flux2-dev-nvfp4.safetensors": "flux2-dev.safetensors",
+    },
+}
+
+
+def backend_models(required: list[str], *, workflow_key: str, backend: str) -> list[str]:
+    """Translate a bundled workflow's required-model list for *backend*."""
+    if backend != "cloud":
+        return list(required)
+    overrides = CLOUD_MODEL_OVERRIDES.get(workflow_key, {})
+    return [overrides.get(name, name) for name in required]
+
+
+def apply_backend_models(
+    workflow: dict[str, Any], *, workflow_key: str, backend: str
+) -> dict[str, Any]:
+    """Rewrite model filenames in *workflow* to match *backend*.
+
+    Mutates and returns *workflow*. A no-op for the local backend and for
+    any workflow with no registered differences.
+    """
+    if backend != "cloud":
+        return workflow
+    overrides = CLOUD_MODEL_OVERRIDES.get(workflow_key, {})
+    if not overrides:
+        return workflow
+    for node in workflow.values():
+        inputs = node.get("inputs", {}) if isinstance(node, dict) else {}
+        for key, value in inputs.items():
+            if isinstance(value, str) and value in overrides:
+                inputs[key] = overrides[value]
+    return workflow
+
+
 def workflow_hash(workflow: dict[str, Any]) -> str:
     """Return a stable hash of the final workflow JSON submitted to ComfyUI."""
     payload = json.dumps(workflow, sort_keys=True, separators=(",", ":"))

--- a/tools/audio/comfyui_music.py
+++ b/tools/audio/comfyui_music.py
@@ -61,6 +61,7 @@ class ComfyUIMusic(BaseTool):
     install_instructions = (
         "Start a ComfyUI server and set COMFYUI_SERVER_URL "
         "(default http://localhost:8188).\n"
+        "Or use Comfy Cloud instead of running a server: set COMFY_CLOUD_API_KEY (get one at https://platform.comfy.org). A local server takes priority when both are configured; COMFYUI_BACKEND=cloud forces cloud.\n"
         "Requires ace_step_v1_3.5b.safetensors in ComfyUI's checkpoints "
         "directory for the bundled workflow.\n"
         "Running a separate ComfyUI instance for music? Set "
@@ -75,7 +76,8 @@ class ComfyUIMusic(BaseTool):
         "lyrics": True,
         "custom_workflow": True,
         "custom_output_node": True,
-        "offline": True,
+        "offline": True,  # local backend; Comfy Cloud is online
+        "comfy_cloud_backend": True,
     }
     best_for = [
         "local GPU music generation without API costs",

--- a/tools/audio/comfyui_music.py
+++ b/tools/audio/comfyui_music.py
@@ -29,7 +29,8 @@ from tools.base_tool import (
     ToolStatus,
     ToolTier,
 )
-from tools._comfyui.client import ComfyUIClient, ComfyUIError, resolve_backend
+from tools._comfyui.client import ComfyUIClient, ComfyUIError
+from tools._comfyui.cloud_client import make_client
 from tools._comfyui.metadata import (
     BUNDLED_MODEL_STACKS,
     COMFYUI_SETUP_OFFER,
@@ -119,10 +120,12 @@ class ComfyUIMusic(BaseTool):
                 "enum": ["local", "cloud", "auto"],
                 "default": "auto",
                 "description": (
-                    "Which ComfyUI to run on. 'auto' (default) means local — it "
-                    "never picks Comfy Cloud on its own, because Cloud is "
-                    "metered. Pass 'cloud' (or set COMFYUI_BACKEND=cloud) to opt "
-                    "in; that needs COMFY_CLOUD_API_KEY."
+                    "Which ComfyUI to run on. 'auto' (default) uses a local "
+                    "server whenever one is configured — even if a cloud key "
+                    "is also present, since local is free and cloud is "
+                    "metered. With no local server configured, a "
+                    "COMFY_CLOUD_API_KEY selects Comfy Cloud. 'local'/'cloud' "
+                    "force the choice, as does COMFYUI_BACKEND."
                 ),
             },
             "workflow_json": {
@@ -180,9 +183,7 @@ class ComfyUIMusic(BaseTool):
         """Return a client for *backend*, resolving ``auto`` once per key."""
         key = (backend or "").strip().lower() or "_auto"
         if key not in self._clients:
-            self._clients[key] = ComfyUIClient(
-                capability="music", backend=resolve_backend(backend)
-            )
+            self._clients[key] = make_client("music", backend)
         return self._clients[key]
 
     @property

--- a/tools/audio/comfyui_music.py
+++ b/tools/audio/comfyui_music.py
@@ -29,7 +29,7 @@ from tools.base_tool import (
     ToolStatus,
     ToolTier,
 )
-from tools._comfyui.client import ComfyUIClient, ComfyUIError
+from tools._comfyui.client import ComfyUIClient, ComfyUIError, resolve_backend
 from tools._comfyui.metadata import (
     BUNDLED_MODEL_STACKS,
     COMFYUI_SETUP_OFFER,
@@ -114,6 +114,17 @@ class ComfyUIMusic(BaseTool):
             "lyrics_strength": {"type": "number", "default": 0.99},
             "seed": {"type": "integer", "description": "Random if omitted"},
             "output_path": {"type": "string", "description": "Where to save the audio"},
+            "backend": {
+                "type": "string",
+                "enum": ["local", "cloud", "auto"],
+                "default": "auto",
+                "description": (
+                    "Which ComfyUI to run on. 'auto' (default) means local — it "
+                    "never picks Comfy Cloud on its own, because Cloud is "
+                    "metered. Pass 'cloud' (or set COMFYUI_BACKEND=cloud) to opt "
+                    "in; that needs COMFY_CLOUD_API_KEY."
+                ),
+            },
             "workflow_json": {
                 "type": "string",
                 "description": "Optional full ComfyUI workflow JSON. Requires output_node.",
@@ -162,18 +173,35 @@ class ComfyUIMusic(BaseTool):
     user_visible_verification = ["Listen to generated audio for mood, genre accuracy, and quality"]
 
     def __init__(self) -> None:
-        self._client = ComfyUIClient(capability="music")
+        self._clients: dict[str, ComfyUIClient] = {}
         self._last_progress_log = 0.0
 
+    def _client_for(self, backend: str | None = None) -> ComfyUIClient:
+        """Return a client for *backend*, resolving ``auto`` once per key."""
+        key = (backend or "").strip().lower() or "_auto"
+        if key not in self._clients:
+            self._clients[key] = ComfyUIClient(
+                capability="music", backend=resolve_backend(backend)
+            )
+        return self._clients[key]
+
+    @property
+    def _client(self) -> ComfyUIClient:
+        return self._client_for(None)
+
     def get_status(self) -> ToolStatus:
-        if not self._client.is_available():
+        client = self._client
+        if not client.is_available():
             return ToolStatus.UNAVAILABLE
-        _, missing = self._client.check_models(_REQUIRED_MODELS)
+        _, missing = client.check_models(_REQUIRED_MODELS)
         if missing:
             return ToolStatus.DEGRADED
         return ToolStatus.AVAILABLE
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        # ACE-Step is open weights: free locally, GPU-billed on Comfy Cloud.
+        if self._client_for(inputs.get("backend")).is_cloud:
+            return 0.05
         return 0.0
 
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
@@ -206,11 +234,12 @@ class ComfyUIMusic(BaseTool):
                 ),
             )
 
-        if not self._client.is_available():
-            return ToolResult(success=False, error=self._client.unavailable_reason())
+        client = self._client_for(inputs.get("backend"))
+        if not client.is_available():
+            return ToolResult(success=False, error=client.unavailable_reason())
 
         if not custom_workflow:
-            _, missing = self._client.check_models(_REQUIRED_MODELS)
+            _, missing = client.check_models(_REQUIRED_MODELS)
             if missing:
                 return ToolResult(
                     success=False,
@@ -255,7 +284,8 @@ class ComfyUIMusic(BaseTool):
                 output_node = "10"
 
             provenance = self._workflow_provenance(inputs, custom_workflow, output_node, workflow)
-            paths = self._client.generate(
+            provenance["backend"] = client.backend
+            paths = client.generate(
                 workflow,
                 output_node=output_node,
                 dest=output_path,
@@ -273,7 +303,7 @@ class ComfyUIMusic(BaseTool):
                     f"running server-side. To recover it without resubmitting, call "
                     f"execute() again with resume_prompt_id={exc.prompt_id!r} "
                     f"(and a longer timeout_seconds if it needs more time), or poll "
-                    f"GET {{COMFYUI_SERVER_URL}}/history/{exc.prompt_id} directly."
+                    f"{client.recovery_hint(exc.prompt_id)} directly."
                 )
             else:
                 error_msg = str(exc)
@@ -288,7 +318,7 @@ class ComfyUIMusic(BaseTool):
             data={
                 "provider": "comfyui",
                 "model": model_name,
-                "prompt": inputs["prompt"],
+                "prompt": inputs.get("prompt", ""),
                 "lyrics": inputs.get("lyrics", ""),
                 "duration_seconds": duration,
                 "output": str(paths[0]),
@@ -296,7 +326,7 @@ class ComfyUIMusic(BaseTool):
                 "workflow_provenance": provenance,
             },
             artifacts=[str(p) for p in paths],
-            cost_usd=0.0,
+            cost_usd=self.estimate_cost(inputs),
             duration_seconds=round(time.time() - start, 2),
             seed=seed,
             model=model_name,

--- a/tools/graphics/comfyui_image.py
+++ b/tools/graphics/comfyui_image.py
@@ -97,6 +97,14 @@ class ComfyUIImage(BaseTool):
             "guidance": {"type": "number", "default": 3.5},
             "seed": {"type": "integer", "description": "Random if omitted"},
             "output_path": {"type": "string", "description": "Where to save the image"},
+            "timeout_seconds": {
+                "type": "integer",
+                "default": 900,
+                "description": (
+                    "How long to wait for the job before raising. Matches "
+                    "comfyui_video / comfyui_music, which already expose this."
+                ),
+            },
             "backend": {
                 "type": "string",
                 "enum": ["local", "cloud", "auto"],
@@ -261,7 +269,10 @@ class ComfyUIImage(BaseTool):
             )
             provenance["backend"] = client.backend
             paths = client.generate(
-                workflow, output_node=output_node, dest=output_path, timeout=900,
+                workflow,
+                output_node=output_node,
+                dest=output_path,
+                timeout=int(inputs.get("timeout_seconds", 900)),
             )
 
         except ComfyUIError as exc:

--- a/tools/graphics/comfyui_image.py
+++ b/tools/graphics/comfyui_image.py
@@ -23,10 +23,12 @@ from tools.base_tool import (
     ToolStatus,
     ToolTier,
 )
-from tools._comfyui.client import ComfyUIClient, ComfyUIError
+from tools._comfyui.client import ComfyUIClient, ComfyUIError, resolve_backend
 from tools._comfyui.metadata import (
     BUNDLED_MODEL_STACKS,
     COMFYUI_SETUP_OFFER,
+    apply_backend_models,
+    backend_models,
     missing_models_payload,
     model_stack,
     workflow_hash,
@@ -95,6 +97,17 @@ class ComfyUIImage(BaseTool):
             "guidance": {"type": "number", "default": 3.5},
             "seed": {"type": "integer", "description": "Random if omitted"},
             "output_path": {"type": "string", "description": "Where to save the image"},
+            "backend": {
+                "type": "string",
+                "enum": ["local", "cloud", "auto"],
+                "default": "auto",
+                "description": (
+                    "Which ComfyUI to run on. 'auto' (default) means local — it "
+                    "never picks Comfy Cloud on its own, because Cloud is "
+                    "metered. Pass 'cloud' (or set COMFYUI_BACKEND=cloud) to opt "
+                    "in; that needs COMFY_CLOUD_API_KEY."
+                ),
+            },
             "workflow_json": {
                 "type": "string",
                 "description": "Optional full ComfyUI workflow JSON. Requires output_node.",
@@ -135,17 +148,41 @@ class ComfyUIImage(BaseTool):
     user_visible_verification = ["Inspect generated image for quality and prompt adherence"]
 
     def __init__(self) -> None:
-        self._client = ComfyUIClient(capability="image")
+        self._clients: dict[str, ComfyUIClient] = {}
+
+    def _client_for(self, backend: str | None = None) -> ComfyUIClient:
+        """Return a client for *backend*, resolving ``auto`` once per key."""
+        key = (backend or "").strip().lower() or "_auto"
+        if key not in self._clients:
+            self._clients[key] = ComfyUIClient(
+                capability="image", backend=resolve_backend(backend)
+            )
+        return self._clients[key]
+
+    @property
+    def _client(self) -> ComfyUIClient:
+        return self._client_for(None)
+
+    def _required_models(self, client: ComfyUIClient) -> list[str]:
+        return backend_models(
+            _REQUIRED_MODELS, workflow_key="flux2-txt2img", backend=client.backend
+        )
 
     def get_status(self) -> ToolStatus:
-        if not self._client.is_available():
+        client = self._client
+        if not client.is_available():
             return ToolStatus.UNAVAILABLE
-        _, missing = self._client.check_models(_REQUIRED_MODELS)
+        _, missing = client.check_models(self._required_models(client))
         if missing:
             return ToolStatus.DEGRADED
         return ToolStatus.AVAILABLE
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        # Local GPU time is free. Comfy Cloud bills the run as GPU hours;
+        # this is a documented flat figure for the bundled FLUX 2 graph, not
+        # a quote for arbitrary workflows.
+        if self._client_for(inputs.get("backend")).is_cloud:
+            return 0.05
         return 0.0
 
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
@@ -168,14 +205,15 @@ class ComfyUIImage(BaseTool):
                 ),
             )
 
-        if not self._client.is_available():
+        client = self._client_for(inputs.get("backend"))
+        if not client.is_available():
             return ToolResult(
                 success=False,
-                error=self._client.unavailable_reason(),
+                error=client.unavailable_reason(),
             )
 
         if not custom_workflow:
-            _, missing = self._client.check_models(_REQUIRED_MODELS)
+            _, missing = client.check_models(self._required_models(client))
             if missing:
                 return ToolResult(
                     success=False,
@@ -213,13 +251,17 @@ class ComfyUIImage(BaseTool):
                     "10": {"steps": steps, "width": width, "height": height},
                     "13": {"filename_prefix": output_path.stem},
                 })
+                workflow = apply_backend_models(
+                    workflow, workflow_key="flux2-txt2img", backend=client.backend
+                )
                 output_node = "13"
 
             provenance = self._workflow_provenance(
                 inputs, custom_workflow, output_node, workflow
             )
-            paths = self._client.generate(
-                workflow, output_node=output_node, dest=output_path, timeout=600,
+            provenance["backend"] = client.backend
+            paths = client.generate(
+                workflow, output_node=output_node, dest=output_path, timeout=900,
             )
 
         except ComfyUIError as exc:
@@ -227,7 +269,7 @@ class ComfyUIImage(BaseTool):
         except Exception as exc:
             return ToolResult(success=False, error=f"ComfyUI image generation failed: {exc}")
 
-        model_name = self._model_name(inputs, custom_workflow)
+        model_name = self._model_name(inputs, custom_workflow, client.backend)
         return ToolResult(
             success=True,
             data={
@@ -243,7 +285,7 @@ class ComfyUIImage(BaseTool):
                 "workflow_provenance": provenance,
             },
             artifacts=[str(p) for p in paths],
-            cost_usd=0.0,
+            cost_usd=self.estimate_cost(inputs),
             duration_seconds=round(time.time() - start, 2),
             seed=seed,
             model=model_name,
@@ -256,9 +298,13 @@ class ComfyUIImage(BaseTool):
         return ComfyUIClient.load_workflow(Path(inputs["workflow_path"]))
 
     @staticmethod
-    def _model_name(inputs: dict[str, Any], custom_workflow: bool) -> str:
+    def _model_name(
+        inputs: dict[str, Any], custom_workflow: bool, backend: str = "local"
+    ) -> str:
         if not custom_workflow:
-            return "flux2-dev-nvfp4"
+            # Cloud runs the stock bf16 build, not the NVFP4 quant the local
+            # graph names — report what actually ran, not what was requested.
+            return "flux2-dev" if backend == "cloud" else "flux2-dev-nvfp4"
         return (
             inputs.get("workflow_model")
             or inputs.get("model")

--- a/tools/graphics/comfyui_image.py
+++ b/tools/graphics/comfyui_image.py
@@ -23,7 +23,8 @@ from tools.base_tool import (
     ToolStatus,
     ToolTier,
 )
-from tools._comfyui.client import ComfyUIClient, ComfyUIError, resolve_backend
+from tools._comfyui.client import ComfyUIClient, ComfyUIError
+from tools._comfyui.cloud_client import make_client
 from tools._comfyui.metadata import (
     BUNDLED_MODEL_STACKS,
     COMFYUI_SETUP_OFFER,
@@ -99,7 +100,7 @@ class ComfyUIImage(BaseTool):
             "output_path": {"type": "string", "description": "Where to save the image"},
             "timeout_seconds": {
                 "type": "integer",
-                "default": 900,
+                "default": 600,
                 "description": (
                     "How long to wait for the job before raising. Matches "
                     "comfyui_video / comfyui_music, which already expose this."
@@ -110,10 +111,12 @@ class ComfyUIImage(BaseTool):
                 "enum": ["local", "cloud", "auto"],
                 "default": "auto",
                 "description": (
-                    "Which ComfyUI to run on. 'auto' (default) means local — it "
-                    "never picks Comfy Cloud on its own, because Cloud is "
-                    "metered. Pass 'cloud' (or set COMFYUI_BACKEND=cloud) to opt "
-                    "in; that needs COMFY_CLOUD_API_KEY."
+                    "Which ComfyUI to run on. 'auto' (default) uses a local "
+                    "server whenever one is configured — even if a cloud key "
+                    "is also present, since local is free and cloud is "
+                    "metered. With no local server configured, a "
+                    "COMFY_CLOUD_API_KEY selects Comfy Cloud. 'local'/'cloud' "
+                    "force the choice, as does COMFYUI_BACKEND."
                 ),
             },
             "workflow_json": {
@@ -162,9 +165,7 @@ class ComfyUIImage(BaseTool):
         """Return a client for *backend*, resolving ``auto`` once per key."""
         key = (backend or "").strip().lower() or "_auto"
         if key not in self._clients:
-            self._clients[key] = ComfyUIClient(
-                capability="image", backend=resolve_backend(backend)
-            )
+            self._clients[key] = make_client("image", backend)
         return self._clients[key]
 
     @property
@@ -272,7 +273,7 @@ class ComfyUIImage(BaseTool):
                 workflow,
                 output_node=output_node,
                 dest=output_path,
-                timeout=int(inputs.get("timeout_seconds", 900)),
+                timeout=int(inputs.get("timeout_seconds", 600)),
             )
 
         except ComfyUIError as exc:

--- a/tools/graphics/comfyui_image.py
+++ b/tools/graphics/comfyui_image.py
@@ -61,6 +61,7 @@ class ComfyUIImage(BaseTool):
     install_instructions = (
         "Start a ComfyUI server and set COMFYUI_SERVER_URL "
         "(default http://localhost:8188).\n"
+        "Or use Comfy Cloud instead of running a server: set COMFY_CLOUD_API_KEY (get one at https://platform.comfy.org). A local server takes priority when both are configured; COMFYUI_BACKEND=cloud forces cloud.\n"
         "See https://github.com/comfyanonymous/ComfyUI for setup.\n"
         "Running a separate ComfyUI instance for images? Set COMFYUI_IMAGE_SERVER_URL "
         "instead -- it takes priority over COMFYUI_SERVER_URL for this tool only."
@@ -73,7 +74,8 @@ class ComfyUIImage(BaseTool):
         "custom_size": True,
         "custom_workflow": True,
         "custom_output_node": True,
-        "offline": True,
+        "offline": True,  # local backend; Comfy Cloud is online
+        "comfy_cloud_backend": True,
     }
     best_for = [
         "local GPU generation without API costs",

--- a/tools/video/comfyui_video.py
+++ b/tools/video/comfyui_video.py
@@ -110,6 +110,7 @@ class ComfyUIVideo(BaseTool):
     install_instructions = (
         "Start a ComfyUI server and set COMFYUI_SERVER_URL "
         "(default http://localhost:8188).\n"
+        "Or use Comfy Cloud instead of running a server: set COMFY_CLOUD_API_KEY (get one at https://platform.comfy.org). A local server takes priority when both are configured; COMFYUI_BACKEND=cloud forces cloud.\n"
         "Bundled local WAN requires WAN 2.2 models and LightX2V LoRAs. Local "
         "MiniMax H3 requires its official model stack and exported API workflow.\n"
         "Gemini Omni, Seedance 2.5, and MiniMax H3 Partner Nodes require a "
@@ -132,7 +133,8 @@ class ComfyUIVideo(BaseTool):
         "reference_image": True,
         "custom_workflow": True,
         "custom_output_node": True,
-        "offline": True,
+        "offline": True,  # local backend; Comfy Cloud is online
+        "comfy_cloud_backend": True,
         "gemini_omni_flash_partner_node": True,
         "seedance_2_5_partner_node": True,
         "minimax_h3_partner_node": True,

--- a/tools/video/comfyui_video.py
+++ b/tools/video/comfyui_video.py
@@ -26,8 +26,10 @@ from tools.base_tool import (
     ToolStatus,
     ToolTier,
 )
-from tools._comfyui.client import ComfyUIClient, ComfyUIError
+from tools._comfyui.client import ComfyUIClient, ComfyUIError, resolve_backend
 from tools._comfyui.metadata import (
+    apply_backend_models,
+    backend_models,
     BUNDLED_MODEL_STACKS,
     COMFYUI_SETUP_OFFER,
     missing_models_payload,
@@ -224,6 +226,26 @@ class ComfyUIVideo(BaseTool):
             "generate_audio": {"type": "boolean", "default": True},
             "seed": {"type": "integer", "description": "Random if omitted"},
             "output_path": {"type": "string", "description": "Where to save the video"},
+            "negative_prompt": {
+                "type": "string",
+                "description": (
+                    "Extra terms to suppress, appended to the bundled WAN "
+                    "quality negative (which is kept). WAN 2.2 readily invents "
+                    "people and camera moves that were never asked for; this "
+                    "is how you rule them out."
+                ),
+            },
+            "backend": {
+                "type": "string",
+                "enum": ["local", "cloud", "auto"],
+                "default": "auto",
+                "description": (
+                    "Which ComfyUI to run on. 'auto' (default) means local — it "
+                    "never picks Comfy Cloud on its own, because Cloud is "
+                    "metered. Pass 'cloud' (or set COMFYUI_BACKEND=cloud) to opt "
+                    "in; that needs COMFY_CLOUD_API_KEY."
+                ),
+            },
             "workflow_json": {
                 "type": "string",
                 "description": "Optional full ComfyUI workflow JSON. Requires output_node.",
@@ -296,8 +318,21 @@ class ComfyUIVideo(BaseTool):
     ]
 
     def __init__(self) -> None:
-        self._client = ComfyUIClient(capability="video")
+        self._clients: dict[str, ComfyUIClient] = {}
         self._last_progress_log = 0.0
+
+    def _client_for(self, backend: str | None = None) -> ComfyUIClient:
+        """Return a client for *backend*, resolving ``auto`` once per key."""
+        key = (backend or "").strip().lower() or "_auto"
+        if key not in self._clients:
+            self._clients[key] = ComfyUIClient(
+                capability="video", backend=resolve_backend(backend)
+            )
+        return self._clients[key]
+
+    @property
+    def _client(self) -> ComfyUIClient:
+        return self._client_for(None)
 
     def _log_progress(self, data: dict) -> None:
         """Print a throttled progress line for long video renders.
@@ -391,6 +426,10 @@ class ComfyUIVideo(BaseTool):
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
         family = str(inputs.get("model_family", "wan2.2"))
+        if family == "wan2.2" and self._client_for(inputs.get("backend")).is_cloud:
+            # WAN 2.2 is open weights — free on a local GPU, billed as Comfy
+            # Cloud GPU hours. Flat figure for the bundled 4-step graph.
+            return 0.25
         duration = float(inputs.get("duration", 5))
         if family == "gemini_omni_flash":
             return round(0.146 * duration, 4)
@@ -452,10 +491,11 @@ class ComfyUIVideo(BaseTool):
                 ),
             )
 
-        if not self._client.is_available():
+        client = self._client_for(inputs.get("backend"))
+        if not client.is_available():
             return ToolResult(
                 success=False,
-                error=self._client.unavailable_reason(),
+                error=client.unavailable_reason(),
             )
 
         operation = inputs.get("operation", "text_to_video")
@@ -466,7 +506,16 @@ class ComfyUIVideo(BaseTool):
                 if operation == "image_to_video"
                 else _REQUIRED_MODELS_T2V
             )
-            _, missing = self._client.check_models(required)
+            required = backend_models(
+                required,
+                workflow_key=(
+                    "wan22-i2v-4step"
+                    if operation == "image_to_video"
+                    else "wan22-t2v-4step"
+                ),
+                backend=client.backend,
+            )
+            _, missing = client.check_models(required)
             if missing:
                 workflow_key = (
                     "wan22-i2v-4step"
@@ -499,7 +548,7 @@ class ComfyUIVideo(BaseTool):
                 output_node = str(inputs["output_node"])
             elif model_family in partner_nodes:
                 node_class = partner_nodes[model_family]
-                if not self._client.has_node(node_class):
+                if not client.has_node(node_class):
                     raise ComfyUIError(
                         f"ComfyUI server does not expose {node_class}; update ComfyUI "
                         "and enable Partner Nodes. These are hosted API nodes, not offline models."
@@ -508,14 +557,19 @@ class ComfyUIVideo(BaseTool):
                     inputs, seed, output_path, model_family
                 )
             elif operation == "image_to_video":
-                workflow, output_node = self._build_i2v(inputs, seed, output_path)
+                workflow, output_node = self._build_i2v(
+                    inputs, seed, output_path, client=client
+                )
             else:
-                workflow, output_node = self._build_t2v(inputs, seed, output_path)
+                workflow, output_node = self._build_t2v(
+                    inputs, seed, output_path, client=client
+                )
 
             provenance = self._workflow_provenance(
                 inputs, custom_workflow, output_node, operation, workflow, model_family
             )
-            paths = self._client.generate(
+            provenance["backend"] = client.backend
+            paths = client.generate(
                 workflow,
                 output_node=output_node,
                 dest=output_path,
@@ -533,7 +587,7 @@ class ComfyUIVideo(BaseTool):
                     f"running server-side. To recover it without resubmitting, call "
                     f"execute() again with resume_prompt_id={exc.prompt_id!r} "
                     f"(and a longer timeout_seconds if it needs more time), or poll "
-                    f"GET {{COMFYUI_SERVER_URL}}/history/{exc.prompt_id} directly."
+                    f"{client.recovery_hint(exc.prompt_id)} directly."
                 )
             else:
                 error_msg = str(exc)
@@ -593,8 +647,26 @@ class ComfyUIVideo(BaseTool):
     # Workflow builders
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _merge_negative(workflow: dict, node_id: str, extra: str | None) -> dict:
+        """Append caller terms to the workflow's built-in quality negative.
+
+        Replacing it outright would drop the artifact suppression the bundled
+        graph relies on, so the two are joined instead.
+        """
+        if not extra:
+            return workflow
+        base = workflow.get(node_id, {}).get("inputs", {}).get("text", "")
+        joined = f"{base}, {extra}".strip(", ") if base else extra
+        return ComfyUIClient.patch_workflow(workflow, {node_id: {"text": joined}})
+
     def _build_t2v(
-        self, inputs: dict[str, Any], seed: int, output_path: Path
+        self,
+        inputs: dict[str, Any],
+        seed: int,
+        output_path: Path,
+        *,
+        client: ComfyUIClient | None = None,
     ) -> tuple[dict, str]:
         width = inputs.get("width", 832)
         height = inputs.get("height", 480)
@@ -610,10 +682,23 @@ class ComfyUIVideo(BaseTool):
                 "16": {"filename_prefix": output_path.stem},
             },
         )
+        workflow = ComfyUIVideo._merge_negative(
+            workflow, "3", inputs.get("negative_prompt")
+        )
+        workflow = apply_backend_models(
+            workflow,
+            workflow_key="wan22-t2v-4step",
+            backend=(client or self._client).backend,
+        )
         return workflow, _T2V_OUTPUT_NODE
 
     def _build_i2v(
-        self, inputs: dict[str, Any], seed: int, output_path: Path
+        self,
+        inputs: dict[str, Any],
+        seed: int,
+        output_path: Path,
+        *,
+        client: ComfyUIClient | None = None,
     ) -> tuple[dict, str]:
         width = inputs.get("width", 640)
         height = inputs.get("height", 640)
@@ -638,7 +723,9 @@ class ComfyUIVideo(BaseTool):
 
         # Upload to ComfyUI
         upload_name = f"om_{output_path.stem}.png"
-        server_name = self._client.upload_image(Path(ref_path), upload_name)
+        server_name = (client or self._client).upload_image(
+            Path(ref_path), upload_name
+        )
 
         workflow = ComfyUIClient.load_workflow(_WORKFLOWS / "wan22-i2v-4step.json")
         workflow = ComfyUIClient.patch_workflow(
@@ -650,6 +737,14 @@ class ComfyUIVideo(BaseTool):
                 "86": {"noise_seed": seed},
                 "108": {"filename_prefix": output_path.stem},
             },
+        )
+        workflow = ComfyUIVideo._merge_negative(
+            workflow, "89", inputs.get("negative_prompt")
+        )
+        workflow = apply_backend_models(
+            workflow,
+            workflow_key="wan22-i2v-4step",
+            backend=(client or self._client).backend,
         )
         return workflow, _I2V_OUTPUT_NODE
 
@@ -766,6 +861,9 @@ class ComfyUIVideo(BaseTool):
                 "ratio": ratio,
                 "duration": duration,
                 "generate_audio": bool(inputs.get("generate_audio", True)),
+                # Required by the Seedance 2.5 variant; omitting it fails
+                # submit-time validation with "required_input_missing".
+                "output_format": inputs.get("output_format", "mp4"),
             }
         else:
             node_class = "MinimaxHailuo03TextToVideoNode"
@@ -778,10 +876,27 @@ class ComfyUIVideo(BaseTool):
                 "ratio": ratio,
                 "duration": duration,
             }
+        # Partner API nodes cap seed at INT32_MAX, while the local WAN noise
+        # nodes accept the full UINT32 range that random_seed() draws from.
+        # Passing an unclamped seed here fails submit-time validation with
+        # "value_bigger_than_max".
+        partner_seed = seed % 2_147_483_648
+
+        # Partner nodes declare `model` as COMFY_DYNAMICCOMBO_V3: the combo
+        # KEY is the `model` value and its per-variant parameters travel as
+        # sibling `model.<name>` keys. Nesting them in a dict submits fine
+        # but fails at execution with
+        # "execute() missing 1 required positional argument: 'model'".
+        node_inputs: dict[str, Any] = {
+            "model": model.pop("model"),
+            "seed": partner_seed,
+            "watermark": False,
+        }
+        node_inputs.update({f"model.{k}": v for k, v in model.items()})
         workflow = {
             "1": {
                 "class_type": node_class,
-                "inputs": {"model": model, "seed": seed, "watermark": False},
+                "inputs": node_inputs,
             },
             "2": {
                 "class_type": "SaveVideo",

--- a/tools/video/comfyui_video.py
+++ b/tools/video/comfyui_video.py
@@ -26,7 +26,8 @@ from tools.base_tool import (
     ToolStatus,
     ToolTier,
 )
-from tools._comfyui.client import ComfyUIClient, ComfyUIError, resolve_backend
+from tools._comfyui.client import ComfyUIClient, ComfyUIError
+from tools._comfyui.cloud_client import make_client
 from tools._comfyui.metadata import (
     apply_backend_models,
     backend_models,
@@ -240,10 +241,12 @@ class ComfyUIVideo(BaseTool):
                 "enum": ["local", "cloud", "auto"],
                 "default": "auto",
                 "description": (
-                    "Which ComfyUI to run on. 'auto' (default) means local — it "
-                    "never picks Comfy Cloud on its own, because Cloud is "
-                    "metered. Pass 'cloud' (or set COMFYUI_BACKEND=cloud) to opt "
-                    "in; that needs COMFY_CLOUD_API_KEY."
+                    "Which ComfyUI to run on. 'auto' (default) uses a local "
+                    "server whenever one is configured — even if a cloud key "
+                    "is also present, since local is free and cloud is "
+                    "metered. With no local server configured, a "
+                    "COMFY_CLOUD_API_KEY selects Comfy Cloud. 'local'/'cloud' "
+                    "force the choice, as does COMFYUI_BACKEND."
                 ),
             },
             "workflow_json": {
@@ -325,9 +328,7 @@ class ComfyUIVideo(BaseTool):
         """Return a client for *backend*, resolving ``auto`` once per key."""
         key = (backend or "").strip().lower() or "_auto"
         if key not in self._clients:
-            self._clients[key] = ComfyUIClient(
-                capability="video", backend=resolve_backend(backend)
-            )
+            self._clients[key] = make_client("video", backend)
         return self._clients[key]
 
     @property


### PR DESCRIPTION
## Summary

Adds Comfy Cloud as a second backend for `comfyui_image`, `comfyui_video`, and
`comfyui_music`, so those tools work without a local GPU or model downloads.

Comfy Cloud runs real ComfyUI behind an `/api` prefix and an `X-API-Key` header,
so the bundled FLUX 2 / WAN 2.2 / ACE-Step workflows execute unchanged. It is a
second transport, not a new provider: no new tools, no selector changes, and the
`workflow_json` / `output_node` override contract behaves identically on both
backends.

**Local always wins.** Under `auto`, a configured local server is used even when
a cloud key is also present — local is free and cloud is metered, so silently
billing someone who stood up a server would be the wrong default. With no local
server configured, a cloud key selects cloud. `COMFYUI_BACKEND=cloud` or a
per-call `backend: "cloud"` forces the choice either way.

| `COMFYUI_SERVER_URL` | `COMFY_CLOUD_API_KEY` | backend |
|---|---|---|
| set | — | local |
| set | set | **local** — key ignored |
| — | set | **cloud** |
| — | — | local |

## Related issue

Closes #563

## Changes

Eight commits, ordered so the two optional ones can be dropped without touching
the rest. Both drops are verified, not assumed.

| Commit | What |
|---|---|
| `feat` | Comfy Cloud as a second backend |
| `docs` | Comfy Cloud setup and cost model |
| `docs` | pre-existing per-capability server overrides — **droppable, unrelated** |
| `chore` | coverage + showcase scripts |
| `feat` | expose `timeout_seconds` on `comfyui_image` |
| `refactor` | move cloud into a subclass, restoring the local path |
| `fix` | surface Comfy Cloud in the user-facing setup metadata |
| `test` | end-to-end local coverage via a fake server — **droppable, additive** |

Notable pieces:

- **`tools/_comfyui/cloud_client.py`** — `ComfyCloudClient(ComfyUIClient)`
  overriding only what differs: health probe, polling, output normalization,
  redirect-following download, memoized `object_info`, and the `extra_data`
  credential partner nodes require.
- **The local client is left alone.** Its entire diff is a docstring, two class
  constants describing the transport, and a `recovery_hint()` helper — zero
  executable lines changed. A test asserts the local module never mentions a
  cloud symbol, so the separation cannot erode quietly.
- **Pre-existing bugs fixed along the way**, all on paths that needed a Comfy
  account and so had never been executed:
  - partner nodes read the credential from `extra_data`, not the header
  - `model` is a flattened dynamic combo (`model` + `model.<name>`), not a
    nested dict — the nested form passes validation then dies at execution
  - `random_seed()` draws UINT32; partner nodes cap at INT32_MAX
  - Seedance 2.5 requires `output_format`
  - `comfyui_music` dereferenced `inputs["prompt"]` on the custom-workflow path,
    crashing *after* a successful paid generation
  - `cost_usd` was hardcoded to `0.0`, making cloud spend invisible to the cost
    tracker
- **`negative_prompt` on the WAN workflows.** Appends to the bundled quality
  negative rather than replacing it. WAN 2.2 invents a moving subject when a
  scene has none — it put a film crew in an empty soundstage and a dune buggy on
  untouched dunes — and the tools previously exposed no way to influence node
  `3` / `89`.
- **`scripts/comfy_cloud_e2e.py`** — chains the four bundled workflows and
  composes the result. Free dry run by default; `--live` generates.
- **`scripts/comfy_cloud_backlot.py`** — builds a 24s showcase spot where each
  shot comes from a different adapter surface, so a successful render exercises
  the whole integration including the paths the bundled workflows never touch.

No binaries, no generated assets, nothing from `projects/` in the diff.

## Testing

```bash
make lint          # passes
make test          # 1875 passed, 12 skipped, 3 xfailed
```

**Live, against a real Comfy Cloud workspace** — all four bundled workflows plus
both override paths:

| Surface | Result |
|---|---|
| `flux2-txt2img` | 1280×720 PNG |
| `wan22-t2v-4step` | 832×480 h264, 81f @16fps |
| `wan22-i2v-4step` | 640×640 h264 — also covers `upload_image` |
| `ace-step-1-t2a` | 19.97s stereo MP3 |
| custom `workflow_json` + `output_node` | 18.8s VO via the ElevenLabs partner node |
| `model_family` partner node | Seedance 2.5, 1280×720 with audio |

**Local path** is covered by a fake ComfyUI server (final commit) driving all
three tools through submit → poll → locate artifact → download, with i2v also
uploading its reference. Loopback is explicitly permitted by the session network
guard in `tests/conftest.py`.

That test was validated by mutation rather than by passing:

| Mutation | Rest of suite | Fake-server test |
|---|---|---|
| local tools silently routed to cloud | 7 fail — caught | 10 fail |
| image reads the wrong output node | all 1246 pass — **missed** | 1 fail — caught |

## Deliberate divergences worth a reviewer's attention

1. **Cloud is a subclass, not a `backend` branch inside one class.** The repo's
   existing multi-backend precedent is `veo_video.py`, which branches internally.
   I started there and moved away: branching inside `ComfyUIClient` put an
   `if is_cloud` in every local request, and the local path is both the one most
   users depend on and the one a reviewer without a GPU cannot exercise. The
   subclass buys a genuinely untouched local client.
2. **The fake-HTTP-server test is a new pattern** — I could find no other test in
   the repo that stands up a server. `tests/conftest.py` sanctions loopback, but
   it is first of its kind. It is the last commit specifically so it can be
   dropped.

## Known limitations

- **Nobody has run the local path against a real ComfyUI server since this
  branch.** Every local assertion here is against the fake server. The fixture
  pins the protocol, not the product — if ComfyUI changes its history schema it
  keeps passing while reality breaks. Worth a maintainer with a rig confirming.
- **`runtime` stays `LOCAL_GPU` and `supports.offline` stays `True`.** Both
  describe the default local backend and are class attributes the registry groups
  by; varying them per resolved backend would make discovery output depend on
  environment. Documented rather than made dynamic — open to a better answer.
- **GPU hours bill separately** and appear in no per-node price declaration, so
  estimates for open-weights workflows are a floor, not a quote. Stated plainly
  in `docs/PROVIDERS.md`.
- **No cancellation.** Interrupting a run leaves the cloud job executing and
  billing; `/api/queue` delete and `/api/interrupt` are unimplemented.
- **Concurrency is tier-dependent** (1/3/5 jobs). Extra jobs queue, and the queue
  wait counts against the caller's `timeout_seconds`.
- **402 / 429 were tested with synthetic responses**, not a genuinely empty
  wallet or lapsed subscription.

## Checklist

- [x] The change is focused on a single logical concern.
      *Caveat: it also carries the six pre-existing bug fixes listed above. They
      are included because the partner-node and custom-workflow surfaces cannot
      work without them, but each is separable if you'd prefer them split out.*
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [x] I updated docs/README if behavior or usage changed.
- [x] No unrelated files (build artifacts, local config) are included in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
