### PR TITLE
fix(schema): allow approval policy decisions

### DIFF
--- a/schemas/artifacts/decision_log.schema.json
+++ b/schemas/artifacts/decision_log.schema.json
@@ -39,6 +39,7 @@
               "concept_selection",
               "voice_selection",
               "capability_extension",
+              "approval_policy",
               "playbook_override",
               "visual_accuracy_check"
             ],

--- a/tests/contracts/test_decision_log_approval_policy.py
+++ b/tests/contracts/test_decision_log_approval_policy.py
@@ -1,0 +1,33 @@
+"""Regression coverage for full-run approval policy decisions."""
+
+from schemas.artifacts import validate_artifact
+
+
+def test_decision_log_accepts_approval_policy_category():
+    decision_log = {
+        "version": "1.0",
+        "project_id": "approved-full-run",
+        "decisions": [
+            {
+                "decision_id": "d-approval-1",
+                "stage": "proposal",
+                "category": "approval_policy",
+                "subject": "Human approval policy",
+                "options_considered": [
+                    {
+                        "option_id": "full-run",
+                        "label": "Full-run pre-authorization",
+                        "score": 1.0,
+                        "reason": "The user explicitly approved all later gates.",
+                    }
+                ],
+                "selected": "full-run",
+                "reason": "Record the explicit authorization required by the agent guide.",
+                "user_visible": True,
+                "user_approved": True,
+                "confidence": 1.0,
+            }
+        ],
+    }
+
+    validate_artifact("decision_log", decision_log)


### PR DESCRIPTION
## Summary

Makes the `decision_log` schema agree with the documented full-run approval workflow. `AGENT_GUIDE.md` and `skills/meta/checkpoint-protocol.md` require explicit pre-authorization to be recorded with `category: approval_policy`, but the schema currently rejects that category.

## Changes

- add `approval_policy` to the decision category enum
- add regression coverage that validates a complete full-run approval decision artifact

## Testing

- Focused decision-log and artifact-schema tests: `3 passed, 79 deselected`
- `git diff --check`

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally.
- [x] The test reproduces the documented artifact contract.
- [x] No unrelated files are included.
