### PR TITLE
Backlot: surface assets/images as a clickable References panel

### DIFF
--- a/backlot/state.py
+++ b/backlot/state.py
@@ -530,8 +530,21 @@ def _scan_media(project_dir: Path) -> dict[str, list[dict]]:
                 if f.suffix.lower() in MEDIA_IMAGE_EXT and f.is_file():
                     snapshots.append({"path": _rel(project_dir, f)})
 
+    # assets/images/ is the project convention's home for generated stills
+    # (AGENT_GUIDE "Project Directory Convention"), so reference frames and
+    # contact sheets land here. Kept separate from snapshots because that
+    # bucket only renders in the board's degraded, no-storyboard view.
+    images: list[dict] = []
+    images_dir = project_dir / "assets" / "images"
+    if images_dir.is_dir():
+        for f in sorted(images_dir.iterdir()):
+            if f.suffix.lower() in MEDIA_IMAGE_EXT and f.is_file():
+                images.append({"path": _rel(project_dir, f), "name": f.name})
+    # A contact sheet indexes the rest, so it leads.
+    images.sort(key=lambda i: (not i["name"].upper().startswith("CONTACT-SHEET"), i["name"]))
+
     renders.sort(key=lambda r: r.get("mtime", 0), reverse=True)
-    return {"renders": renders, "snapshots": snapshots, "music": music}
+    return {"renders": renders, "snapshots": snapshots, "music": music, "images": images}
 
 
 def _find_poster(project_dir: Path, state: dict) -> Optional[str]:

--- a/backlot/ui/board.css
+++ b/backlot/ui/board.css
@@ -1040,3 +1040,16 @@ body:not(.first) .approval-review { animation: none; }
   .approval-review-foot button { width: 100%; }
   .approval-status { white-space: normal; }
 }
+
+/* Reference thumbnails carry a filename so a viewer can name what they picked;
+   the grid itself is shared with "what the watcher found". */
+.thumb-caption {
+  display: block;
+  padding: 4px 2px 0;
+  font-size: 11px;
+  line-height: 1.3;
+  color: var(--text-3);
+  word-break: break-all;
+}
+.thumb a { display: block; }
+.thumb a:focus-visible { outline: 2px solid var(--accent, #e8a33d); outline-offset: 2px; }

--- a/backlot/ui/board.js
+++ b/backlot/ui/board.js
@@ -867,6 +867,27 @@ function renderFoundMedia(s) {
     grid);
 }
 
+function renderReferences(s) {
+  // Reference stills from assets/images/. Deliberately NOT gated on the
+  // absence of a storyboard the way renderFoundMedia is — these stay useful
+  // once shots exist, which is exactly when you want to compare a take
+  // against the frame it came from.
+  const images = s.media.images;
+  if (!images.length) return null;
+  const grid = el("div", { class: "found-grid" });
+  for (const img of images) {
+    grid.append(el("div", { class: "thumb" },
+      el("a", { href: mediaURL(s.project_id, img.path), target: "_blank",
+                rel: "noopener", title: img.name || img.path },
+        el("img", { src: thumbURL(s.project_id, img.path, 640), loading: "lazy", alt: img.name || "" })),
+      el("span", { class: "thumb-caption" }, img.name || img.path)));
+  }
+  return el("div", {},
+    el("div", { class: "section-title" }, "References",
+      el("span", { class: "meta" }, `${images.length} image${images.length === 1 ? "" : "s"} · click to open full size`)),
+    grid);
+}
+
 function renderNoState(s) {
   if (s.has_pipeline_state) return null;
   return el("div", { class: "notice", style: "border-color:#2b2b33;background:var(--surface-2);color:var(--text-3)" },
@@ -1084,16 +1105,17 @@ function render() {
   // never pushes them below the fold — the column flows beside the rail.
   const storyboard = renderStoryboard(s);
   const found = renderFoundMedia(s);
+  const references = renderReferences(s);
   const renders = renderRenders(s);
 
   if (approvalReview || script || decisions || activity) {
-    for (const section of [storyboard, found, renders]) {
+    for (const section of [storyboard, found, references, renders]) {
       if (section) main.append(section);
     }
     const hasAside = Boolean(decisions || activity);
     app.append(el("div", { class: `board${hasAside ? "" : " solo"}` }, main, hasAside ? aside : null));
   } else {
-    for (const section of [storyboard, found, renders]) {
+    for (const section of [storyboard, found, references, renders]) {
       if (section) app.append(section);
     }
   }
@@ -1112,6 +1134,7 @@ function normalize(s) {
   s.media.renders = Array.isArray(s.media.renders) ? s.media.renders : [];
   s.media.snapshots = Array.isArray(s.media.snapshots) ? s.media.snapshots : [];
   s.media.music = Array.isArray(s.media.music) ? s.media.music : [];
+  s.media.images = Array.isArray(s.media.images) ? s.media.images : [];
   s.events = Array.isArray(s.events) ? s.events : [];
   if (s.storyboard && Array.isArray(s.storyboard.scenes)) {
     for (const c of s.storyboard.scenes) {


### PR DESCRIPTION
The board never scans `assets/images/`, even though AGENT_GUIDE's "Project Directory Convention" names it as the home for generated stills and `backlot/README.md` says the board is "derived from what the pipeline already writes to `projects/<id>/`". Reference frames and contact sheets are invisible today.

## The trap this avoids

`renderFoundMedia` already displays loose images, so routing `assets/images/` into the `snapshots` bucket looks like a one-line fix. But its first line is:

```js
if (s.storyboard || !s.media.snapshots.length) return null;
```

That's a **degraded, no-storyboard view**. Reference images would show up now and then silently disappear the moment `scene_plan` runs — exactly when comparing a generated take against the frame it came from is most useful. Hence a separate bucket and a panel that isn't gated on the absence of a storyboard.

## Changes

| File | Change |
|---|---|
| `backlot/state.py` | `_scan_media` gains an `images` bucket scanning `assets/images/`. Contact sheets sort first, since they index the rest. |
| `backlot/ui/board.js` | `renderReferences()` — each thumbnail wrapped in a link to `/media/<project>/<path>` opening full size. **Nothing on the board was clickable before this.** |
| `backlot/ui/board.css` | Filename caption, plus a focus ring so the new links are keyboard-navigable. |

The `/media/` route already existed and needed no change. `mediaURL` and `thumbURL` were already imported in `board.js`.

## Verification

Loaded in a real browser and confirmed the panel renders with 12 images and 12 working links. The only console error is a pre-existing missing `favicon.ico`, unrelated to this change.

```
1828 passed, 12 skipped, 3 xfailed
```

Found while using the board to pick between reference stills for a production — the images were on disk, named and reviewed, and there was no way to see them from the board they belonged to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171Do7yJ6dLopC4jvjTRQig