### PR TITLE
Fix source media review probe and frame sampling

### DIFF
--- a/lib/source_media_review.py
+++ b/lib/source_media_review.py
@@ -52,8 +52,11 @@ def _probe_video(path: Path, tool_registry: Any) -> dict[str, Any]:
     except Exception as e:
         logger.warning("audio_probe failed for %s: %s", path, e)
 
-    # If audio_probe didn't work, try ffprobe directly
-    if not result["technical_probe"]:
+    # audio_probe intentionally reports audio-oriented metadata and may omit
+    # the video stream. A source review needs a normalized video probe, so
+    # fall back to ffprobe whenever resolution is absent as well as when the
+    # tool failed outright.
+    if not result["technical_probe"] or not result["technical_probe"].get("resolution"):
         try:
             import subprocess
             cmd = [
@@ -90,11 +93,16 @@ def _probe_video(path: Path, tool_registry: Any) -> dict[str, Any]:
             timestamps = _sample_timestamps(duration, count=4)
             sample_result = frame_sampler.execute({
                 "input_path": str(path),
+                "strategy": "timestamps",
                 "timestamps": timestamps,
-                "output_dir": str(path.parent / ".source_review_frames"),
+                "output_dir": str(path.parent / ".source_review_frames" / path.stem),
             })
             if sample_result.success:
-                result["representative_frames"] = sample_result.data.get("frame_paths", [])
+                frames = sample_result.data.get("frames", [])
+                result["representative_frames"] = [
+                    frame["path"] if isinstance(frame, dict) else str(frame)
+                    for frame in frames
+                ]
     except Exception as e:
         logger.warning("frame_sampler failed for %s: %s", path, e)
 


### PR DESCRIPTION
`_probe_video` in `lib/source_media_review.py` had three bugs that left source reviews with no video metadata and no frames.

**1. ffprobe fallback never triggered on partial data**

`audio_probe` reports audio-oriented metadata and may omit the video stream entirely. The fallback only fired when the tool failed outright, so a successful call that returned no resolution left the review with no video dimensions. It now falls back whenever resolution is missing.

**2. `frame_sampler` was called without its required `strategy`**

`tools/analysis/frame_sampler.py` declares `"required": ["input_path", "strategy"]`, but the call omitted it, so every sampling attempt failed.

**3. The result was read under a key that does not exist**

`frame_sampler` returns its output under `frames` as a list of frame records. The call read `frame_paths`, which is never set, so `representative_frames` was always empty even when extraction succeeded.

Each source also gets its own frame subdirectory (`.source_review_frames/<stem>/`) so concurrent reviews do not overwrite one another.

## Verification

`pytest tests/ -k "source_media or frame_sampler"` passes (4 passed).

Full suite on this branch matches clean `main` exactly: same 18 failures and 13 errors, all pre-existing and unrelated (`tests/backlot/test_ui_bug_bash.py`, `tests/contracts/test_phase3_contracts.py`, and the two Google backend test files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)