### PR TITLE
fix(backlot): simulate run writes the proposal stage before script

### DIFF
--- a/scripts/backlot_simulate_run.py
+++ b/scripts/backlot_simulate_run.py
@@ -94,6 +94,50 @@ def main() -> int:
     brief["topic"] = "The Last Lighthouse"
     cp("research", "completed", {"research_brief": brief})
 
+    # proposal gates: awaiting_human -> approved. lib/checkpoint.py enforces
+    # the manifest's stage order, so script cannot advance without a completed,
+    # approved proposal checkpoint.
+    cp("proposal", "in_progress", {})
+    proposal = sample_artifact("proposal_packet")
+    proposal["concept_options"][0].update({
+        "title": "The Last Lighthouse",
+        "hook": "The coast holds its breath.",
+        "narrative_structure": "story",
+        "visual_approach": "generated cinematic stills with slow motion moves",
+    })
+    proposal["selected_concept"] = {"concept_id": "c1",
+                                    "rationale": "Strongest emotional arc for a 21s teaser"}
+    proposal["production_plan"]["pipeline"] = "cinematic"
+    decision_log = {
+        "version": "1.0",
+        "project_id": pid,
+        "decisions": [{
+            "decision_id": "d1",
+            "stage": "proposal",
+            "category": "render_runtime_selection",
+            "subject": "Composition runtime",
+            "options_considered": [
+                {"option_id": "remotion", "label": "Remotion", "score": 0.9,
+                 "reason": "Spring-animated stills suit the slow, moody treatment"},
+                {"option_id": "hyperframes", "label": "HyperFrames", "score": 0.6,
+                 "reason": "Stronger for kinetic typography than for still-led mood",
+                 "rejected_because": "Brief is still-led, not typography-led"},
+            ],
+            "selected": "remotion",
+            "reason": "Still-led cinematic treatment renders best with Remotion",
+            "user_visible": True,
+            "user_approved": True,
+            "confidence": 0.85,
+        }],
+    }
+    save_artifact("proposal_packet", proposal)
+    save_artifact("decision_log", decision_log)
+    cp("proposal", "awaiting_human",
+       {"proposal_packet": proposal, "decision_log": decision_log})
+    time.sleep(wait)  # "user picks a concept on the board"
+    cp("proposal", "completed",
+       {"proposal_packet": proposal, "decision_log": decision_log}, human_approved=True)
+
     # script gates: awaiting_human -> approved
     cp("script", "in_progress", {})
     save_artifact("script", art["script"])


### PR DESCRIPTION
## What changed

`scripts/backlot_simulate_run.py` jumped from `research` straight to `script`. Since `lib/checkpoint.py` started enforcing the manifest's stage order (commit 9482edd), the documented Backlot demo died at the first gated stage and never populated the board.

This adds a gated `proposal` stage between `research` and `script`:

- `in_progress` -> `awaiting_human` -> `completed` with `human_approved=True`, matching the other gated stages in the script
- a schema-valid `proposal_packet` built from the contract fixture (`tests/contracts/test_phase0_contracts.py::sample_artifact`) with the lighthouse concept and `pipeline: cinematic`
- a `decision_log` with one `render_runtime_selection` entry (Remotion selected, HyperFrames considered) so the board's Decisions rail is exercised by the demo too

No changes outside the simulate script.

## How it was tested

**Before** (`python scripts/backlot_simulate_run.py --fast` on `main`):

```
[sim] checkpoint research -> in_progress
[sim] checkpoint research -> completed
[sim] checkpoint script -> in_progress
lib.checkpoint.CheckpointValidationError: PREREQUISITE VIOLATION: stage 'script' cannot advance; incomplete or missing: ['proposal']. Pipeline order: ['research', 'proposal', 'script', 'scene_plan', 'assets', 'edit', 'compose', 'publish'].
```

**After** (same command on this branch):

```
[sim] checkpoint research -> completed
[sim] checkpoint proposal -> in_progress
[sim] checkpoint proposal -> awaiting_human
[sim] checkpoint proposal -> completed
[sim] checkpoint script -> in_progress
... (script, scene_plan, assets all gate and complete)
[sim] done — board at http://127.0.0.1:4750/p/backlot-demo-run
```

Opened the board in Chrome: research / proposal / script / scene_plan / assets show as completed and approved with timestamps, the Decisions rail shows "Composition runtime -> Remotion (also considered: HyperFrames)", the activity feed lists the four `flux_image` events, and generation spend reads $0.20.

Regression: `pytest tests/backlot tests/contracts tests/lib` -> 1270 passed, 8 skipped. Full suite on this machine before the change: 1828 passed, 12 skipped, 3 xfailed (Windows, Python 3.10, ffmpeg 9).

## Risks / follow-up

- The fixture's `proposal_packet` keeps a `stages` list referencing `animated-explainer`-style tools; only `pipeline` is overridden. It validates against the schema and the board doesn't render that field, so it's cosmetic in the demo.
- Console output on Windows cp1252 still prints `…`/`—` as `�` in the `[sim]` lines. Pre-existing, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMgj3DLFyHKYa23omo6Uzk
