### PR TITLE
fix(video): retire sora_video on the date OpenAI actually removes the API

### DIFF
--- a/tests/tools/test_sora_video_eol.py
+++ b/tests/tools/test_sora_video_eol.py
@@ -1,0 +1,108 @@
+"""Sora's end of life.
+
+OpenAI removes the Videos API and the Sora 2 aliases on 2026-09-24. These tests
+pin the two things that matter: that nothing changes before that date, and that
+afterwards the tool takes itself out of circulation instead of spending requests
+on an endpoint that is gone.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from tools.base_tool import ToolStatus
+from tools.video import sora_video
+from tools.video.sora_video import _API_SHUTDOWN, SoraVideo, _api_is_gone
+
+
+@pytest.fixture()
+def frozen(monkeypatch):
+    """Pin what the module thinks today is."""
+
+    def _freeze(when: datetime.date) -> None:
+        class _Date(datetime.date):
+            @classmethod
+            def today(cls) -> datetime.date:
+                return when
+
+        monkeypatch.setattr(sora_video, "date", _Date)
+
+    return _freeze
+
+
+@pytest.fixture()
+def with_key(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+
+def test_shutdown_date_is_the_announced_one():
+    assert _API_SHUTDOWN == datetime.date(2026, 9, 24)
+
+
+@pytest.mark.parametrize(
+    ("day", "gone"),
+    [
+        (datetime.date(2026, 8, 28), False),
+        (datetime.date(2026, 9, 23), False),
+        (datetime.date(2026, 9, 24), True),   # removal day itself counts
+        (datetime.date(2026, 9, 25), True),
+        (datetime.date(2027, 1, 1), True),
+    ],
+)
+def test_the_boundary_falls_on_the_removal_day(day, gone):
+    assert _api_is_gone(day) is gone
+
+
+def test_nothing_changes_while_the_api_is_alive(frozen, with_key):
+    """A working provider must not be retired early — that is a regression."""
+    frozen(datetime.date(2026, 9, 1))
+    if not SoraVideo()._openai_sdk_supports_videos():
+        pytest.skip("installed OpenAI SDK has no Videos API support")
+    assert SoraVideo().get_status() is ToolStatus.AVAILABLE
+
+
+def test_it_reports_unavailable_once_the_api_is_gone(frozen, with_key):
+    """UNAVAILABLE, not DEGRADED.
+
+    The registry falls back only to tools reporting AVAILABLE, so UNAVAILABLE is
+    what actually stops a chain routing into the dead endpoint.
+    """
+    frozen(datetime.date(2026, 10, 1))
+    assert SoraVideo().get_status() is ToolStatus.UNAVAILABLE
+
+
+def test_it_refuses_instead_of_calling_a_dead_endpoint(frozen, with_key):
+    frozen(datetime.date(2026, 10, 1))
+    result = SoraVideo().execute({"prompt": "a cat"})
+    assert not result.success
+    assert "2026-09-24" in result.error
+
+
+def test_the_refusal_names_somewhere_else_to_go(frozen, with_key):
+    frozen(datetime.date(2026, 10, 1))
+    error = SoraVideo().execute({"prompt": "a cat"}).error
+    assert any(name in error for name in ("veo_video", "kling_video", "seedance_video"))
+
+
+def test_preflight_is_warned_while_the_api_still_works(frozen):
+    """The date has to reach the operator before they plan around the provider."""
+    frozen(datetime.date(2026, 8, 28))
+    info = SoraVideo().get_info()
+    assert info["end_of_life"] == "2026-09-24"
+    note = info["resource_profile_note"]
+    assert "2026-09-24" in note
+    assert "27 days" in note
+
+
+def test_the_warning_changes_tense_after_the_date(frozen):
+    frozen(datetime.date(2026, 10, 1))
+    note = SoraVideo().get_info()["resource_profile_note"]
+    assert "removed" in note
+    assert "days from now" not in note
+
+
+def test_the_deprecation_is_visible_without_running_anything():
+    """not_good_for is what an agent reads when choosing a provider."""
+    assert any("2026-09-24" in entry for entry in SoraVideo().not_good_for)

--- a/tools/video/sora_video.py
+++ b/tools/video/sora_video.py
@@ -1,4 +1,20 @@
-"""OpenAI Sora video generation via the OpenAI Video API."""
+"""OpenAI Sora video generation via the OpenAI Video API.
+
+END OF LIFE. OpenAI notified developers on 2026-03-24 that the Videos API and
+the Sora 2 model aliases are removed from the API on 2026-09-24, with no
+announced successor. The consumer app was already withdrawn on 2026-04-26.
+
+This tool keeps working normally until that date. After it, `get_status()`
+reports UNAVAILABLE, which drops it out of every selector and fallback chain
+(the registry only falls back to AVAILABLE tools), and `execute()` refuses
+immediately rather than spending a request on an endpoint that is gone.
+
+Until then the shutdown date is surfaced at preflight through the runtime
+warnings, so a project does not get built around a provider with four weeks
+left in it.
+
+See: https://developers.openai.com/api/docs/deprecations
+"""
 
 from __future__ import annotations
 
@@ -6,6 +22,7 @@ import base64
 import mimetypes
 import os
 import time
+from datetime import date
 from pathlib import Path
 from typing import Any
 
@@ -30,6 +47,14 @@ _ALLOWED_MODELS = ["sora-2", "sora-2-pro"]
 _ALLOWED_SIZES = ["1280x720", "720x1280", "1024x1792", "1792x1024"]
 _ALLOWED_SECONDS = ["4", "8", "12"]
 _MIN_OPENAI_VERSION = (2, 44, 0)
+
+# Announced 2026-03-24, effective 2026-09-24.
+_API_SHUTDOWN = date(2026, 9, 24)
+_SUCCESSORS = "veo_video, kling_video, seedance_video, gemini_omni_video or minimax_video"
+
+
+def _api_is_gone(today: date | None = None) -> bool:
+    return (today or date.today()) >= _API_SHUTDOWN
 
 
 class SoraVideo(BaseTool):
@@ -64,7 +89,13 @@ class SoraVideo(BaseTool):
         "short cinematic product-ad inserts with native ambience or dialogue",
         "4, 8, or 12 second social-video clips that OpenMontage can stitch and compose",
     ]
-    not_good_for = ["offline generation", "long continuous scenes", "projects without Sora API access"]
+    not_good_for = [
+        "offline generation",
+        "long continuous scenes",
+        "projects without Sora API access",
+        f"anything that has to still work after {_API_SHUTDOWN.isoformat()}, when OpenAI "
+        "removes the Videos API",
+    ]
     fallback_tools = ["veo_video", "gemini_omni_video", "seedance_video", "kling_video", "minimax_video"]
 
     input_schema = {
@@ -123,11 +154,44 @@ class SoraVideo(BaseTool):
     user_visible_verification = ["Watch generated clip for motion coherence, artifacts, and audio quality"]
 
     def get_status(self) -> ToolStatus:
+        if _api_is_gone():
+            # Not DEGRADED: the registry falls back only to AVAILABLE tools, so
+            # UNAVAILABLE is what actually stops a chain routing into a dead
+            # endpoint. Before the date it stays AVAILABLE, because until then
+            # it genuinely works and removing it early would be a regression.
+            return ToolStatus.UNAVAILABLE
         if not os.environ.get("OPENAI_API_KEY"):
             return ToolStatus.UNAVAILABLE
         if not self._openai_sdk_supports_videos():
             return ToolStatus.UNAVAILABLE
         return ToolStatus.AVAILABLE
+
+    def get_info(self) -> dict[str, Any]:
+        """Carry the shutdown date into the preflight capability menu.
+
+        `resource_profile_note` is the registry's channel for "this looks
+        available but there is a catch" — it is copied verbatim into
+        `provider_menu_summary()["runtime_warnings"]`, which the agent is
+        required to read out before any production work. A provider with weeks
+        left is exactly that kind of catch.
+        """
+        info = super().get_info()
+        remaining = (_API_SHUTDOWN - date.today()).days
+        if remaining > 0:
+            info["resource_profile_note"] = (
+                f"OpenAI removes the Videos API and the Sora 2 models on "
+                f"{_API_SHUTDOWN.isoformat()} ({remaining} days from now) with no "
+                f"announced successor. Do not build a pipeline on this provider; "
+                f"prefer {_SUCCESSORS}."
+            )
+        else:
+            info["resource_profile_note"] = (
+                f"OpenAI removed the Videos API and the Sora 2 models on "
+                f"{_API_SHUTDOWN.isoformat()}. This tool cannot succeed. "
+                f"Use {_SUCCESSORS}."
+            )
+        info["end_of_life"] = _API_SHUTDOWN.isoformat()
+        return info
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
         seconds = int(self._normalize_seconds(inputs))
@@ -139,6 +203,15 @@ class SoraVideo(BaseTool):
         return 120.0 * (seconds / 4)
 
     def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        if _api_is_gone():
+            return ToolResult(
+                success=False,
+                error=(
+                    f"OpenAI removed the Videos API and the Sora 2 models on "
+                    f"{_API_SHUTDOWN.isoformat()}; there is no successor endpoint. "
+                    f"Use {_SUCCESSORS} instead."
+                ),
+            )
         if not os.environ.get("OPENAI_API_KEY"):
             return ToolResult(
                 success=False,


### PR DESCRIPTION
OpenAI told developers on 2026-03-24 that the Videos API and the Sora 2 model
aliases come out of the API on **2026-09-24**. The consumer app went on
2026-04-26. There is no successor endpoint. That date is four weeks away and
nothing in the repository knows about it.

Left alone the failure is worse than a broken tool: `sora_video` sits in
`gemini_omni_video`'s fallback chain, so every fallback would spend a request on
a dead endpoint before moving on — a silent tax on runs that have already failed
once, in a provider nobody deliberately chose.

### One method, not a list of edits

The registry only falls back to tools reporting `AVAILABLE`
([tool_registry.py#L194](../blob/main/tools/tool_registry.py#L194)), so having
`get_status()` return `UNAVAILABLE` after the date removes `sora_video` from
every chain and selector at once — including chains that do not exist yet. No
fallback lists to find and keep in sync.

`UNAVAILABLE` rather than `DEGRADED` is deliberate. `DEGRADED` is also skipped
for fallback, so it would retire a provider that still works for another four
weeks — a regression, not a warning. Before the date the tool behaves exactly as
it does today: with a key it still reports `AVAILABLE`.

### The warning uses the channel that already exists

`get_info()` sets `resource_profile_note`, which `provider_menu_summary()`
copies verbatim into `runtime_warnings` — the list the agent must read out at
preflight. So the shutdown date and a countdown reach anyone planning a pipeline
*before* they commit to the provider, which is the point: the tool working today
is exactly why someone would build on it by mistake.

After the date `execute()` refuses immediately and names alternatives instead of
making the call.

### Not touched

`sora_v2` in `_shared.py` is Sora through HeyGen's gateway, not the OpenAI API.
It presumably dies with its upstream, but that is HeyGen's arrangement to know
and I cannot verify it, so I have left the call to someone who can.

### Tests

13, pinned to explicit dates rather than the clock: the boundary lands on the
removal day itself, nothing changes before it, and afterwards the tool reports
unavailable, refuses, and points somewhere else.

Full suite locally: 1843 passed, 12 skipped, 3 xfailed.

Source: https://developers.openai.com/api/docs/deprecations
