### PR TITLE
feat(tts): add Inworld Realtime TTS-2 provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,8 @@ GOOGLE_CLOUD_LOCATION=
 # --- Voice ---
 # TTS narration, music generation, sound effects.
 ELEVENLABS_API_KEY=
+# Inworld Realtime TTS-2 expressive narration and word timestamps.
+INWORLD_API_KEY=
 # OpenAI TTS fallback and GPT Image 2 image generation.
 OPENAI_API_KEY=
 # Grok image generation/editing and Grok video generation.

--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ Each tool declares which Layer 3 skills it relies on. The agent reads Layer 1 to
 | Provider | Type | Notes |
 |----------|------|-------|
 | **ElevenLabs** | Cloud API | Premium voice quality |
+| **Inworld Realtime TTS-2** | Cloud API | Expressive multilingual speech with word timestamps |
 | **Google TTS** | Cloud API | 700+ voices, 50+ languages — best for localization |
 | **Kling Official TTS** | Cloud API | Official Kling narration when a `voice_id` is known |
 | **OpenAI TTS** | Cloud API | Fast, affordable |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -153,7 +153,7 @@ Selectors route based on: user preference when explicitly set, then scored ranki
 
 **Analysis (5):** transcriber (WhisperX), azure_stt, scene_detect, frame_sampler, video_understand (CLIP/BLIP-2)
 
-**Audio (9):** elevenlabs_tts, google_tts, openai_tts, piper_tts, azure_tts, tts_selector, music_gen, audio_mixer, audio_enhance
+**Audio (10):** elevenlabs_tts, inworld_tts, google_tts, openai_tts, piper_tts, azure_tts, tts_selector, music_gen, audio_mixer, audio_enhance
 
 **Avatar (2):** talking_head (SadTalker/MuseTalk), lip_sync (Wav2Lip)
 
@@ -384,6 +384,7 @@ All config is validated via Pydantic models in `lib/config_model.py`.
 | Variable | Used By | Purpose |
 |----------|---------|---------|
 | `ELEVENLABS_API_KEY` | elevenlabs_tts, music_gen | TTS, music, sound effects |
+| `INWORLD_API_KEY` | inworld_tts | Inworld Realtime TTS-2 narration |
 | `AZURE_SPEECH_KEY` + `AZURE_SPEECH_REGION` | azure_stt, azure_tts | Azure AI Speech cloud transcription + neural TTS (one resource, both directions) |
 | `OPENAI_API_KEY` | openai_tts, openai_image | TTS fallback, GPT Image 2 |
 | `XAI_API_KEY` | grok_image, grok_video | Grok image editing/generation, Grok video generation |

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -40,6 +40,7 @@ GOOGLE_API_KEY=              # Google TTS + Imagen + Lyria music + Gemini Omni/V
 
 # VOICE + MUSIC
 ELEVENLABS_API_KEY=          # TTS, music, sound effects (10K chars/month free)
+INWORLD_API_KEY=             # Inworld Realtime TTS-2 expressive narration
 FISH_AUDIO_API_KEY=          # fish.audio TTS (voice cloning via reference_id, inline emotion tags)
 OPENAI_API_KEY=              # OpenAI TTS + GPT Image 2 images
 XAI_API_KEY=                 # xAI Grok image generation/editing + Grok video generation
@@ -497,6 +498,30 @@ machine-readable Atlas page and should be reconfirmed before a paid batch.
 | Scale | $330/mo | 2,000,000 | Priority support |
 
 **Free tier:** 10,000 characters/month (roughly 2-3 minutes of narration). API access included. Music generation and sound effects also available on free tier with limited credits.
+
+---
+
+### Inworld — Realtime TTS-2
+
+> **Expressive multilingual narration with alignment metadata.** Inworld's
+> non-streaming API returns MP3 or LINEAR16 audio and can include word- or
+> character-level timestamps for captions and lip-sync workflows.
+
+**Tool unlocked:** `inworld_tts`
+**Env var:** `INWORLD_API_KEY`
+
+1. Create an API key in the Inworld Portal.
+2. Copy the Base64 credential exactly as shown.
+3. Add `INWORLD_API_KEY=...` to `.env`.
+4. Select it through `tts_selector` with `preferred_provider: "inworld"`.
+
+The adapter supports built-in or custom voice IDs, BCP-47 language hints,
+stable/balanced/creative delivery modes, optional text normalization, and word
+or character timestamps. The non-streaming endpoint accepts up to 2,000 input
+characters per request.
+
+On-demand Realtime TTS-2 pricing is $25 per million characters. Volume plans
+may be lower; verify current pricing before large runs.
 
 ---
 
@@ -1418,6 +1443,7 @@ These tools require only FFmpeg or Python packages — no GPU, no API key.
 | **Azure AI Speech** | `AZURE_SPEECH_KEY` + `AZURE_SPEECH_REGION` | `azure_stt`, `azure_tts` | Free tier + paid |
 | **Google** | `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) | `google_tts`, `google_imagen`, `google_music`, `gemini_omni_video`, `veo_video` | Free tier (TTS) + paid |
 | **ElevenLabs** | `ELEVENLABS_API_KEY` | `elevenlabs_tts`, `music_gen` | Free tier + paid |
+| **Inworld** | `INWORLD_API_KEY` | `inworld_tts` | Pay-as-you-go |
 | **fish.audio** | `FISH_AUDIO_API_KEY` | `fish_audio_tts` | Free tier (s2.1-pro-free) + paid |
 | **fal.ai** | `FAL_KEY` | `flux_image`, `recraft_image`, `kling_video`, `veo_video`, `seedance_video`, `gemini_omni_fal`, `minimax_fal_video` | Pay-as-you-go |
 | **Atlas Cloud** | `ATLASCLOUD_API_KEY` | `atlas_image`, `atlas_video` | Pay-as-you-go |
@@ -1446,7 +1472,7 @@ How many providers cover each capability:
 |-----------|----------------|-----------------|--------------|
 | **Image Generation** | FLUX, Kling Official, Grok, Google Imagen, GPT Image 2, Recraft | Local Diffusion | Pexels, Pixabay (stock) |
 | **Video Generation** | Grok, Kling Official, fal.ai, Seedance via Volcengine Ark, Runway, Veo, Gemini Omni, Higgsfield, MiniMax, HeyGen, Tencent Hunyuan, ComfyUI Partner Nodes | WAN, Hunyuan, CogVideo, LTX, ComfyUI WAN, ComfyUI MiniMax H3 | Pexels, Pixabay (stock) |
-| **Text-to-Speech** | Azure AI Speech, ElevenLabs, fish.audio, Google TTS, Kling Official, OpenAI | Piper | Piper, Google free tier, ElevenLabs free tier, Azure free tier, fish.audio s2.1-pro-free |
+| **Text-to-Speech** | Azure AI Speech, ElevenLabs, Inworld, fish.audio, Google TTS, Kling Official, OpenAI | Piper | Piper, Google free tier, ElevenLabs free tier, Azure free tier, fish.audio s2.1-pro-free |
 | **Music Generation** | ElevenLabs, Suno, Google Lyria | — | ElevenLabs free tier |
 | **Post-Production** | — | FFmpeg (compose, stitch, trim, mix, enhance, grade) | All free |
 | **Analysis** | — | WhisperX, Scene Detect, Frame Sampler, CLIP/BLIP-2 | All free |

--- a/tests/contracts/test_inworld_tts.py
+++ b/tests/contracts/test_inworld_tts.py
@@ -1,0 +1,156 @@
+"""Contract tests for the Inworld TTS provider."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+from tools.audio.inworld_tts import InworldTTS
+from tools.base_tool import ToolStatus
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            import requests
+
+            raise requests.HTTPError(f"HTTP {self.status_code}", response=self)
+
+
+def test_registry_discovers_inworld_tts(monkeypatch, isolated_tool_registry):
+    monkeypatch.delenv("INWORLD_API_KEY", raising=False)
+    isolated_tool_registry.discover("tools")
+    tool = isolated_tool_registry.get("inworld_tts")
+    assert tool is not None
+    assert tool.capability == "tts"
+    assert tool.provider == "inworld"
+
+
+def test_status_and_cost(monkeypatch):
+    monkeypatch.delenv("INWORLD_API_KEY", raising=False)
+    tool = InworldTTS()
+    assert tool.get_status() == ToolStatus.UNAVAILABLE
+    monkeypatch.setenv("INWORLD_API_KEY", "test-key")
+    assert tool.get_status() == ToolStatus.AVAILABLE
+    assert tool.estimate_cost({"text": "a" * 1000}) == 0.025
+
+
+def test_rejects_long_text_before_request(monkeypatch):
+    monkeypatch.setenv("INWORLD_API_KEY", "test-key")
+    monkeypatch.setattr(
+        "tools.audio.inworld_tts.requests.post",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must not call API")),
+    )
+    result = InworldTTS().execute({"text": "x" * 2001})
+    assert not result.success
+    assert "2,000" in result.error
+
+
+def test_execute_writes_decoded_audio(monkeypatch, tmp_path):
+    monkeypatch.setenv("INWORLD_API_KEY", "test-key")
+    captured = {}
+
+    def fake_post(url, headers, json, timeout):
+        captured.update(url=url, headers=headers, json=json, timeout=timeout)
+        return FakeResponse(
+            {
+                "audioContent": base64.b64encode(b"fake-mp3").decode("ascii"),
+                "usage": {"processedCharactersCount": 5},
+                "timestampInfo": {"wordAlignment": []},
+            }
+        )
+
+    monkeypatch.setattr("tools.audio.inworld_tts.requests.post", fake_post)
+    monkeypatch.setattr("tools.analysis.audio_probe.probe_duration", lambda path: 1.25)
+    output = tmp_path / "speech.mp3"
+    result = InworldTTS().execute(
+        {"text": "Hello", "voice_id": "Alex", "output_path": str(output)}
+    )
+
+    assert result.success
+    assert output.read_bytes() == b"fake-mp3"
+    assert captured["url"].endswith("/tts/v1/voice")
+    assert captured["headers"]["Authorization"] == "Basic test-key"
+    assert captured["json"]["voiceId"] == "Alex"
+    assert captured["json"]["modelId"] == "inworld-tts-2"
+    assert result.data["audio_duration_seconds"] == 1.25
+    assert result.data["processed_characters"] == 5
+
+
+def test_list_voices_uses_current_voice_api(monkeypatch):
+    monkeypatch.setenv("INWORLD_API_KEY", "test-key")
+    captured = {}
+
+    def fake_get(url, headers, params, timeout):
+        captured.update(url=url, headers=headers, params=params, timeout=timeout)
+        return FakeResponse({"voices": [{"voiceId": "Alex"}]})
+
+    monkeypatch.setattr("tools.audio.inworld_tts.requests.get", fake_get)
+    voices = InworldTTS().list_voices(language="en-US")
+    assert voices == [{"voiceId": "Alex"}]
+    assert captured["url"].endswith("/voices/v1/voices")
+    assert captured["params"] == {"language": "en-US"}
+
+
+def test_selector_can_choose_inworld(monkeypatch, isolated_tool_registry):
+    from tools.base_tool import ToolResult
+
+    monkeypatch.setenv("INWORLD_API_KEY", "test-key")
+    isolated_tool_registry.discover("tools")
+    tool = isolated_tool_registry.get("inworld_tts")
+    monkeypatch.setattr(
+        tool,
+        "execute",
+        lambda inputs: ToolResult(success=True, data={}, artifacts=["speech.mp3"]),
+    )
+
+    result = isolated_tool_registry.get("tts_selector").execute(
+        {
+            "text": "Inworld narration",
+            "preferred_provider": "inworld",
+            "allowed_providers": ["inworld"],
+        }
+    )
+    assert result.success
+    assert result.data["selected_provider"] == "inworld"
+
+
+def test_selector_aliases_and_wav_encoding(monkeypatch, tmp_path):
+    monkeypatch.setenv("INWORLD_API_KEY", "test-key")
+    captured = {}
+
+    def fake_post(url, headers, json, timeout):
+        captured.update(json=json)
+        return FakeResponse(
+            {"audioContent": base64.b64encode(b"fake-wav").decode("ascii")}
+        )
+
+    monkeypatch.setattr("tools.audio.inworld_tts.requests.post", fake_post)
+    monkeypatch.setattr("tools.analysis.audio_probe.probe_duration", lambda path: 0.5)
+    result = InworldTTS().execute(
+        {
+            "text": "Bonjour",
+            "voice": "Dennis",
+            "model": "inworld-tts-2",
+            "format": "wav",
+            "language_code": "fr-FR",
+            "apply_text_normalization": "auto",
+            "output_path": str(tmp_path / "speech.wav"),
+        }
+    )
+
+    assert result.success
+    assert captured["json"]["voiceId"] == "Dennis"
+    assert captured["json"]["audioConfig"]["audioEncoding"] == "LINEAR16"
+    assert captured["json"]["language"] == "fr-FR"
+    assert (
+        captured["json"]["applyTextNormalization"]
+        == "APPLY_TEXT_NORMALIZATION_UNSPECIFIED"
+    )

--- a/tests/contracts/test_inworld_tts.py
+++ b/tests/contracts/test_inworld_tts.py
@@ -154,3 +154,66 @@ def test_selector_aliases_and_wav_encoding(monkeypatch, tmp_path):
         captured["json"]["applyTextNormalization"]
         == "APPLY_TEXT_NORMALIZATION_UNSPECIFIED"
     )
+
+
+def test_normalization_schema_matches_selector_contract():
+    schema = InworldTTS.input_schema["properties"]["apply_text_normalization"]
+    assert schema["default"] == "auto"
+    assert schema["enum"] == ["auto", "on", "off"]
+
+
+def test_idempotency_key_covers_audio_affecting_inputs():
+    tool = InworldTTS()
+    baseline = {"text": "Hello"}
+    variants = {
+        "voice_id": "Alex",
+        "model_id": "inworld-tts-2-max",
+        "format": "wav",
+        "sample_rate_hertz": 24000,
+        "language": "fr-FR",
+        "delivery_mode": "CREATIVE",
+        "timestamp_type": "CHARACTER",
+        "apply_text_normalization": "off",
+    }
+
+    for field, value in variants.items():
+        assert tool.idempotency_key(baseline) != tool.idempotency_key(
+            {**baseline, field: value}
+        ), field
+
+
+def test_idempotency_key_canonicalizes_selector_aliases_and_defaults():
+    tool = InworldTTS()
+    canonical = {
+        "text": "Bonjour",
+        "voice_id": "Alex",
+        "model_id": "inworld-tts-2",
+        "language": "fr-FR",
+        "timestamp_type": "WORD",
+        "apply_text_normalization": "auto",
+    }
+    aliases = {
+        "text": "Bonjour",
+        "voice": "Alex",
+        "model": "inworld-tts-2",
+        "language_code": "fr-FR",
+        "timestamps": True,
+        "apply_text_normalization": "AUTO",
+    }
+
+    assert tool.idempotency_key(canonical) == tool.idempotency_key(aliases)
+    assert tool.idempotency_key({"text": "Hello"}) == tool.idempotency_key(
+        {
+            "text": "Hello",
+            "voice_id": "Dennis",
+            "model_id": "inworld-tts-2",
+            "format": "mp3",
+            "sample_rate_hertz": 48000,
+            "delivery_mode": "BALANCED",
+            "timestamp_type": "WORD",
+            "apply_text_normalization": "auto",
+        }
+    )
+    assert tool.idempotency_key({"text": "Hello", "timestamps": False}) != (
+        tool.idempotency_key({"text": "Hello", "timestamps": True})
+    )

--- a/tests/contracts/test_phase3_contracts.py
+++ b/tests/contracts/test_phase3_contracts.py
@@ -698,6 +698,7 @@ class TestCapabilityMetadata:
             "fish_audio",
             "fal.ai",
             "google_tts",
+            "inworld",
             "kling_official",
             "openai",
             "piper",

--- a/tools/audio/inworld_tts.py
+++ b/tools/audio/inworld_tts.py
@@ -112,8 +112,8 @@ class InworldTTS(BaseTool):
             },
             "apply_text_normalization": {
                 "type": "string",
-                "default": "ON",
-                "enum": ["ON", "OFF", "APPLY_TEXT_NORMALIZATION_UNSPECIFIED"],
+                "default": "auto",
+                "enum": ["auto", "on", "off"],
             },
             "output_path": {"type": "string"},
         },
@@ -130,7 +130,11 @@ class InworldTTS(BaseTool):
         "voice_id",
         "model_id",
         "format",
+        "sample_rate_hertz",
+        "language",
         "delivery_mode",
+        "timestamp_type",
+        "apply_text_normalization",
     ]
     side_effects = ["writes audio file to output_path", "calls Inworld API"]
     user_visible_verification = ["Listen to generated audio for intelligibility and tone"]
@@ -225,7 +229,7 @@ class InworldTTS(BaseTool):
             "voiceId": voice_id,
             "modelId": model_id,
             "deliveryMode": inputs.get("delivery_mode", "BALANCED"),
-            "timestampType": inputs.get("timestamp_type", "WORD"),
+            "timestampType": self._timestamp_type(inputs),
             "applyTextNormalization": self._normalization_mode(inputs),
             "audioConfig": {
                 "audioEncoding": self._ENCODINGS[fmt],
@@ -280,7 +284,7 @@ class InworldTTS(BaseTool):
 
     @staticmethod
     def _normalization_mode(inputs: dict[str, Any]) -> str:
-        value = str(inputs.get("apply_text_normalization", "ON")).upper()
+        value = str(inputs.get("apply_text_normalization", "auto")).upper()
         return {
             "AUTO": "APPLY_TEXT_NORMALIZATION_UNSPECIFIED",
             "APPLY_TEXT_NORMALIZATION_UNSPECIFIED": (
@@ -289,3 +293,37 @@ class InworldTTS(BaseTool):
             "ON": "ON",
             "OFF": "OFF",
         }.get(value, "ON")
+
+    @staticmethod
+    def _timestamp_type(inputs: dict[str, Any]) -> str:
+        """Resolve the selector's boolean timestamp control to Inworld's enum."""
+        if inputs.get("timestamp_type") is not None:
+            return str(inputs["timestamp_type"]).upper()
+        if "timestamps" in inputs:
+            return "WORD" if inputs["timestamps"] else "TIMESTAMP_TYPE_UNSPECIFIED"
+        return "WORD"
+
+    @classmethod
+    def _effective_inputs(cls, inputs: dict[str, Any]) -> dict[str, Any]:
+        """Return the effective API inputs used to generate the audio.
+
+        Selector aliases and omitted defaults are canonicalized so equivalent
+        requests share a key while every audio-affecting option remains part of
+        it.
+        """
+        return {
+            "text": str(inputs.get("text", "")),
+            "voice_id": inputs.get("voice_id") or inputs.get("voice") or "Dennis",
+            "model_id": (
+                inputs.get("model_id") or inputs.get("model") or "inworld-tts-2"
+            ),
+            "format": str(inputs.get("format", "mp3")).lower(),
+            "sample_rate_hertz": int(inputs.get("sample_rate_hertz", 48000)),
+            "language": inputs.get("language") or inputs.get("language_code"),
+            "delivery_mode": inputs.get("delivery_mode", "BALANCED"),
+            "timestamp_type": cls._timestamp_type(inputs),
+            "apply_text_normalization": cls._normalization_mode(inputs),
+        }
+
+    def idempotency_key(self, inputs: dict[str, Any]) -> str:
+        return super().idempotency_key(self._effective_inputs(inputs))

--- a/tools/audio/inworld_tts.py
+++ b/tools/audio/inworld_tts.py
@@ -1,0 +1,291 @@
+"""Inworld text-to-speech provider tool."""
+
+from __future__ import annotations
+
+import base64
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from tools.base_tool import (
+    BaseTool,
+    Determinism,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+    ToolTier,
+)
+
+
+class InworldTTS(BaseTool):
+    """Generate narration with Inworld TTS 2."""
+
+    name = "inworld_tts"
+    version = "0.1.0"
+    tier = ToolTier.VOICE
+    capability = "tts"
+    provider = "inworld"
+    stability = ToolStability.BETA
+    execution_mode = ExecutionMode.SYNC
+    determinism = Determinism.STOCHASTIC
+    runtime = ToolRuntime.API
+
+    dependencies = []
+    install_instructions = (
+        "Set INWORLD_API_KEY to the Base64 credential shown in the Inworld "
+        "Portal's API Keys page."
+    )
+    fallback = "piper_tts"
+    fallback_tools = ["piper_tts"]
+    agent_skills = ["text-to-speech"]
+
+    capabilities = [
+        "text_to_speech",
+        "voice_selection",
+        "multilingual",
+        "word_timestamps",
+    ]
+    supports = {
+        "voice_cloning": False,
+        "multilingual": True,
+        "offline": False,
+        "native_audio": True,
+        "word_timestamps": True,
+        "expressive_delivery": True,
+    }
+    best_for = [
+        "expressive narration",
+        "multilingual narration",
+        "word-timestamped speech for captions",
+    ]
+    not_good_for = ["offline production", "voice cloning"]
+
+    input_schema = {
+        "type": "object",
+        "required": ["text"],
+        "properties": {
+            "text": {
+                "type": "string",
+                "maxLength": 2000,
+                "description": "Text to synthesize (maximum 2,000 characters).",
+            },
+            "voice_id": {
+                "type": "string",
+                "default": "Dennis",
+                "description": "Inworld built-in or custom voice ID.",
+            },
+            "model_id": {
+                "type": "string",
+                "default": "inworld-tts-2",
+            },
+            "format": {
+                "type": "string",
+                "default": "mp3",
+                "enum": ["mp3", "wav"],
+            },
+            "sample_rate_hertz": {
+                "type": "integer",
+                "default": 48000,
+                "minimum": 8000,
+                "maximum": 48000,
+            },
+            "language": {
+                "type": "string",
+                "description": "Optional BCP-47 language code, such as en-US.",
+            },
+            "delivery_mode": {
+                "type": "string",
+                "default": "BALANCED",
+                "enum": ["STABLE", "BALANCED", "CREATIVE"],
+            },
+            "timestamp_type": {
+                "type": "string",
+                "default": "WORD",
+                "enum": ["TIMESTAMP_TYPE_UNSPECIFIED", "WORD", "CHARACTER"],
+            },
+            "apply_text_normalization": {
+                "type": "string",
+                "default": "ON",
+                "enum": ["ON", "OFF", "APPLY_TEXT_NORMALIZATION_UNSPECIFIED"],
+            },
+            "output_path": {"type": "string"},
+        },
+    }
+
+    resource_profile = ResourceProfile(
+        cpu_cores=1, ram_mb=256, vram_mb=0, disk_mb=50, network_required=True
+    )
+    retry_policy = RetryPolicy(
+        max_retries=2, retryable_errors=["rate_limit", "timeout", "server_error"]
+    )
+    idempotency_key_fields = [
+        "text",
+        "voice_id",
+        "model_id",
+        "format",
+        "delivery_mode",
+    ]
+    side_effects = ["writes audio file to output_path", "calls Inworld API"]
+    user_visible_verification = ["Listen to generated audio for intelligibility and tone"]
+
+    _SYNTHESIS_URL = "https://api.inworld.ai/tts/v1/voice"
+    _VOICES_URL = "https://api.inworld.ai/voices/v1/voices"
+    _ENCODINGS = {"mp3": "MP3", "wav": "LINEAR16"}
+
+    def get_status(self) -> ToolStatus:
+        return (
+            ToolStatus.AVAILABLE
+            if os.environ.get("INWORLD_API_KEY")
+            else ToolStatus.UNAVAILABLE
+        )
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        # Inworld TTS-2 on-demand list price: $25 per million characters.
+        return round(len(inputs.get("text", "")) * 0.000025, 4)
+
+    def _headers(self) -> dict[str, str]:
+        api_key = os.environ.get("INWORLD_API_KEY")
+        if not api_key:
+            raise RuntimeError("No Inworld API key. " + self.install_instructions)
+        return {
+            "Authorization": f"Basic {api_key}",
+            "Content-Type": "application/json",
+        }
+
+    @staticmethod
+    def _raise_api_error(response: requests.Response) -> None:
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            try:
+                detail = response.json().get("message") or response.json().get("error")
+            except (ValueError, AttributeError):
+                detail = None
+            suffix = f": {str(detail)[:300]}" if detail else ""
+            raise RuntimeError(f"Inworld API returned HTTP {response.status_code}{suffix}") from exc
+
+    def list_voices(self, language: str | None = None) -> list[dict[str, Any]]:
+        """List available voices using Inworld's current Voice API endpoint."""
+        params = {"language": language} if language else None
+        response = requests.get(
+            self._VOICES_URL,
+            headers=self._headers(),
+            params=params,
+            timeout=30,
+        )
+        self._raise_api_error(response)
+        payload = response.json()
+        voices = payload.get("voices", [])
+        if not isinstance(voices, list):
+            raise RuntimeError("Inworld voices response did not contain a voices list.")
+        return voices
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        if not os.environ.get("INWORLD_API_KEY"):
+            return ToolResult(success=False, error="No Inworld API key. " + self.install_instructions)
+
+        text = str(inputs.get("text", ""))
+        if not text.strip():
+            return ToolResult(success=False, error="Inworld TTS text cannot be empty.")
+        if len(text) > 2000:
+            return ToolResult(
+                success=False,
+                error="Inworld TTS accepts at most 2,000 characters per request.",
+            )
+
+        started = time.time()
+        try:
+            result = self._generate(inputs)
+        except Exception as exc:
+            return ToolResult(success=False, error=f"Inworld TTS failed: {exc}")
+
+        result.duration_seconds = round(time.time() - started, 2)
+        result.cost_usd = self.estimate_cost(inputs)
+        return result
+
+    def _generate(self, inputs: dict[str, Any]) -> ToolResult:
+        from tools.analysis.audio_probe import probe_duration
+
+        text = str(inputs["text"])
+        voice_id = inputs.get("voice_id") or inputs.get("voice") or "Dennis"
+        model_id = inputs.get("model_id") or inputs.get("model") or "inworld-tts-2"
+        fmt = str(inputs.get("format", "mp3")).lower()
+        if fmt not in self._ENCODINGS:
+            raise ValueError("Inworld TTS format must be 'mp3' or 'wav'.")
+
+        payload: dict[str, Any] = {
+            "text": text,
+            "voiceId": voice_id,
+            "modelId": model_id,
+            "deliveryMode": inputs.get("delivery_mode", "BALANCED"),
+            "timestampType": inputs.get("timestamp_type", "WORD"),
+            "applyTextNormalization": self._normalization_mode(inputs),
+            "audioConfig": {
+                "audioEncoding": self._ENCODINGS[fmt],
+                "sampleRateHertz": int(inputs.get("sample_rate_hertz", 48000)),
+            },
+        }
+        language = inputs.get("language") or inputs.get("language_code")
+        if language:
+            payload["language"] = language
+
+        response = requests.post(
+            self._SYNTHESIS_URL,
+            headers=self._headers(),
+            json=payload,
+            timeout=120,
+        )
+        self._raise_api_error(response)
+        response_payload = response.json()
+        encoded_audio = response_payload.get("audioContent")
+        if not encoded_audio:
+            raise RuntimeError("Inworld response did not contain audioContent.")
+        try:
+            audio = base64.b64decode(encoded_audio, validate=True)
+        except (ValueError, TypeError) as exc:
+            raise RuntimeError("Inworld returned invalid Base64 audioContent.") from exc
+        if not audio:
+            raise RuntimeError("Inworld returned empty audioContent.")
+
+        output_path = Path(inputs.get("output_path", f"inworld_tts.{fmt}"))
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(audio)
+        duration = probe_duration(output_path)
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": self.provider,
+                "model": model_id,
+                "voice": voice_id,
+                "format": fmt,
+                "text_length": len(text),
+                "processed_characters": response_payload.get("usage", {}).get(
+                    "processedCharactersCount"
+                ),
+                "audio_duration_seconds": round(duration, 2) if duration else None,
+                "timestamp_info": response_payload.get("timestampInfo"),
+                "output": str(output_path),
+            },
+            artifacts=[str(output_path)],
+            model=model_id,
+        )
+
+    @staticmethod
+    def _normalization_mode(inputs: dict[str, Any]) -> str:
+        value = str(inputs.get("apply_text_normalization", "ON")).upper()
+        return {
+            "AUTO": "APPLY_TEXT_NORMALIZATION_UNSPECIFIED",
+            "APPLY_TEXT_NORMALIZATION_UNSPECIFIED": (
+                "APPLY_TEXT_NORMALIZATION_UNSPECIFIED"
+            ),
+            "ON": "ON",
+            "OFF": "OFF",
+        }.get(value, "ON")


### PR DESCRIPTION
## Summary

Adds Inworld Realtime TTS-2 as an automatically discovered OpenMontage TTS provider. The adapter supports expressive delivery modes, multilingual language hints, MP3/LINEAR16 output, voice selection, text normalization, and word or character timestamps.

## Changes

- add the `inworld_tts` provider tool with API error handling, cost estimation, and audio probing
- support selector-compatible voice, model, language, and normalization inputs
- add registry, request-shape, file-output, validation, voice-listing, and selector tests
- document setup, capabilities, limits, and current on-demand pricing

## Testing

- Inworld and phase-three contract suites: `91 passed`
- Python compilation check for the provider
- `git diff --check`

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally.
- [x] I updated docs/README for the new provider.
- [x] No unrelated files, generated artifacts, or local configuration are included.
