### PR TITLE
feat(comfyui): split queue / execution / download timing in generate()

### DIFF
--- a/tests/contracts/test_comfyui_tools.py
+++ b/tests/contracts/test_comfyui_tools.py
@@ -1303,3 +1303,123 @@ class TestCustomWorkflowSelectorEligibility:
                 "workflow_model_stack",
             ):
                 assert field in props, f"{selector.name} missing {field}"
+
+
+class TestComfyUITiming:
+    """Issue #617: split queue / execution / download instead of wall time."""
+
+    _ENTRY = {
+        "status": {
+            "messages": [
+                ["execution_start", {"timestamp": 1000.0}],
+                ["execution_cached", {"nodes": ["1"]}],
+                ["execution_success", {"timestamp": 1042.5}],
+            ]
+        },
+        "outputs": {
+            "9": {"images": [{"filename": "out.mp4", "subfolder": "", "type": "output"}]}
+        },
+    }
+
+    def test_history_execution_seconds_from_server_timestamps(self):
+        from tools._comfyui.client import history_execution_seconds
+
+        assert history_execution_seconds(self._ENTRY) == 42.5
+
+    def test_history_execution_seconds_normalizes_milliseconds(self):
+        from tools._comfyui.client import history_execution_seconds
+
+        entry = {
+            "status": {
+                "messages": [
+                    ["execution_start", {"timestamp": 1700000000000}],
+                    ["execution_success", {"timestamp": 1700000007500}],
+                ]
+            }
+        }
+        assert history_execution_seconds(entry) == 7.5
+
+    def test_history_execution_seconds_missing_or_negative(self):
+        from tools._comfyui.client import history_execution_seconds
+
+        assert history_execution_seconds({"status": {"messages": []}}) is None
+        assert history_execution_seconds({}) is None
+        entry = {
+            "status": {
+                "messages": [
+                    ["execution_start", {"timestamp": 200.0}],
+                    ["execution_success", {"timestamp": 100.0}],
+                ]
+            }
+        }
+        assert history_execution_seconds(entry) is None
+
+    def test_generate_populates_last_timing(self, tmp_path):
+        from tools._comfyui.client import ComfyUIClient
+
+        client = ComfyUIClient("http://localhost:8188")
+        client.submit = lambda workflow: "prompt-1"
+        client._wait = lambda prompt_id, **kw: dict(self._ENTRY)
+        client.download = lambda *a, **k: None
+
+        dest = tmp_path / "out.mp4"
+        paths = client.generate(
+            {"1": {}}, output_node="9", dest=dest, timeout=5, interval=1
+        )
+        assert paths == [dest]
+        timing = client.last_timing
+        assert timing is not None
+        assert timing["prompt_id"] == "prompt-1"
+        assert timing["comfy_prompt_exec_s"] == 42.5
+        assert timing["timing_source"] == "history_messages"
+        for key in ("submit_s", "client_queue_and_poll_s", "download_s"):
+            assert isinstance(timing[key], float) and timing[key] >= 0
+
+    def test_generate_last_timing_without_history_timestamps(self, tmp_path):
+        from tools._comfyui.client import ComfyUIClient
+
+        client = ComfyUIClient("http://localhost:8188")
+        client.submit = lambda workflow: "prompt-2"
+        client._wait = lambda prompt_id, **kw: {
+            "status": {},
+            "outputs": {"9": {"images": [{"filename": "o.mp4", "subfolder": "", "type": "output"}]}},
+        }
+        client.download = lambda *a, **k: None
+
+        client.generate({"1": {}}, output_node="9", dest=tmp_path / "o.mp4")
+        assert client.last_timing["comfy_prompt_exec_s"] is None
+        assert client.last_timing["timing_source"] == "poll_wall"
+
+    def test_video_result_surfaces_timing_split(self, tmp_path):
+        from tools.video.comfyui_video import ComfyUIVideo
+
+        tool = ComfyUIVideo()
+        tool._client.is_available = lambda: True
+        tool._client.check_models = lambda required: (list(required), [])
+
+        def fake_generate(workflow, output_node, dest, **kwargs):
+            Path(dest).write_bytes(b"mp4")
+            tool._client.last_timing = {
+                "prompt_id": "p",
+                "submit_s": 0.1,
+                "client_queue_and_poll_s": 30.0,
+                "comfy_prompt_exec_s": 120.0,
+                "download_s": 1.2,
+                "poll_interval_s": 10,
+                "timing_source": "history_messages",
+            }
+            return [Path(dest)]
+
+        tool._client.generate = fake_generate
+
+        result = tool.execute({
+            "prompt": "test",
+            "workflow_json": json.dumps({"42": {"inputs": {}}}),
+            "output_node": "42",
+            "output_path": str(tmp_path / "video.mp4"),
+        })
+        assert result.success is True
+        timing = result.data["timing"]
+        assert timing["comfy_prompt_exec_s"] == 120.0
+        assert timing["client_queue_and_poll_s"] == 30.0
+        assert timing["wall_s"] >= timing["client_overhead_s"] >= 0

--- a/tools/_comfyui/client.py
+++ b/tools/_comfyui/client.py
@@ -32,6 +32,49 @@ class ComfyUIError(Exception):
         self.prompt_id = prompt_id
 
 
+def _timestamp_seconds(value: Any) -> float | None:
+    """Normalize a ComfyUI history timestamp to seconds.
+
+    Servers have been observed emitting both seconds and milliseconds.
+    """
+    if not isinstance(value, (int, float)):
+        return None
+    ts = float(value)
+    if ts > 1e11:  # implausibly large for epoch seconds → milliseconds
+        return ts / 1000.0
+    return ts
+
+
+def history_execution_seconds(entry: dict[str, Any]) -> float | None:
+    """Server-side execution time from ``execution_start`` → terminal event.
+
+    Reads the timestamps ComfyUI itself records in the history entry's
+    ``status.messages``, so the number reflects real workflow execution and
+    not queue wait or artifact download.
+    """
+    messages = (entry.get("status") or {}).get("messages") or []
+    if not isinstance(messages, list):
+        return None
+    start_ts = None
+    end_ts = None
+    for item in messages:
+        if not (isinstance(item, (list, tuple)) and len(item) >= 2):
+            continue
+        kind, payload = item[0], item[1]
+        if not isinstance(payload, dict):
+            continue
+        if kind == "execution_start":
+            start_ts = _timestamp_seconds(payload.get("timestamp"))
+        elif kind in {"execution_success", "execution_interrupted", "execution_error"}:
+            end_ts = _timestamp_seconds(payload.get("timestamp"))
+    if start_ts is None or end_ts is None:
+        return None
+    delta = end_ts - start_ts
+    if delta < 0:
+        return None
+    return round(delta, 3)
+
+
 class ComfyUIClient:
     """Client for the ComfyUI REST API.
 
@@ -63,6 +106,9 @@ class ComfyUIClient:
         # Scopes websocket execution events to this client (see wait_ws) and
         # is echoed back on /prompt so the server targets messages to us.
         self.client_id = str(uuid.uuid4())
+        # Populated by generate(): splits queue / execution / download so
+        # callers don't have to treat wall time as GPU time.
+        self.last_timing: dict[str, Any] | None = None
 
     def _capability_url(self) -> str | None:
         if self._capability_env_var:
@@ -429,8 +475,15 @@ class ComfyUIClient:
         detection, optional live ``on_progress`` callback) and transparently
         falls back to REST polling if ``websocket-client`` isn't installed or
         the connection can't be used. See :meth:`_wait`.
+
+        After a successful run, :attr:`last_timing` holds a dict splitting
+        ``submit_s``, ``client_queue_and_poll_s``, ``comfy_prompt_exec_s``
+        (server-side, when history timestamps are present) and ``download_s``.
         """
+        self.last_timing = None
+        t0 = time.perf_counter()
         prompt_id = resume_prompt_id or self.submit(workflow)
+        t_submitted = time.perf_counter()
         if resume_prompt_id:
             # A prompt resumed by a new client instance was submitted with the
             # original instance's client_id, so its websocket events are not
@@ -440,6 +493,7 @@ class ComfyUIClient:
             entry = self._wait(
                 prompt_id, timeout=timeout, interval=interval, on_progress=on_progress
             )
+        t_polled = time.perf_counter()
 
         outputs = entry.get("outputs", {})
         node_output = outputs.get(output_node, {})
@@ -472,6 +526,17 @@ class ComfyUIClient:
                 item.get("type", "output"),
             )
             paths.append(target)
+        t_downloaded = time.perf_counter()
+        exec_s = history_execution_seconds(entry)
+        self.last_timing = {
+            "prompt_id": prompt_id,
+            "submit_s": round(t_submitted - t0, 3),
+            "client_queue_and_poll_s": round(t_polled - t_submitted, 3),
+            "comfy_prompt_exec_s": exec_s,
+            "download_s": round(t_downloaded - t_polled, 3),
+            "poll_interval_s": interval,
+            "timing_source": "history_messages" if exec_s is not None else "poll_wall",
+        }
         return paths
 
     # ------------------------------------------------------------------

--- a/tools/video/comfyui_video.py
+++ b/tools/video/comfyui_video.py
@@ -579,6 +579,17 @@ class ComfyUIVideo(BaseTool):
                     "duration_seconds": round(num_frames / 16, 2),
                 }
             )
+        wall = round(time.time() - start, 3)
+        comfy_timing = dict(getattr(self._client, "last_timing", None) or {})
+        exec_s = comfy_timing.get("comfy_prompt_exec_s")
+        overhead = wall
+        if isinstance(exec_s, (int, float)):
+            overhead = round(max(0.0, wall - float(exec_s)), 3)
+        result_data["timing"] = {
+            **comfy_timing,
+            "client_overhead_s": overhead,
+            "wall_s": wall,
+        }
         return ToolResult(
             success=True,
             data=result_data,


### PR DESCRIPTION
Closes #617.

## What

Wall time around a ComfyUI generation conflates queue wait, real workflow execution, and artifact download. This PR splits them.

**`tools/_comfyui/client.py`**
- `generate()` now measures `submit_s`, `client_queue_and_poll_s`, `download_s` from its own clock
- `comfy_prompt_exec_s` is read from the history entry's `execution_start` → `execution_success` timestamps (ComfyUI already records these; helper normalizes servers that emit milliseconds vs seconds)
- result exposed as `client.last_timing` (`None` before the first run) so **any** ComfyUI tool can surface it without API changes

**`tools/video/comfyui_video.py`**
- `result.data["timing"]` merges the client split with `wall_s` and a derived `client_overhead_s`

Backwards compatible: no schema changes; callers that ignore the new fields see no difference.

## Tests

`TestComfyUITiming` (6 tests): timestamp normalization (seconds / milliseconds / negative / missing), `generate()` instrumentation with and without history timestamps, and the tool-level timing split. Full `tests/contracts/test_comfyui_tools.py` passes (125 tests).

## Example result

```json
"timing": {
  "prompt_id": "...",
  "submit_s": 0.1,
  "client_queue_and_poll_s": 30.0,
  "comfy_prompt_exec_s": 120.0,
  "download_s": 1.2,
  "timing_source": "history_messages",
  "client_overhead_s": 32.4,
  "wall_s": 152.4
}
```