### PR TITLE
fix(stock-sources): generate deterministic URL IDs

### DIFF
--- a/tests/tools/test_stock_source_adapters.py
+++ b/tests/tools/test_stock_source_adapters.py
@@ -1,9 +1,11 @@
 import sys
 import types
+from pathlib import Path
 
 import pytest
 
 from tools.video.stock_sources import SearchFilters, all_sources, get_source
+from tools.video.stock_sources.base import stable_url_id
 from tools.video.stock_sources.unsplash import _build_download_url, _orientation_for_unsplash
 from tools.video.stock_sources.wikimedia import (
     _build_search_queries,
@@ -75,6 +77,28 @@ def test_unsplash_helpers_preserve_query_params():
     assert "ixid=abc" in url
     assert "w=1920" in url
     assert "fm=jpg" in url
+
+
+def test_stable_url_id_is_deterministic_and_url_specific():
+    url = "https://example.test/media/launch.mp4"
+
+    assert stable_url_id(url) == "57d3145f3621a60c"
+    assert stable_url_id(url) == stable_url_id(url)
+    assert stable_url_id(url) != stable_url_id("https://example.test/media/landing.mp4")
+
+
+@pytest.mark.parametrize("adapter", ["esa.py", "noaa.py", "loc.py"])
+def test_url_backed_adapters_do_not_use_randomized_python_hash(adapter):
+    source = (
+        Path(__file__).parents[2]
+        / "tools"
+        / "video"
+        / "stock_sources"
+        / adapter
+    ).read_text(encoding="utf-8")
+
+    assert "stable_url_id(" in source
+    assert "hash(" not in source
 
 
 # ---------------------------------------------------------------------

--- a/tools/video/stock_sources/base.py
+++ b/tools/video/stock_sources/base.py
@@ -35,6 +35,7 @@ Adding a new source
 """
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional, Protocol, runtime_checkable
@@ -78,6 +79,15 @@ class Candidate:
         directly when it materialises the row.
         """
         return f"{self.source}_{self.source_id}"
+
+
+def stable_url_id(url: str) -> str:
+    """Return a process-independent identifier for a URL-backed result.
+
+    Python's built-in ``hash`` is randomized between interpreter processes, so
+    it cannot identify cached media or corpus rows across separate runs.
+    """
+    return hashlib.sha256(url.encode("utf-8")).hexdigest()[:16]
 
 
 @dataclass

--- a/tools/video/stock_sources/esa.py
+++ b/tools/video/stock_sources/esa.py
@@ -24,7 +24,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-from .base import Candidate, SearchFilters
+from .base import Candidate, SearchFilters, stable_url_id
 
 _log = logging.getLogger(__name__)
 
@@ -118,7 +118,7 @@ class ESASource:
             out.append(
                 Candidate(
                     source=self.name,
-                    source_id=f"esa_{hash(href) & 0xFFFFFFFF:08x}",
+                    source_id=stable_url_id(href),
                     source_url=href,
                     download_url=href,  # Will be resolved in download()
                     kind=candidate_kind,

--- a/tools/video/stock_sources/loc.py
+++ b/tools/video/stock_sources/loc.py
@@ -27,7 +27,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from .base import Candidate, SearchFilters
+from .base import Candidate, SearchFilters, stable_url_id
 
 _log = logging.getLogger(__name__)
 
@@ -177,7 +177,7 @@ class LibraryOfCongressSource:
                     out.append(
                         Candidate(
                             source=self.name,
-                            source_id=f"loc_{hash(full_url) & 0xFFFFFFFF:08x}",
+                            source_id=stable_url_id(full_url),
                             source_url=source_url,
                             download_url=full_url,
                             kind="video" if is_video else "image",
@@ -201,7 +201,7 @@ class LibraryOfCongressSource:
             out.append(
                 Candidate(
                     source=self.name,
-                    source_id=f"loc_{hash(full_url) & 0xFFFFFFFF:08x}",
+                    source_id=stable_url_id(full_url),
                     source_url=source_url,
                     download_url=full_url,
                     kind="image",

--- a/tools/video/stock_sources/noaa.py
+++ b/tools/video/stock_sources/noaa.py
@@ -23,7 +23,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from .base import Candidate, SearchFilters
+from .base import Candidate, SearchFilters, stable_url_id
 
 _log = logging.getLogger(__name__)
 
@@ -103,7 +103,7 @@ class NOAASource:
                 out.append(
                     Candidate(
                         source=self.name,
-                        source_id=f"noaa_{hash(href) & 0xFFFFFFFF:08x}",
+                        source_id=stable_url_id(href),
                         source_url=href,
                         download_url=href,  # Resolved in download()
                         kind="video",


### PR DESCRIPTION

## Summary

Replaces Python's process-randomized `hash()` usage in the ESA, NOAA, and Library of Congress stock-source adapters with deterministic SHA-256 URL identifiers.

This keeps `Candidate.clip_id` stable across separate OpenMontage runs, preventing avoidable cache misses, duplicate corpus records, repeated downloads, and unreliable deduplication.

## Related issue

Closes #596

## Changes

- Added a shared `stable_url_id()` helper using a truncated SHA-256 digest.
- Updated the ESA adapter to generate deterministic URL-backed source IDs.
- Updated the NOAA adapter to generate deterministic URL-backed source IDs.
- Updated both Library of Congress candidate paths to use deterministic IDs.
- Added regression coverage for deterministic and URL-specific identifiers.
- Added checks preventing the affected adapters from using Python's randomized `hash()` again.

## Testing

- Ran the stock-source adapter test suite:

  `/usr/bin/python3 -m pytest tests/tools/test_stock_source_adapters.py -q`

- Result: `39 passed, 3 xfailed`.
- The three expected failures are existing documented transport-error cases.
- Ran `git diff --check` successfully.
- Manually reproduced the original bug using different `PYTHONHASHSEED` values and verified that SHA-256 produces the same identifier across processes.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [x] Documentation changes are not required because this is an internal identifier-stability fix with no user-facing API change.
- [x] No unrelated files (build artifacts, local config) are included in the diff.
