### PR TITLE
fix(comfyui): compact execution errors instead of raw message dumps

### DIFF
--- a/tests/contracts/test_comfyui_tools.py
+++ b/tests/contracts/test_comfyui_tools.py
@@ -1303,3 +1303,77 @@ class TestCustomWorkflowSelectorEligibility:
                 "workflow_model_stack",
             ):
                 assert field in props, f"{selector.name} missing {field}"
+
+
+class TestCompactExecutionError:
+    """Issue #615: surface one actionable line instead of raw message dumps."""
+
+    _EXEC_ERROR_MESSAGES = [
+        "execution_interrupt",
+        [
+            "execution_error",
+            {
+                "prompt_id": "abc",
+                "node_id": "3",
+                "node_type": "KSampler",
+                "exception_type": "ValueError",
+                "exception_message": "expected float tensor\n<hundreds of lines of latent tensor repr>",
+                "traceback": ["tb line 1", "tb line 2"],
+            },
+        ],
+    ]
+
+    def test_extracts_node_type_and_first_line(self):
+        from tools._comfyui.client import compact_execution_error
+
+        text = compact_execution_error(self._EXEC_ERROR_MESSAGES)
+        assert text == "KSampler: ValueError: expected float tensor"
+        assert "latent tensor repr" not in text
+
+    def test_falls_back_to_node_id_when_node_type_missing(self):
+        from tools._comfyui.client import compact_execution_error
+
+        msgs = [["execution_error", {"node_id": "7", "exception_message": "boom"}]]
+        assert compact_execution_error(msgs) == "7: Error: boom"
+
+    def test_truncates_at_limit(self):
+        from tools._comfyui.client import compact_execution_error
+
+        msgs = [["execution_error", {"node_type": "N", "exception_message": "x" * 5000}]]
+        assert len(compact_execution_error(msgs)) == 1500
+        assert len(compact_execution_error(msgs, limit=50)) == 50
+
+    def test_non_exec_error_payloads_json_fallback(self):
+        from tools._comfyui.client import compact_execution_error
+
+        assert compact_execution_error("plain string") == "plain string"
+        text = compact_execution_error([["other_event", {"k": "v"}]])
+        assert "other_event" in text
+
+    def test_history_entry_raises_compact_error_with_prompt_id(self, monkeypatch):
+        from tools._comfyui import client as client_module
+        from tools._comfyui.client import ComfyUIClient, ComfyUIError
+
+        class FakeResponse:
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {
+                    "abc": {
+                        "status": {
+                            "status_str": "error",
+                            "messages": TestCompactExecutionError._EXEC_ERROR_MESSAGES,
+                        }
+                    }
+                }
+
+        monkeypatch.setattr(
+            "tools._comfyui.client.requests.get", lambda *a, **k: FakeResponse()
+        )
+        c = ComfyUIClient("http://localhost:8188")
+        with pytest.raises(ComfyUIError) as exc_info:
+            c._history_entry("abc")
+        assert exc_info.value.prompt_id == "abc"
+        assert "KSampler: ValueError: expected float tensor" in str(exc_info.value)
+        assert "latent tensor repr" not in str(exc_info.value)

--- a/tools/_comfyui/client.py
+++ b/tools/_comfyui/client.py
@@ -32,6 +32,31 @@ class ComfyUIError(Exception):
         self.prompt_id = prompt_id
 
 
+def compact_execution_error(messages: Any, *, limit: int = 1500) -> str:
+    """Summarize ComfyUI ``status.messages`` into one actionable line.
+
+    A failed prompt reports an ``execution_error`` message whose payload embeds
+    the full exception content; rendering the raw list can run hundreds of
+    lines of JSON that neither an operator nor an agent log can act on. This
+    extracts the useful core — node, exception type, and the first line of the
+    exception message — and truncates defensively.
+    """
+    if isinstance(messages, list):
+        for item in messages:
+            if not (isinstance(item, (list, tuple)) and len(item) >= 2):
+                continue
+            kind, payload = item[0], item[1]
+            if kind == "execution_error" and isinstance(payload, dict):
+                node = payload.get("node_type") or payload.get("node_id")
+                exc = payload.get("exception_type") or "Error"
+                msg = str(payload.get("exception_message") or "").strip().splitlines()
+                first = msg[0] if msg else ""
+                text = f"{node}: {exc}: {first}"
+                return text[:limit]
+    text = json.dumps(messages, default=str) if not isinstance(messages, str) else messages
+    return text[:limit]
+
+
 class ComfyUIClient:
     """Client for the ComfyUI REST API.
 
@@ -231,7 +256,10 @@ class ComfyUIClient:
         status = entry.get("status", {})
         if status.get("status_str") == "error":
             msgs = status.get("messages", [])
-            raise ComfyUIError(f"Execution error: {msgs}", prompt_id=prompt_id)
+            raise ComfyUIError(
+                f"Execution error: {compact_execution_error(msgs)}",
+                prompt_id=prompt_id,
+            )
         return entry
 
     def _history_entry_if_reachable(self, prompt_id: str) -> dict | None:


### PR DESCRIPTION
Closes #615.

## What

When a ComfyUI prompt fails, `_history_entry()` raised `ComfyUIError` with the raw `status.messages` list. For `execution_error` that payload embeds the full nested exception content — hundreds of lines of JSON that neither an operator nor an agent log can act on.

This PR adds a `compact_execution_error(messages)` helper and uses it on the error path:

- extracts `node_type`, `exception_type`, and the **first line** of `exception_message` → e.g. `KSampler: ValueError: expected float tensor`
- falls back to JSON-serializing non-`execution_error` shapes
- truncates defensively at a 1500-char cap
- `prompt_id` (for the resume flow) is preserved unchanged

## Tests

New `TestCompactExecutionError` class (5 tests): execution_error extraction, `node_id` fallback, truncation cap, fallback shapes, and the `_history_entry` integration. Full `tests/contracts/test_comfyui_tools.py` passes (124 tests).

## Example

Before:
```
ComfyUIError: Execution error: ['execution_interrupt', ['execution_error', {'prompt_id': '...', 'node_id': '3', 'node_type': 'KSampler', 'exception_type': 'ValueError', 'exception_message': '...', 'traceback': [...very long...]}]]
```
After:
```
ComfyUIError: Execution error: KSampler: ValueError: expected float tensor
```