### PR TITLE
Fix Gemini Omni: unreachable 1.1 model and two wrong price constants

### DIFF
--- a/.agents/skills/gemini-omni/SKILL.md
+++ b/.agents/skills/gemini-omni/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gemini-omni
 description: |
-  Generate and conversationally edit short videos with Google Gemini Omni Flash (`gemini-omni-flash-preview`). Use when: (1) iterating on a clip with natural-language edits instead of regenerating ("make the phone invisible, keep everything else the same"), (2) generating 3-10s 720p clips with synthesized audio, rendered on-screen text, or timecoded beats, (3) binding reference images to roles with <FIRST_FRAME>/<IMAGE_REF_N> prompt tags, (4) editing an existing uploaded video. Accessed via the `gemini_omni_video` tool using the project's GEMINI_API_KEY/GOOGLE_API_KEY — the same key as Imagen and Google TTS.
+  Generate and conversationally edit short videos with Google Gemini Omni Flash (`gemini-omni-1.1-flash`, default; `gemini-omni-flash-preview` still selectable). Use when: (1) iterating on a clip with natural-language edits instead of regenerating ("make the phone invisible, keep everything else the same"), (2) generating 3-10s 720p clips with synthesized audio, rendered on-screen text, or timecoded beats, (3) binding reference images to roles with <FIRST_FRAME>/<IMAGE_REF_N> prompt tags, (4) editing an existing uploaded video. Accessed via the `gemini_omni_video` tool using the project's GEMINI_API_KEY/GOOGLE_API_KEY — the same key as Imagen and Google TTS.
 allowed-tools: Bash, Read, Write
 metadata:
   openclaw:
@@ -84,8 +84,38 @@ holding <IMAGE_REF_1> [3-6s] Then we see the man <IMAGE_REF_2> holding <IMAGE_RE
 ```
 
 - `<FIRST_FRAME>` makes an image the opening frame: `<FIRST_FRAME> a woman is walking`.
+- `<LAST_FRAME>` pins the closing frame (1.1 only, and only valid alongside
+  `<FIRST_FRAME>`). Pass both images in the `input` list and describe the
+  transition — the model interpolates between them. This is the continuity
+  mechanism for multi-shot work: carry the tail frame of shot N into shot N+1.
 - Use high-resolution images; describe the intended motion specifically rather than "make it move."
 - Say what each image *is* (product / character / style / background reference) — the model decides usage from context.
+
+## Resolution and the draft tier (1.1)
+
+`resolution` rides in `response_format` and takes `360p`, `720p` (default),
+`1080p` or `4k`; the top two are upscaled. It sets the price as well as the
+size — roughly $0.03 / $0.10 / $0.15 / $0.30 per second of output. Published
+360p figures vary ($0.03-$0.043), so treat a draft quote as approximate.
+
+**Draft at 360p before committing.** It costs about a third of 720p and renders
+up to 60% faster, which makes it the right way to test a likeness, a camera
+move, or a prompt rewrite before paying for the real take.
+
+## Scene extension (1.1)
+
+1.1 reads up to 10 seconds of prior context when continuing a clip, against the
+single final frame earlier models used. Extensions run in 10-second increments
+to a cumulative 40 seconds, generating 3-10 seconds per call. Invoke it the same
+way as an edit — pass `previous_interaction_id` — and note the constraints:
+append only (no prepending, no mid-clip insertion), uploaded inputs must be 10
+seconds or shorter, and you cannot add new dialogue when extending an *uploaded*
+clip where someone speaks. Multi-turn extension of a clip the model generated
+itself does support spoken dialogue.
+
+This is the one capability with no equivalent on the fal route
+(`gemini_omni_fal`), which exposes no extend endpoint and accepts no interaction
+id as input.
 
 ## Conversational editing (the differentiator)
 

--- a/tests/tools/test_gemini_omni_fal_v11_payloads.py
+++ b/tests/tools/test_gemini_omni_fal_v11_payloads.py
@@ -1,0 +1,118 @@
+"""Lock gemini_omni_fal's request shape to Gemini Omni 1.1 on fal.
+
+The tool previously pointed at the unversioned `google/gemini-omni-flash/*`
+slugs, which still resolve to the pre-1.1 preview model, and priced every
+resolution at a flat $0.13/s. These key sets were verified on 2026-09-05
+against fal's live OpenAPI documents at
+`https://fal.ai/api/openapi/queue/openapi.json?endpoint_id=<slug>`; the
+assertions below are the offline copy so a later edit cannot silently drift
+off-contract or back onto the old model.
+"""
+
+import pytest
+import requests
+
+from tools.video.gemini_omni_fal import _ENDPOINTS, GeminiOmniFalVideo
+
+# Exact Input-schema property names published by fal for each v1.1 endpoint.
+LIVE_SCHEMA_KEYS = {
+    "text_to_video": {"prompt", "aspect_ratio", "resolution", "duration"},
+    "image_to_video": {
+        "prompt",
+        "image_url",
+        "end_image_url",
+        "aspect_ratio",
+        "resolution",
+        "duration",
+    },
+    "reference_to_video": {
+        "prompt",
+        "image_urls",
+        "reference_video_urls",
+        "aspect_ratio",
+        "resolution",
+        "duration",
+    },
+    # The edit endpoint inherits framing and length from the source clip.
+    "edit_video": {"prompt", "video_url", "resolution"},
+}
+
+CASES = {
+    "text_to_video": {"prompt": "a bridge"},
+    "image_to_video": {
+        "prompt": "he turns",
+        "image_url": "https://x/a.jpg",
+        "end_image_url": "https://x/b.jpg",
+    },
+    "reference_to_video": {
+        "prompt": "same man",
+        "reference_image_urls": ["https://x/a.jpg"],
+        "reference_video_urls": ["https://x/c.mp4"],
+    },
+    "edit_video": {"prompt": "swap the patch", "video_url": "https://x/in.mp4"},
+}
+
+
+@pytest.fixture
+def sent(monkeypatch):
+    """Capture the outbound request without letting it leave the machine."""
+    box = {}
+
+    def fake_post(url, **kw):
+        box["url"] = url
+        box["json"] = kw.get("json")
+        raise RuntimeError("intercepted")
+
+    monkeypatch.setenv("FAL_KEY", "test")
+    monkeypatch.setattr(requests, "post", fake_post)
+    return box
+
+
+@pytest.mark.parametrize("operation", sorted(CASES))
+def test_payload_matches_fal_v11_schema(operation, sent, tmp_path):
+    GeminiOmniFalVideo().execute(
+        {
+            **CASES[operation],
+            "operation": operation,
+            "output_path": str(tmp_path / "out.mp4"),
+        }
+    )
+    assert sent["url"] == f"https://queue.fal.run/{_ENDPOINTS[operation]}"
+    assert "/v1.1/" in sent["url"], "must target Omni 1.1, not the preview model"
+    unknown = set(sent["json"]) - LIVE_SCHEMA_KEYS[operation]
+    assert not unknown, f"{operation} sends fields fal will reject: {sorted(unknown)}"
+
+
+def test_edit_omits_framing_and_length(sent, tmp_path):
+    # Sending these to /edit is a 422 — the endpoint takes neither.
+    GeminiOmniFalVideo().execute(
+        {
+            **CASES["edit_video"],
+            "operation": "edit_video",
+            "aspect_ratio": "9:16",
+            "duration": 10,
+            "output_path": str(tmp_path / "out.mp4"),
+        }
+    )
+    assert "aspect_ratio" not in sent["json"]
+    assert "duration" not in sent["json"]
+
+
+@pytest.mark.parametrize(
+    "resolution, expected",
+    [("360p", 0.24), ("720p", 0.80), ("1080p", 1.20), ("4k", 2.40)],
+)
+def test_cost_follows_resolution_tier(resolution, expected):
+    # fal bills per output second by tier; the old flat 0.13/s over-reported
+    # 720p by 30% and under-reported 4k by 3x.
+    cost = GeminiOmniFalVideo().estimate_cost(
+        {"duration": 8, "resolution": resolution}
+    )
+    assert cost == pytest.approx(expected)
+
+
+def test_cost_defaults_to_720p():
+    tool = GeminiOmniFalVideo()
+    assert tool.estimate_cost({"duration": 8}) == tool.estimate_cost(
+        {"duration": 8, "resolution": "720p"}
+    )

--- a/tests/tools/test_gemini_omni_video.py
+++ b/tests/tools/test_gemini_omni_video.py
@@ -131,9 +131,14 @@ def test_gemini_omni_text_to_video_via_uri_delivery(monkeypatch, tmp_path, gemin
     assert result.data["editable"] is True
 
     payload = calls["post"][0]["json"]
-    assert payload["model"] == "gemini-omni-flash-preview"
+    assert payload["model"] == "gemini-omni-1.1-flash"
     assert payload["input"] == "A marble rolling on a track, single continuous shot."
-    assert payload["response_format"] == {"type": "video", "aspect_ratio": "9:16", "delivery": "uri"}
+    assert payload["response_format"] == {
+        "type": "video",
+        "aspect_ratio": "9:16",
+        "resolution": "720p",
+        "delivery": "uri",
+    }
     assert calls["post"][0]["headers"]["x-goog-api-key"] == "test-gemini-key"
     assert calls["get"][1]["url"].endswith("files/vid-123:download")
     assert calls["get"][1]["params"] == {"alt": "media"}
@@ -283,3 +288,48 @@ def test_gemini_omni_store_false_marks_result_not_editable(monkeypatch, tmp_path
     assert result.success, result.error
     assert result.data["editable"] is False
     assert calls["post"][0]["json"]["store"] is False
+
+
+def test_resolution_reaches_response_format(monkeypatch, tmp_path, gemini_env):
+    """360p is the draft tier; it must survive into response_format, not be dropped."""
+    from tools.video.gemini_omni_video import GeminiOmniVideo
+
+    calls = _install_fake_requests(
+        monkeypatch,
+        post_responses=[
+            FakeResponse({"id": "int_9", "output_video": {"uri": "files/vid-9"}}),
+        ],
+        get_responses=[
+            FakeResponse({"state": "ACTIVE"}),
+            FakeResponse(content=b"draft mp4"),
+        ],
+    )
+    out = tmp_path / "draft.mp4"
+    result = GeminiOmniVideo().execute(
+        {"prompt": "a bridge", "resolution": "360p", "output_path": str(out)}
+    )
+    assert result.success, result.error
+    assert calls["post"][0]["json"]["response_format"]["resolution"] == "360p"
+    assert result.data["resolution"] == "360p"
+
+
+@pytest.mark.parametrize(
+    "resolution, expected",
+    [("360p", 0.24), ("720p", 0.80), ("1080p", 1.20), ("4k", 2.40)],
+)
+def test_cost_follows_resolution_tier(resolution, expected):
+    # A flat per-second rate quoted a 4k clip at a third of its real price.
+    from tools.video.gemini_omni_video import GeminiOmniVideo
+
+    cost = GeminiOmniVideo().estimate_cost({"duration": "8", "resolution": resolution})
+    assert cost == pytest.approx(expected)
+
+
+def test_unsupported_resolution_is_rejected(tmp_path, gemini_env):
+    from tools.video.gemini_omni_video import GeminiOmniVideo
+
+    result = GeminiOmniVideo().execute(
+        {"prompt": "x", "resolution": "8k", "output_path": str(tmp_path / "o.mp4")}
+    )
+    assert not result.success
+    assert "resolution" in result.error

--- a/tests/tools/test_new_video_model_support.py
+++ b/tests/tools/test_new_video_model_support.py
@@ -94,7 +94,7 @@ def test_fal_gemini_omni_and_minimax_h3_are_discovered_and_submit(
         }
     )
     assert gemini.success, gemini.error
-    assert calls["posts"][0][0].endswith("/google/gemini-omni-flash/image-to-video")
+    assert calls["posts"][0][0].endswith("/google/gemini-omni-flash/v1.1/image-to-video")
 
     calls = _queue_mocks(monkeypatch)
     edited = GeminiOmniFalVideo().execute(
@@ -106,10 +106,13 @@ def test_fal_gemini_omni_and_minimax_h3_are_discovered_and_submit(
         }
     )
     assert edited.success, edited.error
-    assert calls["posts"][0][0].endswith("/google/gemini-omni-flash/edit")
+    assert calls["posts"][0][0].endswith("/google/gemini-omni-flash/v1.1/edit")
+    # The edit endpoint inherits aspect_ratio and duration from the source clip;
+    # resolution is the only knob it accepts.
     assert calls["posts"][0][1] == {
         "prompt": "Remove the sign",
         "video_url": "https://video-input",
+        "resolution": "720p",
     }
 
     calls = _queue_mocks(monkeypatch)

--- a/tests/tools/test_provider_model_defaults.py
+++ b/tests/tools/test_provider_model_defaults.py
@@ -10,15 +10,21 @@ than the schema promised — a Decision-Communication / cost-accuracy violation.
 
 import pytest
 
+import tools.video.gemini_omni_video as gemini_omni_video
 import tools.video.higgsfield_video as higgsfield_video
 import tools.video.runway_video as runway_video
+from tools.video.gemini_omni_video import GeminiOmniVideo
 from tools.video.higgsfield_video import HiggsFieldVideo
 from tools.video.runway_video import RunwayVideo
 
 
 @pytest.mark.parametrize(
     "tool_cls, module",
-    [(RunwayVideo, runway_video), (HiggsFieldVideo, higgsfield_video)],
+    [
+        (RunwayVideo, runway_video),
+        (HiggsFieldVideo, higgsfield_video),
+        (GeminiOmniVideo, gemini_omni_video),
+    ],
 )
 def test_default_model_constant_matches_schema(tool_cls, module):
     # `execute()` reads `model` via `_DEFAULT_MODEL`; locking the constant to the

--- a/tools/video/gemini_omni_fal.py
+++ b/tools/video/gemini_omni_fal.py
@@ -21,9 +21,26 @@ from tools.base_tool import (
 )
 
 
+# fal serves Omni 1.1 under a /v1.1/ path segment; the unversioned slugs still
+# resolve to the pre-1.1 preview model. Verified against fal's published API docs
+# 2026-09-05.
+_ENDPOINTS = {
+    "text_to_video": "google/gemini-omni-flash/v1.1/text-to-video",
+    "image_to_video": "google/gemini-omni-flash/v1.1/image-to-video",
+    "reference_to_video": "google/gemini-omni-flash/v1.1/reference-to-video",
+    "edit_video": "google/gemini-omni-flash/v1.1/edit",
+}
+
+# fal's published per-output-second rates by resolution tier (2026-09-05).
+# The prior flat 0.13/s constant over-reported 720p by 30%.
+_PRICE_PER_SECOND = {"360p": 0.03, "720p": 0.10, "1080p": 0.15, "4k": 0.30}
+_DEFAULT_RESOLUTION = "720p"
+_DEFAULT_DURATION = 8
+
+
 class GeminiOmniFalVideo(BaseTool):
     name = "gemini_omni_fal"
-    version = "0.2.0"
+    version = "0.3.0"
     tier = ToolTier.GENERATE
     capability = "video_generation"
     provider = "gemini_omni"
@@ -44,13 +61,24 @@ class GeminiOmniFalVideo(BaseTool):
         "reference_to_video": True,
         "video_to_video": True,
         "multiple_reference_images": True,
+        "reference_video": True,
+        "first_last_frame_to_video": True,
         "native_audio": True,
     }
     best_for = [
-        "Gemini Omni Flash with a fal.ai key",
+        "Gemini Omni 1.1 Flash with a fal.ai key",
         "reference-image-driven 3-10 second video with synchronized audio",
+        "first-and-last-frame interpolation via end_image_url",
+        "cheap 360p drafts at $0.03/s before committing to a 720p or 1080p take",
     ]
-    not_good_for = ["Google interaction-id workflows", "offline generation"]
+    # Scene extension (10s of prior context, cumulative 40s) is a multi-turn
+    # previous_interaction_id workflow on Google's own Interactions API. fal
+    # exposes no extend endpoint and accepts no interaction id as input, so that
+    # capability stays with the direct `gemini_omni_video` tool.
+    not_good_for = [
+        "scene extension / multi-turn continuation (use gemini_omni_video)",
+        "offline generation",
+    ]
     fallback_tools = ["gemini_omni_video", "runway_video", "veo_video"]
     dependencies = ["env:FAL_KEY"]
     install_instructions = (
@@ -74,8 +102,28 @@ class GeminiOmniFalVideo(BaseTool):
             },
             "image_url": {"type": "string"},
             "image_path": {"type": "string"},
+            "end_image_url": {
+                "type": "string",
+                "description": (
+                    "Closing frame for image_to_video. When set, the model "
+                    "interpolates from image_url to this frame."
+                ),
+            },
+            "end_image_path": {
+                "type": "string",
+                "description": "Local closing frame, uploaded then used as end_image_url.",
+            },
             "reference_image_urls": {"type": "array", "items": {"type": "string"}},
             "reference_image_paths": {"type": "array", "items": {"type": "string"}},
+            "reference_video_urls": {
+                "type": "array",
+                "items": {"type": "string"},
+                "maxItems": 3,
+                "description": (
+                    "reference_to_video only. Up to three clips, each at most "
+                    "three seconds. Reference media is consumed in list order."
+                ),
+            },
             "video_url": {
                 "type": "string",
                 "description": "Source clip for edit_video",
@@ -85,7 +133,18 @@ class GeminiOmniFalVideo(BaseTool):
                 "enum": ["16:9", "9:16"],
                 "default": "16:9",
             },
-            "duration": {"type": "integer", "minimum": 3, "maximum": 10, "default": 8},
+            "resolution": {
+                "type": "string",
+                "enum": ["360p", "720p", "1080p", "4k"],
+                "default": _DEFAULT_RESOLUTION,
+                "description": "Drives both output size and price; 360p is the draft tier.",
+            },
+            "duration": {
+                "type": "integer",
+                "minimum": 3,
+                "maximum": 10,
+                "default": _DEFAULT_DURATION,
+            },
             "output_path": {"type": "string"},
         },
     }
@@ -99,6 +158,7 @@ class GeminiOmniFalVideo(BaseTool):
         "prompt",
         "operation",
         "aspect_ratio",
+        "resolution",
         "duration",
         "reference_image_urls",
     ]
@@ -113,7 +173,11 @@ class GeminiOmniFalVideo(BaseTool):
         return ToolStatus.AVAILABLE if self._api_key() else ToolStatus.UNAVAILABLE
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
-        return round(0.13 * int(inputs.get("duration", 8)), 2)
+        rate = _PRICE_PER_SECOND.get(
+            str(inputs.get("resolution") or _DEFAULT_RESOLUTION).lower(),
+            _PRICE_PER_SECOND[_DEFAULT_RESOLUTION],
+        )
+        return round(rate * int(inputs.get("duration", _DEFAULT_DURATION)), 2)
 
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         return 90.0
@@ -135,19 +199,26 @@ class GeminiOmniFalVideo(BaseTool):
             urls.insert(0, inputs["image_url"])
         elif inputs.get("image_path"):
             urls.insert(0, upload_image_fal(inputs["image_path"]))
-        if operation in {"image_to_video", "reference_to_video"} and not urls:
+        reference_videos = list(inputs.get("reference_video_urls") or [])
+        if len(reference_videos) > 3:
             return ToolResult(
                 success=False,
-                error=f"{operation} requires at least one reference image",
+                error="reference_video_urls accepts at most three clips",
+            )
+        if operation == "image_to_video" and not urls:
+            return ToolResult(
+                success=False,
+                error="image_to_video requires at least one reference image",
+            )
+        # 1.1 lets reference_to_video be driven by videos alone, so images are no
+        # longer the only admissible reference.
+        if operation == "reference_to_video" and not urls and not reference_videos:
+            return ToolResult(
+                success=False,
+                error="reference_to_video requires reference images or reference videos",
             )
 
-        endpoints = {
-            "text_to_video": "google/gemini-omni-flash",
-            "image_to_video": "google/gemini-omni-flash/image-to-video",
-            "reference_to_video": "google/gemini-omni-flash/reference-to-video",
-            "edit_video": "google/gemini-omni-flash/edit",
-        }
-        if operation not in endpoints:
+        if operation not in _ENDPOINTS:
             return ToolResult(
                 success=False, error=f"unsupported Gemini Omni operation: {operation}"
             )
@@ -156,20 +227,43 @@ class GeminiOmniFalVideo(BaseTool):
                 success=False,
                 error=f"{operation} does not accept reference images on fal.ai",
             )
-        endpoint = endpoints[operation]
+        endpoint = _ENDPOINTS[operation]
+        resolution = str(
+            inputs.get("resolution") or _DEFAULT_RESOLUTION
+        ).lower()
+        if resolution not in _PRICE_PER_SECOND:
+            return ToolResult(
+                success=False,
+                error=f"unsupported resolution: {resolution}",
+            )
         payload: dict[str, Any] = {
             "prompt": inputs["prompt"],
             "aspect_ratio": inputs.get("aspect_ratio", "16:9"),
-            "duration": int(inputs.get("duration", 8)),
+            "resolution": resolution,
+            "duration": int(inputs.get("duration", _DEFAULT_DURATION)),
         }
         if operation == "image_to_video":
             payload["image_url"] = urls[0]
+            end_url = inputs.get("end_image_url")
+            if not end_url and inputs.get("end_image_path"):
+                end_url = upload_image_fal(inputs["end_image_path"])
+            if end_url:
+                payload["end_image_url"] = end_url
         elif operation == "reference_to_video":
-            payload["image_urls"] = urls
+            if urls:
+                payload["image_urls"] = urls
+            if reference_videos:
+                payload["reference_video_urls"] = reference_videos
         elif operation == "edit_video":
             if not inputs.get("video_url"):
                 return ToolResult(success=False, error="edit_video requires video_url")
-            payload = {"prompt": inputs["prompt"], "video_url": inputs["video_url"]}
+            # The edit endpoint takes no aspect_ratio or duration — it inherits
+            # both from the source clip.
+            payload = {
+                "prompt": inputs["prompt"],
+                "video_url": inputs["video_url"],
+                "resolution": resolution,
+            }
         headers = {
             "Authorization": f"Key {api_key}",
             "Content-Type": "application/json",
@@ -202,7 +296,8 @@ class GeminiOmniFalVideo(BaseTool):
                 queued["response_url"], headers=headers, timeout=30
             )
             result_response.raise_for_status()
-            video_url = result_response.json()["video"]["url"]
+            result_json = result_response.json()
+            video_url = result_json["video"]["url"]
             download = requests.get(video_url, timeout=120)
             download.raise_for_status()
             output_path = Path(inputs.get("output_path", "gemini_omni_fal_output.mp4"))
@@ -219,6 +314,10 @@ class GeminiOmniFalVideo(BaseTool):
                 "gateway": "fal.ai",
                 "model": endpoint,
                 "operation": operation,
+                "resolution": resolution,
+                # The edit endpoint returns one; fal accepts no interaction id as
+                # input, so this is for traceability, not for multi-turn resume.
+                "interaction_id": result_json.get("interaction_id"),
                 "output": str(output_path),
                 **probe_output(output_path),
             },

--- a/tools/video/gemini_omni_video.py
+++ b/tools/video/gemini_omni_video.py
@@ -37,10 +37,24 @@ from tools.base_tool import (
 
 _BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
 _UPLOAD_URL = "https://generativelanguage.googleapis.com/upload/v1beta/files"
-_DEFAULT_MODEL = "gemini-omni-flash-preview"
-# Billed at 5,792 output tokens per second of 720p video, $17.50/1M tokens
-# (ai.google.dev/gemini-api/docs/pricing) — effectively ~$0.10 per second.
-_COST_PER_SECOND = 0.10
+# Model ids verified against ai.google.dev/gemini-api/docs/models/gemini-omni-flash
+# on 2026-09-05. 1.1 is the stable line; scene extension (10s of prior context,
+# cumulative 40s) and first/last-frame control exist only there.
+_DEFAULT_MODEL = "gemini-omni-1.1-flash"
+_MODELS = ["gemini-omni-1.1-flash", "gemini-omni-flash-preview"]
+# Billed per second of output, by resolution tier. 720p checks out against the
+# token math: 5,792 output tokens/sec at $17.50/1M = $0.1014/sec
+# (ai.google.dev/gemini-api/docs/pricing). Published 360p figures disagree
+# across sources ($0.03 vs $0.043); Google states "a third of 720p", so $0.03 is
+# the optimistic end — treat a 360p quote as approximate, not a guarantee.
+_COST_PER_SECOND_BY_RESOLUTION = {
+    "360p": 0.03,
+    "720p": 0.10,
+    "1080p": 0.15,
+    "4k": 0.30,
+}
+_DEFAULT_RESOLUTION = "720p"
+_COST_PER_SECOND = _COST_PER_SECOND_BY_RESOLUTION[_DEFAULT_RESOLUTION]
 _DEFAULT_DURATION_SECONDS = 8
 _POLL_INTERVAL_SECONDS = 5
 _MAX_POLL_SECONDS = 900
@@ -61,7 +75,8 @@ class GeminiOmniVideo(BaseTool):
     install_instructions = (
         "Set GEMINI_API_KEY or GOOGLE_API_KEY to a Google AI Studio API key.\n"
         "  Get one at https://aistudio.google.com/apikey\n"
-        "  Gemini Omni Flash is paid-tier only (no free tier); ~$0.10 per second of video."
+        "  Gemini Omni Flash is paid-tier only (no free tier). Priced per second of\n"
+        "  output by resolution: ~$0.03 (360p), $0.10 (720p), $0.15 (1080p), $0.30 (4k)."
     )
     agent_skills = ["gemini-omni", "ai-video-gen"]
 
@@ -75,33 +90,49 @@ class GeminiOmniVideo(BaseTool):
         "native_audio": True,
         "text_rendering": True,
         "timecode_control": True,
-        # Preview limitations — no sampler controls of any kind.
+        # No sampler controls of any kind on either model id.
         "seed": False,
         "negative_prompt": False,
-        "first_last_frame_to_video": False,
+        # True only since 1.1 + the resolution/last-frame plumbing below: two
+        # images in `input` bound with <FIRST_FRAME>/<LAST_FRAME> prompt tags.
+        # Selecting the -preview model id forfeits this.
+        "first_last_frame_to_video": True,
     }
     best_for = [
         "iterative natural-language video editing (edit a clip without regenerating it)",
-        "reference-image-driven clips via <FIRST_FRAME>/<IMAGE_REF_N> prompt tags",
-        "fast 3-10s clips with synced audio, rendered text, and timecoded beats from one Google key",
+        "multi-shot continuity: scene extension reads 10s of prior context, to 40s cumulative",
+        "first-and-last-frame control via <FIRST_FRAME>/<LAST_FRAME> prompt tags",
+        "reference-image-driven clips via <IMAGE_REF_N> prompt tags",
+        "cheap 360p drafts before committing to a 720p, 1080p or 4k take",
     ]
     not_good_for = [
-        "clips longer than 10 seconds or above 720p",
+        "single calls longer than 10 seconds (extend multi-turn instead)",
         "seed-reproducible output or negative-prompt control",
         "offline generation",
     ]
     fallback_tools = ["veo_video", "sora_video", "kling_video", "minimax_video"]
-    # Conversational editing + native audio are unique in the fleet, but preview
-    # output is capped at 720p/10s — below seedance (0.95) and grok/runway (0.9)
-    # on raw generation fidelity. Without a quality_score the scorer would only
-    # count supports/stability flags and bury the editing capability entirely.
-    # See lib/scoring.py.
+    # Conversational editing, scene extension and native audio are unique in the
+    # fleet. Without a quality_score the scorer would count only supports and
+    # stability flags and bury those entirely. See lib/scoring.py.
+    # Held at 0.85 deliberately: 1.1 lifted the old 720p ceiling to 4k, which
+    # arguably closes the gap to seedance (0.95) and grok/runway (0.9), but this
+    # value ranks the whole fleet and no ranking comparison has been run. Raise
+    # it only alongside that measurement.
     quality_score = 0.85
 
     input_schema = {
         "type": "object",
         "required": ["prompt"],
         "properties": {
+            "model": {
+                "type": "string",
+                "enum": _MODELS,
+                "default": _DEFAULT_MODEL,
+                "description": (
+                    "gemini-omni-1.1-flash adds scene extension, first/last-frame "
+                    "control and 4K; the -preview id is the older first model."
+                ),
+            },
             "prompt": {
                 "type": "string",
                 "description": (
@@ -119,6 +150,16 @@ class GeminiOmniVideo(BaseTool):
                 "type": "string",
                 "enum": ["16:9", "9:16"],
                 "default": "16:9",
+            },
+            "resolution": {
+                "type": "string",
+                "enum": ["360p", "720p", "1080p", "4k"],
+                "default": _DEFAULT_RESOLUTION,
+                "description": (
+                    "Drives both output size and price. 360p is the draft tier — "
+                    "roughly a third the cost and up to 60% faster; 1080p and 4k "
+                    "are upscaled. 1.1 models only."
+                ),
             },
             "duration": {
                 "type": "string",
@@ -198,7 +239,11 @@ class GeminiOmniVideo(BaseTool):
         return max(3, min(10, seconds))
 
     def estimate_cost(self, inputs: dict[str, Any]) -> float:
-        return _COST_PER_SECOND * self._duration_hint(inputs)
+        rate = _COST_PER_SECOND_BY_RESOLUTION.get(
+            str(inputs.get("resolution") or _DEFAULT_RESOLUTION).lower(),
+            _COST_PER_SECOND,
+        )
+        return rate * self._duration_hint(inputs)
 
     def estimate_runtime(self, inputs: dict[str, Any]) -> float:
         return 180.0
@@ -378,8 +423,12 @@ class GeminiOmniVideo(BaseTool):
         except Exception as e:
             return ToolResult(success=False, error=f"Gemini Omni input preparation failed: {e}")
 
+        model = inputs.get("model") or _DEFAULT_MODEL
+        resolution = str(inputs.get("resolution") or _DEFAULT_RESOLUTION).lower()
+        if resolution not in _COST_PER_SECOND_BY_RESOLUTION:
+            return ToolResult(success=False, error=f"unsupported resolution: {resolution}")
         payload: dict[str, Any] = {
-            "model": _DEFAULT_MODEL,
+            "model": model,
             # Plain string for text-only turns (the documented minimal form),
             # typed parts when images or an uploaded video ride along.
             "input": prompt if not parts else parts + [{"type": "text", "text": prompt}],
@@ -388,6 +437,7 @@ class GeminiOmniVideo(BaseTool):
             "response_format": {
                 "type": "video",
                 "aspect_ratio": aspect_ratio,
+                "resolution": resolution,
                 "delivery": "uri",
             },
         }
@@ -435,11 +485,12 @@ class GeminiOmniVideo(BaseTool):
             success=True,
             data={
                 "provider": self.provider,
-                "model": _DEFAULT_MODEL,
+                "model": model,
                 "prompt": prompt,
                 "operation": operation,
                 "output": str(output_path),
                 "aspect_ratio": aspect_ratio,
+                "resolution": resolution,
                 "has_audio": True,
                 # Feed this back as previous_interaction_id to edit this clip.
                 "interaction_id": interaction_id,
@@ -448,5 +499,5 @@ class GeminiOmniVideo(BaseTool):
             artifacts=[str(output_path)],
             cost_usd=self.estimate_cost(inputs),
             duration_seconds=round(time.time() - start, 2),
-            model=_DEFAULT_MODEL,
+            model=model,
         )


### PR DESCRIPTION
All three Gemini Omni routes in the repo are pinned to the pre-1.1 preview model, and both Omni cost functions are wrong. This fixes both. Everything below was verified against fal's live OpenAPI documents and `ai.google.dev` — **no paid call was made.**

## `gemini_omni_fal` (0.2.0 → 0.3.0)

| Issue | Detail |
|---|---|
| Wrong model | The unversioned `google/gemini-omni-flash/*` slugs resolve to the pre-1.1 model. fal serves 1.1 at `google/gemini-omni-flash/v1.1/*`. |
| Missing 1.1 fields | Adds `resolution` (360p/720p/1080p/4k), `end_image_url` for first-and-last-frame interpolation, and `reference_video_urls` (max 3, ≤3s each). |
| **Latent 422** | `edit_video` sent `aspect_ratio` and `duration`. That endpoint accepts **neither** — this would have failed on the first paid call. |
| Wrong price | `estimate_cost` was a flat `$0.13/s`. Published tiers are `$0.03 / $0.10 / $0.15 / $0.30`, so it over-reported 720p by 30% and under-reported 4k by more than 2x. |

## `gemini_omni_video`

- `_DEFAULT_MODEL` was hardcoded to `gemini-omni-flash-preview` with no way to select anything else. Now defaults to `gemini-omni-1.1-flash` and `model` is a schema field. Both ids verified against [the model docs](https://ai.google.dev/gemini-api/docs/models/gemini-omni-flash).
- `response_format` never carried `resolution`, so the 360p draft tier and everything above 720p were unreachable on the direct route.
- `estimate_cost` was a flat `$0.10/s` — correct only for 720p.
- `supports.first_last_frame_to_video` becomes `true`, earned: 1.1 binds two images via `<FIRST_FRAME>`/`<LAST_FRAME>`.
- The result now reports the model and resolution actually requested rather than the module constant.

**Deliberately unchanged:** `quality_score` stays `0.85`. 1.1 lifting the 720p ceiling arguably closes the gap to seedance and grok, but that value ranks the whole fleet through `lib/scoring.py` and I ran no ranking comparison. Reasoning left in a comment for whoever does.

## Skill doc

`.agents/skills/gemini-omni/SKILL.md` was describing the preview model. Adds `<LAST_FRAME>`, the resolution and draft tiers, and scene extension with its real constraints (append-only, 10s cap on uploaded input, no new dialogue when extending an uploaded speaking clip). Also records that scene extension is a `previous_interaction_id` workflow on Google's Interactions API with **no equivalent on the fal route** — fal exposes no extend endpoint and accepts no interaction id as input.

## Verification

All four fal operations were diffed against the live schemas at `fal.ai/api/openapi/queue/openapi.json`, with `requests.post` intercepted before send:

```
text_to_video       exact key match, correct URL   ✓
image_to_video      + end_image_url, image_url     ✓
reference_to_video  + image_urls, reference_video_urls ✓
edit_video          prompt, resolution, video_url  ✓

4/4 — no unknown keys, no missing required fields
```

New `tests/tools/test_gemini_omni_fal_v11_payloads.py` (10 tests) pins the payload shape and per-resolution pricing offline so this can't silently drift back.

**Suite: 1845 passed, 12 skipped, 3 xfailed.**

## Known gap

Google publishes no OpenAPI document for the Interactions API, so unlike the fal route the direct request shape rests on documentation plus unit tests rather than a live schema diff. Worth a maintainer's eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171Do7yJ6dLopC4jvjTRQig