### PR TITLE
Add Magnific provider: video, image, upscale, and audio tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,9 +36,6 @@ HIGGSFIELD_API_SECRET=
 # Create it at https://www.magnific.com/user/organization/api-keys
 # (paid plan required; key and secret are shown only once).
 MAGNIFIC_API_KEY=
-# Optional. Default webhook target for async task notifications; any tool's
-# own webhook_url input overrides it.
-MAGNIFIC_WEBHOOK_URL=
 # No key? Magnific also runs an OAuth MCP server that uses your normal
 # magnific.com account instead:
 #   claude mcp add --transport http magnific https://mcp.magnific.com

--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,19 @@ HIGGSFIELD_API_KEY=
 HIGGSFIELD_API_SECRET=
 # HIGGSFIELD_KEY=            # Combined key:secret — set this INSTEAD of the _KEY/_SECRET pair if you prefer.
 
+# --- Magnific (formerly the Freepik API) ---
+# One key covers magnific_upscale, magnific_video, magnific_image,
+# magnific_music, magnific_sound_effects, and magnific_audio_isolation.
+# Create it at https://www.magnific.com/user/organization/api-keys
+# (paid plan required; key and secret are shown only once).
+MAGNIFIC_API_KEY=
+# Optional. Default webhook target for async task notifications; any tool's
+# own webhook_url input overrides it.
+MAGNIFIC_WEBHOOK_URL=
+# No key? Magnific also runs an OAuth MCP server that uses your normal
+# magnific.com account instead:
+#   claude mcp add --transport http magnific https://mcp.magnific.com
+
 # --- Kling official direct API ---
 # Official Kling API key; enables video, image, TTS, avatar, lip sync.
 KLING_API_KEY=

--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ Each tool declares which Layer 3 skills it relies on. The agent reads Layer 1 to
 | **Google Veo 3.1** | Cloud API | Premium cinematic video via Google GenAI or fal.ai |
 | **Grok Imagine Video** | Cloud API | Strong reference-image video and xAI-native short-form generation |
 | **Higgsfield** | Cloud API | Multi-model orchestrator with Soul ID for character consistency |
+| **Magnific** | Cloud API | One key across Seedance 2, Kling v3, Veo 3.1, WAN, LTX, Runway, Hailuo — plus image, upscaling, and audio |
 | **MiniMax / H3** | Cloud API | Cost-effective generation, including text, image, and reference-driven H3 workflows |
 | **HeyGen** | Cloud API | Multi-model gateway |
 | **WAN 2.1 / 2.2** | Local GPU | Free local variants plus accelerated ComfyUI workflows |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -153,17 +153,17 @@ Selectors route based on: user preference when explicitly set, then scored ranki
 
 **Analysis (5):** transcriber (WhisperX), azure_stt, scene_detect, frame_sampler, video_understand (CLIP/BLIP-2)
 
-**Audio (9):** elevenlabs_tts, google_tts, openai_tts, piper_tts, azure_tts, tts_selector, music_gen, audio_mixer, audio_enhance
+**Audio (12):** elevenlabs_tts, google_tts, openai_tts, piper_tts, azure_tts, tts_selector, music_gen, magnific_music, magnific_sound_effects, magnific_audio_isolation, audio_mixer, audio_enhance
 
 **Avatar (2):** talking_head (SadTalker/MuseTalk), lip_sync (Wav2Lip)
 
-**Enhancement (5):** upscale (Real-ESRGAN), bg_remove (rembg/U2Net), face_enhance, face_restore (CodeFormer/GFPGAN), color_grade (FFmpeg LUTs)
+**Enhancement (6):** upscale (Real-ESRGAN), magnific_upscale (Magnific Creative/Precision), bg_remove (rembg/U2Net), face_enhance, face_restore (CodeFormer/GFPGAN), color_grade (FFmpeg LUTs)
 
-**Graphics (13):** flux_image, grok_image, google_imagen, openai_image, recraft_image, local_diffusion, pexels_image, pixabay_image, image_selector, code_snippet, diagram_gen, math_animate (ManimCE), image_gen (deprecated)
+**Graphics (14):** flux_image, magnific_image, grok_image, google_imagen, openai_image, recraft_image, local_diffusion, pexels_image, pixabay_image, image_selector, code_snippet, diagram_gen, math_animate (ManimCE), image_gen (deprecated)
 
 **Subtitle (1):** subtitle_gen
 
-**Video (18):** grok_video, heygen_video, higgsfield_video, veo_video, kling_video, runway_video, minimax_video, wan_video, hunyuan_video, cogvideo_video, ltx_video_local, ltx_video_modal, pexels_video, pixabay_video, video_selector, video_compose (FFmpeg), video_stitch, video_trimmer
+**Video (19):** grok_video, heygen_video, higgsfield_video, magnific_video, veo_video, kling_video, runway_video, minimax_video, wan_video, hunyuan_video, cogvideo_video, ltx_video_local, ltx_video_modal, pexels_video, pixabay_video, video_selector, video_compose (FFmpeg), video_stitch, video_trimmer
 
 ---
 
@@ -396,6 +396,7 @@ All config is validated via Pydantic models in `lib/config_model.py`.
 | `GOOGLE_API_KEY` | google_imagen, google_tts | Google Imagen images, Google Cloud TTS |
 | `RUNWAY_API_KEY` | runway_video | Runway Gen-3/Gen-4 direct |
 | `HIGGSFIELD_API_KEY` + `HIGGSFIELD_API_SECRET` | higgsfield_video | Higgsfield multi-model video |
+| `MAGNIFIC_API_KEY` | magnific_image, magnific_video, magnific_upscale, magnific_music, magnific_sound_effects, magnific_audio_isolation | Magnific multi-modal suite (Business tier+) |
 | `MODAL_LTX2_ENDPOINT_URL` | ltx_video_modal | Self-hosted LTX-2 |
 | `VIDEO_GEN_LOCAL_ENABLED` | local video tools | Enable local GPU generation |
 | `VIDEO_GEN_LOCAL_MODEL` | wan, hunyuan, ltx, cogvideo | Select local model |

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -985,7 +985,7 @@ Gen-3 Alpha Turbo and Gen-4 Aleph were removed from the Runway API on
 > **One key across image, video, upscaling, and audio.** Magnific (formerly the Freepik API) fronts Mystic, Flux 2, Seedream 5, Seedance 2, Kling, Veo 3.1, WAN, LTX, Runway, Hailuo, PixVerse, ElevenLabs Music, and the Magnific upscalers. It is the broadest single-key surface in this table — the natural alternative to Higgsfield when you want stills, clips, upscaling, and audio behind one credential.
 
 **Tools unlocked:** `magnific_image`, `magnific_video`, `magnific_upscale`, `magnific_music`, `magnific_sound_effects`, `magnific_audio_isolation`
-**Env var:** `MAGNIFIC_API_KEY` (optional: `MAGNIFIC_WEBHOOK_URL`)
+**Env var:** `MAGNIFIC_API_KEY`
 
 #### Setup
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -980,6 +980,64 @@ Gen-3 Alpha Turbo and Gen-4 Aleph were removed from the Runway API on
 
 ---
 
+### Magnific — Multi-Modal Generation Suite
+
+> **One key across image, video, upscaling, and audio.** Magnific (formerly the Freepik API) fronts Mystic, Flux 2, Seedream 5, Seedance 2, Kling, Veo 3.1, WAN, LTX, Runway, Hailuo, PixVerse, ElevenLabs Music, and the Magnific upscalers. It is the broadest single-key surface in this table — the natural alternative to Higgsfield when you want stills, clips, upscaling, and audio behind one credential.
+
+**Tools unlocked:** `magnific_image`, `magnific_video`, `magnific_upscale`, `magnific_music`, `magnific_sound_effects`, `magnific_audio_isolation`
+**Env var:** `MAGNIFIC_API_KEY` (optional: `MAGNIFIC_WEBHOOK_URL`)
+
+#### Setup
+
+1. Sign in at [magnific.com](https://www.magnific.com/)
+2. Subscribe to a paid plan. Third-party guides claim API keys need Business tier; verified working on **Pro** as of 2026-09-04, so check your own org's API Keys page rather than assuming
+3. Open the user menu → organization **Settings** → **API Keys**
+4. Create a key. **The key and secret are shown only once** — copy them before closing
+5. Add to `.env`:
+   ```
+   MAGNIFIC_API_KEY=your-api-key
+   ```
+
+#### No API key? Use the MCP server instead
+
+Magnific also runs an official MCP server that authenticates with OAuth against
+an ordinary magnific.com account — no API key to manage or rotate — and it draws
+on the same credit balance as the web app and the REST API:
+
+```bash
+claude mcp add --transport http magnific https://mcp.magnific.com
+```
+
+That path exposes Magnific's own tool surface directly to the agent
+(`images_generate`, `images_upscale`, `video_generate`, `audio_tts`,
+`models3d_generate`, `custom_references_create` for Soul character training, plus
+creation history). It does **not** register OpenMontage tools, so it sits outside
+the pipeline system and its cost does not flow through the cost tracker. Use the
+REST tools above for anything a pipeline drives; use MCP for ad-hoc chat work.
+
+#### Models
+
+| Capability | Tool | Notable models |
+|------------|------|----------------|
+| Image | `magnific_image` | Mystic (realism / fluid / zen / flexible / super_real / editorial_portraits), Flux 2 Pro/Turbo, Seedream 5 Pro/Lite, Nano Banana Pro, Z-Image, Hyperflux |
+| Video | `magnific_video` | Seedance 2.0 Pro (480p–4K, default), Seedance 2.5 Pro, Kling v3, Veo 3.1, WAN 2.7, LTX 2 Pro, Hailuo 2.3, Runway 4.5, PixVerse V6 |
+| Upscale | `magnific_upscale` | Creative (prompt-guided, up to 16x) and Precision (faithful) |
+| Audio | `magnific_music`, `magnific_sound_effects`, `magnific_audio_isolation` | ElevenLabs Music (10–240s), SFX (0.5–22s), SAM Audio isolation |
+
+#### Pricing
+
+Magnific bills **credits**, not per-call USD, and publishes no per-endpoint rate.
+The `estimate_cost` values in these tools are order-of-magnitude planning figures
+for budget gates — reconcile real spend against the Analytics API
+(`POST /v1/analytics/team-credit-usage`).
+
+> **Note:** an "Unlimited" allowance on a Magnific subscription covers the web app
+> only. API calls always draw on the credit balance.
+
+**Free tier:** None for the API — it always draws on the credit balance.
+
+---
+
 ### HeyGen — Avatar Video Gateway
 
 > **Multi-model video gateway.** Access VEO, Sora, Runway, Kling, and Seedance through a single API.
@@ -1428,6 +1486,7 @@ These tools require only FFmpeg or Python packages — no GPU, no API key.
 | **xAI** | `XAI_API_KEY` | `grok_image`, `grok_video` | Paid only |
 | **Runway** | `RUNWAY_API_KEY` | `runway_video` | Free trial + paid |
 | **Higgsfield** | `HIGGSFIELD_API_KEY` + `HIGGSFIELD_API_SECRET` | `higgsfield_video` | Subscription ($15-84/mo) |
+| **Magnific** | `MAGNIFIC_API_KEY` | `magnific_image`, `magnific_video`, `magnific_upscale`, `magnific_music`, `magnific_sound_effects`, `magnific_audio_isolation` | Credits (verified on Pro); OAuth MCP server needs no key |
 | **HeyGen** | `HEYGEN_API_KEY` | `heygen_video` | Pay-as-you-go |
 | **Suno** | `SUNO_API_KEY` | `suno_music` | Pay-as-you-go |
 | **Tencent Hunyuan** | `TENCENT_TOKENHUB_API_KEY` | `hunyuan_cloud_video` | Pay-as-you-go (~$0.25–0.83/gen) |

--- a/tests/tools/test_magnific_tools.py
+++ b/tests/tools/test_magnific_tools.py
@@ -270,12 +270,12 @@ def test_poll_reports_a_failed_task(monkeypatch):
         mag.poll("/v1/ai/x", "t1")
 
 
-def test_webhook_url_prefers_the_explicit_input(monkeypatch):
-    monkeypatch.setenv("MAGNIFIC_WEBHOOK_URL", "https://env.example/hook")
-    assert mag.webhook_url({"webhook_url": "https://call.example/hook"}) == "https://call.example/hook"
-    assert mag.webhook_url({}) == "https://env.example/hook"
-    monkeypatch.delenv("MAGNIFIC_WEBHOOK_URL")
-    assert mag.webhook_url({}) is None
+def test_webhook_is_opt_in_per_call_only():
+    # There is no ambient webhook env var: an env-wide default would make every
+    # generation POST to a URL nothing in this repo listens on, and the tools
+    # block on polling regardless.
+    assert not hasattr(mag, "webhook_url")
+    assert "MAGNIFIC_WEBHOOK" not in Path(".env.example").read_text()
 
 
 @pytest.mark.parametrize("tool_cls", ALL_TOOLS)

--- a/tests/tools/test_magnific_tools.py
+++ b/tests/tools/test_magnific_tools.py
@@ -376,3 +376,101 @@ def test_video_always_sends_a_reproducible_seed():
     for inputs in ({}, {"seed": -1}):
         seed = tool._seed(inputs)
         assert isinstance(seed, int) and 0 <= seed <= 4294967295
+
+
+# --- Registry + selector routing (docs/PR_REVIEW_GUIDE.md "New Provider or Tool"
+#     minimum coverage: registry discovery, status behavior, selector routing).
+
+@pytest.mark.parametrize("tool_cls", ALL_TOOLS)
+def test_registry_discovers_every_magnific_tool(tool_cls):
+    from tools.tool_registry import registry
+
+    registry.ensure_discovered()
+    assert registry.get(tool_cls.name) is not None, f"{tool_cls.name} is not discoverable"
+
+
+def test_registry_does_not_register_the_abstract_base():
+    from tools.tool_registry import registry
+
+    registry.ensure_discovered()
+    registered = [n for n in registry.list_all() if "magnific" in n]
+    assert len(registered) == len(ALL_TOOLS)
+    assert not any(n.lower() == "magnifictool" for n in registry.list_all())
+
+
+@pytest.mark.parametrize(
+    "capability, tool_name",
+    [
+        ("video_generation", "magnific_video"),
+        ("image_generation", "magnific_image"),
+        ("music_generation", "magnific_music"),
+        ("image_upscale", "magnific_upscale"),
+    ],
+)
+def test_selectors_can_route_to_magnific(capability, tool_name):
+    # Selectors auto-discover by capability (video_selector.py:252), so a wrong
+    # capability string would silently make the tool unroutable.
+    from tools.tool_registry import registry
+
+    registry.ensure_discovered()
+    found = registry.get_by_capability(capability)
+    names = [getattr(t, "name", t) for t in found]
+    assert tool_name in names, f"{tool_name} not reachable via capability {capability!r}"
+
+
+@pytest.mark.parametrize(
+    "ratio, expected",
+    [
+        ("16:9", "widescreen_16_9"),
+        ("9:16", "social_story_9_16"),
+        ("1:1", "square_1_1"),
+        ("16x9", "widescreen_16_9"),
+        ("widescreen_16_9", "widescreen_16_9"),
+    ],
+)
+def test_selector_style_aspect_ratio_hints_are_normalized(ratio, expected):
+    # image_selector declares aspect_ratio as a free-form string hint, so a
+    # routed call arrives as "16:9" rather than Magnific's own name.
+    assert mag.normalize_ratio(ratio, magnific_image._ASPECT_RATIOS) == expected
+    assert mag.normalize_ratio(ratio, magnific_video._ASPECT_RATIOS) == expected
+
+
+def test_unknown_aspect_ratio_is_left_alone_for_the_api_to_reject():
+    # Guessing would be worse than a clear API error: 21:9 genuinely has no
+    # image equivalent in Magnific's vocabulary.
+    assert mag.normalize_ratio("7:3", magnific_image._ASPECT_RATIOS) == "7:3"
+    assert mag.normalize_ratio("21:9", magnific_image._ASPECT_RATIOS) == "21:9"
+    assert mag.normalize_ratio("21:9", magnific_video._ASPECT_RATIOS) == "film_horizontal_21_9"
+
+
+@pytest.mark.parametrize("tool_cls", ALL_TOOLS)
+def test_status_tracks_the_credential(monkeypatch, tool_cls):
+    monkeypatch.setenv(mag.ENV_KEY, "k")
+    assert tool_cls().get_status().value == "available"
+    monkeypatch.delenv(mag.ENV_KEY)
+    assert tool_cls().get_status().value == "unavailable"
+
+
+@pytest.mark.parametrize("tool_cls", ALL_TOOLS)
+def test_install_instructions_name_the_env_var(tool_cls):
+    # The provider menu shows this text when the tool is unavailable.
+    assert mag.ENV_KEY in tool_cls().install_instructions
+
+
+def test_no_heavyweight_imports_at_module_import_time():
+    # The registry imports every tool module to build its catalog, so a module
+    # -level `import requests` would put network-stack import cost in discovery.
+    import ast
+
+    for path in (
+        "tools/_magnific.py",
+        "tools/video/magnific_video.py",
+        "tools/graphics/magnific_image.py",
+        "tools/audio/magnific_audio.py",
+        "tools/enhancement/magnific_upscale.py",
+    ):
+        tree = ast.parse(Path(path).read_text())
+        top_level = [n for n in tree.body if isinstance(n, (ast.Import, ast.ImportFrom))]
+        names = {a.name.split(".")[0] for n in top_level if isinstance(n, ast.Import) for a in n.names}
+        names |= {n.module.split(".")[0] for n in top_level if isinstance(n, ast.ImportFrom) and n.module}
+        assert "requests" not in names, f"{path} imports requests at module level"

--- a/tests/tools/test_magnific_tools.py
+++ b/tests/tools/test_magnific_tools.py
@@ -1,0 +1,378 @@
+"""Offline checks for the Magnific tool family.
+
+Everything here runs without a network call or an API key: endpoint-table
+consistency, input normalization, the poll loop's timing contract, and the
+guards that reject a request before it costs credits.
+
+Schema-default agreement is covered for magnific_video/magnific_image by the
+shared regression suite in `test_provider_model_defaults.py`.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import tools._magnific as mag
+import tools.graphics.magnific_image as magnific_image
+import tools.video.magnific_video as magnific_video
+from tools.audio.magnific_audio import (
+    MagnificAudioIsolation,
+    MagnificMusic,
+    MagnificSoundEffects,
+)
+from tools.enhancement.magnific_upscale import MagnificUpscale
+from tools.graphics.magnific_image import MagnificImage
+from tools.video.magnific_video import MagnificVideo
+
+ALL_TOOLS = [
+    MagnificUpscale,
+    MagnificVideo,
+    MagnificImage,
+    MagnificMusic,
+    MagnificSoundEffects,
+    MagnificAudioIsolation,
+]
+
+
+@pytest.mark.parametrize("tool_cls", ALL_TOOLS)
+def test_required_inputs_are_declared_properties(tool_cls):
+    schema = tool_cls().input_schema
+    props = schema.get("properties", {})
+    for field in schema.get("required", []):
+        assert field in props, f"{tool_cls.name}: required field {field!r} has no schema entry"
+
+
+@pytest.mark.parametrize("tool_cls", ALL_TOOLS)
+def test_output_path_default_is_declared(tool_cls):
+    # MagnificTool.default_output() reads this at runtime, so a missing default
+    # would only surface as a KeyError mid-generation, after credits were spent.
+    assert tool_cls().default_output()
+
+
+@pytest.mark.parametrize(
+    "module, tool_cls",
+    [(magnific_video, MagnificVideo), (magnific_image, MagnificImage)],
+)
+def test_model_enum_matches_the_model_table(module, tool_cls):
+    # execute() resolves endpoints through _MODELS; an enum entry with no table
+    # row would fail only at call time.
+    assert set(tool_cls().input_schema["properties"]["model"]["enum"]) == set(module._MODELS)
+
+
+def test_video_model_table_entries_are_complete():
+    for name, spec in magnific_video._MODELS.items():
+        endpoints = [spec.endpoint("text_to_video"), spec.endpoint("image_to_video")]
+        assert any(endpoints), f"{name} supports neither operation"
+        for endpoint in filter(None, endpoints):
+            assert endpoint.startswith("/v1/ai/"), f"{name} endpoint is not an API path"
+        if spec.status is not None:
+            assert spec.status.startswith("/v1/ai/")
+        assert spec.cost > 0 and spec.runtime > 0
+
+
+def test_image_model_table_entries_are_complete():
+    for name, spec in magnific_image._MODELS.items():
+        assert spec.path.startswith("/v1/ai/"), f"{name} path is not an API path"
+        assert spec.cost > 0 and spec.runtime > 0
+
+
+def test_video_rejects_an_operation_the_model_cannot_do():
+    tool = MagnificVideo()
+    # pixverse_v6 is text-to-video only in the endpoint catalog.
+    with pytest.raises(ValueError, match="does not support"):
+        tool._resolve({"prompt": "x", "model": "pixverse_v6", "operation": "image_to_video"})
+    # hailuo is image-to-video only.
+    with pytest.raises(ValueError, match="does not support"):
+        tool._resolve({"prompt": "x", "model": "minimax_hailuo_2_3_1080p"})
+
+
+def test_video_infers_operation_and_endpoint():
+    tool = MagnificVideo()
+    _, _, op, endpoint = tool._resolve({"prompt": "x"})
+    assert op == "text_to_video"
+    assert endpoint == "/v1/ai/video/seedance-2-pro-1080p"
+
+    _, spec, op, endpoint = tool._resolve({"prompt": "x", "image": "https://example.com/a.png"})
+    assert op == "image_to_video"
+    # Seedance serves both operations from one endpoint but polls a shared path.
+    assert spec.status_for(endpoint) == "/v1/ai/video/seedance-2-pro"
+
+    _, _, _, endpoint = tool._resolve({"prompt": "x", "model": "veo_3_1", "image": "https://e.com/a.png"})
+    assert endpoint == "/v1/ai/image-to-video/veo-3-1"
+
+
+def test_video_cost_and_runtime_scale_with_duration():
+    tool = MagnificVideo()
+    base = tool.estimate_cost({"model": "seedance_2_pro_1080p", "duration": 5})
+    assert tool.estimate_cost({"model": "seedance_2_pro_1080p", "duration": 10}) == pytest.approx(base * 2)
+    assert tool.estimate_runtime({"model": "seedance_2_pro_1080p", "duration": 10}) > tool.estimate_runtime({})
+
+
+def test_image_4k_costs_more_only_for_mystic():
+    tool = MagnificImage()
+    assert tool.estimate_cost({"resolution": "4k"}) > tool.estimate_cost({"resolution": "2k"})
+    # `resolution` is a Mystic-only body field. Scaling other models by it quoted
+    # — and reserved budget for — 2x a request that never changed.
+    flux = {"model": "flux_2_turbo"}
+    assert tool.estimate_cost({**flux, "resolution": "4k"}) == tool.estimate_cost(flux)
+    assert tool.estimate_runtime({**flux, "resolution": "4k"}) == tool.estimate_runtime(flux)
+
+
+def test_image_rejects_references_the_model_would_ignore():
+    # Silently dropping the reference still costs credits, so fail before paying.
+    result = MagnificImage().execute(
+        {"prompt": "x", "model": "flux_2_turbo", "style_reference": "https://e.com/a.png"}
+    )
+    assert result.success is False
+    assert "style_reference" in result.error and "mystic" in result.error
+
+
+def test_isolation_requires_exactly_one_media_input():
+    tool = MagnificAudioIsolation()
+    both = tool.execute({"description": "speech", "audio": "a.wav", "video": "v.mp4"})
+    neither = tool.execute({"description": "speech"})
+    for result in (both, neither):
+        assert result.success is False
+        assert "exactly one" in result.error
+
+
+def test_isolation_refuses_to_inline_an_oversized_local_file(tmp_path):
+    big = tmp_path / "big.wav"
+    big.write_bytes(b"\0" * (mag.MAX_INLINE_BYTES + 1))
+    result = MagnificAudioIsolation().execute({"description": "speech", "audio": str(big)})
+    assert result.success is False
+    assert "too large" in result.error
+
+
+def test_as_input_passes_urls_through_and_encodes_files(tmp_path):
+    import base64
+
+    url = "https://example.com/a.png"
+    assert mag.as_input(url) == url, "a URL must not be re-encoded — the docs warn it loses quality"
+
+    f = tmp_path / "a.png"
+    f.write_bytes(b"binary-bytes")
+    assert base64.b64decode(mag.as_input(str(f))) == b"binary-bytes"
+
+    assert mag.as_input("data:image/png;base64,QUJD") == "QUJD"
+
+
+def test_as_input_size_guard_applies_to_every_local_file(tmp_path):
+    # The guard lives in the shared client so all six tools inherit it, not just
+    # audio isolation (upscale sources and video reference frames are large too).
+    big = tmp_path / "big.png"
+    big.write_bytes(b"\0" * 11)
+    with pytest.raises(ValueError, match="too large"):
+        mag.as_input(str(big), max_bytes=10)
+
+
+@pytest.mark.parametrize(
+    "content_type, expected",
+    [("image/jpeg", ".jpg"), ("image/png", ".png"), ("video/mp4", ".mp4"), ("", ".bin")],
+)
+def test_suffix_for_content_type(content_type, expected):
+    got = mag.suffix_for(content_type)
+    # mimetypes may map image/jpeg to .jpg or .jpe depending on the platform.
+    assert got == expected or (expected == ".jpg" and got in {".jpg", ".jpeg", ".jpe"})
+
+
+def test_download_honors_a_caller_supplied_suffix(tmp_path, monkeypatch):
+    # House convention (_kling/media.py:output_path_with_suffix, seedream_image,
+    # openai_image): a suffix the caller chose is authoritative. Only fill one in
+    # when it is missing. The true served type comes back separately.
+    monkeypatch.setattr(
+        mag,
+        "asset_session",
+        lambda: SimpleNamespace(
+            get=lambda url, timeout=None: SimpleNamespace(
+                headers={"Content-Type": "image/jpeg"},
+                content=b"jpeg-bytes",
+                raise_for_status=lambda: None,
+            )
+        ),
+    )
+    kept = mag.download("https://e.com/x", tmp_path / "out.png")
+    assert kept.path.name == "out.png", "caller's extension must survive"
+    assert kept.content_type == "image/jpeg", "the real format is still reported"
+
+    derived = mag.download("https://e.com/x", tmp_path / "out")
+    assert derived.path.suffix in {".jpg", ".jpeg", ".jpe"}
+
+
+def test_submit_drops_none_so_server_defaults_survive(monkeypatch):
+    sent = {}
+
+    def fake_post(url, json=None, timeout=None):
+        sent.update(json)
+        return SimpleNamespace(status_code=200, json=lambda: {"data": {"task_id": "t1"}}, text="")
+
+    monkeypatch.setenv(mag.ENV_KEY, "k")
+    monkeypatch.setattr(mag, "session", lambda: SimpleNamespace(post=fake_post))
+    mag.submit("/v1/ai/x", {"a": None, "b": 0, "c": False, "d": ""})
+    assert sent == {"b": 0, "c": False, "d": ""}
+
+
+def test_poll_checks_before_sleeping(monkeypatch):
+    # Sleeping first charged every call a flat 5s floor — a 6s generation spent
+    # ~78% of its wall-clock waiting to be looked at. Matches atlas_client.py:146
+    # and _shared.py:494, which both GET before sleeping.
+    order = []
+    monkeypatch.setattr(mag.time, "sleep", lambda s: order.append(("sleep", s)))
+
+    def fake_get(url, timeout=None):
+        order.append(("get", None))
+        return SimpleNamespace(
+            status_code=200,
+            json=lambda: {"data": {"status": "COMPLETED", "generated": ["u"]}},
+            text="",
+        )
+
+    monkeypatch.setattr(mag, "session", lambda: SimpleNamespace(get=fake_get))
+    assert mag.poll("/v1/ai/x", "t1") == ["u"]
+    assert order == [("get", None)], "a task that is already done must not sleep at all"
+
+
+def test_poll_backs_off_up_to_the_cap(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr(mag.time, "sleep", sleeps.append)
+    statuses = iter(["IN_PROGRESS"] * 6 + ["COMPLETED"])
+
+    def fake_get(url, timeout=None):
+        status = next(statuses)
+        return SimpleNamespace(
+            status_code=200,
+            json=lambda: {"data": {"status": status, "generated": ["u"] if status == "COMPLETED" else []}},
+            text="",
+        )
+
+    monkeypatch.setattr(mag, "session", lambda: SimpleNamespace(get=fake_get))
+    mag.poll("/v1/ai/x", "t1", max_wait=600)
+    assert sleeps[0] == mag._POLL_START, "first wait is short so fast tasks return fast"
+    assert sleeps == sorted(sleeps), "interval must ramp, never shrink"
+    assert max(sleeps) <= mag._POLL_CAP
+
+
+def test_poll_reports_a_failed_task(monkeypatch):
+    monkeypatch.setattr(mag.time, "sleep", lambda s: None)
+    monkeypatch.setattr(
+        mag,
+        "session",
+        lambda: SimpleNamespace(
+            get=lambda url, timeout=None: SimpleNamespace(
+                status_code=200,
+                json=lambda: {"data": {"status": "FAILED", "error": "nsfw"}},
+                text="",
+            )
+        ),
+    )
+    with pytest.raises(mag.MagnificError, match="nsfw"):
+        mag.poll("/v1/ai/x", "t1")
+
+
+def test_webhook_url_prefers_the_explicit_input(monkeypatch):
+    monkeypatch.setenv("MAGNIFIC_WEBHOOK_URL", "https://env.example/hook")
+    assert mag.webhook_url({"webhook_url": "https://call.example/hook"}) == "https://call.example/hook"
+    assert mag.webhook_url({}) == "https://env.example/hook"
+    monkeypatch.delenv("MAGNIFIC_WEBHOOK_URL")
+    assert mag.webhook_url({}) is None
+
+
+@pytest.mark.parametrize("tool_cls", ALL_TOOLS)
+def test_tools_fail_closed_without_a_key(monkeypatch, tool_cls):
+    monkeypatch.delenv(mag.ENV_KEY, raising=False)
+    tool = tool_cls()
+    assert tool.get_status().value == "unavailable"
+    # A missing key must be reported, never turned into a live request.
+    minimal = {
+        "prompt": "x", "image": "https://example.com/a.png", "text": "x",
+        "description": "x", "audio": "https://example.com/a.wav", "duration_seconds": 5,
+    }
+    result = tool.execute(minimal)
+    assert result.success is False
+    assert mag.ENV_KEY in result.error
+
+
+
+def test_asset_downloads_carry_no_credentials(monkeypatch):
+    # The API key must never leave api.magnific.com. Generated assets live on a
+    # separate CDN host, and requests only strips `Authorization` across a
+    # cross-host redirect — a custom auth header would follow it and leak.
+    monkeypatch.setenv(mag.ENV_KEY, "secret-key")
+    mag._API_SESSION = None
+    mag._ASSET_SESSION = None
+    assert "x-magnific-api-key" in mag.session().headers
+    assert "x-magnific-api-key" not in mag.asset_session().headers
+    assert mag.session() is not mag.asset_session()
+
+
+def test_poll_survives_transient_errors(monkeypatch):
+    # The generation is already paid for; one reset connection must not bin it.
+    monkeypatch.setattr(mag.time, "sleep", lambda s: None)
+    attempts = {"n": 0}
+
+    def flaky_get(url, timeout=None):
+        attempts["n"] += 1
+        if attempts["n"] <= 3:
+            raise OSError("connection reset")
+        return SimpleNamespace(
+            status_code=200,
+            json=lambda: {"data": {"status": "COMPLETED", "generated": ["u"]}},
+            text="",
+        )
+
+    monkeypatch.setattr(mag, "session", lambda: SimpleNamespace(get=flaky_get))
+    assert mag.poll("/v1/ai/x", "t1", max_wait=600) == ["u"]
+
+
+def test_poll_gives_up_after_repeated_errors(monkeypatch):
+    monkeypatch.setattr(mag.time, "sleep", lambda s: None)
+
+    def always_fails(url, timeout=None):
+        raise OSError("connection reset")
+
+    monkeypatch.setattr(mag, "session", lambda: SimpleNamespace(get=always_fails))
+    with pytest.raises(mag.MagnificError, match="may still be running"):
+        mag.poll("/v1/ai/x", "t1", max_wait=600)
+
+
+def test_poll_does_not_retry_a_4xx(monkeypatch):
+    # A 400/404 will never become a 200; retrying it just burns the deadline.
+    monkeypatch.setattr(mag.time, "sleep", lambda s: None)
+    calls = {"n": 0}
+
+    def not_found(url, timeout=None):
+        calls["n"] += 1
+        return SimpleNamespace(status_code=404, text="nope", json=lambda: {})
+
+    monkeypatch.setattr(mag, "session", lambda: SimpleNamespace(get=not_found))
+    with pytest.raises(mag.MagnificError, match="404"):
+        mag.poll("/v1/ai/x", "t1", max_wait=600)
+    assert calls["n"] == 1
+
+
+def test_as_input_rejects_a_missing_file_instead_of_posting_it(tmp_path):
+    # Previously a typo'd path was POSTed verbatim as base64 and came back as an
+    # opaque HTTP 400 after the request was already made.
+    with pytest.raises(ValueError, match="File not found"):
+        mag.as_input(str(tmp_path / "nope.png"))
+    with pytest.raises(ValueError, match="File not found"):
+        mag.as_input("projects/foo/frame_01.png")
+    # A genuine base64 blob has no path shape and must still pass through.
+    assert mag.as_input("aVZCT1J3MEtHZ28=") == "aVZCT1J3MEtHZ28="
+
+
+def test_as_input_rejects_a_malformed_data_uri():
+    with pytest.raises(ValueError, match="Malformed data"):
+        mag.as_input("data:image/png;base64")
+
+
+def test_video_always_sends_a_reproducible_seed():
+    tool = MagnificVideo()
+    # An explicit seed is honored.
+    assert tool._seed({"seed": 42}) == 42
+    # -1 and omitted both draw a concrete seed rather than letting the server
+    # pick one the caller can never recover.
+    for inputs in ({}, {"seed": -1}):
+        seed = tool._seed(inputs)
+        assert isinstance(seed, int) and 0 <= seed <= 4294967295

--- a/tests/tools/test_provider_model_defaults.py
+++ b/tests/tools/test_provider_model_defaults.py
@@ -10,15 +10,24 @@ than the schema promised — a Decision-Communication / cost-accuracy violation.
 
 import pytest
 
+import tools.graphics.magnific_image as magnific_image
 import tools.video.higgsfield_video as higgsfield_video
+import tools.video.magnific_video as magnific_video
 import tools.video.runway_video as runway_video
+from tools.graphics.magnific_image import MagnificImage
 from tools.video.higgsfield_video import HiggsFieldVideo
+from tools.video.magnific_video import MagnificVideo
 from tools.video.runway_video import RunwayVideo
 
 
 @pytest.mark.parametrize(
     "tool_cls, module",
-    [(RunwayVideo, runway_video), (HiggsFieldVideo, higgsfield_video)],
+    [
+        (RunwayVideo, runway_video),
+        (HiggsFieldVideo, higgsfield_video),
+        (MagnificVideo, magnific_video),
+        (MagnificImage, magnific_image),
+    ],
 )
 def test_default_model_constant_matches_schema(tool_cls, module):
     # `execute()` reads `model` via `_DEFAULT_MODEL`; locking the constant to the
@@ -27,7 +36,9 @@ def test_default_model_constant_matches_schema(tool_cls, module):
     assert module._DEFAULT_MODEL == schema_default
 
 
-@pytest.mark.parametrize("tool_cls", [RunwayVideo, HiggsFieldVideo])
+@pytest.mark.parametrize(
+    "tool_cls", [RunwayVideo, HiggsFieldVideo, MagnificVideo, MagnificImage]
+)
 def test_estimate_default_model_matches_schema(tool_cls):
     tool = tool_cls()
     schema_default = tool.input_schema["properties"]["model"]["default"]

--- a/tools/_magnific.py
+++ b/tools/_magnific.py
@@ -298,11 +298,6 @@ def download(url: str, dest: str | Path, *, timeout: int = 300) -> Downloaded:
     return Downloaded(out, content_type.split(";", 1)[0].strip())
 
 
-def webhook_url(inputs: dict[str, Any]) -> Optional[str]:
-    """Explicit per-call webhook_url wins; otherwise MAGNIFIC_WEBHOOK_URL."""
-    return inputs.get("webhook_url") or os.environ.get("MAGNIFIC_WEBHOOK_URL") or None
-
-
 class MagnificTool(BaseTool):
     """Shared contract for every Magnific-backed tool.
 
@@ -355,7 +350,7 @@ class MagnificTool(BaseTool):
             return self._unconfigured()
 
         start = time.time()
-        payload = {**payload, "webhook_url": webhook_url(inputs)}
+        payload = {**payload, "webhook_url": inputs.get("webhook_url")}
         base = Path(inputs.get("output_path") or self.default_output())
         try:
             urls = run(endpoint, payload, status_path=status_path, max_wait=self._max_wait(inputs))

--- a/tools/_magnific.py
+++ b/tools/_magnific.py
@@ -1,0 +1,377 @@
+"""Shared client and base tool for the Magnific API (https://api.magnific.com).
+
+Every Magnific AI endpoint follows the same async contract:
+
+    POST <path>            -> {"data": {"task_id": ..., "status": "CREATED"}}
+    GET  <status>/<task>   -> {"data": {"task_id": ..., "status": ..., "generated": [url, ...]}}
+
+Status is one of CREATED / IN_PROGRESS / COMPLETED / FAILED. `MagnificTool` owns
+submit + poll + download + ToolResult so the six Magnific tools only describe
+their endpoint and payload.
+
+Auth is a single ``MAGNIFIC_API_KEY`` sent as the ``x-magnific-api-key`` header.
+Docs: https://docs.magnific.com/llms.txt
+"""
+
+from __future__ import annotations
+
+import base64
+import mimetypes
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Any, NamedTuple, Optional
+
+from tools.base_tool import (
+    BaseTool,
+    ExecutionMode,
+    ResourceProfile,
+    RetryPolicy,
+    ToolResult,
+    ToolRuntime,
+    ToolStability,
+    ToolStatus,
+)
+
+API_BASE = "https://api.magnific.com"
+ENV_KEY = "MAGNIFIC_API_KEY"
+
+INSTALL_INSTRUCTIONS = (
+    "Set MAGNIFIC_API_KEY to a Magnific API key.\n"
+    "  Create one at https://www.magnific.com/user/organization/api-keys\n"
+    "  (paid plan required; the key and secret are shown only once.)\n"
+    "  Prefer chat-driven use instead? Magnific also runs an official MCP server\n"
+    "  at https://mcp.magnific.com which signs in with OAuth and needs no key:\n"
+    "    claude mcp add --transport http magnific https://mcp.magnific.com"
+)
+
+TERMINAL_OK = "COMPLETED"
+TERMINAL_FAIL = "FAILED"
+
+# Base64-inlining a large file bloats the JSON body (1.33x encoded, then copied
+# again by json.dumps) and usually times out; a public URL is the documented path.
+MAX_INLINE_BYTES = 20 * 1024 * 1024
+
+# Poll cadence: check immediately, then ramp so a 6-second task is not charged a
+# flat 5-second floor while a 3-minute video keeps the same steady-state cadence.
+_POLL_START = 1.0
+_POLL_FACTOR = 1.5
+_POLL_CAP = 5.0
+_MAX_POLL_ERRORS = 5
+
+
+class MagnificError(RuntimeError):
+    """Raised when the Magnific API rejects a request or a task fails."""
+
+
+class _FatalPoll(Exception):
+    """A 4xx during polling — retrying will not help, so stop immediately."""
+
+
+class Downloaded(NamedTuple):
+    """A saved asset plus the content type the server actually served."""
+
+    path: Path
+    content_type: str
+
+
+def api_key() -> Optional[str]:
+    return os.environ.get(ENV_KEY) or None
+
+
+# Two sessions, deliberately. Both keep connections alive across a generation's
+# dozens of polls, but the API key must never leave api.magnific.com: generated
+# assets live on a separate CDN host, and requests only strips `Authorization`
+# on a cross-host redirect (see SessionRedirectMixin.rebuild_auth) — a custom
+# auth header would follow the redirect and leak. `_ASSET_SESSION` carries no
+# credentials, matching how every other tool here fetches results.
+_API_SESSION: Any = None
+_ASSET_SESSION: Any = None
+_SESSION_LOCK = threading.Lock()
+
+
+def _make_session() -> Any:
+    import requests
+
+    return requests.Session()
+
+
+def session() -> Any:
+    """Authenticated session for api.magnific.com. Never use it for asset URLs."""
+    global _API_SESSION
+    key = api_key()
+    if not key:
+        raise MagnificError(f"{ENV_KEY} not set. {INSTALL_INSTRUCTIONS}")
+    with _SESSION_LOCK:
+        if _API_SESSION is None:
+            _API_SESSION = _make_session()
+        _API_SESSION.headers.update(
+            {"x-magnific-api-key": key, "Content-Type": "application/json"}
+        )
+        return _API_SESSION
+
+
+def asset_session() -> Any:
+    """Credential-free session for downloading generated assets from the CDN."""
+    global _ASSET_SESSION
+    with _SESSION_LOCK:
+        if _ASSET_SESSION is None:
+            _ASSET_SESSION = _make_session()
+        return _ASSET_SESSION
+
+
+_MEDIA_SUFFIXES = {
+    ".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp", ".tif", ".tiff",
+    ".mp4", ".mov", ".webm", ".avi", ".mkv",
+    ".wav", ".mp3", ".flac", ".ogg", ".m4a",
+}
+
+
+def _looks_like_path(value: str) -> bool:
+    """True when a non-existent value was clearly meant to be a file path."""
+    return "/" in value or "\\" in value or Path(value).suffix.lower() in _MEDIA_SUFFIXES
+
+
+def as_input(value: str, *, max_bytes: int = MAX_INLINE_BYTES) -> str:
+    """Normalize an image/audio/video input for a Magnific request body.
+
+    Magnific accepts either a public https URL or a raw (unprefixed) base64
+    string. A URL is passed through untouched — the docs are explicit that a URL
+    preserves more quality than a re-encoded local copy. A local path is read and
+    base64-encoded; a ``data:`` URI is stripped down to its payload.
+
+    Raises ValueError for a local file too large to inline.
+    """
+    if value.startswith(("http://", "https://")):
+        return value
+    if value.startswith("data:"):
+        head, comma, payload = value.partition(",")
+        if not comma:
+            raise ValueError(f"Malformed data: URI (no comma): {head[:60]}")
+        return payload
+    path = Path(value)
+    if path.is_file():
+        size = path.stat().st_size
+        if size > max_bytes:
+            raise ValueError(
+                f"{path.name} is {size / 1e6:.1f} MB — too large to base64-inline. "
+                "Upload it and pass a public https URL instead."
+            )
+        return base64.b64encode(path.read_bytes()).decode("ascii")
+    if _looks_like_path(value):
+        # Fail here rather than POSTing the literal string and getting back an
+        # opaque HTTP 400 from the API.
+        raise ValueError(f"File not found: {value}")
+    # Already-encoded base64 handed in directly.
+    return value
+
+
+def submit(path: str, payload: dict[str, Any], *, timeout: int = 60) -> str:
+    """POST a generation request and return its task_id.
+
+    None values are dropped here so every caller keeps the server-side defaults
+    without having to remember a prune step.
+    """
+    body = {k: v for k, v in payload.items() if v is not None}
+    resp = session().post(f"{API_BASE}{path}", json=body, timeout=timeout)
+    if resp.status_code >= 400:
+        raise MagnificError(f"POST {path} -> HTTP {resp.status_code}: {resp.text[:400]}")
+    data = (resp.json() or {}).get("data") or {}
+    task_id = data.get("task_id")
+    if not task_id:
+        raise MagnificError(f"POST {path} returned no task_id: {resp.text[:400]}")
+    return task_id
+
+
+def poll(status_path: str, task_id: str, *, max_wait: float = 900.0) -> list[str]:
+    """Poll a task to completion and return its generated asset URLs.
+
+    The generation is already paid for by the time polling starts, so a blip —
+    a reset connection, a 5xx from the edge, a truncated body — must not throw
+    the task away. Transient failures are tolerated until `_MAX_POLL_ERRORS` of
+    them happen back to back, matching `atlas_client.poll`.
+    """
+    deadline = time.monotonic() + max_wait
+    url = f"{API_BASE}{status_path}/{task_id}"
+    interval = _POLL_START
+    last_status = "UNKNOWN"
+    errors = 0
+    while True:
+        try:
+            resp = session().get(url, timeout=30)
+            if resp.status_code >= 500:
+                raise MagnificError(f"HTTP {resp.status_code}: {resp.text[:200]}")
+            if resp.status_code >= 400:
+                raise _FatalPoll(
+                    f"GET {status_path}/{task_id} -> HTTP {resp.status_code}: {resp.text[:400]}"
+                )
+            data = (resp.json() or {}).get("data") or {}
+        except _FatalPoll as exc:
+            raise MagnificError(str(exc)) from None
+        except Exception as exc:  # noqa: BLE001 — transient until proven otherwise
+            errors += 1
+            if errors >= _MAX_POLL_ERRORS:
+                raise MagnificError(
+                    f"Task {task_id} polling failed {errors}x in a row; "
+                    f"the task may still be running. Last error: {exc}"
+                ) from exc
+            time.sleep(interval)
+            interval = min(interval * _POLL_FACTOR, _POLL_CAP)
+            continue
+        errors = 0
+        last_status = data.get("status", "UNKNOWN")
+        if last_status == TERMINAL_OK:
+            generated = data.get("generated") or []
+            if not generated:
+                raise MagnificError(f"Task {task_id} completed but returned no assets.")
+            return list(generated)
+        if last_status == TERMINAL_FAIL:
+            raise MagnificError(f"Task {task_id} failed: {data.get('error') or resp.text[:300]}")
+        if time.monotonic() + interval >= deadline:
+            raise MagnificError(
+                f"Task {task_id} timed out after {max_wait:.0f}s (last status: {last_status})."
+            )
+        time.sleep(interval)
+        interval = min(interval * _POLL_FACTOR, _POLL_CAP)
+
+
+def run(
+    path: str,
+    payload: dict[str, Any],
+    *,
+    status_path: Optional[str] = None,
+    max_wait: float = 900.0,
+) -> list[str]:
+    """Submit a task and block until it produces assets.
+
+    ``status_path`` defaults to ``path``; pass it explicitly for the endpoints
+    whose GET differs from their POST (e.g. Seedance posts to
+    ``/v1/ai/video/seedance-2-pro-720p`` but polls ``/v1/ai/video/seedance-2-pro``).
+    """
+    return poll(status_path or path, submit(path, payload), max_wait=max_wait)
+
+
+def suffix_for(content_type: str, default: str = ".bin") -> str:
+    """Map a Content-Type to a file suffix, matching _kling/media.py's approach."""
+    if not content_type:
+        return default
+    return mimetypes.guess_extension(content_type.split(";", 1)[0].strip()) or default
+
+
+def download(url: str, dest: str | Path, *, timeout: int = 300) -> Downloaded:
+    """Download a generated asset. Magnific URLs expire ~24h after creation.
+
+    A caller-supplied suffix is authoritative and left alone, matching the rest of
+    the repo (`_kling/media.py:output_path_with_suffix`, `seedream_image`,
+    `openai_image`). A suffix is only derived when the destination has none. The
+    served content type is returned alongside so callers can report the real
+    format even when it differs from the extension they chose.
+    """
+    resp = asset_session().get(url, timeout=timeout)
+    resp.raise_for_status()
+    content_type = resp.headers.get("Content-Type", "")
+    out = Path(dest)
+    if not out.suffix:
+        out = out.with_suffix(suffix_for(content_type))
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_bytes(resp.content)
+    return Downloaded(out, content_type.split(";", 1)[0].strip())
+
+
+def webhook_url(inputs: dict[str, Any]) -> Optional[str]:
+    """Explicit per-call webhook_url wins; otherwise MAGNIFIC_WEBHOOK_URL."""
+    return inputs.get("webhook_url") or os.environ.get("MAGNIFIC_WEBHOOK_URL") or None
+
+
+class MagnificTool(BaseTool):
+    """Shared contract for every Magnific-backed tool.
+
+    Abstract (no ``execute``), so ToolRegistry skips it during discovery.
+    """
+
+    provider = "magnific"
+    stability = ToolStability.EXPERIMENTAL
+    execution_mode = ExecutionMode.ASYNC
+    runtime = ToolRuntime.API
+
+    dependencies = ["env:MAGNIFIC_API_KEY", "python:requests"]
+    install_instructions = INSTALL_INSTRUCTIONS
+
+    resource_profile = ResourceProfile(cpu_cores=1, ram_mb=256, disk_mb=200, network_required=True)
+    retry_policy = RetryPolicy(max_retries=2, backoff_seconds=3.0, retryable_errors=["rate_limit", "timeout"])
+
+    def get_status(self) -> ToolStatus:
+        return ToolStatus.AVAILABLE if api_key() else ToolStatus.UNAVAILABLE
+
+    def default_output(self) -> str:
+        """The schema's advertised output_path, so code and schema cannot drift."""
+        return self.input_schema["properties"]["output_path"]["default"]
+
+    def _unconfigured(self) -> ToolResult:
+        return ToolResult(success=False, error=f"Magnific not configured. {INSTALL_INSTRUCTIONS}")
+
+    def _max_wait(self, inputs: dict[str, Any]) -> float:
+        """Generous ceiling around the tool's own runtime estimate."""
+        return self.estimate_runtime(inputs) * 8 + 120
+
+    def _generate(
+        self,
+        inputs: dict[str, Any],
+        endpoint: str,
+        payload: dict[str, Any],
+        *,
+        model: str,
+        status_path: Optional[str] = None,
+        data_extra: Optional[dict[str, Any]] = None,
+        saves: Optional[int] = 1,
+    ) -> ToolResult:
+        """Submit, poll, download, and build the standard ToolResult.
+
+        ``saves`` caps how many returned assets are written; None writes all of
+        them. Extras go alongside the first with a -2, -3 suffix. Returns a
+        failed ToolResult rather than raising.
+        """
+        if not api_key():
+            return self._unconfigured()
+
+        start = time.time()
+        payload = {**payload, "webhook_url": webhook_url(inputs)}
+        base = Path(inputs.get("output_path") or self.default_output())
+        try:
+            urls = run(endpoint, payload, status_path=status_path, max_wait=self._max_wait(inputs))
+            saved = self._save(urls if saves is None else urls[:saves], base)
+        except Exception as e:
+            return ToolResult(success=False, error=f"{self.name} failed: {e}")
+
+        return ToolResult(
+            success=True,
+            data={
+                "provider": "magnific",
+                "model": model,
+                "source_urls": urls,
+                "source_url": urls[0],
+                "format": saved[0].content_type,
+                "output": str(saved[0].path),
+                "output_path": str(saved[0].path),
+                "output_paths": [str(d.path) for d in saved],
+                **(data_extra or {}),
+            },
+            artifacts=[str(d.path) for d in saved],
+            cost_usd=self.estimate_cost(inputs),
+            duration_seconds=round(time.time() - start, 2),
+            model=model,
+        )
+
+    @staticmethod
+    def _save(urls: list[str], base: Path) -> list[Downloaded]:
+        """Download assets to base (and base-2, base-3, …), in parallel past one."""
+        def dest(i: int) -> Path:
+            return base if i == 0 else base.with_name(f"{base.stem}-{i + 1}{base.suffix}")
+
+        if len(urls) == 1:
+            return [download(urls[0], dest(0))]
+        from concurrent.futures import ThreadPoolExecutor
+
+        with ThreadPoolExecutor(max_workers=min(len(urls), 8)) as pool:
+            return list(pool.map(lambda iu: download(iu[1], dest(iu[0])), enumerate(urls)))

--- a/tools/_magnific.py
+++ b/tools/_magnific.py
@@ -167,6 +167,25 @@ def as_input(value: str, *, max_bytes: int = MAX_INLINE_BYTES) -> str:
     return value
 
 
+def normalize_ratio(value: Optional[str], allowed: list[str]) -> Optional[str]:
+    """Accept a plain "16:9"/"16x9" ratio and resolve it to Magnific's own name.
+
+    The selectors pass `aspect_ratio` as a free-form hint (image_selector.py
+    declares it as an untyped string), so a caller routed through one would
+    otherwise send "16:9" and get an HTTP 400. Magnific's names all end in
+    `_<w>_<h>`, so the mapping is derived from the enum rather than duplicated
+    in a table that could drift from it.
+    """
+    if not value or value in allowed:
+        return value
+    normalized = value.strip().lower().replace("x", ":").replace("/", ":")
+    if ":" not in normalized:
+        return value
+    w, _, h = normalized.partition(":")
+    matches = [name for name in allowed if name.endswith(f"_{w.strip()}_{h.strip()}")]
+    return matches[0] if len(matches) == 1 else value
+
+
 def submit(path: str, payload: dict[str, Any], *, timeout: int = 60) -> str:
     """POST a generation request and return its task_id.
 

--- a/tools/audio/magnific_audio.py
+++ b/tools/audio/magnific_audio.py
@@ -1,0 +1,210 @@
+"""Magnific audio APIs: music generation, sound effects, and audio isolation.
+
+Three separate tools so the registry routes each by its own capability. All the
+shared plumbing lives in `MagnificTool`.
+
+  * MagnificMusic          POST /v1/ai/music-generation   (ElevenLabs Music)
+  * MagnificSoundEffects   POST /v1/ai/sound-effects
+  * MagnificAudioIsolation POST /v1/ai/audio-isolation    (SAM Audio)
+
+API: https://docs.magnific.com/api-reference/music-generation/overview
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tools import _magnific as mag
+from tools._magnific import MagnificTool
+from tools.base_tool import Determinism, ToolResult, ToolTier
+
+
+class MagnificMusic(MagnificTool):
+    """Generate an original music track from a text description."""
+
+    name = "magnific_music"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "music_generation"
+    determinism = Determinism.STOCHASTIC
+    agent_skills = ["music", "elevenlabs"]
+
+    capabilities = ["generate_background_music", "generate_instrumental"]
+    supports = {"exact_duration": True, "style_control": True, "instrumental": True}
+    best_for = [
+        "background score cut to an exact runtime (10-240s)",
+        "genre-, mood-, and instrument-directed beds for explainers and trailers",
+    ]
+    not_good_for = ["vocals with specific lyrics", "tracks longer than 4 minutes", "licensed or recognizable music"]
+    fallback_tools = ["fal_elevenlabs_music", "music_gen", "google_music", "pixabay_music"]
+    quality_score = 0.85
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt", "duration_seconds"],
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "maxLength": 2500,
+                "description": "Name the genre, mood, instruments, and tempo — e.g. 'slow melancholic piano with soft strings'.",
+            },
+            "duration_seconds": {"type": "integer", "minimum": 10, "maximum": 240},
+            "output_path": {"type": "string", "default": "magnific_music.mp3"},
+            "webhook_url": {"type": "string"},
+        },
+    }
+    output_schema = {"type": "object", "properties": {"output_path": {"type": "string"}}}
+    idempotency_key_fields = ["prompt", "duration_seconds"]
+    side_effects = ["writes an audio file to output_path", "calls the Magnific API (consumes credits)"]
+    user_visible_verification = ["Listen end to end — check the loop point and that the mood matches the edit"]
+
+    @staticmethod
+    def _seconds(inputs: dict[str, Any]) -> int:
+        return int(inputs.get("duration_seconds", 60) or 60)
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        # Planning estimate; Magnific bills in credits with no published USD rate.
+        return round(0.02 * max(1, self._seconds(inputs) / 30), 4)
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        return 30.0 + self._seconds(inputs) * 0.5
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        return self._generate(
+            inputs,
+            "/v1/ai/music-generation",
+            {"prompt": inputs["prompt"], "music_length_seconds": int(inputs["duration_seconds"])},
+            model="magnific_music",
+        )
+
+
+class MagnificSoundEffects(MagnificTool):
+    """Generate a sound effect from a text description."""
+
+    name = "magnific_sound_effects"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "sound_effects"
+    determinism = Determinism.STOCHASTIC
+    agent_skills = ["sound-effects"]
+
+    capabilities = ["generate_sound_effect", "generate_loopable_ambience"]
+    supports = {"loopable": True, "prompt_influence": True, "short_form_only": True}
+    best_for = [
+        "one-off foley and UI stings for a cut (0.5-22s)",
+        "seamlessly looping ambience beds (loop=true)",
+    ]
+    not_good_for = ["music", "dialogue or speech", "anything longer than 22 seconds"]
+    fallback_tools = ["freesound_music"]
+    quality_score = 0.82
+
+    input_schema = {
+        "type": "object",
+        "required": ["text", "duration_seconds"],
+        "properties": {
+            "text": {"type": "string", "maxLength": 2500, "description": "The sound to create, e.g. 'ocean waves crashing on shingle'."},
+            "duration_seconds": {"type": "number", "minimum": 0.5, "maximum": 22},
+            "loop": {"type": "boolean", "default": False, "description": "Produce a seamlessly looping effect."},
+            "prompt_influence": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.3,
+                "description": "Higher sticks closer to the text; lower is more varied.",
+            },
+            "output_path": {"type": "string", "default": "magnific_sfx.mp3"},
+            "webhook_url": {"type": "string"},
+        },
+    }
+    output_schema = {"type": "object", "properties": {"output_path": {"type": "string"}}}
+    idempotency_key_fields = ["text", "duration_seconds", "loop", "prompt_influence"]
+    side_effects = ["writes an audio file to output_path", "calls the Magnific API (consumes credits)"]
+    user_visible_verification = ["Listen in context against the picture; for loops, check the seam"]
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        return 0.01
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        return 20.0
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        return self._generate(
+            inputs,
+            "/v1/ai/sound-effects",
+            {
+                "text": inputs["text"],
+                "duration_seconds": float(inputs["duration_seconds"]),
+                "loop": inputs.get("loop"),
+                "prompt_influence": inputs.get("prompt_influence"),
+            },
+            model="magnific_sound_effects",
+        )
+
+
+class MagnificAudioIsolation(MagnificTool):
+    """Isolate a described sound from an audio or video file (SAM Audio)."""
+
+    name = "magnific_audio_isolation"
+    version = "0.1.0"
+    tier = ToolTier.ENHANCE
+    capability = "audio_processing"
+    determinism = Determinism.DETERMINISTIC
+    agent_skills = ["ffmpeg", "speech-to-text"]
+
+    capabilities = ["isolate_sound", "denoise_speech", "stem_separation"]
+    supports = {"audio_input": True, "video_input": True, "spatial_bounding_box": True, "text_targeted": True}
+    best_for = [
+        "pulling clean dialogue out of a noisy location recording",
+        "lifting one instrument or effect out of a mixed track",
+        "isolating the sound of a specific on-screen region of a video (x1/y1/x2/y2)",
+    ]
+    not_good_for = ["generating new audio", "restoring detail that was never recorded"]
+    fallback_tools = ["audio_enhance"]
+    quality_score = 0.84
+
+    input_schema = {
+        "type": "object",
+        "required": ["description"],
+        "properties": {
+            "description": {"type": "string", "maxLength": 2500, "description": "The sound to isolate, e.g. 'a person speaking'."},
+            "audio": {"type": "string", "description": "WAV/MP3/FLAC/OGG/M4A as https URL or local path. Mutually exclusive with `video`."},
+            "video": {"type": "string", "description": "MP4/MOV/WEBM/AVI as https URL or local path. Mutually exclusive with `audio`."},
+            "x1": {"type": "integer", "minimum": 0, "description": "Bounding box left edge, video input only."},
+            "y1": {"type": "integer", "minimum": 0, "description": "Bounding box top edge, video input only."},
+            "x2": {"type": "integer", "minimum": 0, "description": "Bounding box right edge, video input only."},
+            "y2": {"type": "integer", "minimum": 0, "description": "Bounding box bottom edge, video input only."},
+            "sample_fps": {"type": "number", "description": "Frames per second sampled for source localization."},
+            "output_path": {"type": "string", "default": "magnific_isolated.wav"},
+            "webhook_url": {"type": "string"},
+        },
+    }
+    output_schema = {"type": "object", "properties": {"output_path": {"type": "string"}}}
+    idempotency_key_fields = ["description", "audio", "video", "x1", "y1", "x2", "y2"]
+    side_effects = ["writes a WAV file to output_path", "calls the Magnific API (consumes credits)"]
+    user_visible_verification = ["Listen for artefacts and check the target sound survived intact"]
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        return 0.05
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        return 60.0
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        audio, video = inputs.get("audio"), inputs.get("video")
+        if bool(audio) == bool(video):
+            return ToolResult(
+                success=False,
+                error="Provide exactly one of `audio` or `video` — the API rejects both and neither.",
+            )
+        try:
+            media = {"audio": mag.as_input(audio)} if audio else {"video": mag.as_input(video)}
+        except ValueError as e:
+            return ToolResult(success=False, error=str(e))
+        except Exception as e:
+            return ToolResult(success=False, error=f"Could not read the media input: {e}")
+
+        payload: dict[str, Any] = {"description": inputs["description"], **media}
+        if video:
+            for field in ("x1", "y1", "x2", "y2", "sample_fps"):
+                payload[field] = inputs.get(field)
+        return self._generate(inputs, "/v1/ai/audio-isolation", payload, model="magnific_audio_isolation")

--- a/tools/enhancement/magnific_upscale.py
+++ b/tools/enhancement/magnific_upscale.py
@@ -1,0 +1,171 @@
+"""Magnific AI image upscaling (Creative and Precision engines).
+
+Creative reimagines detail as it enlarges — prompt-guided, hallucinating texture
+that was never in the source. Precision is faithful super-resolution: sharper
+edges and micro-contrast with no invented content. Pick by `mode`.
+
+API: https://docs.magnific.com/api-reference/image-upscaler-creative/image-upscaler
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tools import _magnific as mag
+from tools._magnific import MagnificTool
+from tools.base_tool import Determinism, ToolResult, ToolTier
+
+_CREATIVE_PATH = "/v1/ai/image-upscaler"
+_PRECISION_PATH = "/v1/ai/image-upscaler-precision"
+
+# Approximate USD per call. Magnific bills in credits and does not publish a
+# per-endpoint USD rate, so these are order-of-magnitude figures for planning and
+# budget gates only — reconcile real spend against the Analytics API.
+_COST_BY_SCALE = {"2x": 0.06, "4x": 0.12, "8x": 0.24, "16x": 0.48}
+_RUNTIME_BY_SCALE = {"2x": 45.0, "4x": 90.0, "8x": 180.0, "16x": 360.0}
+_PRECISION_COST = 0.05
+
+
+class MagnificUpscale(MagnificTool):
+    """Upscale a still image through the Magnific API."""
+
+    name = "magnific_upscale"
+    version = "0.1.0"
+    tier = ToolTier.ENHANCE
+    capability = "image_upscale"
+    determinism = Determinism.STOCHASTIC
+    agent_skills = ["flux-best-practices", "visual-style"]
+
+    capabilities = ["image_upscale", "detail_enhancement"]
+    supports = {
+        "creative_upscale": True,
+        "faithful_upscale": True,
+        "prompt_guided": True,
+        "up_to_16x": True,
+        "style_presets": True,
+    }
+    best_for = [
+        "rescuing low-resolution stills for large-format or 4K delivery",
+        "adding believable texture to AI-generated images (reuse the original prompt)",
+        "faithful super-resolution of logos, UI captures, and scans (mode=precision)",
+    ]
+    not_good_for = [
+        "video frames in bulk (per-frame API cost and no temporal consistency)",
+        "offline or free upscaling — use the local `upscale` tool for that",
+    ]
+    fallback_tools = ["upscale", "face_enhance"]
+    quality_score = 0.92
+
+    input_schema = {
+        "type": "object",
+        "required": ["image"],
+        "properties": {
+            "image": {
+                "type": "string",
+                "description": "Local file path, public https URL, or base64. A URL preserves the most quality.",
+            },
+            "mode": {
+                "type": "string",
+                "enum": ["creative", "precision"],
+                "default": "creative",
+                "description": "creative = prompt-guided detail invention; precision = faithful, no new content.",
+            },
+            "output_path": {"type": "string", "default": "magnific_upscaled.png"},
+
+            # --- creative mode ---
+            "scale_factor": {"type": "string", "enum": ["2x", "4x", "8x", "16x"], "default": "2x"},
+            "optimized_for": {
+                "type": "string",
+                "enum": [
+                    "standard", "soft_portraits", "hard_portraits", "art_n_illustration",
+                    "videogame_assets", "nature_n_landscapes", "films_n_photography",
+                    "3d_renders", "science_fiction_n_horror",
+                ],
+                "default": "standard",
+            },
+            "prompt": {"type": "string", "description": "Guides creative upscaling. Reuse the source image's own prompt."},
+            "creativity": {"type": "integer", "minimum": -10, "maximum": 10, "default": 0},
+            "hdr": {"type": "integer", "minimum": -10, "maximum": 10, "default": 0},
+            "resemblance": {"type": "integer", "minimum": -10, "maximum": 10, "default": 0},
+            "fractality": {"type": "integer", "minimum": -10, "maximum": 10, "default": 0},
+            "engine": {
+                "type": "string",
+                "enum": ["automatic", "magnific_illusio", "magnific_sharpy", "magnific_sparkle"],
+                "default": "automatic",
+            },
+
+            # --- precision mode ---
+            "sharpen": {"type": "integer", "minimum": 0, "maximum": 100, "default": 50},
+            "smart_grain": {"type": "integer", "minimum": 0, "maximum": 100, "default": 7},
+            "ultra_detail": {"type": "integer", "minimum": 0, "maximum": 100, "default": 30},
+
+            "filter_nsfw": {"type": "boolean", "default": False},
+            "webhook_url": {"type": "string"},
+        },
+    }
+    output_schema = {
+        "type": "object",
+        "properties": {
+            "output_path": {"type": "string"},
+            "mode": {"type": "string"},
+            "format": {"type": "string"},
+        },
+    }
+
+    idempotency_key_fields = ["image", "mode", "scale_factor", "prompt", "engine"]
+    side_effects = ["writes an image to output_path", "calls the Magnific API (consumes credits)"]
+    user_visible_verification = [
+        "Open the output at 100% zoom and check edges, skin, and text for invented artifacts",
+    ]
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        if inputs.get("mode", "creative") == "precision":
+            return _PRECISION_COST
+        return _COST_BY_SCALE.get(inputs.get("scale_factor", "2x"), 0.06)
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        # Larger scale factors take proportionally longer per the API docs.
+        return _RUNTIME_BY_SCALE.get(inputs.get("scale_factor", "2x"), 45.0)
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        if not mag.api_key():
+            return self._unconfigured()
+
+        mode = inputs.get("mode", "creative")
+        try:
+            image = mag.as_input(inputs["image"])
+        except Exception as e:
+            return ToolResult(success=False, error=f"Could not read image input: {e}")
+
+        common = {"image": image, "filter_nsfw": inputs.get("filter_nsfw")}
+        if mode == "precision":
+            endpoint = _PRECISION_PATH
+            payload = {
+                **common,
+                "sharpen": inputs.get("sharpen"),
+                "smart_grain": inputs.get("smart_grain"),
+                "ultra_detail": inputs.get("ultra_detail"),
+            }
+            extra: dict[str, Any] = {"mode": mode}
+        else:
+            endpoint = _CREATIVE_PATH
+            payload = {
+                **common,
+                "scale_factor": inputs.get("scale_factor"),
+                "optimized_for": inputs.get("optimized_for"),
+                "prompt": inputs.get("prompt"),
+                "creativity": inputs.get("creativity"),
+                "hdr": inputs.get("hdr"),
+                "resemblance": inputs.get("resemblance"),
+                "fractality": inputs.get("fractality"),
+                "engine": inputs.get("engine"),
+            }
+            extra = {
+                "mode": mode,
+                "scale_factor": inputs.get("scale_factor", "2x"),
+                "engine": inputs.get("engine", "automatic"),
+            }
+
+        return self._generate(
+            inputs, endpoint, payload, model=f"magnific_upscaler_{mode}", data_extra=extra
+        )

--- a/tools/graphics/magnific_image.py
+++ b/tools/graphics/magnific_image.py
@@ -1,0 +1,220 @@
+"""Magnific image generation — Mystic plus the Flux / Seedream / Z-Image catalog.
+
+Mystic is Magnific's own workflow and the default here: photoreal output up to
+4K with structure and style references, and `@character` LoRA syntax in the
+prompt. The other models are reached through the shared text-to-image endpoints.
+
+Mystic's parameters are modelled in full. The other models each have their own
+request schema, so only the parameters they all share are typed here — anything
+model-specific goes through `params`, which is merged into the request body
+verbatim.
+
+API: https://docs.magnific.com/api-reference/mystic/mystic
+"""
+
+from __future__ import annotations
+
+from typing import Any, NamedTuple
+
+from tools import _magnific as mag
+from tools._magnific import MagnificTool
+from tools.base_tool import Determinism, ToolResult, ToolTier
+
+_DEFAULT_MODEL = "mystic"
+
+# 4K Mystic costs materially more, and takes longer, than 1k/2k.
+_4K_MULTIPLIER = 2.0
+
+
+class ImageModel(NamedTuple):
+    """One model's endpoint and planning hints.
+
+    `cost` is approximate USD per image and `runtime` approximate seconds.
+    Magnific bills in credits with no published per-model USD rate, so these are
+    planning estimates for budget gates, not invoice values.
+    """
+
+    path: str
+    cost: float
+    runtime: float
+
+
+_MODELS: dict[str, ImageModel] = {
+    _DEFAULT_MODEL: ImageModel("/v1/ai/mystic", 0.05, 45.0),
+    "flux_2_pro": ImageModel("/v1/ai/text-to-image/flux-2-pro", 0.05, 30.0),
+    "flux_2_turbo": ImageModel("/v1/ai/text-to-image/flux-2-turbo", 0.02, 12.0),
+    "flux_dev": ImageModel("/v1/ai/text-to-image/flux-dev", 0.02, 20.0),
+    "flux_kontext_pro": ImageModel("/v1/ai/text-to-image/flux-kontext-pro", 0.05, 30.0),
+    "hyperflux": ImageModel("/v1/ai/text-to-image/hyperflux", 0.01, 8.0),
+    "seedream_v5_pro": ImageModel("/v1/ai/text-to-image/seedream-v5-pro", 0.05, 30.0),
+    "seedream_v5_lite": ImageModel("/v1/ai/text-to-image/seedream-v5-lite", 0.02, 15.0),
+    "seedream_v4_5": ImageModel("/v1/ai/text-to-image/seedream-v4-5", 0.04, 25.0),
+    "nano_banana_pro": ImageModel("/v1/ai/text-to-image/nano-banana-pro", 0.05, 30.0),
+    "z_image": ImageModel("/v1/ai/text-to-image/z-image", 0.01, 10.0),
+    "runway_t2i": ImageModel("/v1/ai/text-to-image/runway", 0.04, 25.0),
+}
+
+_ASPECT_RATIOS = [
+    "square_1_1", "classic_4_3", "traditional_3_4", "widescreen_16_9",
+    "social_story_9_16", "smartphone_horizontal_20_9", "smartphone_vertical_9_20",
+    "standard_3_2", "portrait_2_3", "horizontal_2_1", "vertical_1_2",
+    "social_5_4", "social_post_4_5",
+]
+
+
+class MagnificImage(MagnificTool):
+    """Generate a still image through the Magnific API."""
+
+    name = "magnific_image"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "image_generation"
+    determinism = Determinism.STOCHASTIC
+    agent_skills = ["flux-best-practices", "visual-style", "bfl-api"]
+
+    capabilities = ["text_to_image", "style_transfer", "structure_reference"]
+    supports = {
+        "text_to_image": True,
+        "style_reference": True,
+        "structure_reference": True,
+        "character_lora": True,
+        "up_to_4k": True,
+        "multi_model_routing": True,
+        "fixed_generation": True,
+    }
+    best_for = [
+        "photoreal stills at 4K with a house style locked by a style_reference image",
+        "editorial-grade close-up portraits (model=mystic, mystic_model=editorial_portraits)",
+        "turning a sketch or 3D blockout into a finished frame via structure_reference",
+        "reaching Flux 2, Seedream 5, and Nano Banana Pro on one Magnific key",
+    ]
+    not_good_for = ["offline generation", "precise text rendering at small sizes", "vector output"]
+    fallback_tools = ["flux_image", "seedream_image", "image_gen", "openai_image"]
+    quality_score = 0.9
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "Scene description. Mystic also accepts @character or @character::strength LoRA syntax.",
+            },
+            "model": {"type": "string", "enum": sorted(_MODELS), "default": _DEFAULT_MODEL},
+            "output_path": {"type": "string", "default": "magnific_image.png"},
+            "aspect_ratio": {"type": "string", "enum": _ASPECT_RATIOS, "default": "square_1_1"},
+
+            # --- mystic only ---
+            "mystic_model": {
+                "type": "string",
+                "enum": ["realism", "fluid", "zen", "flexible", "super_real", "editorial_portraits"],
+                "default": "realism",
+                "description": "Mystic sub-model. fluid/flexible/super_real/editorial_portraits ignore LoRAs.",
+            },
+            "resolution": {"type": "string", "enum": ["1k", "2k", "4k"], "default": "2k"},
+            "engine": {
+                "type": "string",
+                "enum": ["automatic", "magnific_illusio", "magnific_sharpy", "magnific_sparkle"],
+                "default": "automatic",
+            },
+            "structure_reference": {"type": "string", "description": "Image whose shapes guide the result. Disables LoRAs."},
+            "structure_strength": {"type": "integer", "minimum": 0, "maximum": 100, "default": 50},
+            "style_reference": {"type": "string", "description": "Image whose aesthetic guides the result. Disables LoRAs."},
+            "adherence": {"type": "integer", "minimum": 0, "maximum": 100, "default": 50},
+            "hdr": {"type": "integer", "minimum": 0, "maximum": 100, "default": 50},
+            "creative_detailing": {"type": "integer", "minimum": 0, "maximum": 100, "default": 33},
+            "fixed_generation": {"type": "boolean", "default": False, "description": "Same settings -> same image."},
+
+            "filter_nsfw": {"type": "boolean", "default": True},
+            "params": {
+                "type": "object",
+                "description": "Model-specific body fields merged verbatim into the request.",
+            },
+            "webhook_url": {"type": "string"},
+        },
+    }
+    output_schema = {
+        "type": "object",
+        "properties": {"output_path": {"type": "string"}, "output_paths": {"type": "array"}},
+    }
+
+    idempotency_key_fields = ["prompt", "model", "mystic_model", "resolution", "aspect_ratio"]
+    side_effects = ["writes image files to output_path", "calls the Magnific API (consumes credits)"]
+    user_visible_verification = ["Check hands, faces, and any rendered text before approving the frame"]
+
+    @staticmethod
+    def _multiplier(inputs: dict[str, Any]) -> float:
+        # `resolution` is only sent for Mystic; scaling anything else by it would
+        # quote (and reserve budget for) 2x a request that never changes.
+        is_mystic = inputs.get("model", _DEFAULT_MODEL) == _DEFAULT_MODEL
+        return _4K_MULTIPLIER if is_mystic and inputs.get("resolution") == "4k" else 1.0
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        spec = _MODELS.get(inputs.get("model", _DEFAULT_MODEL))
+        if spec is None:
+            return 0.0
+        return round(spec.cost * self._multiplier(inputs), 4)
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        spec = _MODELS.get(inputs.get("model", _DEFAULT_MODEL))
+        return 0.0 if spec is None else spec.runtime * self._multiplier(inputs)
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        if not mag.api_key():
+            return self._unconfigured()
+
+        model = inputs.get("model", _DEFAULT_MODEL)
+        spec = _MODELS.get(model)
+        if spec is None:
+            return ToolResult(
+                success=False,
+                error=f"Unknown Magnific image model {model!r}. Known: {', '.join(sorted(_MODELS))}",
+            )
+
+        payload: dict[str, Any] = {
+            "prompt": inputs["prompt"],
+            "aspect_ratio": inputs.get("aspect_ratio"),
+        }
+        extra: dict[str, Any] = {
+            "prompt": inputs["prompt"],
+            "aspect_ratio": inputs.get("aspect_ratio", "square_1_1"),
+        }
+
+        if model == _DEFAULT_MODEL:
+            payload.update({
+                "model": inputs.get("mystic_model"),
+                "resolution": inputs.get("resolution"),
+                "engine": inputs.get("engine"),
+                "structure_strength": inputs.get("structure_strength") if inputs.get("structure_reference") else None,
+                "adherence": inputs.get("adherence") if inputs.get("style_reference") else None,
+                "hdr": inputs.get("hdr") if inputs.get("style_reference") else None,
+                "creative_detailing": inputs.get("creative_detailing"),
+                "fixed_generation": inputs.get("fixed_generation"),
+                "filter_nsfw": inputs.get("filter_nsfw"),
+            })
+            try:
+                for field in ("structure_reference", "style_reference"):
+                    if inputs.get(field):
+                        payload[field] = mag.as_input(inputs[field])
+            except Exception as e:
+                return ToolResult(success=False, error=f"Could not read a reference image: {e}")
+            extra["mystic_model"] = inputs.get("mystic_model", "realism")
+            extra["resolution"] = inputs.get("resolution", "2k")
+
+        else:
+            ignored = [f for f in ("structure_reference", "style_reference") if inputs.get(f)]
+            if ignored:
+                return ToolResult(
+                    success=False,
+                    error=(
+                        f"{', '.join(ignored)} only applies to model='mystic'; "
+                        f"{model!r} would silently ignore it and still cost credits."
+                    ),
+                )
+
+        if isinstance(inputs.get("params"), dict):
+            payload.update(inputs["params"])
+
+        return self._generate(
+            inputs, spec.path, payload, model=model, data_extra=extra, saves=None
+        )

--- a/tools/graphics/magnific_image.py
+++ b/tools/graphics/magnific_image.py
@@ -173,7 +173,7 @@ class MagnificImage(MagnificTool):
 
         payload: dict[str, Any] = {
             "prompt": inputs["prompt"],
-            "aspect_ratio": inputs.get("aspect_ratio"),
+            "aspect_ratio": mag.normalize_ratio(inputs.get("aspect_ratio"), _ASPECT_RATIOS),
         }
         extra: dict[str, Any] = {
             "prompt": inputs["prompt"],

--- a/tools/video/magnific_video.py
+++ b/tools/video/magnific_video.py
@@ -1,0 +1,255 @@
+"""Magnific video generation — one API key across Seedance, Kling, Veo, WAN, LTX,
+Hailuo, Runway, and PixVerse.
+
+Magnific (formerly the Freepik API) is a multi-model aggregator, so this is the
+direct counterpart to `higgsfield_video`: pick a `model`, everything else stays
+the same. Seedance 2.0 Pro is the default, matching the house preference for
+premium clips with native audio.
+
+Endpoints verified against https://docs.magnific.com/llms.txt
+
+API: https://docs.magnific.com/api-reference/video/seedance-2-pro/overview
+"""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+from typing import Any, NamedTuple, Optional
+
+from tools import _magnific as mag
+from tools._magnific import MagnificTool
+from tools.base_tool import Determinism, ResourceProfile, ToolResult, ToolTier
+
+_DEFAULT_MODEL = "seedance_2_pro_1080p"
+_MAX_SEED = 4294967295
+
+
+class VideoModel(NamedTuple):
+    """One model's endpoints and planning hints.
+
+    `path` serves both operations for the models with a single unified endpoint;
+    `t2v`/`i2v` override it for the models that split them, and None means the
+    model does not support that operation at all. `status` is the GET path when
+    it differs from the POST (Seedance posts per-resolution, polls one path).
+    `cost` is approximate USD for a 5s clip — Magnific bills in credits with no
+    published per-model USD rate, so it is a planning estimate only.
+    """
+
+    path: str = ""
+    t2v: Optional[str] = None
+    i2v: Optional[str] = None
+    status: Optional[str] = None
+    audio: bool = False
+    cost: float = 0.0
+    runtime: float = 0.0
+
+    def endpoint(self, operation: str) -> Optional[str]:
+        override = self.i2v if operation == "image_to_video" else self.t2v
+        if override is not None:
+            return override
+        return self.path or None
+
+    def status_for(self, endpoint: str) -> str:
+        return self.status or endpoint
+
+
+_SEEDANCE_PRO = "/v1/ai/video/seedance-2-pro"
+_SEEDANCE_2_5 = "/v1/ai/video/seedance-2-5-pro"
+_KLING_V3 = "/v1/ai/video/kling-v3"
+
+_MODELS: dict[str, VideoModel] = {
+    "seedance_2_pro_480p": VideoModel(f"{_SEEDANCE_PRO}-480p", status=_SEEDANCE_PRO, audio=True, cost=0.30, runtime=90.0),
+    "seedance_2_pro_720p": VideoModel(f"{_SEEDANCE_PRO}-720p", status=_SEEDANCE_PRO, audio=True, cost=0.55, runtime=120.0),
+    "seedance_2_pro_1080p": VideoModel(f"{_SEEDANCE_PRO}-1080p", status=_SEEDANCE_PRO, audio=True, cost=0.85, runtime=150.0),
+    "seedance_2_pro_4k": VideoModel(f"{_SEEDANCE_PRO}-4k", status=_SEEDANCE_PRO, audio=True, cost=2.00, runtime=300.0),
+    "seedance_2_fast_720p": VideoModel("/v1/ai/video/seedance-2-fast-720p", status="/v1/ai/video/seedance-2-fast", audio=True, cost=0.30, runtime=60.0),
+    "seedance_2_mini_720p": VideoModel("/v1/ai/video/seedance-2-mini-720p", status="/v1/ai/video/seedance-2-mini", audio=True, cost=0.15, runtime=45.0),
+    "seedance_2_5_pro_1080p": VideoModel(f"{_SEEDANCE_2_5}-1080p", status=_SEEDANCE_2_5, audio=True, cost=0.85, runtime=150.0),
+    "kling_v3_pro": VideoModel("/v1/ai/video/kling-v3-pro", status=_KLING_V3, cost=0.50, runtime=180.0),
+    "kling_v3_std": VideoModel("/v1/ai/video/kling-v3-std", status=_KLING_V3, cost=0.25, runtime=150.0),
+    "veo_3_1": VideoModel(t2v="/v1/ai/text-to-video/veo-3-1", i2v="/v1/ai/image-to-video/veo-3-1", audio=True, cost=1.50, runtime=180.0),
+    "veo_3_1_fast": VideoModel(t2v="/v1/ai/text-to-video/veo-3-1-fast", i2v="/v1/ai/image-to-video/veo-3-1-fast", audio=True, cost=0.60, runtime=90.0),
+    "wan_2_7": VideoModel(t2v="/v1/ai/text-to-video/wan-2-7", i2v="/v1/ai/image-to-video/wan-2-7", cost=0.20, runtime=120.0),
+    "ltx_2_pro": VideoModel(t2v="/v1/ai/text-to-video/ltx-2-pro", i2v="/v1/ai/image-to-video/ltx-2-pro", audio=True, cost=0.40, runtime=120.0),
+    "minimax_hailuo_2_3_1080p": VideoModel(i2v="/v1/ai/image-to-video/minimax-hailuo-2-3-1080p", cost=0.45, runtime=150.0),
+    "runway_4_5": VideoModel(t2v="/v1/ai/text-to-video/runway-4-5", i2v="/v1/ai/image-to-video/runway-4-5", cost=0.50, runtime=120.0),
+    "pixverse_v6": VideoModel(t2v="/v1/ai/text-to-video/pixverse-v6", cost=0.25, runtime=90.0),
+}
+
+_ASPECT_RATIOS = [
+    "film_horizontal_21_9", "widescreen_16_9", "classic_4_3", "square_1_1",
+    "traditional_3_4", "social_story_9_16", "film_vertical_9_21",
+]
+
+
+class MagnificVideo(MagnificTool):
+    """Generate a video clip through the Magnific multi-model API."""
+
+    name = "magnific_video"
+    version = "0.1.0"
+    tier = ToolTier.GENERATE
+    capability = "video_generation"
+    determinism = Determinism.SEEDED
+    agent_skills = ["seedance-2-0", "seedance-2-5", "ai-video-gen"]
+
+    resource_profile = ResourceProfile(cpu_cores=1, ram_mb=512, disk_mb=1000, network_required=True)
+
+    capabilities = ["text_to_video", "image_to_video"]
+    supports = {
+        "text_to_video": True,
+        "image_to_video": True,
+        "first_to_last_frame": True,
+        "reference_images": True,
+        "native_audio": True,
+        "multi_model_routing": True,
+        "camera_direction": True,
+        "seeded": True,
+    }
+    best_for = [
+        "multi-model video generation behind a single Magnific key",
+        "Seedance 2.0 Pro clips with native synchronized audio at up to 4K",
+        "first-to-last-frame transitions from two stills (image + image_end)",
+        "reference-driven shots — up to 9 images cited as @Image1..@Image9 in the prompt",
+    ]
+    not_good_for = ["offline generation", "sub-4-second micro-clips", "frame-exact editorial control"]
+    fallback_tools = ["higgsfield_video", "seedance_video", "kling_video", "veo_video"]
+    quality_score = 0.89
+
+    input_schema = {
+        "type": "object",
+        "required": ["prompt"],
+        "properties": {
+            "prompt": {"type": "string", "description": "Scene, motion, style, and camera movement. Up to 2000 chars."},
+            "model": {"type": "string", "enum": sorted(_MODELS), "default": _DEFAULT_MODEL},
+            "operation": {
+                "type": "string",
+                "enum": ["text_to_video", "image_to_video"],
+                "default": "text_to_video",
+                "description": "Inferred from `image` when omitted.",
+            },
+            "image": {"type": "string", "description": "First-frame image: local path, https URL, or base64."},
+            "image_end": {"type": "string", "description": "Last-frame image. With `image`, generates a transition."},
+            "reference_images": {
+                "type": "array",
+                "items": {"type": "string"},
+                "maxItems": 9,
+                "description": "Seedance only. Cite them in the prompt as @Image1..@Image9.",
+            },
+            "duration": {"type": "integer", "minimum": 4, "maximum": 15, "default": 5},
+            "aspect_ratio": {"type": "string", "enum": _ASPECT_RATIOS, "default": "widescreen_16_9"},
+            "camera_fixed": {"type": "boolean", "default": False, "description": "true = locked tripod shot."},
+            "sound_effects": {"type": "boolean", "default": True, "description": "Native audio, on models that support it."},
+            "no_music": {"type": "boolean", "default": False, "description": "Keep dialogue and SFX, drop the score."},
+            "seed": {
+                "type": "integer",
+                "minimum": -1,
+                "maximum": _MAX_SEED,
+                "default": -1,
+                "description": "-1 draws a random seed, which is sent and reported so the clip can be reproduced.",
+            },
+            "output_path": {"type": "string", "default": "magnific_video.mp4"},
+            "webhook_url": {"type": "string"},
+        },
+    }
+    output_schema = {
+        "type": "object",
+        "properties": {"output_path": {"type": "string"}, "model": {"type": "string"}},
+    }
+
+    idempotency_key_fields = ["prompt", "model", "operation", "duration", "seed"]
+    side_effects = ["writes a video file to output_path", "calls the Magnific API (consumes credits)"]
+    user_visible_verification = ["Watch the clip for motion coherence, identity drift, and audio sync"]
+
+    def _resolve(self, inputs: dict[str, Any]) -> tuple[str, VideoModel, str, str]:
+        """Return (model, spec, operation, endpoint), raising on an unsupported combination."""
+        model = inputs.get("model", _DEFAULT_MODEL)
+        spec = _MODELS.get(model)
+        if spec is None:
+            raise ValueError(f"Unknown Magnific model {model!r}. Known: {', '.join(sorted(_MODELS))}")
+        operation = inputs.get("operation") or ("image_to_video" if inputs.get("image") else "text_to_video")
+        endpoint = spec.endpoint(operation)
+        if endpoint is None:
+            other = "image_to_video" if operation == "text_to_video" else "text_to_video"
+            raise ValueError(f"Magnific model {model!r} does not support {operation}; it only supports {other}.")
+        return model, spec, operation, endpoint
+
+    @staticmethod
+    def _seed(inputs: dict[str, Any]) -> int:
+        """Resolve an explicit seed, or draw one so the clip stays reproducible.
+
+        `-1` is the API's "pick randomly" sentinel, which would leave the caller
+        with no way to regenerate a clip they liked.
+        """
+        seed = inputs.get("seed")
+        if seed is None or seed == -1:
+            return random.randint(0, _MAX_SEED)
+        return int(seed)
+
+    @staticmethod
+    def _duration(inputs: dict[str, Any]) -> int:
+        return int(inputs.get("duration", 5) or 5)
+
+    def estimate_cost(self, inputs: dict[str, Any]) -> float:
+        spec = _MODELS.get(inputs.get("model", _DEFAULT_MODEL))
+        return 0.0 if spec is None else round(spec.cost * (self._duration(inputs) / 5), 4)
+
+    def estimate_runtime(self, inputs: dict[str, Any]) -> float:
+        spec = _MODELS.get(inputs.get("model", _DEFAULT_MODEL))
+        return 0.0 if spec is None else round(spec.runtime * (self._duration(inputs) / 5), 1)
+
+    def _max_wait(self, inputs: dict[str, Any]) -> float:
+        # Video queues are deeper than the still/audio endpoints, so allow a
+        # longer ceiling relative to the estimate than the shared default.
+        return self.estimate_runtime(inputs) * 6 + 180
+
+    def execute(self, inputs: dict[str, Any]) -> ToolResult:
+        if not mag.api_key():
+            return self._unconfigured()
+
+        try:
+            model, spec, operation, endpoint = self._resolve(inputs)
+        except ValueError as e:
+            return ToolResult(success=False, error=str(e))
+
+        seed = self._seed(inputs)
+        payload: dict[str, Any] = {
+            "prompt": inputs["prompt"],
+            "duration": inputs.get("duration"),
+            "aspect_ratio": inputs.get("aspect_ratio"),
+            "camera_fixed": inputs.get("camera_fixed"),
+            "seed": seed,
+        }
+        if spec.audio:
+            payload["sound_effects"] = inputs.get("sound_effects")
+            payload["no_music"] = inputs.get("no_music")
+
+        try:
+            if inputs.get("image"):
+                payload["image"] = mag.as_input(inputs["image"])
+            if inputs.get("image_end"):
+                payload["image_end"] = mag.as_input(inputs["image_end"])
+            if inputs.get("reference_images"):
+                payload["reference_images"] = [mag.as_input(r) for r in inputs["reference_images"]]
+        except Exception as e:
+            return ToolResult(success=False, error=f"Could not read a reference image: {e}")
+
+        result = self._generate(
+            inputs,
+            endpoint,
+            payload,
+            model=model,
+            status_path=spec.status_for(endpoint),
+            data_extra={
+                "prompt": inputs["prompt"],
+                "operation": operation,
+                "aspect_ratio": inputs.get("aspect_ratio", "widescreen_16_9"),
+                "native_audio": bool(spec.audio and inputs.get("sound_effects", True)),
+            },
+        )
+        if result.success:
+            from tools.video._shared import probe_output
+
+            result.data.update(probe_output(Path(result.data["output_path"])))
+            result.seed = seed
+        return result

--- a/tools/video/magnific_video.py
+++ b/tools/video/magnific_video.py
@@ -216,7 +216,7 @@ class MagnificVideo(MagnificTool):
         payload: dict[str, Any] = {
             "prompt": inputs["prompt"],
             "duration": inputs.get("duration"),
-            "aspect_ratio": inputs.get("aspect_ratio"),
+            "aspect_ratio": mag.normalize_ratio(inputs.get("aspect_ratio"), _ASPECT_RATIOS),
             "camera_fixed": inputs.get("camera_fixed"),
             "seed": seed,
         }


### PR DESCRIPTION
## Summary

Adds Magnific (formerly the Freepik API) as a provider gateway. One `MAGNIFIC_API_KEY` covers four capabilities that today need separate keys — video, image, upscaling, and audio — behind the single async task contract every Magnific endpoint shares.

The closest existing provider is `higgsfield_video`, which is video-only. Magnific covers the same multi-model video surface (Seedance 2, Kling v3, Veo 3.1, WAN, LTX, Hailuo, Runway, PixVerse) and adds Mystic/Flux 2/Seedream 5 stills, the Magnific Creative and Precision upscalers, and ElevenLabs music, sound effects, and SAM Audio isolation. `image_upscale` and `sound_effects` currently have no other cloud provider.

No selector changes: all six tools are discovered by capability through the existing registry.

## Related issue

No tracking issue. Shape follows the Atlas Cloud gateway pattern also proposed in #569 for a different provider.

## Changes

- `tools/_magnific.py` — shared client (submit/poll/download) plus a `MagnificTool` base carrying the credential guard and result envelope. Follows the existing per-provider client pattern (`tools/_kling/`, `tools/atlas_client.py`).
- Six tools: `magnific_video`, `magnific_image`, `magnific_upscale`, `magnific_music`, `magnific_sound_effects`, `magnific_audio_isolation`.
- `docs/PROVIDERS.md`, `docs/ARCHITECTURE.md`, `README.md`, `.env.example`.
- `magnific_video` / `magnific_image` added to the existing `test_provider_model_defaults.py` regression suite rather than re-spelling that invariant locally.

Choices worth a reviewer's attention:

- **Two HTTP sessions.** Generated assets are served from a separate CDN host, and `requests` only strips `Authorization` across a cross-host redirect (`SessionRedirectMixin.rebuild_auth`) — a custom auth header would follow it. The authenticated session is never used to download an asset; there is a test pinning this.
- **Polling** checks before it sleeps and ramps 1.0s → 5.0s, matching `atlas_client.poll` and `_shared.poll_heygen`. It tolerates five consecutive transport errors before abandoning a generation that has already been paid for; a 4xx fails immediately.
- **Costs are approximate USD.** Magnific bills credits and publishes no per-endpoint rate, so `estimate_cost` is for budget gates only. Flagged in the code and in `PROVIDERS.md`, including that an "Unlimited" plan allowance covers the web app but not the API.
- **`output_path` suffix is the caller's.** Matches `_kling/media.py:output_path_with_suffix` and `seedream_image`; the served content type is reported separately as `data["format"]`.
- **`aspect_ratio`** accepts a plain `"16:9"` because `image_selector` passes the key as a free-form hint. The mapping is derived from each tool's own enum, not a second table.
- **Video draws and reports a seed** when none is given, so a clip can actually be reproduced — the tool declares `Determinism.SEEDED` and lists `seed` in `idempotency_key_fields`.

Magnific also runs an OAuth MCP server at `https://mcp.magnific.com` needing no API key. `PROVIDERS.md` documents when to reach for which — the REST tools for anything a pipeline drives and cost-tracks, MCP for ad-hoc chat work.

## Testing

- `make test` — 1923 passed, 12 skipped, 3 xfailed.
- `make test-contracts` — 1223 passed, 7 skipped.
- 78 offline tests for this provider: endpoint-table consistency, poll timing and retry ceiling, credential isolation, input validation, registry discovery, capability routing per selector-backed capability, and no `requests` import at module import time.
- Live API calls against a Pro-tier key: Mystic and Hyperflux images, Precision upscale (2048×2048), sound effects. Video was exercised through the shared client path but not billed at 1080p.
- Provider menu verified: Magnific appears under `video_generation`, `image_generation`, `image_upscale`, `music_generation`, `sound_effects`, and `audio_processing`.

## Checklist

- [x] The change is focused on a single logical concern.
- [x] I ran the relevant tests locally (`make test-contracts` / `make test`) where applicable.
- [x] I updated docs/README if behavior or usage changed.
- [x] No unrelated files (build artifacts, local config) are included in the diff.

Closes #664
